### PR TITLE
39062 cluster variables should be exported properly to secondary storage

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -801,14 +801,14 @@
       <column name="VAR_VALUE" type="VARCHAR(8192)"/>
       <column name="VAR_FULL_VALUE" type="CLOB"/>
       <column name="IS_PREVIEW" type="BOOLEAN"/>
-      <column name="TENANT_ID" type="VARCHAR(255)"/>
+      <column name="TENANT_ID" type="VARCHAR(${userCharColumnSize})"/>
       <column name="SCOPE" type="VARCHAR(255)"/>
     </createTable>
 
     <createIndex tableName="${prefix}CLUSTER_VARIABLE"
       indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID_SCOPE">
-      <column name="TENANT_ID"/>
       <column name="SCOPE"/>
+      <column name="TENANT_ID"/>
     </createIndex>
 
     <modifySql dbms="oracle">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -440,11 +440,13 @@
       <column name="ENTITY_TYPE" type="VARCHAR(255)"/>
     </createTable>
 
-    <createIndex tableName="${prefix}TENANT_MEMBER" indexName="${prefix}idx_tenant_member_tenant_id">
+    <createIndex tableName="${prefix}TENANT_MEMBER"
+      indexName="${prefix}idx_tenant_member_tenant_id">
       <column name="TENANT_ID"/>
     </createIndex>
 
-    <createIndex tableName="${prefix}TENANT_MEMBER" indexName="${prefix}idx_tenant_member_entity_id">
+    <createIndex tableName="${prefix}TENANT_MEMBER"
+      indexName="${prefix}idx_tenant_member_entity_id">
       <column name="ENTITY_ID"/>
     </createIndex>
   </changeSet>
@@ -703,7 +705,8 @@
       <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
-    <createIndex tableName="${prefix}USAGE_METRIC_TU" indexName="${prefix}IDX_USAGE_METRIC_TU_END_TIME">
+    <createIndex tableName="${prefix}USAGE_METRIC_TU"
+      indexName="${prefix}IDX_USAGE_METRIC_TU_END_TIME">
       <column name="END_TIME"/>
     </createIndex>
 
@@ -783,6 +786,33 @@
     </modifySql>
     <modifySql dbms="mssql">
       <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_table" author="camunda">
+    <createTable tableName="${prefix}CLUSTER_VARIABLE">
+      <column name="CLUSTER_VARIABLE_ID" type="VARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="VAR_NAME" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="TYPE" type="VARCHAR(255)"/>
+      <column name="DOUBLE_VALUE" type="DOUBLE"/>
+      <column name="LONG_VALUE" type="BIGINT"/>
+      <column name="VAR_VALUE" type="VARCHAR(8192)"/>
+      <column name="VAR_FULL_VALUE" type="CLOB"/>
+      <column name="IS_PREVIEW" type="BOOLEAN"/>
+      <column name="RESOURCE_ID" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="SCOPE" type="VARCHAR(${userCharColumnSize})"/>
+    </createTable>
+
+    <createIndex tableName="${prefix}CLUSTER_VARIABLE"
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_RESOURCE_ID">
+      <column name="RESOURCE_ID"/>
+    </createIndex>
+
+    <modifySql dbms="oracle">
+      <!-- Oracle only supports a size 4000 characters in varchar2 -->
+      <replace replace="VARCHAR2(8192)" with="VARCHAR2(4000)"/>
     </modifySql>
   </changeSet>
 

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -806,9 +806,13 @@
     </createTable>
 
     <createIndex tableName="${prefix}CLUSTER_VARIABLE"
-      indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID_SCOPE">
-      <column name="SCOPE"/>
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID">
       <column name="TENANT_ID"/>
+    </createIndex>
+
+    <createIndex tableName="${prefix}CLUSTER_VARIABLE"
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_SCOPE">
+      <column name="SCOPE"/>
     </createIndex>
 
     <modifySql dbms="oracle">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -801,13 +801,13 @@
       <column name="VAR_VALUE" type="VARCHAR(8192)"/>
       <column name="VAR_FULL_VALUE" type="CLOB"/>
       <column name="IS_PREVIEW" type="BOOLEAN"/>
-      <column name="RESOURCE_ID" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="VARCHAR(${userCharColumnSize})"/>
       <column name="SCOPE" type="VARCHAR(${userCharColumnSize})"/>
     </createTable>
 
     <createIndex tableName="${prefix}CLUSTER_VARIABLE"
-      indexName="${prefix}IDX_CLUSTER_VARIABLE_RESOURCE_ID">
-      <column name="RESOURCE_ID"/>
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID">
+      <column name="TENANT_ID"/>
     </createIndex>
 
     <modifySql dbms="oracle">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -801,13 +801,14 @@
       <column name="VAR_VALUE" type="VARCHAR(8192)"/>
       <column name="VAR_FULL_VALUE" type="CLOB"/>
       <column name="IS_PREVIEW" type="BOOLEAN"/>
-      <column name="TENANT_ID" type="VARCHAR(${userCharColumnSize})"/>
-      <column name="SCOPE" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="TENANT_ID" type="VARCHAR(255)"/>
+      <column name="SCOPE" type="VARCHAR(255)"/>
     </createTable>
 
     <createIndex tableName="${prefix}CLUSTER_VARIABLE"
-      indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID">
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_TENANT_ID_SCOPE">
       <column name="TENANT_ID"/>
+      <column name="SCOPE"/>
     </createIndex>
 
     <modifySql dbms="oracle">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.ClusterVariableDbReader;
 import io.camunda.db.rdbms.read.service.CorrelatedMessageSubscriptionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
@@ -55,6 +56,7 @@ public class RdbmsService {
   private final ProcessDefinitionDbReader processDefinitionReader;
   private final ProcessInstanceDbReader processInstanceReader;
   private final VariableDbReader variableReader;
+  private final ClusterVariableDbReader clusterVariableDbReader;
   private final RoleDbReader roleReader;
   private final RoleMemberDbReader roleMemberReader;
   private final TenantDbReader tenantReader;
@@ -85,6 +87,7 @@ public class RdbmsService {
       final ProcessDefinitionDbReader processDefinitionReader,
       final ProcessInstanceDbReader processInstanceReader,
       final VariableDbReader variableReader,
+      final ClusterVariableDbReader clusterVariableDbReader,
       final RoleDbReader roleReader,
       final RoleMemberDbReader roleMemberReader,
       final TenantDbReader tenantReader,
@@ -115,6 +118,7 @@ public class RdbmsService {
     this.roleMemberReader = roleMemberReader;
     this.tenantReader = tenantReader;
     this.variableReader = variableReader;
+    this.clusterVariableDbReader = clusterVariableDbReader;
     this.roleReader = roleReader;
     this.tenantMemberReader = tenantMemberReader;
     this.userReader = userReader;
@@ -181,6 +185,10 @@ public class RdbmsService {
 
   public VariableDbReader getVariableReader() {
     return variableReader;
+  }
+
+  public ClusterVariableDbReader getClusterVariableReader() {
+    return clusterVariableDbReader;
   }
 
   public RoleDbReader getRoleReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record ClusterVariableDbQuery(
+    ClusterVariableFilter filter,
+    List<String> authorizedResourceIds,
+    List<String> authorizedTenantIds,
+    DbQuerySorting<ClusterVariableEntity> sort,
+    DbQueryPage page) {
+
+  public static ClusterVariableDbQuery of(
+      final Function<ClusterVariableDbQuery.Builder, ObjectBuilder<ClusterVariableDbQuery>> fn) {
+    return fn.apply(new ClusterVariableDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<ClusterVariableDbQuery> {
+
+    private static final ClusterVariableFilter EMPTY_FILTER =
+        FilterBuilders.clusterVariable().build();
+
+    private ClusterVariableFilter filter;
+    private List<String> authorizedResourceIds = List.of();
+    private List<String> authorizedTenantIds = List.of();
+    private DbQuerySorting<ClusterVariableEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final ClusterVariableFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder authorizedResourceIds(final List<String> authorizedResourceIds) {
+      this.authorizedResourceIds = authorizedResourceIds;
+      return this;
+    }
+
+    public Builder authorizedTenantIds(final List<String> authorizedTenantIds) {
+      this.authorizedTenantIds = authorizedTenantIds;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<ClusterVariableEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<ClusterVariableFilter.Builder, ObjectBuilder<ClusterVariableFilter>> fn) {
+      return filter(FilterBuilders.clusterVariable(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<ClusterVariableEntity>,
+                ObjectBuilder<DbQuerySorting<ClusterVariableEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public ClusterVariableDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
+      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      return new ClusterVariableDbQuery(
+          filter, authorizedResourceIds, authorizedTenantIds, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
@@ -11,6 +11,7 @@ import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -79,9 +80,11 @@ public record ClusterVariableDbQuery(
     @Override
     public ClusterVariableDbQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
-      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
-      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
-      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(Collections.emptyList()));
+      authorizedResourceIds =
+          Objects.requireNonNullElse(authorizedResourceIds, Collections.emptyList());
+      authorizedTenantIds =
+          Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList());
       return new ClusterVariableDbQuery(
           filter, authorizedResourceIds, authorizedTenantIds, sort, page);
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 
 public record ClusterVariableDbQuery(
     ClusterVariableFilter filter,
+    boolean tenancyEnabled,
     List<String> authorizedResourceIds,
     List<String> authorizedTenantIds,
     DbQuerySorting<ClusterVariableEntity> sort,
@@ -38,9 +39,15 @@ public record ClusterVariableDbQuery(
     private List<String> authorizedTenantIds = List.of();
     private DbQuerySorting<ClusterVariableEntity> sort;
     private DbQueryPage page;
+    private boolean tenancyEnabled;
 
     public Builder filter(final ClusterVariableFilter value) {
       filter = value;
+      return this;
+    }
+
+    public Builder tenancyEnabled(final boolean value) {
+      tenancyEnabled = value;
       return this;
     }
 
@@ -86,7 +93,7 @@ public record ClusterVariableDbQuery(
       authorizedTenantIds =
           Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList());
       return new ClusterVariableDbQuery(
-          filter, authorizedResourceIds, authorizedTenantIds, sort, page);
+          filter, tenancyEnabled, authorizedResourceIds, authorizedTenantIds, sort, page);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
+import io.camunda.db.rdbms.sql.columns.ClusterVariableSearchColumn;
+import io.camunda.search.clients.reader.ClusterVariableReader;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.filter.ClusterVariableFilter.Builder;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.ClusterVariableSort;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariableEntity>
+    implements ClusterVariableReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterVariableDbReader.class);
+
+  private final ClusterVariableMapper clusterVariableMapper;
+
+  public ClusterVariableDbReader(final ClusterVariableMapper clusterVariableMapper) {
+    super(ClusterVariableSearchColumn.values());
+    this.clusterVariableMapper = clusterVariableMapper;
+  }
+
+  @Override
+  public SearchQueryResult<ClusterVariableEntity> search(
+      final ClusterVariableQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    final var dbSort = convertSort(query.sort(), ClusterVariableSearchColumn.VAR_NAME);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+
+    final var dbQuery =
+        ClusterVariableDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedResourceIds(resourceAccessChecks.getAuthorizedResourceIds())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(convertPaging(dbSort, query.page())));
+    LOG.trace("[RDBMS DB] Search for cluster variables with filter {}", query);
+    final var totalHits = clusterVariableMapper.count(dbQuery);
+    final var hits = clusterVariableMapper.search(dbQuery);
+    return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public SearchQueryResult<ClusterVariableEntity> search(final ClusterVariableQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
+  }
+
+  @Override
+  public ClusterVariableEntity getTenantScopedClusterVariable(
+      final String tenant, final String name) {
+    return search(
+            new ClusterVariableQuery(
+                new Builder().resourceIds(tenant).scopes("TENANT").names(name).build(),
+                ClusterVariableSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(1))))
+        .items()
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  public ClusterVariableEntity getGloballyScopedClusterVariable(final String name) {
+    return search(
+            new ClusterVariableQuery(
+                new Builder().scopes("GLOBAL").names(name).build(),
+                ClusterVariableSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(1))))
+        .items()
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -79,13 +79,17 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
   public ClusterVariableEntity getGloballyScopedClusterVariable(
       final String name, final ResourceAccessChecks resourceAccessChecks) {
     return search(
-            new ClusterVariableQuery(
-                new Builder().scopes("GLOBAL").names(name).build(),
-                ClusterVariableSort.of(b -> b),
-                SearchQueryPage.of(b -> b.from(0).size(1))))
+            ClusterVariableQuery.of(
+                b -> b.filter(f -> f.names(name).scopes("GLOBAL")).page(p -> p.from(0).size(1))))
         .items()
         .stream()
         .findFirst()
         .orElse(null);
+  }
+
+  @Override
+  protected boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
+    return resourceAccessChecks.authorizationCheck().enabled()
+        && resourceAccessChecks.getAuthorizedResourceIds().isEmpty();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -66,7 +66,7 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
       final String tenant, final String name) {
     return search(
             new ClusterVariableQuery(
-                new Builder().resourceIds(tenant).scopes("TENANT").names(name).build(),
+                new Builder().tenantIds(tenant).scopes("TENANT").names(name).build(),
                 ClusterVariableSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(1))))
         .items()

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -63,7 +63,7 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
 
   @Override
   public ClusterVariableEntity getTenantScopedClusterVariable(
-      final String tenant, final String name) {
+      final String tenant, final String name, final ResourceAccessChecks resourceAccessChecks) {
     return search(
             new ClusterVariableQuery(
                 new Builder().tenantIds(tenant).scopes("TENANT").names(name).build(),
@@ -76,7 +76,8 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
   }
 
   @Override
-  public ClusterVariableEntity getGloballyScopedClusterVariable(final String name) {
+  public ClusterVariableEntity getGloballyScopedClusterVariable(
+      final String name, final ResourceAccessChecks resourceAccessChecks) {
     return search(
             new ClusterVariableQuery(
                 new Builder().scopes("GLOBAL").names(name).build(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -46,15 +46,11 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
 
     dbQueryBuilder
         .filter(query.filter())
+        .tenancyEnabled(resourceAccessChecks.tenantCheck().enabled())
+        .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
         .authorizedResourceIds(resourceAccessChecks.getAuthorizedResourceIds())
         .sort(dbSort)
         .page(convertPaging(dbSort, query.page()));
-
-    if (resourceAccessChecks.tenantCheck().enabled()) {
-      dbQueryBuilder
-          .tenancyEnabled(true)
-          .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds());
-    }
 
     final var dbQuery = dbQueryBuilder.build();
     LOG.trace("[RDBMS DB] Search for cluster variables with filter {}", query);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 public interface ClusterVariableMapper {
 
+  ClusterVariableEntity get(String id);
+
   void insert(ClusterVariableDbModel variable);
 
   void delete(ClusterVariableDbModel variable);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.search.entities.ClusterVariableEntity;
+import java.util.List;
+
+public interface ClusterVariableMapper extends HistoryCleanupMapper {
+
+  void insert(ClusterVariableDbModel variable);
+
+  void delete(ClusterVariableDbModel variable);
+
+  Long count(ClusterVariableDbQuery filter);
+
+  List<ClusterVariableEntity> search(ClusterVariableDbQuery filter);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
@@ -12,7 +12,7 @@ import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.search.entities.ClusterVariableEntity;
 import java.util.List;
 
-public interface ClusterVariableMapper extends HistoryCleanupMapper {
+public interface ClusterVariableMapper {
 
   void insert(ClusterVariableDbModel variable);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ClusterVariableSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ClusterVariableSearchColumn.java
@@ -10,11 +10,11 @@ package io.camunda.db.rdbms.sql.columns;
 import io.camunda.search.entities.ClusterVariableEntity;
 
 public enum ClusterVariableSearchColumn implements SearchColumn<ClusterVariableEntity> {
-  CLUSTER_VARIABLE_ID("clusterVariableId"),
+  CLUSTER_VARIABLE_ID("id"),
   VAR_NAME("name"),
   VAR_VALUE("value"),
   VAR_FULL_VALUE("fullValue"),
-  RESOURCE_ID("resourceId"),
+  TENANT_ID("tenantId"),
   SCOPE("scope"),
   IS_PREVIEW("isPreview");
   private final String property;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ClusterVariableSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ClusterVariableSearchColumn.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.ClusterVariableEntity;
+
+public enum ClusterVariableSearchColumn implements SearchColumn<ClusterVariableEntity> {
+  CLUSTER_VARIABLE_ID("clusterVariableId"),
+  VAR_NAME("name"),
+  VAR_VALUE("value"),
+  VAR_FULL_VALUE("fullValue"),
+  RESOURCE_ID("resourceId"),
+  SCOPE("scope"),
+  IS_PREVIEW("isPreview");
+  private final String property;
+
+  ClusterVariableSearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<ClusterVariableEntity> getEntityClass() {
+    return ClusterVariableEntity.class;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
@@ -26,6 +27,7 @@ import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.service.AuthorizationWriter;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.db.rdbms.write.service.CorrelatedMessageSubscriptionWriter;
 import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
 import io.camunda.db.rdbms.write.service.DecisionInstanceWriter;
@@ -67,6 +69,7 @@ public class RdbmsWriter {
   private final ProcessInstanceWriter processInstanceWriter;
   private final TenantWriter tenantWriter;
   private final VariableWriter variableWriter;
+  private final ClusterVariableWriter clusterVariableWriter;
   private final RoleWriter roleWriter;
   private final UserWriter userWriter;
   private final UserTaskWriter userTaskWriter;
@@ -102,7 +105,8 @@ public class RdbmsWriter {
       final UsageMetricTUMapper usageMetricTUMapper,
       final BatchOperationMapper batchOperationMapper,
       final MessageSubscriptionMapper messageSubscriptionMapper,
-      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper) {
+      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
+      final ClusterVariableMapper clusterVariableMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
@@ -140,6 +144,7 @@ public class RdbmsWriter {
     correlatedMessageSubscriptionWriter =
         new CorrelatedMessageSubscriptionWriter(
             executionQueue, correlatedMessageSubscriptionMapper);
+    clusterVariableWriter = new ClusterVariableWriter(executionQueue, vendorDatabaseProperties);
 
     historyCleanupService =
         new HistoryCleanupService(
@@ -202,6 +207,10 @@ public class RdbmsWriter {
 
   public VariableWriter getVariableWriter() {
     return variableWriter;
+  }
+
+  public ClusterVariableWriter getClusterVariableWriter() {
+    return clusterVariableWriter;
   }
 
   public RoleWriter getRoleWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
@@ -49,6 +50,7 @@ public class RdbmsWriterFactory {
   private final BatchOperationMapper batchOperationMapper;
   private final MessageSubscriptionMapper messageSubscriptionMapper;
   private final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper;
+  private final ClusterVariableMapper clusterVariableMapper;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -69,7 +71,8 @@ public class RdbmsWriterFactory {
       final UsageMetricTUMapper usageMetricTUMapper,
       final BatchOperationMapper batchOperationMapper,
       final MessageSubscriptionMapper messageSubscriptionMapper,
-      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper) {
+      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
+      final ClusterVariableMapper clusterVariableMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -89,6 +92,7 @@ public class RdbmsWriterFactory {
     this.batchOperationMapper = batchOperationMapper;
     this.messageSubscriptionMapper = messageSubscriptionMapper;
     this.correlatedMessageSubscriptionMapper = correlatedMessageSubscriptionMapper;
+    this.clusterVariableMapper = clusterVariableMapper;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {
@@ -115,6 +119,7 @@ public class RdbmsWriterFactory {
         usageMetricTUMapper,
         batchOperationMapper,
         messageSubscriptionMapper,
-        correlatedMessageSubscriptionMapper);
+        correlatedMessageSubscriptionMapper,
+        clusterVariableMapper);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -12,13 +12,14 @@ import static io.camunda.util.ValueTypeUtil.mapDouble;
 import static io.camunda.util.ValueTypeUtil.mapLong;
 
 import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.util.ValueTypeUtil;
 import java.util.function.Function;
 
 public record ClusterVariableDbModel(
-    String clusterVariableId,
+    String id,
     String name,
     ValueTypeEnum type,
     Double doubleValue,
@@ -26,8 +27,8 @@ public record ClusterVariableDbModel(
     String value,
     String fullValue,
     boolean isPreview,
-    String resourceId,
-    String scope)
+    String tenantId,
+    ClusterVariableScope scope)
     implements Copyable<ClusterVariableDbModel> {
 
   @Override
@@ -39,7 +40,7 @@ public record ClusterVariableDbModel(
             new ClusterVariableDbModelBuilder()
                 .name(name)
                 .value(value)
-                .resourceId(resourceId)
+                .tenantId(tenantId)
                 .scope(scope))
         .build();
   }
@@ -59,7 +60,7 @@ public record ClusterVariableDbModel(
     }
 
     return new ClusterVariableDbModel(
-        clusterVariableId,
+        id,
         name,
         type,
         doubleValue,
@@ -67,7 +68,7 @@ public record ClusterVariableDbModel(
         truncatedValue,
         fullValue,
         isPreview,
-        resourceId,
+        tenantId,
         scope);
   }
 
@@ -75,8 +76,8 @@ public record ClusterVariableDbModel(
       implements ObjectBuilder<ClusterVariableDbModel> {
     private String name;
     private String value;
-    private String resourceId;
-    private String scope;
+    private String tenantId;
+    private ClusterVariableScope scope;
 
     public ClusterVariableDbModelBuilder name(final String name) {
       this.name = name;
@@ -88,13 +89,13 @@ public record ClusterVariableDbModel(
       return this;
     }
 
-    public ClusterVariableDbModelBuilder scope(final String scope) {
+    public ClusterVariableDbModelBuilder scope(final ClusterVariableScope scope) {
       this.scope = scope;
       return this;
     }
 
-    public ClusterVariableDbModelBuilder resourceId(final String resourceId) {
-      this.resourceId = resourceId;
+    public ClusterVariableDbModelBuilder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
       return this;
     }
 
@@ -119,14 +120,14 @@ public record ClusterVariableDbModel(
           value,
           null,
           false,
-          resourceId,
+          tenantId,
           scope);
     }
 
     private String getCompositeId() {
       return switch (scope) {
-        case "GLOBAL" -> name;
-        case "TENANT" -> "%s-%s".formatted(name, resourceId);
+        case GLOBAL -> name;
+        case TENANT -> "%s-%s".formatted(name, tenantId);
         default ->
             throw new IllegalArgumentException("Unknown scope for cluster variable: " + scope);
       };
@@ -134,7 +135,7 @@ public record ClusterVariableDbModel(
 
     private ClusterVariableDbModel getModel(final ValueTypeEnum valueTypeEnum, final String value) {
       return new ClusterVariableDbModel(
-          getCompositeId(), name, valueTypeEnum, null, null, value, null, false, resourceId, scope);
+          getCompositeId(), name, valueTypeEnum, null, null, value, null, false, tenantId, scope);
     }
 
     private ClusterVariableDbModel getDoubleModel() {
@@ -147,7 +148,7 @@ public record ClusterVariableDbModel(
           value,
           null,
           false,
-          resourceId,
+          tenantId,
           scope);
     }
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import static io.camunda.util.ValueTypeUtil.mapBoolean;
+import static io.camunda.util.ValueTypeUtil.mapDouble;
+import static io.camunda.util.ValueTypeUtil.mapLong;
+
+import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.ValueTypeEnum;
+import io.camunda.util.ObjectBuilder;
+import io.camunda.util.ValueTypeUtil;
+import java.util.function.Function;
+
+public record ClusterVariableDbModel(
+    String clusterVariableId,
+    String name,
+    ValueTypeEnum type,
+    Double doubleValue,
+    Long longValue,
+    String value,
+    String fullValue,
+    boolean isPreview,
+    String resourceId,
+    String scope)
+    implements Copyable<ClusterVariableDbModel> {
+
+  @Override
+  public ClusterVariableDbModel copy(
+      final Function<ObjectBuilder<ClusterVariableDbModel>, ObjectBuilder<ClusterVariableDbModel>>
+          builderFunction) {
+    return builderFunction
+        .apply(
+            new ClusterVariableDbModelBuilder()
+                .name(name)
+                .value(value)
+                .resourceId(resourceId)
+                .scope(scope))
+        .build();
+  }
+
+  public ClusterVariableDbModel truncateValue(final int sizeLimit, final Integer byteLimit) {
+    var truncatedValue = value;
+    String fullValue = null;
+    var isPreview = false;
+
+    if (type == ValueTypeEnum.STRING && value != null) {
+      truncatedValue = TruncateUtil.truncateValue(truncatedValue, sizeLimit, byteLimit);
+
+      if (truncatedValue.length() < value.length()) {
+        fullValue = value;
+        isPreview = true;
+      }
+    }
+
+    return new ClusterVariableDbModel(
+        clusterVariableId,
+        name,
+        type,
+        doubleValue,
+        longValue,
+        truncatedValue,
+        fullValue,
+        isPreview,
+        resourceId,
+        scope);
+  }
+
+  public static class ClusterVariableDbModelBuilder
+      implements ObjectBuilder<ClusterVariableDbModel> {
+    private String name;
+    private String value;
+    private String resourceId;
+    private String scope;
+
+    public ClusterVariableDbModelBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public ClusterVariableDbModelBuilder value(final String value) {
+      this.value = value;
+      return this;
+    }
+
+    public ClusterVariableDbModelBuilder scope(final String scope) {
+      this.scope = scope;
+      return this;
+    }
+
+    public ClusterVariableDbModelBuilder resourceId(final String resourceId) {
+      this.resourceId = resourceId;
+      return this;
+    }
+
+    @Override
+    public ClusterVariableDbModel build() {
+      return switch (ValueTypeUtil.getValueType(value)) {
+        case LONG -> getLongModel();
+        case DOUBLE -> getDoubleModel();
+        case BOOLEAN -> getModel(ValueTypeEnum.BOOLEAN, mapBoolean(value));
+        case NULL -> getModel(ValueTypeEnum.NULL, null);
+        default -> getModel(ValueTypeEnum.STRING, value);
+      };
+    }
+
+    private ClusterVariableDbModel getLongModel() {
+      return new ClusterVariableDbModel(
+          getCompositeId(),
+          name,
+          ValueTypeEnum.LONG,
+          null,
+          mapLong(value),
+          value,
+          null,
+          false,
+          resourceId,
+          scope);
+    }
+
+    private String getCompositeId() {
+      return switch (scope) {
+        case "GLOBAL" -> name;
+        case "TENANT" -> "%s-%s".formatted(name, resourceId);
+        default ->
+            throw new IllegalArgumentException("Unknown scope for cluster variable: " + scope);
+      };
+    }
+
+    private ClusterVariableDbModel getModel(final ValueTypeEnum valueTypeEnum, final String value) {
+      return new ClusterVariableDbModel(
+          getCompositeId(), name, valueTypeEnum, null, null, value, null, false, resourceId, scope);
+    }
+
+    private ClusterVariableDbModel getDoubleModel() {
+      return new ClusterVariableDbModel(
+          getCompositeId(),
+          name,
+          ValueTypeEnum.DOUBLE,
+          mapDouble(value),
+          null,
+          value,
+          null,
+          false,
+          resourceId,
+          scope);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -126,10 +126,12 @@ public record ClusterVariableDbModel(
 
     private String getCompositeId() {
       return switch (scope) {
-        case GLOBAL -> name;
-        case TENANT -> "%s-%s".formatted(name, tenantId);
-        default ->
-            throw new IllegalArgumentException("Unknown scope for cluster variable: " + scope);
+        case GLOBAL -> String.format("%s-%s", name, scope);
+        case TENANT -> String.format("%s-%s-%s", name, tenantId, scope);
+        // This should never happen, as any other scope would be rejected by the processor before
+        // mutating the state, as the safety check, but we need a default case for the switch
+        // expression
+        default -> String.format("%s-%s", name, scope);
       };
     }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -14,6 +14,7 @@ import static io.camunda.util.ValueTypeUtil.mapLong;
 import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
+import io.camunda.util.ClusterVariableUtil;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.util.ValueTypeUtil;
 import java.util.function.Function;
@@ -125,14 +126,7 @@ public record ClusterVariableDbModel(
     }
 
     private String getCompositeId() {
-      return switch (scope) {
-        case GLOBAL -> String.format("%s-%s", name, scope);
-        case TENANT -> String.format("%s-%s-%s", name, tenantId, scope);
-        // This should never happen, as any other scope would be rejected by the processor before
-        // mutating the state, as the safety check, but we need a default case for the switch
-        // expression
-        default -> String.format("%s-%s", name, scope);
-      };
+      return ClusterVariableUtil.generateID(name, tenantId, scope);
     }
 
     private ClusterVariableDbModel getModel(final ValueTypeEnum valueTypeEnum, final String value) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -30,7 +30,8 @@ public enum ContextType {
   USAGE_METRIC_TU(false),
   USER(false),
   USER_TASK(true),
-  VARIABLE(false);
+  VARIABLE(false),
+  CLUSTER_VARIABLE(false);
 
   private final boolean preserveOrder;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ClusterVariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ClusterVariableWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+
+public class ClusterVariableWriter {
+
+  private final ExecutionQueue executionQueue;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
+
+  public ClusterVariableWriter(
+      final ExecutionQueue executionQueue,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
+    this.executionQueue = executionQueue;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
+  }
+
+  public void create(final ClusterVariableDbModel clusterVariable) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.CLUSTER_VARIABLE,
+            WriteStatementType.INSERT,
+            clusterVariable.clusterVariableId(),
+            "io.camunda.db.rdbms.sql.ClusterVariableMapper.insert",
+            clusterVariable.truncateValue(
+                vendorDatabaseProperties.variableValuePreviewSize(),
+                vendorDatabaseProperties.charColumnMaxBytes())));
+  }
+
+  public void delete(final ClusterVariableDbModel clusterVariable) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.CLUSTER_VARIABLE,
+            WriteStatementType.DELETE,
+            clusterVariable.clusterVariableId(),
+            "io.camunda.db.rdbms.sql.ClusterVariableMapper.delete",
+            clusterVariable));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ClusterVariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ClusterVariableWriter.java
@@ -31,7 +31,7 @@ public class ClusterVariableWriter {
         new QueueItem(
             ContextType.CLUSTER_VARIABLE,
             WriteStatementType.INSERT,
-            clusterVariable.clusterVariableId(),
+            clusterVariable.id(),
             "io.camunda.db.rdbms.sql.ClusterVariableMapper.insert",
             clusterVariable.truncateValue(
                 vendorDatabaseProperties.variableValuePreviewSize(),
@@ -43,7 +43,7 @@ public class ClusterVariableWriter {
         new QueueItem(
             ContextType.CLUSTER_VARIABLE,
             WriteStatementType.DELETE,
-            clusterVariable.clusterVariableId(),
+            clusterVariable.id(),
             "io.camunda.db.rdbms.sql.ClusterVariableMapper.delete",
             clusterVariable));
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -22,6 +22,7 @@ public class RdbmsPurger {
           "BATCH_OPERATION",
           "CANDIDATE_GROUP",
           "CANDIDATE_USER",
+          "CLUSTER_VARIABLE",
           "CORRELATED_MESSAGE_SUBSCRIPTION",
           "DECISION_DEFINITION",
           "DECISION_INSTANCE_INPUT",

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.ClusterVariableMapper">
+
+  <resultMap id="clusterVariableResultMap" type="io.camunda.search.entities.ClusterVariableEntity">
+    <constructor>
+      <idArg column="CLUSTER_VARIABLE_ID" javaType="java.lang.String"/>
+      <arg column="VAR_NAME" javaType="java.lang.String"/>
+      <arg column="VAR_VALUE" javaType="java.lang.String"/>
+      <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
+      <arg column="IS_PREVIEW" javaType="boolean"/>
+      <arg column="SCOPE" javaType="java.lang.String"/>
+      <arg column="RESOURCE_ID" javaType="java.lang.String"/>
+    </constructor>
+  </resultMap>
+
+  <select id="count" resultType="java.lang.Long">
+    SELECT COUNT(*)
+    FROM ${prefix}CLUSTER_VARIABLE
+    <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
+  </select>
+
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.ClusterVariableMapper.clusterVariableResultMap">
+    SELECT * FROM (
+    SELECT
+    CLUSTER_VARIABLE_ID,
+    VAR_NAME,
+    VAR_VALUE,
+    VAR_FULL_VALUE,
+    RESOURCE_ID,
+    SCOPE,
+    IS_PREVIEW
+    FROM ${prefix}CLUSTER_VARIABLE
+    <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
+    INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
+                                           LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
+                                           RESOURCE_ID,
+                                           SCOPE)
+    VALUES (#{clusterVariableId}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
+            #{longValue, jdbcType=NUMERIC},
+            #{value},
+            #{fullValue}, #{isPreview}, #{resourceId}, #{scope})
+  </insert>
+
+  <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
+    DELETE
+    FROM ${prefix}CLUSTER_VARIABLE
+    WHERE CLUSTER_VARIABLE_ID = #{clusterVariableId}
+  </delete>
+
+  <sql id="searchFilter">
+    <where>
+      <!-- authorization filters -->
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND RESOURCE_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
+          close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+
+      <!-- basic filters -->
+      <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+        <foreach collection="filter.nameOperations" item="operation">
+          AND VAR_NAME
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <if test="filter.scopeOperations != null and !filter.scopeOperations.isEmpty()">
+        <foreach collection="filter.scopeOperations" item="operation">
+          AND SCOPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <if test="filter.resourceIdOperations != null and !filter.resourceIdOperations.isEmpty()">
+        <foreach collection="filter.resourceIdOperations" item="operation">
+          AND RESOURCE_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <!-- advanced filters on variable values -->
+      <if test="filter.valueOperations != null and !filter.valueOperations.isEmpty()">
+        <foreach collection="filter.valueOperations" item="operation">
+          AND
+          <include refid="io.camunda.db.rdbms.sql.Commons.variableOperationCondition"/>
+        </foreach>
+      </if>
+    </where>
+  </sql>
+
+
+</mapper>
+

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -74,6 +74,12 @@
           #{resourceId}
         </foreach>
       </if>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
 
       <!-- basic filters -->
       <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -17,8 +17,8 @@
       <arg column="VAR_VALUE" javaType="java.lang.String"/>
       <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
       <arg column="IS_PREVIEW" javaType="boolean"/>
-      <arg column="SCOPE" javaType="java.lang.String"/>
-      <arg column="RESOURCE_ID" javaType="java.lang.String"/>
+      <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
     </constructor>
   </resultMap>
 
@@ -36,7 +36,7 @@
     VAR_NAME,
     VAR_VALUE,
     VAR_FULL_VALUE,
-    RESOURCE_ID,
+    TENANT_ID,
     SCOPE,
     IS_PREVIEW
     FROM ${prefix}CLUSTER_VARIABLE
@@ -50,25 +50,25 @@
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
     INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
                                            LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
-                                           RESOURCE_ID,
+                                           TENANT_ID,
                                            SCOPE)
-    VALUES (#{clusterVariableId}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
+    VALUES (#{id}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
             #{longValue, jdbcType=NUMERIC},
             #{value},
-            #{fullValue}, #{isPreview}, #{resourceId}, #{scope})
+            #{fullValue}, #{isPreview}, #{tenantId}, #{scope})
   </insert>
 
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
     DELETE
     FROM ${prefix}CLUSTER_VARIABLE
-    WHERE CLUSTER_VARIABLE_ID = #{clusterVariableId}
+    WHERE CLUSTER_VARIABLE_ID = #{id}
   </delete>
 
   <sql id="searchFilter">
     <where>
       <!-- authorization filters -->
       <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
-        AND RESOURCE_ID IN
+        AND VAR_NAME IN
         <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
           close=")">
           #{resourceId}
@@ -90,9 +90,9 @@
         </foreach>
       </if>
 
-      <if test="filter.resourceIdOperations != null and !filter.resourceIdOperations.isEmpty()">
-        <foreach collection="filter.resourceIdOperations" item="operation">
-          AND RESOURCE_ID
+      <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+        <foreach collection="filter.tenantIdOperations" item="operation">
+          AND TENANT_ID
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -47,6 +47,14 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
+
+  <select id="get" parameterType="java.lang.String"
+    resultMap="io.camunda.db.rdbms.sql.ClusterVariableMapper.clusterVariableResultMap">
+    SELECT *
+    FROM ${prefix}CLUSTER_VARIABLE
+    WHERE CLUSTER_VARIABLE_ID = #{id}
+  </select>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
     INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
                                            LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
@@ -74,12 +82,20 @@
           #{resourceId}
         </foreach>
       </if>
-      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
-        AND TENANT_ID IN
-        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
-          #{tenantId}
-        </foreach>
+      <if
+        test="tenancyEnabled == true">
+        AND
+        <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+          TENANT_ID IN
+          <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator=","
+            close=")">
+            #{tenantId}
+          </foreach>
+          OR
+        </if>
+        TENANT_ID IS NULL
       </if>
+
 
       <!-- basic filters -->
       <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -84,7 +84,7 @@
       </if>
       <if
         test="tenancyEnabled == true">
-        AND
+        AND (
         <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
           TENANT_ID IN
           <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator=","
@@ -93,7 +93,7 @@
           </foreach>
           OR
         </if>
-        TENANT_ID IS NULL
+        TENANT_ID IS NULL )
       </if>
 
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
+import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
@@ -126,7 +127,12 @@ public class SearchColumnTest {
           Map.entry(
               EntityType.class,
               List.of(
-                  Tuple.of(EntityType.USER, EntityType.USER), Tuple.of(EntityType.USER, "USER"))));
+                  Tuple.of(EntityType.USER, EntityType.USER), Tuple.of(EntityType.USER, "USER"))),
+          Map.entry(
+              ClusterVariableScope.class,
+              List.of(
+                  Tuple.of(ClusterVariableScope.GLOBAL, ClusterVariableScope.GLOBAL),
+                  Tuple.of(ClusterVariableScope.GLOBAL, "GLOBAL"))));
 
   private static List<Object[]> provideSearchColumns() {
     return SearchColumnUtils.findAll().stream()

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
@@ -136,7 +137,9 @@ public class BackupPriorityConfiguration {
             new UserIndex(indexPrefix, isElasticsearch),
             // USAGE METRICS
             new UsageMetricTemplate(indexPrefix, isElasticsearch),
-            new UsageMetricTUTemplate(indexPrefix, isElasticsearch));
+            new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
+            // CAMUNDA
+            new ClusterVariableIndex(indexPrefix, isElasticsearch));
 
     LOG.debug("Prio1 are {}", prio1);
     LOG.debug("Prio2 are {}", prio2);

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
@@ -195,6 +196,12 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<VariableMapper> variableMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, VariableMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<ClusterVariableMapper> clusterVariableMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, ClusterVariableMapper.class);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.ClusterVariableDbReader;
 import io.camunda.db.rdbms.read.service.CorrelatedMessageSubscriptionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
@@ -44,6 +45,7 @@ import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
@@ -93,6 +95,12 @@ public class RdbmsConfiguration {
   @Bean
   public VariableDbReader variableRdbmsReader(final VariableMapper variableMapper) {
     return new VariableDbReader(variableMapper);
+  }
+
+  @Bean
+  public ClusterVariableDbReader clusterVariableRdbmsReader(
+      final ClusterVariableMapper clusterVariableMapper) {
+    return new ClusterVariableDbReader(clusterVariableMapper);
   }
 
   @Bean
@@ -282,7 +290,8 @@ public class RdbmsConfiguration {
       final UsageMetricTUMapper usageMetricTUMapper,
       final BatchOperationMapper batchOperationMapper,
       final MessageSubscriptionMapper messageSubscriptionMapper,
-      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper) {
+      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
+      final ClusterVariableMapper clusterVariableMapper) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -302,13 +311,15 @@ public class RdbmsConfiguration {
         usageMetricTUMapper,
         batchOperationMapper,
         messageSubscriptionMapper,
-        correlatedMessageSubscriptionMapper);
+        correlatedMessageSubscriptionMapper,
+        clusterVariableMapper);
   }
 
   @Bean
   public RdbmsService rdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
       final VariableDbReader variableReader,
+      final ClusterVariableDbReader clusterVariableDbReader,
       final AuthorizationDbReader authorizationReader,
       final DecisionDefinitionDbReader decisionDefinitionReader,
       final DecisionInstanceDbReader decisionInstanceReader,
@@ -348,6 +359,7 @@ public class RdbmsConfiguration {
         processDefinitionReader,
         processInstanceReader,
         variableReader,
+        clusterVariableDbReader,
         roleReader,
         roleMemberReader,
         tenantReader,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.BatchOperationItemReader;
 import io.camunda.search.clients.reader.BatchOperationReader;
+import io.camunda.search.clients.reader.ClusterVariableReader;
 import io.camunda.search.clients.reader.CorrelatedMessageSubscriptionReader;
 import io.camunda.search.clients.reader.DecisionDefinitionReader;
 import io.camunda.search.clients.reader.DecisionInstanceReader;
@@ -154,7 +155,8 @@ public class SearchClientDatabaseConfiguration {
       final UsageMetricsTUReader usageMetricsTUReader,
       final UserReader userReader,
       final UserTaskReader userTaskReader,
-      final VariableReader variableReader) {
+      final VariableReader variableReader,
+      final ClusterVariableReader clusterVariableReader) {
     return new SearchClientReaders(
         authorizationReader,
         batchOperationReader,
@@ -186,6 +188,7 @@ public class SearchClientDatabaseConfiguration {
         usageMetricsTUReader,
         userReader,
         userTaskReader,
-        variableReader);
+        variableReader,
+        clusterVariableReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -17,6 +17,8 @@ import io.camunda.search.clients.reader.BatchOperationDocumentReader;
 import io.camunda.search.clients.reader.BatchOperationItemDocumentReader;
 import io.camunda.search.clients.reader.BatchOperationItemReader;
 import io.camunda.search.clients.reader.BatchOperationReader;
+import io.camunda.search.clients.reader.ClusterVariableDocumentReader;
+import io.camunda.search.clients.reader.ClusterVariableReader;
 import io.camunda.search.clients.reader.CorrelatedMessageSubscriptionDocumentReader;
 import io.camunda.search.clients.reader.CorrelatedMessageSubscriptionReader;
 import io.camunda.search.clients.reader.DecisionDefinitionDocumentReader;
@@ -78,6 +80,7 @@ import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
@@ -365,5 +368,11 @@ public class SearchClientReaderConfiguration {
   public VariableReader variableReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
     return new VariableDocumentReader(executor, descriptors.get(VariableTemplate.class));
+  }
+
+  @Bean
+  public ClusterVariableReader clusterVariableReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new ClusterVariableDocumentReader(executor, descriptors.get(ClusterVariableIndex.class));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -174,7 +174,8 @@ class BackupPrioritiesTest {
             "camunda-tenant-8.8.0_",
             "camunda-user-8.8.0_",
             "camunda-usage-metric-8.8.0_",
-            "camunda-usage-metric-tu-8.8.0_");
+            "camunda-usage-metric-tu-8.8.0_",
+            "camunda-cluster-variable-8.9.0_");
 
     for (final var indexList : indices) {
       assertThat(indexList.allIndices())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.clustervariables;
+
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomGlobalClusterVariablesAndReturnOne;
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomTenantClusterVariablesAndReturnOne;
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveVariables;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.ClusterVariableDbReader;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel.ClusterVariableDbModelBuilder;
+import io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures;
+import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.sort.ClusterVariableSort;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class ClusterVariableIT {
+
+  public static final int PARTITION_ID = 0;
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  @TestTemplate
+  public void shouldSaveAndFindTenantClusterVariableByNameAndResource(
+      final CamundaRdbmsTestApplication testApplication) {
+    final ClusterVariableDbModel randomizedVariable =
+        createAndSaveRandomTenantClusterVariablesAndReturnOne(testApplication);
+
+    final var instance =
+        testApplication
+            .getRdbmsService()
+            .getClusterVariableReader()
+            .getTenantScopedClusterVariable(
+                randomizedVariable.resourceId(), randomizedVariable.name());
+
+    assertThat(instance).isNotNull();
+    assertVariableDbModelEqualToEntity(randomizedVariable, instance);
+    assertThat(instance.fullValue()).isNull();
+    assertThat(instance.isPreview()).isFalse();
+  }
+
+  @TestTemplate
+  public void shouldSaveAndFindGlobalClusterVariableByNameAndResource(
+      final CamundaRdbmsTestApplication testApplication) {
+    final ClusterVariableDbModel randomizedVariable =
+        createAndSaveRandomGlobalClusterVariablesAndReturnOne(testApplication);
+
+    final var instance =
+        testApplication
+            .getRdbmsService()
+            .getClusterVariableReader()
+            .getGloballyScopedClusterVariable(randomizedVariable.name());
+
+    assertThat(instance).isNotNull();
+    assertVariableDbModelEqualToEntity(randomizedVariable, instance);
+    assertThat(instance.fullValue()).isNull();
+    assertThat(instance.isPreview()).isFalse();
+  }
+
+  @TestTemplate
+  public void shouldSaveAndFindBigTenantClusterVariableByNameAndResource(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String bigValue = generateRandomString(9000);
+    final ClusterVariableDbModel randomizedVariable =
+        ClusterVariableFixtures.createRandomTenantClusterVariable(bigValue);
+    createAndSaveVariables(rdbmsService, randomizedVariable);
+
+    final var instance =
+        rdbmsService
+            .getClusterVariableReader()
+            .getTenantScopedClusterVariable(
+                randomizedVariable.resourceId(), randomizedVariable.name());
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.isPreview()).isTrue();
+    assertThat(instance.fullValue()).isEqualTo(bigValue);
+    assertThat(instance.value()).hasSizeLessThan(instance.fullValue().length());
+  }
+
+  @TestTemplate
+  public void shouldSaveAndFindBigGlobalClusterVariableByNameAndResource(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String bigValue = generateRandomString(9000);
+    final ClusterVariableDbModel randomizedVariable =
+        ClusterVariableFixtures.createRandomGlobalClusterVariable(bigValue);
+    createAndSaveVariables(rdbmsService, randomizedVariable);
+
+    final var instance =
+        rdbmsService
+            .getClusterVariableReader()
+            .getGloballyScopedClusterVariable(randomizedVariable.name());
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.isPreview()).isTrue();
+    assertThat(instance.fullValue()).isEqualTo(bigValue);
+    assertThat(instance.value()).hasSizeLessThan(instance.fullValue().length());
+  }
+
+  @TestTemplate
+  public void shouldFindAllTenantClusterVariablesPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String resourceId = CommonFixtures.nextStringId();
+    ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(
+        rdbmsService, resourceId);
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder()
+                        .scopes("TENANT")
+                        .resourceIds(resourceId)
+                        .build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindAllGlobalClusterVariablesPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    ClusterVariableFixtures.createAndSaveRandomsGlobalClusterVariablesWithFixed(
+        rdbmsService, "value");
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder().values("value").scopes("GLOBAL").build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindAllTenantClusterVariablesPageValuesAreNull(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String resourceId = CommonFixtures.nextStringId();
+    ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(
+        rdbmsService, resourceId);
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder()
+                        .scopes("TENANT")
+                        .resourceIds(resourceId)
+                        .build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(null).size(null))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(20);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
+
+    final String resourceId = CommonFixtures.nextStringId();
+    final String variableName = CommonFixtures.nextStringId();
+    final ClusterVariableDbModel randomizedVariable =
+        ClusterVariableFixtures.createRandomTenantClusterVariable(generateRandomString(100));
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(variableName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    final var searchResult =
+        clusterVariableReader.search(
+            new ClusterVariableQuery(
+                new ClusterVariableFilter.Builder()
+                    .names(variableName)
+                    .scopes("TENANT")
+                    .resourceIds(resourceId)
+                    .build(),
+                ClusterVariableSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().name()).isEqualTo(variableName);
+    assertThat(searchResult.items().getFirst().resourceId()).isEqualTo(resourceId);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithSearchAfter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
+
+    final String resourceId = CommonFixtures.nextStringId();
+    ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(
+        rdbmsService, resourceId);
+
+    final var sort = ClusterVariableSort.of(s -> s.name().asc().scope().asc());
+    final var searchResult =
+        clusterVariableReader.search(
+            ClusterVariableQuery.of(
+                b ->
+                    b.filter(f -> f.scopes("TENANT").resourceIds(resourceId))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(20))));
+
+    final var firstPage =
+        clusterVariableReader.search(
+            ClusterVariableQuery.of(
+                b ->
+                    b.filter(f -> f.scopes("TENANT").resourceIds(resourceId))
+                        .sort(sort)
+                        .page(p -> p.size(15))));
+
+    final var nextPage =
+        clusterVariableReader.search(
+            ClusterVariableQuery.of(
+                b ->
+                    b.filter(f -> f.scopes("TENANT").resourceIds(resourceId))
+                        .sort(sort)
+                        .page(p -> p.size(5).after(firstPage.endCursor()))));
+
+    assertThat(nextPage.total()).isEqualTo(20);
+    assertThat(nextPage.items()).hasSize(5);
+    assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
+  }
+
+  private void assertVariableDbModelEqualToEntity(
+      final ClusterVariableDbModel dbModel, final ClusterVariableEntity entity) {
+    assertThat(entity).usingRecursiveComparison().isEqualTo(dbModel);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -50,7 +50,9 @@ public class ClusterVariableIT {
             .getRdbmsService()
             .getClusterVariableReader()
             .getTenantScopedClusterVariable(
-                randomizedVariable.tenantId(), randomizedVariable.name());
+                randomizedVariable.tenantId(),
+                randomizedVariable.name(),
+                CommonFixtures.resourceAccessChecksFromResourceIds(randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertVariableDbModelEqualToEntity(randomizedVariable, instance);
@@ -68,7 +70,9 @@ public class ClusterVariableIT {
         testApplication
             .getRdbmsService()
             .getClusterVariableReader()
-            .getGloballyScopedClusterVariable(randomizedVariable.name());
+            .getGloballyScopedClusterVariable(
+                randomizedVariable.name(),
+                CommonFixtures.resourceAccessChecksFromResourceIds(randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertVariableDbModelEqualToEntity(randomizedVariable, instance);
@@ -90,7 +94,9 @@ public class ClusterVariableIT {
         rdbmsService
             .getClusterVariableReader()
             .getTenantScopedClusterVariable(
-                randomizedVariable.tenantId(), randomizedVariable.name());
+                randomizedVariable.tenantId(),
+                randomizedVariable.name(),
+                CommonFixtures.resourceAccessChecksFromResourceIds(randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertThat(instance.isPreview()).isTrue();
@@ -111,7 +117,9 @@ public class ClusterVariableIT {
     final var instance =
         rdbmsService
             .getClusterVariableReader()
-            .getGloballyScopedClusterVariable(randomizedVariable.name());
+            .getGloballyScopedClusterVariable(
+                randomizedVariable.name(),
+                CommonFixtures.resourceAccessChecksFromResourceIds(randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertThat(instance.isPreview()).isTrue();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -134,7 +134,7 @@ public class ClusterVariableIT {
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
                         .scopes("TENANT")
-                        .resourceIds(resourceId)
+                        .tenantIds(resourceId)
                         .build(),
                     ClusterVariableSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(5))));
@@ -182,7 +182,7 @@ public class ClusterVariableIT {
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
                         .scopes("TENANT")
-                        .resourceIds(resourceId)
+                        .tenantIds(resourceId)
                         .build(),
                     ClusterVariableSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(null).size(null))));
@@ -217,7 +217,7 @@ public class ClusterVariableIT {
                 new ClusterVariableFilter.Builder()
                     .names(variableName)
                     .scopes("TENANT")
-                    .resourceIds(resourceId)
+                    .tenantIds(resourceId)
                     .build(),
                 ClusterVariableSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
@@ -243,7 +243,7 @@ public class ClusterVariableIT {
         clusterVariableReader.search(
             ClusterVariableQuery.of(
                 b ->
-                    b.filter(f -> f.scopes("TENANT").resourceIds(resourceId))
+                    b.filter(f -> f.scopes("TENANT").tenantIds(resourceId))
                         .sort(sort)
                         .page(p -> p.from(0).size(20))));
 
@@ -251,7 +251,7 @@ public class ClusterVariableIT {
         clusterVariableReader.search(
             ClusterVariableQuery.of(
                 b ->
-                    b.filter(f -> f.scopes("TENANT").resourceIds(resourceId))
+                    b.filter(f -> f.scopes("TENANT").tenantIds(resourceId))
                         .sort(sort)
                         .page(p -> p.size(15))));
 
@@ -259,7 +259,7 @@ public class ClusterVariableIT {
         clusterVariableReader.search(
             ClusterVariableQuery.of(
                 b ->
-                    b.filter(f -> f.scopes("TENANT").resourceIds(resourceId))
+                    b.filter(f -> f.scopes("TENANT").tenantIds(resourceId))
                         .sort(sort)
                         .page(p -> p.size(5).after(firstPage.endCursor()))));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.clustervariables;
+
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceIdAndValue;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.sort.ClusterVariableSort;
+import io.camunda.search.sort.ClusterVariableSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class ClusterVariableSortIT {
+
+  @TestTemplate
+  public void shouldSortByValueAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.value().asc(),
+        Comparator.comparing(ClusterVariableEntity::value));
+  }
+
+  @TestTemplate
+  public void shouldSortByValueDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.value().desc(),
+        Comparator.comparing(ClusterVariableEntity::value).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.name().asc(),
+        Comparator.comparing(ClusterVariableEntity::name));
+  }
+
+  @TestTemplate
+  public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.name().desc(),
+        Comparator.comparing(ClusterVariableEntity::name).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByScopeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.scope().asc(),
+        Comparator.comparing(ClusterVariableEntity::scope));
+  }
+
+  @TestTemplate
+  public void shouldSortByScopeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.scope().desc(),
+        Comparator.comparing(ClusterVariableEntity::scope).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().asc(),
+        Comparator.comparing(ClusterVariableEntity::resourceId));
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().desc(),
+        Comparator.comparing(ClusterVariableEntity::resourceId).reversed());
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<ClusterVariableSort>> sortBuilder,
+      final Comparator<ClusterVariableEntity> comparator) {
+    final var resourceId = nextStringId();
+    createAndSaveRandomsTenantClusterVariablesWithFixedResourceIdAndValue(
+        rdbmsService, resourceId, "val-" + nextStringId());
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder()
+                        .scopes("TENANT")
+                        .resourceIds(resourceId)
+                        .build(),
+                    ClusterVariableSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.it.rdbms.db.clustervariables;
 
-import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceIdAndValue;
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedTenantAndValue;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,28 +80,28 @@ public class ClusterVariableSortIT {
   }
 
   @TestTemplate
-  public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantId().asc(),
-        Comparator.comparing(ClusterVariableEntity::resourceId));
+        Comparator.comparing(ClusterVariableEntity::tenantId));
   }
 
   @TestTemplate
-  public void shouldSortByResourceIdDesc(final CamundaRdbmsTestApplication testApplication) {
+  public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantId().desc(),
-        Comparator.comparing(ClusterVariableEntity::resourceId).reversed());
+        Comparator.comparing(ClusterVariableEntity::tenantId).reversed());
   }
 
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<ClusterVariableSort>> sortBuilder,
       final Comparator<ClusterVariableEntity> comparator) {
-    final var resourceId = nextStringId();
-    createAndSaveRandomsTenantClusterVariablesWithFixedResourceIdAndValue(
-        rdbmsService, resourceId, "val-" + nextStringId());
+    final var tenantId = nextStringId();
+    createAndSaveRandomsTenantClusterVariablesWithFixedTenantAndValue(
+        rdbmsService, tenantId, "val-" + nextStringId());
 
     final var searchResult =
         rdbmsService
@@ -110,7 +110,7 @@ public class ClusterVariableSortIT {
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
                         .scopes("TENANT")
-                        .tenantIds(resourceId)
+                        .tenantIds(tenantId)
                         .build(),
                     ClusterVariableSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableSortIT.java
@@ -83,7 +83,7 @@ public class ClusterVariableSortIT {
   public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
-        b -> b.resourceId().asc(),
+        b -> b.tenantId().asc(),
         Comparator.comparing(ClusterVariableEntity::resourceId));
   }
 
@@ -91,7 +91,7 @@ public class ClusterVariableSortIT {
   public void shouldSortByResourceIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
-        b -> b.resourceId().desc(),
+        b -> b.tenantId().desc(),
         Comparator.comparing(ClusterVariableEntity::resourceId).reversed());
   }
 
@@ -110,7 +110,7 @@ public class ClusterVariableSortIT {
                 new ClusterVariableQuery(
                     new ClusterVariableFilter.Builder()
                         .scopes("TENANT")
-                        .resourceIds(resourceId)
+                        .tenantIds(resourceId)
                         .build(),
                     ClusterVariableSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
@@ -349,7 +349,7 @@ public class ClusterVariableValueFilterIT {
     final var clusterVariableFilter =
         new ClusterVariableFilter.Builder()
             .scopes("TENANT")
-            .resourceIds(resourceId)
+            .tenantIds(resourceId)
             .names(varName, "not there")
             .build();
 
@@ -390,7 +390,7 @@ public class ClusterVariableValueFilterIT {
     final var clusterVariableFilter =
         new ClusterVariableFilter.Builder()
             .scopes("TENANT")
-            .resourceIds(resourceId)
+            .tenantIds(resourceId)
             .names(varName, "not there")
             .values(varValue)
             .build();
@@ -439,7 +439,7 @@ public class ClusterVariableValueFilterIT {
                         b.filter(
                             f ->
                                 f.scopes("TENANT")
-                                    .resourceIds(resourceId)
+                                    .tenantIds(resourceId)
                                     .valueOperations(Operation.like(variableValue + "*")))));
 
     // then
@@ -476,7 +476,7 @@ public class ClusterVariableValueFilterIT {
                         b.filter(
                             f ->
                                 f.scopes("TENANT")
-                                    .resourceIds(resourceId)
+                                    .tenantIds(resourceId)
                                     .valueOperations(Operation.like(variableValue + "?")))));
 
     // then
@@ -513,7 +513,7 @@ public class ClusterVariableValueFilterIT {
                         b.filter(
                             f ->
                                 f.scopes("TENANT")
-                                    .resourceIds(resourceId)
+                                    .tenantIds(resourceId)
                                     .valueOperations(Operation.like("ignoreAnyValue\\%X")))));
 
     // then
@@ -549,7 +549,7 @@ public class ClusterVariableValueFilterIT {
                         b.filter(
                             f ->
                                 f.scopes("TENANT")
-                                    .resourceIds(resourceId)
+                                    .tenantIds(resourceId)
                                     .valueOperations(Operation.like("ignoreSingleValue\\_X")))));
 
     // then
@@ -585,7 +585,7 @@ public class ClusterVariableValueFilterIT {
                         b.filter(
                             f ->
                                 f.scopes("TENANT")
-                                    .resourceIds(resourceId)
+                                    .tenantIds(resourceId)
                                     .valueOperations(Operation.like("value\\*any\\%*")))));
 
     // then
@@ -621,7 +621,7 @@ public class ClusterVariableValueFilterIT {
                         b.filter(
                             f ->
                                 f.scopes("TENANT")
-                                    .resourceIds(resourceId)
+                                    .tenantIds(resourceId)
                                     .valueOperations(
                                         Operation.like("value\\?single\\_wildcards?")))));
 
@@ -651,7 +651,7 @@ public class ClusterVariableValueFilterIT {
     final var builder =
         new ClusterVariableFilter.Builder()
             .scopes("TENANT")
-            .resourceIds(resourceId)
+            .tenantIds(resourceId)
             .names(variableName);
     if (operations != null) {
       builder.valueOperations(operations).build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
@@ -1,0 +1,673 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.clustervariables;
+
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceId;
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createRandomTenantClusterVariable;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel.ClusterVariableDbModelBuilder;
+import io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.sort.ClusterVariableSort;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class ClusterVariableValueFilterIT {
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given 20 random tenant variables
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(rdbmsService, resourceId);
+
+    // and one variable with a specific name
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(generateRandomString(50));
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // when we search for it, then we should find one
+    searchAndAssertClusterVariableValueFilters(
+        testApplication.getRdbmsService(), variableWithFixedName, varName, resourceId, null);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndEqValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String valueForOne = "value-42000";
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(valueForOne);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and an eq value filter
+    final Operation<String> operation = Operation.eq(valueForOne);
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndLikeValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "someName";
+    final String valueWithPattern = "variable-42-value";
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(valueWithPattern);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a like value filter
+    final Operation<String> operation = Operation.like("*able-42-v?l*");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndEqNumberValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String numberValue = "42000";
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(numberValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and an eq value filter
+    final Operation<String> operation = Operation.eq("42000");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndEqBooleanValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String boolValue = "true";
+    final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(boolValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and an eq value filter
+    final Operation<String> operation = Operation.eq("true");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndNeqValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given 20 random variables
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(rdbmsService, resourceId);
+
+    // and one variable with a specific name
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(generateRandomString(50));
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a neq value filter
+    final Operation<String> operation = Operation.neq("DEFINITELY NOT");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndGtValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String numValue = "42000";
+    final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(numValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a gt value filter
+    final Operation<String> operation = Operation.gt("40000");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndGteValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String numValue = "42000";
+    final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(numValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a gte value filter
+    final Operation<String> operation = Operation.gte("42000");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndLtValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String negValue = "-42000";
+    final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(negValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a lt value filter
+    final Operation<String> operation = Operation.lt("-40000");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndLteValue(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String negValue = "-42000";
+    final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(negValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a lte value filter
+    final Operation<String> operation = Operation.lte("-42000");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithNameAndLtValueDouble(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final String doubleValue = "-4200.1234";
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(doubleValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and a lt value filter
+    final Operation<String> operation = Operation.lt("-4200.123");
+
+    // when we search for it, we should find one
+    searchAndAssertClusterVariableValueFilter(
+        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMultipleNamesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel randomizedVariable =
+        createRandomTenantClusterVariable(generateRandomString(50));
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and two name filters
+    final var clusterVariableFilter =
+        new ClusterVariableFilter.Builder()
+            .scopes("TENANT")
+            .resourceIds(resourceId)
+            .names(varName, "not there")
+            .build();
+
+    // when we search for it, we should find one
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    clusterVariableFilter,
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().name()).isEqualTo(varName);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMultipleNamesAndValuesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String resourceId = nextStringId();
+    final String varName = "unique-name" + generateRandomString(10);
+    final String varValue = generateRandomString(50);
+    final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(varValue);
+    final ClusterVariableDbModel variableWithFixedName =
+        randomizedVariable.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .resourceId(resourceId)
+                    .scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
+
+    // and two name with value filters
+    final var clusterVariableFilter =
+        new ClusterVariableFilter.Builder()
+            .scopes("TENANT")
+            .resourceIds(resourceId)
+            .names(varName, "not there")
+            .values(varValue)
+            .build();
+
+    // when we search for it, we should find one
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    clusterVariableFilter,
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().name()).isEqualTo(varName);
+    assertThat(searchResult.items().getFirst().value()).isEqualTo(varValue);
+  }
+
+  @TestTemplate
+  public void shouldTransformAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var resourceId = nextStringId();
+    final var variableValue = "transformAnyValue";
+    final ClusterVariableDbModel var1 =
+        createRandomTenantClusterVariable(variableValue + "%wildcards1");
+    final ClusterVariableDbModel var1Fixed =
+        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
+
+    final ClusterVariableDbModel var2 =
+        createRandomTenantClusterVariable(variableValue + "%wildcards2");
+    final ClusterVariableDbModel var2Fixed =
+        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
+
+    // when
+    final var actual =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                ClusterVariableQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.scopes("TENANT")
+                                    .resourceIds(resourceId)
+                                    .valueOperations(Operation.like(variableValue + "*")))));
+
+    // then
+    assertThat(actual.total()).isEqualTo(2);
+    assertThat(actual.items()).hasSize(2);
+    for (final ClusterVariableEntity item : actual.items()) {
+      assertThat(item.value()).startsWith(variableValue);
+    }
+  }
+
+  @TestTemplate
+  public void shouldTransformSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var resourceId = nextStringId();
+    final var variableValue = "transformSingleValue";
+    final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(variableValue + "X");
+    final ClusterVariableDbModel var1Fixed =
+        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
+
+    final ClusterVariableDbModel var2 = createRandomTenantClusterVariable(variableValue + "Y");
+    final ClusterVariableDbModel var2Fixed =
+        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
+
+    // when
+    final var actual =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                ClusterVariableQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.scopes("TENANT")
+                                    .resourceIds(resourceId)
+                                    .valueOperations(Operation.like(variableValue + "?")))));
+
+    // then
+    assertThat(actual.total()).isEqualTo(2);
+    assertThat(actual.items()).hasSize(2);
+    for (final ClusterVariableEntity item : actual.items()) {
+      assertThat(item.value()).startsWith(variableValue);
+    }
+  }
+
+  @TestTemplate
+  public void shouldIgnoreEscapedSQLAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var resourceId = nextStringId();
+    final var variableValue = "ignoreAnyValue%X";
+    final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(variableValue);
+    final ClusterVariableDbModel var1Fixed =
+        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
+
+    final ClusterVariableDbModel var2 = createRandomTenantClusterVariable("ignoreAnyValueXX");
+    final ClusterVariableDbModel var2Fixed =
+        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
+
+    // when
+    final var actual =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                ClusterVariableQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.scopes("TENANT")
+                                    .resourceIds(resourceId)
+                                    .valueOperations(Operation.like("ignoreAnyValue\\%X")))));
+
+    // then
+    assertThat(actual.total()).isEqualTo(1);
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().value()).isEqualTo(variableValue);
+  }
+
+  @TestTemplate
+  public void shouldIgnoreEscapedSQLSingleWildcard(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var resourceId = nextStringId();
+    final var variableValue = "ignoreSingleValue_X";
+    final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(variableValue);
+    final ClusterVariableDbModel var1Fixed =
+        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
+
+    final ClusterVariableDbModel var2 = createRandomTenantClusterVariable("ignoreSingleValueXX");
+    final ClusterVariableDbModel var2Fixed =
+        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
+
+    // when
+    final var actual =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                ClusterVariableQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.scopes("TENANT")
+                                    .resourceIds(resourceId)
+                                    .valueOperations(Operation.like("ignoreSingleValue\\_X")))));
+
+    // then
+    assertThat(actual.total()).isEqualTo(1);
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().value()).isEqualTo(variableValue);
+  }
+
+  @TestTemplate
+  public void shouldUnescapeESAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final var resourceId = nextStringId();
+    final String varValue = "value*any%wildcards1";
+    final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(varValue);
+    final ClusterVariableDbModel var1Fixed =
+        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
+
+    final String varValue2 = "value*any%wildcards2";
+    final ClusterVariableDbModel var2 = createRandomTenantClusterVariable(varValue2);
+    final ClusterVariableDbModel var2Fixed =
+        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
+
+    // when
+    final var actual =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                ClusterVariableQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.scopes("TENANT")
+                                    .resourceIds(resourceId)
+                                    .valueOperations(Operation.like("value\\*any\\%*")))));
+
+    // then
+    assertThat(actual.total()).isEqualTo(2);
+    assertThat(actual.items()).hasSize(2);
+    assertThat(actual.items()).extracting("value").containsExactlyInAnyOrder(varValue, varValue2);
+  }
+
+  @TestTemplate
+  public void shouldUnescapeESSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final var resourceId = nextStringId();
+    final String varValue = "value?single_wildcards1";
+    final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(varValue);
+    final ClusterVariableDbModel var1Fixed =
+        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
+
+    final String varValue2 = "value?single_wildcards2";
+    final ClusterVariableDbModel var2 = createRandomTenantClusterVariable(varValue2);
+    final ClusterVariableDbModel var2Fixed =
+        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+    ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
+
+    // when
+    final var actual =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                ClusterVariableQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.scopes("TENANT")
+                                    .resourceIds(resourceId)
+                                    .valueOperations(
+                                        Operation.like("value\\?single\\_wildcards?")))));
+
+    // then
+    assertThat(actual.total()).isEqualTo(2);
+    assertThat(actual.items()).hasSize(2);
+    assertThat(actual.items()).extracting("value").containsExactlyInAnyOrder(varValue, varValue2);
+  }
+
+  private static void searchAndAssertClusterVariableValueFilter(
+      final RdbmsService rdbmsService,
+      final ClusterVariableDbModel clusterVariableDbModel,
+      final String variableName,
+      final String resourceId,
+      final Operation<String> operation) {
+    searchAndAssertClusterVariableValueFilters(
+        rdbmsService, clusterVariableDbModel, variableName, resourceId, List.of(operation));
+  }
+
+  private static void searchAndAssertClusterVariableValueFilters(
+      final RdbmsService rdbmsService,
+      final ClusterVariableDbModel clusterVariableDbModel,
+      final String variableName,
+      final String resourceId,
+      final List<Operation<String>> operations) {
+
+    final var builder =
+        new ClusterVariableFilter.Builder()
+            .scopes("TENANT")
+            .resourceIds(resourceId)
+            .names(variableName);
+    if (operations != null) {
+      builder.valueOperations(operations).build();
+    }
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    builder.build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().name()).isEqualTo(clusterVariableDbModel.name());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableValueFilterIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.it.rdbms.db.clustervariables;
 
-import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedResourceId;
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedTenantId;
 import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createRandomTenantClusterVariable;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
@@ -20,6 +20,7 @@ import io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
@@ -39,8 +40,8 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given 20 random tenant variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
-    createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(rdbmsService, resourceId);
+    final String tenantId = nextStringId();
+    createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(rdbmsService, tenantId);
 
     // and one variable with a specific name
     final String varName = "var-name-" + nextStringId();
@@ -51,13 +52,13 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // when we search for it, then we should find one
     searchAndAssertClusterVariableValueFilters(
-        testApplication.getRdbmsService(), variableWithFixedName, varName, resourceId, null);
+        testApplication.getRdbmsService(), variableWithFixedName, varName, tenantId, null);
   }
 
   @TestTemplate
@@ -65,7 +66,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String valueForOne = "value-42000";
     final ClusterVariableDbModel randomizedVariable =
@@ -75,8 +76,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and an eq value filter
@@ -84,7 +85,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -92,7 +93,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "someName";
     final String valueWithPattern = "variable-42-value";
     final ClusterVariableDbModel randomizedVariable =
@@ -102,8 +103,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a like value filter
@@ -111,7 +112,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -119,7 +120,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String numberValue = "42000";
     final ClusterVariableDbModel randomizedVariable =
@@ -129,8 +130,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and an eq value filter
@@ -138,7 +139,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -146,7 +147,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String boolValue = "true";
     final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(boolValue);
@@ -155,8 +156,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and an eq value filter
@@ -164,7 +165,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -172,8 +173,8 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given 20 random variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
-    createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(rdbmsService, resourceId);
+    final String tenantId = nextStringId();
+    createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(rdbmsService, tenantId);
 
     // and one variable with a specific name
     final String varName = "var-name-" + nextStringId();
@@ -184,8 +185,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a neq value filter
@@ -193,7 +194,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -201,7 +202,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String numValue = "42000";
     final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(numValue);
@@ -210,8 +211,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a gt value filter
@@ -219,7 +220,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -227,7 +228,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String numValue = "42000";
     final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(numValue);
@@ -236,8 +237,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a gte value filter
@@ -245,7 +246,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -253,7 +254,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String negValue = "-42000";
     final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(negValue);
@@ -262,8 +263,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a lt value filter
@@ -271,7 +272,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -279,7 +280,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String negValue = "-42000";
     final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(negValue);
@@ -288,8 +289,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a lte value filter
@@ -297,7 +298,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -305,7 +306,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final String doubleValue = "-4200.1234";
     final ClusterVariableDbModel randomizedVariable =
@@ -315,8 +316,8 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and a lt value filter
@@ -324,7 +325,7 @@ public class ClusterVariableValueFilterIT {
 
     // when we search for it, we should find one
     searchAndAssertClusterVariableValueFilter(
-        rdbmsService, variableWithFixedName, varName, resourceId, operation);
+        rdbmsService, variableWithFixedName, varName, tenantId, operation);
   }
 
   @TestTemplate
@@ -332,7 +333,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "var-name-" + nextStringId();
     final ClusterVariableDbModel randomizedVariable =
         createRandomTenantClusterVariable(generateRandomString(50));
@@ -341,15 +342,15 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and two name filters
     final var clusterVariableFilter =
         new ClusterVariableFilter.Builder()
-            .scopes("TENANT")
-            .tenantIds(resourceId)
+            .scopes(ClusterVariableScope.TENANT.name())
+            .tenantIds(tenantId)
             .names(varName, "not there")
             .build();
 
@@ -373,7 +374,7 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final String resourceId = nextStringId();
+    final String tenantId = nextStringId();
     final String varName = "unique-name" + generateRandomString(10);
     final String varValue = generateRandomString(50);
     final ClusterVariableDbModel randomizedVariable = createRandomTenantClusterVariable(varValue);
@@ -382,15 +383,15 @@ public class ClusterVariableValueFilterIT {
             b ->
                 ((ClusterVariableDbModelBuilder) b)
                     .name(varName)
-                    .resourceId(resourceId)
-                    .scope("TENANT"));
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, variableWithFixedName);
 
     // and two name with value filters
     final var clusterVariableFilter =
         new ClusterVariableFilter.Builder()
-            .scopes("TENANT")
-            .tenantIds(resourceId)
+            .scopes(ClusterVariableScope.TENANT.name())
+            .tenantIds(tenantId)
             .names(varName, "not there")
             .values(varValue)
             .build();
@@ -415,18 +416,26 @@ public class ClusterVariableValueFilterIT {
   public void shouldTransformAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
-    final var resourceId = nextStringId();
+    final var tenantId = nextStringId();
     final var variableValue = "transformAnyValue";
     final ClusterVariableDbModel var1 =
         createRandomTenantClusterVariable(variableValue + "%wildcards1");
     final ClusterVariableDbModel var1Fixed =
-        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var1.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
 
     final ClusterVariableDbModel var2 =
         createRandomTenantClusterVariable(variableValue + "%wildcards2");
     final ClusterVariableDbModel var2Fixed =
-        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var2.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
 
     // when
@@ -438,8 +447,8 @@ public class ClusterVariableValueFilterIT {
                     b ->
                         b.filter(
                             f ->
-                                f.scopes("TENANT")
-                                    .tenantIds(resourceId)
+                                f.scopes(ClusterVariableScope.TENANT.name())
+                                    .tenantIds(tenantId)
                                     .valueOperations(Operation.like(variableValue + "*")))));
 
     // then
@@ -454,16 +463,24 @@ public class ClusterVariableValueFilterIT {
   public void shouldTransformSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
-    final var resourceId = nextStringId();
+    final var tenantId = nextStringId();
     final var variableValue = "transformSingleValue";
     final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(variableValue + "X");
     final ClusterVariableDbModel var1Fixed =
-        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var1.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
 
     final ClusterVariableDbModel var2 = createRandomTenantClusterVariable(variableValue + "Y");
     final ClusterVariableDbModel var2Fixed =
-        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var2.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
 
     // when
@@ -475,8 +492,8 @@ public class ClusterVariableValueFilterIT {
                     b ->
                         b.filter(
                             f ->
-                                f.scopes("TENANT")
-                                    .tenantIds(resourceId)
+                                f.scopes(ClusterVariableScope.TENANT.name())
+                                    .tenantIds(tenantId)
                                     .valueOperations(Operation.like(variableValue + "?")))));
 
     // then
@@ -491,16 +508,24 @@ public class ClusterVariableValueFilterIT {
   public void shouldIgnoreEscapedSQLAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
-    final var resourceId = nextStringId();
+    final var tenantId = nextStringId();
     final var variableValue = "ignoreAnyValue%X";
     final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(variableValue);
     final ClusterVariableDbModel var1Fixed =
-        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var1.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
 
     final ClusterVariableDbModel var2 = createRandomTenantClusterVariable("ignoreAnyValueXX");
     final ClusterVariableDbModel var2Fixed =
-        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var2.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
 
     // when
@@ -512,8 +537,8 @@ public class ClusterVariableValueFilterIT {
                     b ->
                         b.filter(
                             f ->
-                                f.scopes("TENANT")
-                                    .tenantIds(resourceId)
+                                f.scopes(ClusterVariableScope.TENANT.name())
+                                    .tenantIds(tenantId)
                                     .valueOperations(Operation.like("ignoreAnyValue\\%X")))));
 
     // then
@@ -527,16 +552,24 @@ public class ClusterVariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final var rdbmsService = testApplication.getRdbmsService();
-    final var resourceId = nextStringId();
+    final var tenantId = nextStringId();
     final var variableValue = "ignoreSingleValue_X";
     final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(variableValue);
     final ClusterVariableDbModel var1Fixed =
-        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var1.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
 
     final ClusterVariableDbModel var2 = createRandomTenantClusterVariable("ignoreSingleValueXX");
     final ClusterVariableDbModel var2Fixed =
-        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var2.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
 
     // when
@@ -548,8 +581,8 @@ public class ClusterVariableValueFilterIT {
                     b ->
                         b.filter(
                             f ->
-                                f.scopes("TENANT")
-                                    .tenantIds(resourceId)
+                                f.scopes(ClusterVariableScope.TENANT.name())
+                                    .tenantIds(tenantId)
                                     .valueOperations(Operation.like("ignoreSingleValue\\_X")))));
 
     // then
@@ -562,17 +595,25 @@ public class ClusterVariableValueFilterIT {
   public void shouldUnescapeESAnyWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var resourceId = nextStringId();
+    final var tenantId = nextStringId();
     final String varValue = "value*any%wildcards1";
     final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(varValue);
     final ClusterVariableDbModel var1Fixed =
-        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var1.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
 
     final String varValue2 = "value*any%wildcards2";
     final ClusterVariableDbModel var2 = createRandomTenantClusterVariable(varValue2);
     final ClusterVariableDbModel var2Fixed =
-        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var2.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
 
     // when
@@ -584,8 +625,8 @@ public class ClusterVariableValueFilterIT {
                     b ->
                         b.filter(
                             f ->
-                                f.scopes("TENANT")
-                                    .tenantIds(resourceId)
+                                f.scopes(ClusterVariableScope.TENANT.name())
+                                    .tenantIds(tenantId)
                                     .valueOperations(Operation.like("value\\*any\\%*")))));
 
     // then
@@ -598,17 +639,25 @@ public class ClusterVariableValueFilterIT {
   public void shouldUnescapeESSingleWildcard(final CamundaRdbmsTestApplication testApplication) {
     // given
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var resourceId = nextStringId();
+    final var tenantId = nextStringId();
     final String varValue = "value?single_wildcards1";
     final ClusterVariableDbModel var1 = createRandomTenantClusterVariable(varValue);
     final ClusterVariableDbModel var1Fixed =
-        var1.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var1.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var1Fixed);
 
     final String varValue2 = "value?single_wildcards2";
     final ClusterVariableDbModel var2 = createRandomTenantClusterVariable(varValue2);
     final ClusterVariableDbModel var2Fixed =
-        var2.copy(b -> ((ClusterVariableDbModelBuilder) b).resourceId(resourceId).scope("TENANT"));
+        var2.copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT));
     ClusterVariableFixtures.createAndSaveVariables(rdbmsService, var2Fixed);
 
     // when
@@ -620,8 +669,8 @@ public class ClusterVariableValueFilterIT {
                     b ->
                         b.filter(
                             f ->
-                                f.scopes("TENANT")
-                                    .tenantIds(resourceId)
+                                f.scopes(ClusterVariableScope.TENANT.name())
+                                    .tenantIds(tenantId)
                                     .valueOperations(
                                         Operation.like("value\\?single\\_wildcards?")))));
 
@@ -635,23 +684,23 @@ public class ClusterVariableValueFilterIT {
       final RdbmsService rdbmsService,
       final ClusterVariableDbModel clusterVariableDbModel,
       final String variableName,
-      final String resourceId,
+      final String tenantId,
       final Operation<String> operation) {
     searchAndAssertClusterVariableValueFilters(
-        rdbmsService, clusterVariableDbModel, variableName, resourceId, List.of(operation));
+        rdbmsService, clusterVariableDbModel, variableName, tenantId, List.of(operation));
   }
 
   private static void searchAndAssertClusterVariableValueFilters(
       final RdbmsService rdbmsService,
       final ClusterVariableDbModel clusterVariableDbModel,
       final String variableName,
-      final String resourceId,
+      final String tenantId,
       final List<Operation<String>> operations) {
 
     final var builder =
         new ClusterVariableFilter.Builder()
-            .scopes("TENANT")
-            .tenantIds(resourceId)
+            .scopes(ClusterVariableScope.TENANT.name())
+            .tenantIds(tenantId)
             .names(variableName);
     if (operations != null) {
       builder.valueOperations(operations).build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ClusterVariableFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ClusterVariableFixtures.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel.ClusterVariableDbModelBuilder;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ClusterVariableScope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -56,26 +57,26 @@ public final class ClusterVariableFixtures extends CommonFixtures {
     rdbmsWriter.flush();
   }
 
-  public static void createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(
-      final RdbmsService rdbmsService, final String resourceId) {
+  public static void createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(
+      final RdbmsService rdbmsService, final String tenantId) {
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
 
     for (int i = 0; i < 20; i++) {
       final ClusterVariableDbModel randomized =
-          createRandomizedTenantClusterVariable(b -> b.resourceId(resourceId));
+          createRandomizedTenantClusterVariable(b -> b.tenantId(tenantId));
       rdbmsWriter.getClusterVariableWriter().create(randomized);
     }
 
     rdbmsWriter.flush();
   }
 
-  public static void createAndSaveRandomsTenantClusterVariablesWithFixedResourceIdAndValue(
-      final RdbmsService rdbmsService, final String resourceId, final String value) {
+  public static void createAndSaveRandomsTenantClusterVariablesWithFixedTenantAndValue(
+      final RdbmsService rdbmsService, final String tenantId, final String value) {
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
 
     for (int i = 0; i < 20; i++) {
       final ClusterVariableDbModel randomized =
-          createRandomizedTenantClusterVariable(b -> b.resourceId(resourceId).value(value));
+          createRandomizedTenantClusterVariable(b -> b.tenantId(tenantId).value(value));
       rdbmsWriter.getClusterVariableWriter().create(randomized);
     }
 
@@ -126,8 +127,8 @@ public final class ClusterVariableFixtures extends CommonFixtures {
     final var builder =
         new ClusterVariableDbModelBuilder()
             .name(generateRandomString("name-"))
-            .scope("TENANT")
-            .resourceId(generateRandomStringWithRandomTypes());
+            .scope(ClusterVariableScope.TENANT)
+            .tenantId(generateRandomStringWithRandomTypes());
 
     if (RANDOM.nextInt(10) < 5) {
       builder.value(generateRandomStringWithRandomTypes());
@@ -151,7 +152,9 @@ public final class ClusterVariableFixtures extends CommonFixtures {
       final Function<ClusterVariableDbModelBuilder, ClusterVariableDbModelBuilder>
           builderFunction) {
     final var builder =
-        new ClusterVariableDbModelBuilder().name(generateRandomString("name-")).scope("GLOBAL");
+        new ClusterVariableDbModelBuilder()
+            .name(generateRandomString("name-"))
+            .scope(ClusterVariableScope.GLOBAL);
 
     if (RANDOM.nextInt(10) < 5) {
       builder.value(generateRandomStringWithRandomTypes());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ClusterVariableFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ClusterVariableFixtures.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel.ClusterVariableDbModelBuilder;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class ClusterVariableFixtures extends CommonFixtures {
+
+  private ClusterVariableFixtures() {}
+
+  public static ClusterVariableDbModel createAndSaveRandomTenantClusterVariablesAndReturnOne(
+      final CamundaRdbmsTestApplication testApplication) {
+    return createAndSaveRandomsTenantClusterVariables(testApplication.getRdbmsService(), b -> b)
+        .getLast();
+  }
+
+  public static ClusterVariableDbModel createAndSaveRandomGlobalClusterVariablesAndReturnOne(
+      final CamundaRdbmsTestApplication testApplication) {
+    return createAndSaveRandomsGlobalClusterVariables(testApplication.getRdbmsService(), b -> b)
+        .getLast();
+  }
+
+  public static void createAndSaveRandomsGlobalClusterVariablesWithFixed(
+      final RdbmsService rdbmsService, final String value) {
+    createAndSaveRandomsGlobalClusterVariables(rdbmsService, b -> b.value(value));
+  }
+
+  public static ClusterVariableDbModel createRandomTenantClusterVariable(final String value) {
+    return createRandomizedTenantClusterVariable(b -> b.value(value));
+  }
+
+  public static ClusterVariableDbModel createRandomGlobalClusterVariable(final String value) {
+    return createRandomizedGlobalClusterVariable(b -> b.value(value));
+  }
+
+  public static void createAndSaveVariables(
+      final RdbmsService rdbmsService, final ClusterVariableDbModel clusterVariableDbModel) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
+    rdbmsWriter.getClusterVariableWriter().create(clusterVariableDbModel);
+    rdbmsWriter.flush();
+  }
+
+  public static void createAndSaveRandomsTenantClusterVariablesWithFixedResourceId(
+      final RdbmsService rdbmsService, final String resourceId) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
+
+    for (int i = 0; i < 20; i++) {
+      final ClusterVariableDbModel randomized =
+          createRandomizedTenantClusterVariable(b -> b.resourceId(resourceId));
+      rdbmsWriter.getClusterVariableWriter().create(randomized);
+    }
+
+    rdbmsWriter.flush();
+  }
+
+  public static void createAndSaveRandomsTenantClusterVariablesWithFixedResourceIdAndValue(
+      final RdbmsService rdbmsService, final String resourceId, final String value) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
+
+    for (int i = 0; i < 20; i++) {
+      final ClusterVariableDbModel randomized =
+          createRandomizedTenantClusterVariable(b -> b.resourceId(resourceId).value(value));
+      rdbmsWriter.getClusterVariableWriter().create(randomized);
+    }
+
+    rdbmsWriter.flush();
+  }
+
+  private static List<ClusterVariableDbModel> createAndSaveRandomsTenantClusterVariables(
+      final RdbmsService rdbmsService,
+      final Function<ClusterVariableDbModelBuilder, ClusterVariableDbModelBuilder>
+          builderFunction) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
+
+    final List<ClusterVariableDbModel> models = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      final ClusterVariableDbModel randomized =
+          createRandomizedTenantClusterVariable(builderFunction);
+      models.add(randomized);
+      rdbmsWriter.getClusterVariableWriter().create(randomized);
+    }
+
+    rdbmsWriter.flush();
+
+    return models;
+  }
+
+  private static List<ClusterVariableDbModel> createAndSaveRandomsGlobalClusterVariables(
+      final RdbmsService rdbmsService,
+      final Function<ClusterVariableDbModelBuilder, ClusterVariableDbModelBuilder>
+          builderFunction) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(0L);
+
+    final List<ClusterVariableDbModel> models = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      final ClusterVariableDbModel randomized =
+          createRandomizedGlobalClusterVariable(builderFunction);
+      models.add(randomized);
+      rdbmsWriter.getClusterVariableWriter().create(randomized);
+    }
+
+    rdbmsWriter.flush();
+
+    return models;
+  }
+
+  private static ClusterVariableDbModel createRandomizedTenantClusterVariable(
+      final Function<ClusterVariableDbModelBuilder, ClusterVariableDbModelBuilder>
+          builderFunction) {
+    final var builder =
+        new ClusterVariableDbModelBuilder()
+            .name(generateRandomString("name-"))
+            .scope("TENANT")
+            .resourceId(generateRandomStringWithRandomTypes());
+
+    if (RANDOM.nextInt(10) < 5) {
+      builder.value(generateRandomStringWithRandomTypes());
+    } else {
+      // Sometimes we save a json
+      try {
+        final List<String> randomStrings =
+            IntStream.range(0, 100)
+                .mapToObj(i -> generateRandomStringWithRandomTypes())
+                .collect(Collectors.toList());
+        builder.value(new ObjectMapper().writeValueAsString(randomStrings));
+      } catch (final JsonProcessingException ignored) {
+        System.out.println("Could not serialize object to json");
+      }
+    }
+
+    return builderFunction.apply(builder).build();
+  }
+
+  private static ClusterVariableDbModel createRandomizedGlobalClusterVariable(
+      final Function<ClusterVariableDbModelBuilder, ClusterVariableDbModelBuilder>
+          builderFunction) {
+    final var builder =
+        new ClusterVariableDbModelBuilder().name(generateRandomString("name-")).scope("GLOBAL");
+
+    if (RANDOM.nextInt(10) < 5) {
+      builder.value(generateRandomStringWithRandomTypes());
+    } else {
+      // Sometimes we save a json
+      try {
+        final List<String> randomStrings =
+            IntStream.range(0, 100)
+                .mapToObj(i -> generateRandomStringWithRandomTypes())
+                .collect(Collectors.toList());
+        builder.value(new ObjectMapper().writeValueAsString(randomStrings));
+      } catch (final JsonProcessingException ignored) {
+        System.out.println("Could not serialize object to json");
+      }
+    }
+
+    return builderFunction.apply(builder).build();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -39,6 +39,9 @@ import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.filter.UserFilter.Builder;
 import io.camunda.search.query.UserQuery;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
@@ -228,7 +231,9 @@ class RdbmsExporterIT {
     final var variable =
         rdbmsService
             .getClusterVariableReader()
-            .getGloballyScopedClusterVariable(clusterVariableRecordValue.getName());
+            .getGloballyScopedClusterVariable(
+                clusterVariableRecordValue.getName(),
+                ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     assertThat(variable).isNotNull();
     assertThat(variable.value()).isEqualTo(clusterVariableRecordValue.getValue());
@@ -254,7 +259,9 @@ class RdbmsExporterIT {
         rdbmsService
             .getClusterVariableReader()
             .getTenantScopedClusterVariable(
-                clusterVariableRecordValue.getTenantId(), clusterVariableRecordValue.getName());
+                clusterVariableRecordValue.getTenantId(),
+                clusterVariableRecordValue.getName(),
+                ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     assertThat(variable).isNotNull();
     assertThat(variable.value()).isEqualTo(clusterVariableRecordValue.getValue());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -233,7 +233,8 @@ class RdbmsExporterIT {
     assertThat(variable).isNotNull();
     assertThat(variable.value()).isEqualTo(clusterVariableRecordValue.getValue());
     assertThat(variable.name()).isEqualTo(clusterVariableRecordValue.getName());
-    assertThat(variable.scope()).isEqualTo(clusterVariableRecordValue.getScope().toString());
+    assertThat(variable.scope().toString())
+        .isEqualTo(clusterVariableRecordValue.getScope().toString());
   }
 
   @Test
@@ -257,9 +258,10 @@ class RdbmsExporterIT {
 
     assertThat(variable).isNotNull();
     assertThat(variable.value()).isEqualTo(clusterVariableRecordValue.getValue());
-    assertThat(variable.resourceId()).isEqualTo(clusterVariableRecordValue.getTenantId());
+    assertThat(variable.tenantId()).isEqualTo(clusterVariableRecordValue.getTenantId());
     assertThat(variable.name()).isEqualTo(clusterVariableRecordValue.getName());
-    assertThat(variable.scope()).isEqualTo(clusterVariableRecordValue.getScope().toString());
+    assertThat(variable.scope().toString())
+        .isEqualTo(clusterVariableRecordValue.getScope().toString());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
@@ -36,6 +37,8 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
@@ -43,6 +46,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecord
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
@@ -318,6 +322,43 @@ public class RecordFixtures {
                 .from((UserRecordValue) recordValueRecord.getValue())
                 .withUserKey(userKey)
                 .withUsername(username)
+                .build())
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getGlobalClusterVariableRecord(
+      final ClusterVariableIntent intent) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.CLUSTER_VARIABLE);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(intent)
+        .withPosition(2L)
+        .withTimestamp(System.currentTimeMillis())
+        .withValue(
+            ImmutableClusterVariableRecordValue.builder()
+                .from((ClusterVariableRecordValue) recordValueRecord.getValue())
+                .withScope(ClusterVariableScope.GLOBAL)
+                .build())
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getTenantClusterVariableRecord(
+      final String tenant, final ClusterVariableIntent intent) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.CLUSTER_VARIABLE);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(intent)
+        .withPosition(2L)
+        .withTimestamp(System.currentTimeMillis())
+        .withValue(
+            ImmutableClusterVariableRecordValue.builder()
+                .from((ClusterVariableRecordValue) recordValueRecord.getValue())
+                .withScope(ClusterVariableScope.TENANT)
+                .withTenantId(tenant)
                 .build())
         .build();
   }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1000,6 +1000,7 @@ public class SchemaManagerIT {
         // to make sure no index will be accidentally dropped, names are changed or added
         .containsExactlyInAnyOrder(
             newPrefix + "-camunda-authorization-8.8.0_",
+            newPrefix + "-camunda-cluster-variable-8.9.0_",
             newPrefix + "-camunda-correlated-message-subscription-8.8.0_",
             newPrefix + "-camunda-group-8.8.0_",
             newPrefix + "-camunda-mapping-rule-8.8.0_",

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultTenantAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultTenantAccessProvider.java
@@ -27,7 +27,8 @@ public class DefaultTenantAccessProvider implements TenantAccessProvider {
   @Override
   public <T> TenantAccess hasTenantAccess(
       final CamundaAuthentication authentication, final T resource) {
-    if (resource instanceof final TenantOwnedEntity tenantOwnedEntity) {
+    if (resource instanceof final TenantOwnedEntity tenantOwnedEntity
+        && tenantOwnedEntity.isInTenantScope()) {
       return hasTenantAccessByTenantId(authentication, tenantOwnedEntity.tenantId());
     }
     // if not tenant-owned, no tenant check needed => access granted

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class ClusterVariableDocumentReader extends DocumentBasedReader
+    implements ClusterVariableReader {
+
+  public ClusterVariableDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<ClusterVariableEntity> search(
+      final ClusterVariableQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class,
+            resourceAccessChecks);
+  }
+
+  @Override
+  public ClusterVariableEntity getTenantScopedClusterVariable(
+      final String tenant, final String name) {
+    return getSearchExecutor()
+        .getByQuery(
+            ClusterVariableQuery.of(
+                b -> b.filter(f -> f.names(name).resourceIds(tenant)).singleResult()),
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class);
+  }
+
+  @Override
+  public ClusterVariableEntity getGloballyScopedClusterVariable(final String name) {
+    return getSearchExecutor()
+        .getByQuery(
+            ClusterVariableQuery.of(b -> b.filter(f -> f.names(name)).singleResult()),
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
@@ -12,9 +12,8 @@ import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
-import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 
 public class ClusterVariableDocumentReader extends DocumentBasedReader
     implements ClusterVariableReader {
@@ -39,7 +38,8 @@ public class ClusterVariableDocumentReader extends DocumentBasedReader
       final String tenant, final String name, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .getById(
-            ClusterVariableIndex.generateID(name, tenant, ClusterVariableScope.TENANT),
+            ClusterVariableUtil.generateID(
+                name, tenant, io.camunda.search.entities.ClusterVariableScope.TENANT),
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class,
             indexDescriptor.getFullQualifiedName());
   }
@@ -49,7 +49,8 @@ public class ClusterVariableDocumentReader extends DocumentBasedReader
       final String name, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .getById(
-            ClusterVariableIndex.generateID(name, null, ClusterVariableScope.GLOBAL),
+            ClusterVariableUtil.generateID(
+                name, null, io.camunda.search.entities.ClusterVariableScope.GLOBAL),
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class,
             indexDescriptor.getFullQualifiedName());
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
@@ -13,6 +13,8 @@ import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 
 public class ClusterVariableDocumentReader extends DocumentBasedReader
     implements ClusterVariableReader {
@@ -34,19 +36,21 @@ public class ClusterVariableDocumentReader extends DocumentBasedReader
 
   @Override
   public ClusterVariableEntity getTenantScopedClusterVariable(
-      final String tenant, final String name) {
+      final String tenant, final String name, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
-        .getByQuery(
-            ClusterVariableQuery.of(
-                b -> b.filter(f -> f.names(name).tenantIds(tenant)).singleResult()),
-            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class);
+        .getById(
+            ClusterVariableIndex.generateID(name, tenant, ClusterVariableScope.TENANT),
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 
   @Override
-  public ClusterVariableEntity getGloballyScopedClusterVariable(final String name) {
+  public ClusterVariableEntity getGloballyScopedClusterVariable(
+      final String name, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
-        .getByQuery(
-            ClusterVariableQuery.of(b -> b.filter(f -> f.names(name)).singleResult()),
-            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class);
+        .getById(
+            ClusterVariableIndex.generateID(name, null, ClusterVariableScope.GLOBAL),
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class,
+            indexDescriptor.getFullQualifiedName());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
@@ -38,7 +38,7 @@ public class ClusterVariableDocumentReader extends DocumentBasedReader
     return getSearchExecutor()
         .getByQuery(
             ClusterVariableQuery.of(
-                b -> b.filter(f -> f.names(name).resourceIds(tenant)).singleResult()),
+                b -> b.filter(f -> f.names(name).tenantIds(tenant)).singleResult()),
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.class);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -46,6 +46,7 @@ import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUA
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationItemEntityTransformer;
+import io.camunda.search.clients.transformers.entity.ClusterVariableEntityTransformer;
 import io.camunda.search.clients.transformers.entity.CorrelatedMessageSubscriptionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionDefinitionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTransformer;
@@ -71,6 +72,7 @@ import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationItemFilterTransformer;
+import io.camunda.search.clients.transformers.filter.ClusterVariableFilterTransformer;
 import io.camunda.search.clients.transformers.filter.CorrelatedMessageSubscriptionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DateValueFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionDefinitionFilterTransformer;
@@ -107,6 +109,7 @@ import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfig
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationItemFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.ClusterVariableFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.CorrelatedMessageSubscriptionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionInstanceFieldSortingTransformer;
@@ -133,6 +136,7 @@ import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransform
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.BatchOperationItemFilter;
+import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.CorrelatedMessageSubscriptionFilter;
 import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
@@ -165,6 +169,7 @@ import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -200,6 +205,7 @@ import io.camunda.search.result.ProcessInstanceQueryResultConfig;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
 import io.camunda.search.sort.BatchOperationSort;
+import io.camunda.search.sort.ClusterVariableSort;
 import io.camunda.search.sort.CorrelatedMessageSubscriptionSort;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
@@ -225,6 +231,7 @@ import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
@@ -253,6 +260,7 @@ import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
@@ -369,7 +377,8 @@ public final class ServiceTransformers {
             UsageMetricsTUQuery.class,
             UserTaskQuery.class,
             UserQuery.class,
-            VariableQuery.class)
+            VariableQuery.class,
+            ClusterVariableQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -397,6 +406,7 @@ public final class ServiceTransformers {
     mappers.put(SequenceFlowEntity.class, new SequenceFlowEntityTransformer());
     mappers.put(TaskEntity.class, new UserTaskEntityTransformer());
     mappers.put(VariableEntity.class, new VariableEntityTransformer());
+    mappers.put(ClusterVariableEntity.class, new ClusterVariableEntityTransformer());
     mappers.put(TenantEntity.class, new TenantEntityTransformer());
     mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
     mappers.put(UserEntity.class, new UserEntityTransformer());
@@ -427,6 +437,7 @@ public final class ServiceTransformers {
     mappers.put(TenantMemberSort.class, new TenantMemberFieldSortingTransformer());
     mappers.put(UserTaskSort.class, new UserTaskFieldSortingTransformer());
     mappers.put(VariableSort.class, new VariableFieldSortingTransformer());
+    mappers.put(ClusterVariableSort.class, new ClusterVariableFieldSortingTransformer());
     mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
     mappers.put(UserSort.class, new UserFieldSortingTransformer());
@@ -440,6 +451,9 @@ public final class ServiceTransformers {
         UserTaskFilter.class,
         new UserTaskFilterTransformer(mappers, indexDescriptors.get(TaskTemplate.class)));
     mappers.put(VariableValueFilter.class, new VariableValueFilterTransformer());
+    mappers.put(
+        ClusterVariableFilter.class,
+        new ClusterVariableFilterTransformer(indexDescriptors.get(ClusterVariableIndex.class)));
     mappers.put(DateValueFilter.class, new DateValueFilterTransformer());
     mappers.put(
         VariableFilter.class,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.entity;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableScope;
 
 public class ClusterVariableEntityTransformer
     implements ServiceTransformer<
@@ -24,7 +25,7 @@ public class ClusterVariableEntityTransformer
         value.getValue(),
         value.getFullValue(),
         value.isPreview(),
-        value.getScope(),
-        value.getResourceId());
+        ClusterVariableScope.valueOf(value.getScope().name()),
+        value.getTenantId());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.ClusterVariableEntity;
+
+public class ClusterVariableEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity,
+        ClusterVariableEntity> {
+
+  @Override
+  public ClusterVariableEntity apply(
+      final io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity value) {
+    return new ClusterVariableEntity(
+        value.getId(),
+        value.getName(),
+        value.getValue(),
+        value.getFullValue(),
+        value.isPreview(),
+        value.getScope(),
+        value.getResourceId());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -11,7 +11,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.variableOperations;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.ClusterVariableFilter;
@@ -39,11 +38,15 @@ public final class ClusterVariableFilterTransformer
   @Override
   public SearchQuery toSearchQuery(final ClusterVariableFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
-    queries.addAll(stringOperations(NAME, filter.nameOperations()));
-    queries.addAll(getVariablesQuery(filter.valueOperations()));
+    queries.addAll(getNamesQuery(filter.nameOperations()));
+    queries.addAll(getValuesQuery(filter.valueOperations()));
     queries.addAll(getScopeQuery(filter.scopeOperations()));
     queries.addAll(getTenantQuery(filter.tenantIdOperations()));
     return and(queries);
+  }
+
+  private Collection<SearchQuery> getNamesQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.NAME, operations);
   }
 
   private Collection<SearchQuery> getTenantQuery(final List<Operation<String>> operations) {
@@ -54,7 +57,7 @@ public final class ClusterVariableFilterTransformer
     return stringOperations(ClusterVariableIndex.SCOPE, operations);
   }
 
-  private List<SearchQuery> getVariablesQuery(final List<UntypedOperation> variableFilters) {
+  private List<SearchQuery> getValuesQuery(final List<UntypedOperation> variableFilters) {
     return variableOperations(ClusterVariableIndex.VALUE, variableFilters);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -42,12 +42,12 @@ public final class ClusterVariableFilterTransformer
     queries.addAll(stringOperations(NAME, filter.nameOperations()));
     queries.addAll(getVariablesQuery(filter.valueOperations()));
     queries.addAll(getScopeQuery(filter.scopeOperations()));
-    queries.addAll(getResourceIdQuery(filter.resourceIdOperations()));
+    queries.addAll(getTenantQuery(filter.tenantIdOperations()));
     return and(queries);
   }
 
-  private Collection<SearchQuery> getResourceIdQuery(final List<Operation<String>> operations) {
-    return stringOperations(ClusterVariableIndex.RESOURCE_ID, operations);
+  private Collection<SearchQuery> getTenantQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.TENANT_ID, operations);
   }
 
   private Collection<SearchQuery> getScopeQuery(final List<Operation<String>> operations) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -11,6 +11,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.search.clients.query.SearchQueryBuilders.variableOperations;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -21,6 +22,7 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.security.reader.TenantCheck;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -54,9 +56,7 @@ public final class ClusterVariableFilterTransformer
             .orElse(null);
 
     final var matchGlobalQuery =
-        stringTerms(
-            ClusterVariableIndex.SCOPE,
-            List.of(io.camunda.search.entities.ClusterVariableScope.GLOBAL.name()));
+        term(ClusterVariableIndex.SCOPE, ClusterVariableScope.GLOBAL.name());
 
     return or(matchGlobalQuery, tenantCheckQuery);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -10,9 +10,7 @@ package io.camunda.search.clients.transformers.filter;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
-import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.search.clients.query.SearchQueryBuilders.variableOperations;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.IS_PREVIEW;
 import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -49,7 +47,7 @@ public final class ClusterVariableFilterTransformer
   }
 
   private Collection<SearchQuery> getResourceIdQuery(final List<Operation<String>> operations) {
-    return stringOperations(ClusterVariableIndex.SCOPE, operations);
+    return stringOperations(ClusterVariableIndex.RESOURCE_ID, operations);
   }
 
   private Collection<SearchQuery> getScopeQuery(final List<Operation<String>> operations) {
@@ -58,12 +56,5 @@ public final class ClusterVariableFilterTransformer
 
   private List<SearchQuery> getVariablesQuery(final List<UntypedOperation> variableFilters) {
     return variableOperations(ClusterVariableIndex.VALUE, variableFilters);
-  }
-
-  private SearchQuery getIsTruncatedQuery(final Boolean isTruncated) {
-    if (isTruncated == null) {
-      return null;
-    }
-    return term(IS_PREVIEW, isTruncated);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.search.clients.query.SearchQueryBuilders.variableOperations;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.IS_PREVIEW;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UntypedOperation;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class ClusterVariableFilterTransformer
+    extends IndexFilterTransformer<ClusterVariableFilter> {
+
+  public ClusterVariableFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return stringTerms(ClusterVariableIndex.NAME, authorization.resourceIds());
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final ClusterVariableFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(stringOperations(NAME, filter.nameOperations()));
+    queries.addAll(getVariablesQuery(filter.valueOperations()));
+    queries.addAll(getScopeQuery(filter.scopeOperations()));
+    queries.addAll(getResourceIdQuery(filter.resourceIdOperations()));
+    return and(queries);
+  }
+
+  private Collection<SearchQuery> getResourceIdQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.SCOPE, operations);
+  }
+
+  private Collection<SearchQuery> getScopeQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.SCOPE, operations);
+  }
+
+  private List<SearchQuery> getVariablesQuery(final List<UntypedOperation> variableFilters) {
+    return variableOperations(ClusterVariableIndex.VALUE, variableFilters);
+  }
+
+  private SearchQuery getIsTruncatedQuery(final Boolean isTruncated) {
+    if (isTruncated == null) {
+      return null;
+    }
+    return term(IS_PREVIEW, isTruncated);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IndexFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IndexFilterTransformer.java
@@ -99,6 +99,11 @@ public abstract class IndexFilterTransformer<T extends FilterBase> implements Fi
       return matchAll();
     }
 
+    return toTenantCheckSearchQuery(tenantCheck, field);
+  }
+
+  protected SearchQuery toTenantCheckSearchQuery(
+      final TenantCheck tenantCheck, final Optional<String> field) {
     return Optional.of(tenantCheck)
         .map(TenantCheck::tenantIds)
         .filter(t -> !t.isEmpty())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/ClusterVariableFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/ClusterVariableFieldSortingTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.RESOURCE_ID;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.SCOPE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.VALUE;
+
+public class ClusterVariableFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "name" -> NAME;
+      case "value" -> VALUE;
+      case "scope" -> SCOPE;
+      case "resourceId" -> RESOURCE_ID;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return NAME;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/ClusterVariableFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/ClusterVariableFieldSortingTransformer.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.RESOURCE_ID;
 import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.SCOPE;
 import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.VALUE;
 
@@ -20,7 +20,7 @@ public class ClusterVariableFieldSortingTransformer implements FieldSortingTrans
       case "name" -> NAME;
       case "value" -> VALUE;
       case "scope" -> SCOPE;
-      case "resourceId" -> RESOURCE_ID;
+      case "tenantId" -> TENANT_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTest.java
@@ -72,7 +72,7 @@ public class ClusterVariableFilterTest {
   }
 
   @Test
-  public void shouldSetScopeAndResourceIdFilters() {
+  public void shouldSetScopeAndTenantIdFilters() {
     // given
     final var filterBuilder = new ClusterVariableFilter.Builder();
 
@@ -107,7 +107,7 @@ public class ClusterVariableFilterTest {
   }
 
   @Test
-  public void shouldSetMultipleResourceIds() {
+  public void shouldSetMultipleTenantIds() {
     // given
     final var filterBuilder = new ClusterVariableFilter.Builder();
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.filter.Operation.eq;
+import static io.camunda.search.filter.Operation.gt;
+import static io.camunda.search.filter.Operation.gte;
+import static io.camunda.search.filter.Operation.lt;
+import static io.camunda.search.filter.Operation.lte;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.filter.UntypedOperation;
+import org.junit.jupiter.api.Test;
+
+public class ClusterVariableFilterTest {
+
+  @Test
+  public void shouldCreateDefaultFilter() {
+    // given
+
+    // when
+    final var filter = new ClusterVariableFilter.Builder().names("foo").build();
+
+    // then
+    assertThat(filter.nameOperations()).hasSize(1);
+    assertThat(filter.valueOperations()).isEmpty();
+  }
+
+  @Test
+  public void shouldSetFilters() {
+    // given
+    final var filterBuilder = new ClusterVariableFilter.Builder();
+
+    // when
+    final var filter =
+        filterBuilder
+            .names("name")
+            .valueOperations(eq("equals"), gt("4"), gte("2"), lt("1"), lte("3"))
+            .build();
+
+    // then
+    assertThat(filter.nameOperations()).hasSize(1);
+    assertThat(filter.valueOperations()).hasSize(5);
+  }
+
+  @Test
+  public void shouldSetValueOperationsWithUntypedOperation() {
+    // given
+    final var filterBuilder = new ClusterVariableFilter.Builder();
+
+    // when
+    final var filter =
+        filterBuilder
+            .names("name")
+            .valueOperation(UntypedOperation.of(eq("equals")))
+            .valueOperation(UntypedOperation.of(gt(4)))
+            .valueOperation(UntypedOperation.of(gte(2)))
+            .valueOperation(UntypedOperation.of(lt(1)))
+            .valueOperation(UntypedOperation.of(lte(3)))
+            .build();
+
+    // then
+    assertThat(filter.nameOperations()).hasSize(1);
+    assertThat(filter.valueOperations()).hasSize(5);
+  }
+
+  @Test
+  public void shouldSetScopeAndResourceIdFilters() {
+    // given
+    final var filterBuilder = new ClusterVariableFilter.Builder();
+
+    // when
+    final var filter =
+        filterBuilder
+            .names("name")
+            .scopes("TENANT")
+            .resourceIds("resource-123")
+            .values("some-value")
+            .build();
+
+    // then
+    assertThat(filter.nameOperations()).hasSize(1);
+    assertThat(filter.scopeOperations()).hasSize(1);
+    assertThat(filter.resourceIdOperations()).hasSize(1);
+    assertThat(filter.valueOperations()).hasSize(1);
+  }
+
+  @Test
+  public void shouldSetMultipleNames() {
+    // given
+    final var filterBuilder = new ClusterVariableFilter.Builder();
+
+    // when
+    final var filter = filterBuilder.names("name1", "name2", "name3").build();
+
+    // then
+    assertThat(filter.nameOperations()).hasSize(1);
+    assertThat(filter.nameOperations().getFirst().operator()).isEqualTo(Operator.IN);
+    assertThat(filter.nameOperations().getFirst().values()).hasSize(3);
+  }
+
+  @Test
+  public void shouldSetMultipleResourceIds() {
+    // given
+    final var filterBuilder = new ClusterVariableFilter.Builder();
+
+    // when
+    final var filter = filterBuilder.resourceIds("resource1", "resource2", "resource3").build();
+
+    // then
+    assertThat(filter.resourceIdOperations()).hasSize(1);
+    assertThat(filter.resourceIdOperations().getFirst().operator()).isEqualTo(Operator.IN);
+    assertThat(filter.resourceIdOperations().getFirst().values()).hasSize(3);
+  }
+
+  @Test
+  public void shouldSetMultipleValues() {
+    // given
+    final var filterBuilder = new ClusterVariableFilter.Builder();
+
+    // when
+    final var filter = filterBuilder.values("value1", "value2", "value3").build();
+
+    // then
+    assertThat(filter.valueOperations()).hasSize(1);
+    assertThat(filter.valueOperations().getFirst().operator()).isEqualTo(Operator.IN);
+    assertThat(filter.valueOperations().getFirst().values()).hasSize(3);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTest.java
@@ -81,14 +81,14 @@ public class ClusterVariableFilterTest {
         filterBuilder
             .names("name")
             .scopes("TENANT")
-            .resourceIds("resource-123")
+            .tenantIds("resource-123")
             .values("some-value")
             .build();
 
     // then
     assertThat(filter.nameOperations()).hasSize(1);
     assertThat(filter.scopeOperations()).hasSize(1);
-    assertThat(filter.resourceIdOperations()).hasSize(1);
+    assertThat(filter.tenantIdOperations()).hasSize(1);
     assertThat(filter.valueOperations()).hasSize(1);
   }
 
@@ -112,12 +112,12 @@ public class ClusterVariableFilterTest {
     final var filterBuilder = new ClusterVariableFilter.Builder();
 
     // when
-    final var filter = filterBuilder.resourceIds("resource1", "resource2", "resource3").build();
+    final var filter = filterBuilder.tenantIds("resource1", "resource2", "resource3").build();
 
     // then
-    assertThat(filter.resourceIdOperations()).hasSize(1);
-    assertThat(filter.resourceIdOperations().getFirst().operator()).isEqualTo(Operator.IN);
-    assertThat(filter.resourceIdOperations().getFirst().values()).hasSize(3);
+    assertThat(filter.tenantIdOperations()).hasSize(1);
+    assertThat(filter.tenantIdOperations().getFirst().operator()).isEqualTo(Operator.IN);
+    assertThat(filter.tenantIdOperations().getFirst().values()).hasSize(3);
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ClusterVariableSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ClusterVariableSortTest.java
@@ -90,12 +90,12 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
   }
 
   @Test
-  public void shouldApplySortConditionByResourceIdDESC() {
+  public void shouldApplySortConditionByTenantIdDESC() {
     // given
-    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("resourceId"));
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("tenantId"));
     final var request =
         SearchQueryBuilders.clusterVariableSearchQuery(
-            (q) -> q.filter(clusterVariableFilter).sort((s) -> s.resourceId().desc()).page(p -> p));
+            (q) -> q.filter(clusterVariableFilter).sort((s) -> s.tenantId().desc()).page(p -> p));
 
     // when
     final var sort = transformRequest(request);
@@ -109,7 +109,7 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
         sort.stream()
             .anyMatch(
                 s ->
-                    s.field().field().equals("resourceId")
+                    s.field().field().equals("tenantId")
                         && s.field().order().equals(SortOrder.DESC));
 
     assertThat(sortByResourceIdConditionCheck).isTrue();
@@ -156,7 +156,7 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
         SearchQueryBuilders.clusterVariableSearchQuery(
             (q) ->
                 q.filter(clusterVariableFilter)
-                    .sort((s) -> s.scope().asc().resourceId().desc())
+                    .sort((s) -> s.scope().asc().tenantId().desc())
                     .page(p -> p));
 
     // when
@@ -176,7 +176,7 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
         sort.stream()
             .anyMatch(
                 s ->
-                    s.field().field().equals("resourceId")
+                    s.field().field().equals("tenantId")
                         && s.field().order().equals(SortOrder.DESC));
 
     assertThat(sortByScopeConditionCheck).isTrue();

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ClusterVariableSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ClusterVariableSortTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.SortOrder;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ClusterVariableSortTest extends AbstractSortTransformerTest {
+
+  @Test
+  public void shouldApplySortConditionByValueASC() {
+    // given
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("foo"));
+    final var request =
+        SearchQueryBuilders.clusterVariableSearchQuery(
+            (q) -> q.filter(clusterVariableFilter).sort((s) -> s.value().asc()).page(p -> p));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    // Name being default, we have 2 sort conditions
+    Assertions.assertThat(sort).hasSize(2);
+
+    final boolean sortByValueConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s -> s.field().field().equals("value") && s.field().order().equals(SortOrder.ASC));
+
+    assertThat(sortByValueConditionCheck).isTrue();
+  }
+
+  @Test
+  public void shouldApplySortConditionByNameDESC() {
+    // given
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("bar"));
+    final var request =
+        SearchQueryBuilders.clusterVariableSearchQuery(
+            (q) -> q.filter(clusterVariableFilter).sort((s) -> s.name().desc()).page(p -> p));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    // Name being default, we have 2 sort conditions for the name, ASC and DESC
+    Assertions.assertThat(sort).hasSize(2);
+
+    final boolean sortByNameConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s -> s.field().field().equals("name") && s.field().order().equals(SortOrder.DESC));
+
+    assertThat(sortByNameConditionCheck).isTrue();
+  }
+
+  @Test
+  public void shouldApplySortConditionByScopeASC() {
+    // given
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("scope"));
+    final var request =
+        SearchQueryBuilders.clusterVariableSearchQuery(
+            (q) -> q.filter(clusterVariableFilter).sort((s) -> s.scope().asc()).page(p -> p));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    // Name being default, we have 2 sort conditions
+    Assertions.assertThat(sort).hasSize(2);
+
+    final boolean sortByScopeConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s -> s.field().field().equals("scope") && s.field().order().equals(SortOrder.ASC));
+
+    assertThat(sortByScopeConditionCheck).isTrue();
+  }
+
+  @Test
+  public void shouldApplySortConditionByResourceIdDESC() {
+    // given
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("resourceId"));
+    final var request =
+        SearchQueryBuilders.clusterVariableSearchQuery(
+            (q) -> q.filter(clusterVariableFilter).sort((s) -> s.resourceId().desc()).page(p -> p));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    // Name being default, we have 2 sort conditions
+    Assertions.assertThat(sort).hasSize(2);
+
+    final boolean sortByResourceIdConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s ->
+                    s.field().field().equals("resourceId")
+                        && s.field().order().equals(SortOrder.DESC));
+
+    assertThat(sortByResourceIdConditionCheck).isTrue();
+  }
+
+  @Test
+  public void shouldApplySortConditionByNameAndValueASC() {
+    // given
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("multi"));
+    final var request =
+        SearchQueryBuilders.clusterVariableSearchQuery(
+            (q) ->
+                q.filter(clusterVariableFilter)
+                    .sort((s) -> s.name().asc().value().asc())
+                    .page(p -> p));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    // Name being default, we have 2 sort conditions + 1 default = 3
+    Assertions.assertThat(sort).hasSize(3);
+
+    final boolean sortByNameConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s -> s.field().field().equals("name") && s.field().order().equals(SortOrder.ASC));
+
+    final boolean sortByValueConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s -> s.field().field().equals("value") && s.field().order().equals(SortOrder.ASC));
+
+    assertThat(sortByNameConditionCheck).isTrue();
+    assertThat(sortByValueConditionCheck).isTrue();
+  }
+
+  @Test
+  public void shouldApplySortConditionByScopeAndResourceIdMixedOrder() {
+    // given
+    final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("mixed"));
+    final var request =
+        SearchQueryBuilders.clusterVariableSearchQuery(
+            (q) ->
+                q.filter(clusterVariableFilter)
+                    .sort((s) -> s.scope().asc().resourceId().desc())
+                    .page(p -> p));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).isNotNull();
+    // Name being default, we have 3 sort conditions
+    Assertions.assertThat(sort).hasSize(3);
+
+    final boolean sortByScopeConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s -> s.field().field().equals("scope") && s.field().order().equals(SortOrder.ASC));
+
+    final boolean sortByResourceIdConditionCheck =
+        sort.stream()
+            .anyMatch(
+                s ->
+                    s.field().field().equals("resourceId")
+                        && s.field().order().equals(SortOrder.DESC));
+
+    assertThat(sortByScopeConditionCheck).isTrue();
+    assertThat(sortByResourceIdConditionCheck).isTrue();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ClusterVariableSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/ClusterVariableSortTest.java
@@ -105,14 +105,14 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
     // Name being default, we have 2 sort conditions
     Assertions.assertThat(sort).hasSize(2);
 
-    final boolean sortByResourceIdConditionCheck =
+    final boolean sortByTenantIdConditionCheck =
         sort.stream()
             .anyMatch(
                 s ->
                     s.field().field().equals("tenantId")
                         && s.field().order().equals(SortOrder.DESC));
 
-    assertThat(sortByResourceIdConditionCheck).isTrue();
+    assertThat(sortByTenantIdConditionCheck).isTrue();
   }
 
   @Test
@@ -149,7 +149,7 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
   }
 
   @Test
-  public void shouldApplySortConditionByScopeAndResourceIdMixedOrder() {
+  public void shouldApplySortConditionByScopeAndTenantIdMixedOrder() {
     // given
     final var clusterVariableFilter = FilterBuilders.clusterVariable((f) -> f.names("mixed"));
     final var request =
@@ -172,7 +172,7 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
             .anyMatch(
                 s -> s.field().field().equals("scope") && s.field().order().equals(SortOrder.ASC));
 
-    final boolean sortByResourceIdConditionCheck =
+    final boolean sortByTenantIdConditionCheck =
         sort.stream()
             .anyMatch(
                 s ->
@@ -180,6 +180,6 @@ public class ClusterVariableSortTest extends AbstractSortTransformerTest {
                         && s.field().order().equals(SortOrder.DESC));
 
     assertThat(sortByScopeConditionCheck).isTrue();
-    assertThat(sortByResourceIdConditionCheck).isTrue();
+    assertThat(sortByTenantIdConditionCheck).isTrue();
   }
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.query.ClusterVariableQuery;
+
+public interface ClusterVariableReader
+    extends SearchEntityReader<ClusterVariableEntity, ClusterVariableQuery> {
+
+  ClusterVariableEntity getTenantScopedClusterVariable(String tenant, String name);
+
+  ClusterVariableEntity getGloballyScopedClusterVariable(String name);
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
@@ -9,11 +9,14 @@ package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.security.reader.ResourceAccessChecks;
 
 public interface ClusterVariableReader
     extends SearchEntityReader<ClusterVariableEntity, ClusterVariableQuery> {
 
-  ClusterVariableEntity getTenantScopedClusterVariable(String tenant, String name);
+  ClusterVariableEntity getTenantScopedClusterVariable(
+      String tenant, String name, ResourceAccessChecks resourceAccessChecks);
 
-  ClusterVariableEntity getGloballyScopedClusterVariable(String name);
+  ClusterVariableEntity getGloballyScopedClusterVariable(
+      String name, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -39,4 +39,5 @@ public record SearchClientReaders(
     UsageMetricsTUReader usageMetricsTUReader,
     UserReader userReader,
     UserTaskReader userTaskReader,
-    VariableReader variableReader) {}
+    VariableReader variableReader,
+    ClusterVariableReader clusterVariableReader) {}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -53,6 +54,7 @@ import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -138,6 +140,25 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<CorrelatedMessageSubscriptionEntity>
       searchCorrelatedMessageSubscriptions(final CorrelatedMessageSubscriptionQuery query) {
     return doSearchWithReader(readers.correlatedMessageSubscriptionReader(), query);
+  }
+
+  @Override
+  public ClusterVariableEntity getClusterVariable(final String tenant, final String name) {
+    return doGet(a -> readers.clusterVariableReader().getTenantScopedClusterVariable(tenant, name))
+        .orElseThrow(
+            () -> entityByIdNotFoundException("cluster variable", "%s-%s".formatted(name, tenant)));
+  }
+
+  @Override
+  public ClusterVariableEntity getClusterVariable(final String name) {
+    return doGet(a -> readers.clusterVariableReader().getGloballyScopedClusterVariable(name))
+        .orElseThrow(() -> entityByIdNotFoundException("cluster variable", "%s".formatted(name)));
+  }
+
+  @Override
+  public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
+      final ClusterVariableQuery filter) {
+    return doSearchWithReader(readers.clusterVariableReader(), filter);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -146,13 +146,18 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public ClusterVariableEntity getClusterVariable(final String tenant, final String name) {
     return doGet(a -> readers.clusterVariableReader().getTenantScopedClusterVariable(tenant, name))
         .orElseThrow(
-            () -> entityByIdNotFoundException("cluster variable", "%s-%s".formatted(name, tenant)));
+            () ->
+                entityByIdNotFoundException(
+                    "Tenant-scoped Cluster Variable", "%s-%s".formatted(name, tenant)));
   }
 
   @Override
   public ClusterVariableEntity getClusterVariable(final String name) {
     return doGet(a -> readers.clusterVariableReader().getGloballyScopedClusterVariable(name))
-        .orElseThrow(() -> entityByIdNotFoundException("cluster variable", "%s".formatted(name)));
+        .orElseThrow(
+            () ->
+                entityByIdNotFoundException(
+                    "Global-scoped Cluster Variable", "%s".formatted(name)));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -144,7 +144,11 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public ClusterVariableEntity getClusterVariable(final String tenant, final String name) {
-    return doGet(a -> readers.clusterVariableReader().getTenantScopedClusterVariable(tenant, name))
+    return doGet(
+            resourceAccessChecks ->
+                readers
+                    .clusterVariableReader()
+                    .getTenantScopedClusterVariable(tenant, name, resourceAccessChecks))
         .orElseThrow(
             () ->
                 entityByIdNotFoundException(
@@ -153,7 +157,11 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public ClusterVariableEntity getClusterVariable(final String name) {
-    return doGet(a -> readers.clusterVariableReader().getGloballyScopedClusterVariable(name))
+    return doGet(
+            resourceAccessChecks ->
+                readers
+                    .clusterVariableReader()
+                    .getGloballyScopedClusterVariable(name, resourceAccessChecks))
         .orElseThrow(
             () ->
                 entityByIdNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface ClusterVariableSearchClient {
+
+  ClusterVariableEntity getClusterVariable(final String tenant, final String name);
+
+  ClusterVariableEntity getClusterVariable(final String name);
+
+  SearchQueryResult<ClusterVariableEntity> searchClusterVariables(ClusterVariableQuery filter);
+
+  ClusterVariableSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -31,7 +31,8 @@ public interface SearchClientsProxy
         UsageMetricsSearchClient,
         UserTaskSearchClient,
         UserSearchClient,
-        VariableSearchClient {
+        VariableSearchClient,
+        ClusterVariableSearchClient {
 
   @Override
   SearchClientsProxy withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -43,6 +44,7 @@ import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -315,6 +317,22 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<CorrelatedMessageSubscriptionEntity>
       searchCorrelatedMessageSubscriptions(final CorrelatedMessageSubscriptionQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public ClusterVariableEntity getClusterVariable(final String tenant, final String name) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public ClusterVariableEntity getClusterVariable(final String name) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
+      final ClusterVariableQuery filter) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -44,6 +45,7 @@ import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -317,6 +319,22 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<CorrelatedMessageSubscriptionEntity>
       searchCorrelatedMessageSubscriptions(final CorrelatedMessageSubscriptionQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public ClusterVariableEntity getClusterVariable(final String tenant, final String name) {
+    return null;
+  }
+
+  @Override
+  public ClusterVariableEntity getClusterVariable(final String name) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
+      final ClusterVariableQuery filter) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -17,4 +17,4 @@ public record ClusterVariableEntity(
     String fullValue,
     Boolean isPreview,
     ClusterVariableScope scope,
-    String resourceId) {}
+    String tenantId) {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -17,4 +17,11 @@ public record ClusterVariableEntity(
     String fullValue,
     Boolean isPreview,
     ClusterVariableScope scope,
-    String tenantId) {}
+    String tenantId)
+    implements TenantOwnedEntity {
+
+  @Override
+  public boolean isInTenantScope() {
+    return ClusterVariableScope.TENANT.equals(scope);
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ClusterVariableEntity(
+    String clusterVariableId,
+    String name,
+    String value,
+    String fullValue,
+    Boolean isPreview,
+    String scope,
+    String resourceId) {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableScope.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableScope.java
@@ -9,6 +9,5 @@ package io.camunda.search.entities;
 
 public enum ClusterVariableScope {
   GLOBAL,
-  TENANT,
-  UNSPECIFIED;
+  TENANT;
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableScope.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableScope.java
@@ -7,14 +7,8 @@
  */
 package io.camunda.search.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-public record ClusterVariableEntity(
-    String id,
-    String name,
-    String value,
-    String fullValue,
-    Boolean isPreview,
-    ClusterVariableScope scope,
-    String resourceId) {}
+public enum ClusterVariableScope {
+  GLOBAL,
+  TENANT,
+  UNSPECIFIED;
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantOwnedEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantOwnedEntity.java
@@ -10,4 +10,8 @@ package io.camunda.search.entities;
 public interface TenantOwnedEntity {
 
   String tenantId();
+
+  default boolean isInTenantScope() {
+    return true;
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.search.filter.VariableValueFilter.Builder;
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record ClusterVariableFilter(
+    List<Operation<String>> nameOperations,
+    List<UntypedOperation> valueOperations,
+    List<Operation<String>> scopeOperations,
+    List<Operation<String>> resourceIdOperations)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<ClusterVariableFilter> {
+    List<Operation<String>> nameOperations;
+    List<UntypedOperation> valueOperations;
+    List<Operation<String>> scopeOperations;
+    List<Operation<String>> resourceIdOperations;
+
+    public Builder nameOperations(final List<Operation<String>> operations) {
+      nameOperations = addValuesToList(nameOperations, operations);
+      return this;
+    }
+
+    public Builder names(final String value, final String... values) {
+      return nameOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder names(final List<String> values) {
+      return nameOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder nameOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return nameOperations(collectValues(operation, operations));
+    }
+
+    public Builder valueOperations(final List<Operation<String>> operations) {
+      final List<Operation<String>> ops =
+          Objects.requireNonNullElse(operations, Collections.emptyList());
+      valueOperations =
+          addValuesToList(valueOperations, ops.stream().map(UntypedOperation::of).toList());
+      return this;
+    }
+
+    private Builder valueUntypedOperations(final List<UntypedOperation> operations) {
+      valueOperations = addValuesToList(valueOperations, operations);
+      return this;
+    }
+
+    public Builder values(final String value, final String... values) {
+      return valueOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder values(final List<String> values) {
+      return valueOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder valueOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return valueOperations(collectValues(operation, operations));
+    }
+
+    public Builder valueOperation(final UntypedOperation operation) {
+      valueOperations = addValuesToList(valueOperations, Collections.singletonList(operation));
+      return this;
+    }
+
+    public Builder scopeOperations(final List<Operation<String>> operations) {
+      scopeOperations = addValuesToList(scopeOperations, operations);
+      return this;
+    }
+
+    public Builder scopes(final String value, final String... values) {
+      return scopeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder scopes(final List<String> values) {
+      return scopeOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder scopeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return scopeOperations(collectValues(operation, operations));
+    }
+
+    public Builder resourceIdOperations(final List<Operation<String>> operations) {
+      resourceIdOperations = addValuesToList(resourceIdOperations, operations);
+      return this;
+    }
+
+    public Builder resourceIds(final String value, final String... values) {
+      return resourceIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder resourceIds(final List<String> values) {
+      return resourceIdOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder resourceIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return resourceIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder copyFrom(final ClusterVariableFilter sourceFilter) {
+      return nameOperations(sourceFilter.nameOperations)
+          .valueUntypedOperations(sourceFilter.valueOperations)
+          .scopeOperations(sourceFilter.scopeOperations)
+          .resourceIdOperations(sourceFilter.resourceIdOperations);
+    }
+
+    @Override
+    public ClusterVariableFilter build() {
+      return new ClusterVariableFilter(
+          Objects.requireNonNullElseGet(nameOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(valueOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(scopeOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(resourceIdOperations, Collections::emptyList));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -10,7 +10,6 @@ package io.camunda.search.filter;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
-import io.camunda.search.filter.VariableValueFilter.Builder;
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
@@ -21,14 +20,14 @@ public record ClusterVariableFilter(
     List<Operation<String>> nameOperations,
     List<UntypedOperation> valueOperations,
     List<Operation<String>> scopeOperations,
-    List<Operation<String>> resourceIdOperations)
+    List<Operation<String>> tenantIdOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<ClusterVariableFilter> {
     List<Operation<String>> nameOperations;
     List<UntypedOperation> valueOperations;
     List<Operation<String>> scopeOperations;
-    List<Operation<String>> resourceIdOperations;
+    List<Operation<String>> tenantIdOperations;
 
     public Builder nameOperations(final List<Operation<String>> operations) {
       nameOperations = addValuesToList(nameOperations, operations);
@@ -100,30 +99,30 @@ public record ClusterVariableFilter(
       return scopeOperations(collectValues(operation, operations));
     }
 
-    public Builder resourceIdOperations(final List<Operation<String>> operations) {
-      resourceIdOperations = addValuesToList(resourceIdOperations, operations);
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
       return this;
     }
 
-    public Builder resourceIds(final String value, final String... values) {
-      return resourceIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    public Builder tenantIds(final String value, final String... values) {
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder resourceIds(final List<String> values) {
-      return resourceIdOperations(FilterUtil.mapDefaultToOperation(values));
+    public Builder tenantIds(final List<String> values) {
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(values));
     }
 
     @SafeVarargs
-    public final Builder resourceIdOperations(
+    public final Builder tenantIdOperations(
         final Operation<String> operation, final Operation<String>... operations) {
-      return resourceIdOperations(collectValues(operation, operations));
+      return tenantIdOperations(collectValues(operation, operations));
     }
 
     public Builder copyFrom(final ClusterVariableFilter sourceFilter) {
       return nameOperations(sourceFilter.nameOperations)
           .valueUntypedOperations(sourceFilter.valueOperations)
           .scopeOperations(sourceFilter.scopeOperations)
-          .resourceIdOperations(sourceFilter.resourceIdOperations);
+          .tenantIdOperations(sourceFilter.tenantIdOperations);
     }
 
     @Override
@@ -132,7 +131,7 @@ public record ClusterVariableFilter(
           Objects.requireNonNullElseGet(nameOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(valueOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(scopeOperations, Collections::emptyList),
-          Objects.requireNonNullElseGet(resourceIdOperations, Collections::emptyList));
+          Objects.requireNonNullElseGet(tenantIdOperations, Collections::emptyList));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -118,13 +118,6 @@ public record ClusterVariableFilter(
       return tenantIdOperations(collectValues(operation, operations));
     }
 
-    public Builder copyFrom(final ClusterVariableFilter sourceFilter) {
-      return nameOperations(sourceFilter.nameOperations)
-          .valueUntypedOperations(sourceFilter.valueOperations)
-          .scopeOperations(sourceFilter.scopeOperations)
-          .tenantIdOperations(sourceFilter.tenantIdOperations);
-    }
-
     @Override
     public ClusterVariableFilter build() {
       return new ClusterVariableFilter(

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -203,9 +203,18 @@ public final class FilterBuilders {
     return new VariableFilter.Builder();
   }
 
+  public static ClusterVariableFilter.Builder clusterVariable() {
+    return new ClusterVariableFilter.Builder();
+  }
+
   public static VariableFilter variable(
       final Function<VariableFilter.Builder, ObjectBuilder<VariableFilter>> fn) {
     return fn.apply(variable()).build();
+  }
+
+  public static ClusterVariableFilter clusterVariable(
+      final Function<ClusterVariableFilter.Builder, ObjectBuilder<ClusterVariableFilter>> fn) {
+    return fn.apply(clusterVariable()).build();
   }
 
   public static VariableValueFilter.Builder variableValue() {

--- a/search/search-domain/src/main/java/io/camunda/search/query/ClusterVariableQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ClusterVariableQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.search.query;
+
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.ClusterVariableSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record ClusterVariableQuery(
+    ClusterVariableFilter filter, ClusterVariableSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<ClusterVariableFilter, ClusterVariableSort> {
+
+  public static ClusterVariableQuery of(
+      final Function<Builder, ObjectBuilder<ClusterVariableQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          ClusterVariableQuery, Builder, ClusterVariableFilter, ClusterVariableSort> {
+
+    private static final ClusterVariableFilter EMPTY_FILTER =
+        FilterBuilders.clusterVariable().build();
+    private static final ClusterVariableSort EMPTY_SORT =
+        SortOptionBuilders.clusterVariable().build();
+
+    private ClusterVariableFilter filter;
+    private ClusterVariableSort sort;
+
+    @Override
+    public Builder filter(final ClusterVariableFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final ClusterVariableSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<ClusterVariableFilter.Builder, ObjectBuilder<ClusterVariableFilter>> fn) {
+      return filter(FilterBuilders.clusterVariable(fn));
+    }
+
+    public Builder sort(
+        final Function<ClusterVariableSort.Builder, ObjectBuilder<ClusterVariableSort>> fn) {
+      return sort(SortOptionBuilders.clusterVariable(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ClusterVariableQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new ClusterVariableQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -68,6 +68,15 @@ public final class SearchQueryBuilders {
     return fn.apply(variableSearchQuery()).build();
   }
 
+  public static ClusterVariableQuery.Builder clusterVariableSearchQuery() {
+    return new ClusterVariableQuery.Builder();
+  }
+
+  public static ClusterVariableQuery clusterVariableSearchQuery(
+      final Function<ClusterVariableQuery.Builder, ObjectBuilder<ClusterVariableQuery>> fn) {
+    return fn.apply(clusterVariableSearchQuery()).build();
+  }
+
   public static DecisionDefinitionQuery.Builder decisionDefinitionSearchQuery() {
     return new DecisionDefinitionQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/ClusterVariableSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/ClusterVariableSort.java
@@ -41,8 +41,8 @@ public final record ClusterVariableSort(List<FieldSorting> orderings) implements
       return this;
     }
 
-    public Builder resourceId() {
-      currentOrdering = new FieldSorting("resourceId", null);
+    public Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
       return this;
     }
 

--- a/search/search-domain/src/main/java/io/camunda/search/sort/ClusterVariableSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/ClusterVariableSort.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public final record ClusterVariableSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static ClusterVariableSort of(
+      final Function<Builder, ObjectBuilder<ClusterVariableSort>> fn) {
+    return SortOptionBuilders.clusterVariable(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<ClusterVariableSort> {
+
+    public Builder value() {
+      currentOrdering = new FieldSorting("value", null);
+      return this;
+    }
+
+    public Builder name() {
+      currentOrdering = new FieldSorting("name", null);
+      return this;
+    }
+
+    public Builder scope() {
+      currentOrdering = new FieldSorting("scope", null);
+      return this;
+    }
+
+    public Builder resourceId() {
+      currentOrdering = new FieldSorting("resourceId", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ClusterVariableSort build() {
+      return new ClusterVariableSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -44,6 +44,10 @@ public final class SortOptionBuilders {
     return new VariableSort.Builder();
   }
 
+  public static ClusterVariableSort.Builder clusterVariable() {
+    return new ClusterVariableSort.Builder();
+  }
+
   public static DecisionDefinitionSort.Builder decisionDefinition() {
     return new DecisionDefinitionSort.Builder();
   }
@@ -114,6 +118,11 @@ public final class SortOptionBuilders {
   public static VariableSort variable(
       final Function<VariableSort.Builder, ObjectBuilder<VariableSort>> fn) {
     return fn.apply(variable()).build();
+  }
+
+  public static ClusterVariableSort clusterVariable(
+      final Function<ClusterVariableSort.Builder, ObjectBuilder<ClusterVariableSort>> fn) {
+    return fn.apply(clusterVariable()).build();
   }
 
   public static DecisionDefinitionSort decisionDefinition(

--- a/search/search-domain/src/main/java/io/camunda/util/ClusterVariableUtil.java
+++ b/search/search-domain/src/main/java/io/camunda/util/ClusterVariableUtil.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.util;
+
+import io.camunda.search.entities.ClusterVariableScope;
+
+public class ClusterVariableUtil {
+
+  public static String generateID(
+      final String name, final String tenantId, final ClusterVariableScope scope) {
+    return switch (scope) {
+      case GLOBAL -> String.format("%s-%s", name, scope);
+      case TENANT -> String.format("%s-%s-%s", name, tenantId, scope);
+    };
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.descriptors;
 
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
@@ -80,6 +81,7 @@ public class IndexDescriptors {
                 new TenantIndex(indexPrefix, isElasticsearch),
                 new UserIndex(indexPrefix, isElasticsearch),
                 new VariableTemplate(indexPrefix, isElasticsearch),
+                new ClusterVariableIndex(indexPrefix, isElasticsearch),
                 new MessageTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch))

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.ComponentNames.CAMUNDA;
 
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import java.util.Optional;
 
 public class ClusterVariableIndex extends AbstractIndexDescriptor implements Prio5Backup {
@@ -23,7 +24,7 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   public static final String VALUE = "value";
   public static final String FULL_VALUE = "fullValue";
   public static final String SCOPE = "scope";
-  public static final String RESOURCE_ID = "resourceId";
+  public static final String TENANT_ID = "tenantId";
   public static final String IS_PREVIEW = "isPreview";
 
   public ClusterVariableIndex(final String indexPrefix, final boolean isElasticsearch) {
@@ -48,5 +49,16 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   @Override
   public String getComponentName() {
     return CAMUNDA.toString();
+  }
+
+  public static String generateID(
+      final String name, final String resourceId, final ClusterVariableScope scope) {
+    return switch (scope) {
+      case GLOBAL -> String.format("%s-%s", name, scope);
+      case TENANT -> String.format("%s-%s-%s", name, resourceId, scope);
+      default ->
+          throw new IllegalStateException(
+              "Cluster variable with unspecified scope can not be exported: " + scope);
+    };
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.index;
+
+import static io.camunda.webapps.schema.descriptors.ComponentNames.CAMUNDA;
+
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import java.util.Optional;
+
+public class ClusterVariableIndex extends AbstractIndexDescriptor implements Prio5Backup {
+
+  public static final String INDEX_NAME = "cluster-variable";
+  public static final String INDEX_VERSION = "8.9.0";
+
+  public static final String ID = "id";
+  public static final String NAME = "name";
+  public static final String VALUE = "value";
+  public static final String FULL_VALUE = "fullValue";
+  public static final String SCOPE = "scope";
+  public static final String RESOURCE_ID = "resourceId";
+  public static final String IS_PREVIEW = "isPreview";
+
+  public ClusterVariableIndex(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public Optional<String> getTenantIdField() {
+    return Optional.of(TENANT_ID);
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -11,7 +11,6 @@ import static io.camunda.webapps.schema.descriptors.ComponentNames.CAMUNDA;
 
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
-import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import java.util.Optional;
 
 public class ClusterVariableIndex extends AbstractIndexDescriptor implements Prio5Backup {
@@ -49,13 +48,5 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   @Override
   public String getComponentName() {
     return CAMUNDA.toString();
-  }
-
-  public static String generateID(
-      final String name, final String tenantId, final ClusterVariableScope scope) {
-    return switch (scope) {
-      case GLOBAL -> String.format("%s-%s", name, scope);
-      case TENANT -> String.format("%s-%s-%s", name, tenantId, scope);
-    };
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -56,10 +56,6 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
     return switch (scope) {
       case GLOBAL -> String.format("%s-%s", name, scope);
       case TENANT -> String.format("%s-%s-%s", name, tenantId, scope);
-      // This should never happen, as any other scope would be rejected by the processor before
-      // mutating the state, as the safety check, but we need a default case for the switch
-      // expression
-      default -> String.format("%s-%s", name, scope);
     };
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -52,13 +52,14 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   }
 
   public static String generateID(
-      final String name, final String resourceId, final ClusterVariableScope scope) {
+      final String name, final String tenantId, final ClusterVariableScope scope) {
     return switch (scope) {
       case GLOBAL -> String.format("%s-%s", name, scope);
-      case TENANT -> String.format("%s-%s-%s", name, resourceId, scope);
-      default ->
-          throw new IllegalStateException(
-              "Cluster variable with unspecified scope can not be exported: " + scope);
+      case TENANT -> String.format("%s-%s-%s", name, tenantId, scope);
+      // This should never happen, as any other scope would be rejected by the processor before
+      // mutating the state, as the safety check, but we need a default case for the switch
+      // expression
+      default -> String.format("%s-%s", name, scope);
     };
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -7,21 +7,18 @@
  */
 package io.camunda.webapps.schema.entities.clustervariable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import java.util.Arrays;
 import java.util.Objects;
 
 public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEntity> {
 
-  private String clusterVariableId;
+  private String id;
   private String name;
   private String value;
   private String fullValue;
   private boolean isPreview;
-  private String scope;
-  private String resourceId;
-  @JsonIgnore private Object[] sortValues;
+  private ClusterVariableScope scope;
+  private String tenantId;
 
   public boolean isPreview() {
     return isPreview;
@@ -32,11 +29,11 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
     return this;
   }
 
-  public String getScope() {
+  public ClusterVariableScope getScope() {
     return scope;
   }
 
-  public ClusterVariableEntity setScope(final String scope) {
+  public ClusterVariableEntity setScope(final ClusterVariableScope scope) {
     this.scope = scope;
     return this;
   }
@@ -52,12 +49,12 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
 
   @Override
   public String getId() {
-    return clusterVariableId;
+    return id;
   }
 
   @Override
   public ClusterVariableEntity setId(final String id) {
-    clusterVariableId = id;
+    this.id = id;
     return this;
   }
 
@@ -79,17 +76,18 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
     return this;
   }
 
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public ClusterVariableEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(
-        clusterVariableId,
-        name,
-        value,
-        fullValue,
-        isPreview,
-        scope,
-        resourceId,
-        Arrays.hashCode(sortValues));
+    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId);
   }
 
   @Override
@@ -99,20 +97,19 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
     }
     final ClusterVariableEntity that = (ClusterVariableEntity) o;
     return isPreview == that.isPreview
-        && Objects.equals(clusterVariableId, that.clusterVariableId)
+        && Objects.equals(id, that.id)
         && Objects.equals(name, that.name)
         && Objects.equals(value, that.value)
         && Objects.equals(fullValue, that.fullValue)
-        && Objects.equals(scope, that.scope)
-        && Objects.equals(resourceId, that.resourceId)
-        && Objects.deepEquals(sortValues, that.sortValues);
+        && scope == that.scope
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override
   public String toString() {
     return "ClusterVariableEntity{"
-        + "clusterVariableId='"
-        + clusterVariableId
+        + "id='"
+        + id
         + '\''
         + ", name='"
         + name
@@ -125,32 +122,11 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         + '\''
         + ", isPreview="
         + isPreview
-        + ", scope='"
+        + ", scope="
         + scope
+        + ", tenantId='"
+        + tenantId
         + '\''
-        + ", resourceId='"
-        + resourceId
-        + '\''
-        + ", sortValues="
-        + Arrays.toString(sortValues)
         + '}';
-  }
-
-  public Object[] getSortValues() {
-    return sortValues;
-  }
-
-  public ClusterVariableEntity setSortValues(final Object[] sortValues) {
-    this.sortValues = sortValues;
-    return this;
-  }
-
-  public String getResourceId() {
-    return resourceId;
-  }
-
-  public ClusterVariableEntity setResourceId(final String resourceId) {
-    this.resourceId = resourceId;
-    return this;
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.clustervariable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEntity> {
+
+  private String clusterVariableId;
+  private String name;
+  private String value;
+  private String fullValue;
+  private boolean isPreview;
+  private String scope;
+  private String resourceId;
+  @JsonIgnore private Object[] sortValues;
+
+  public boolean isPreview() {
+    return isPreview;
+  }
+
+  public ClusterVariableEntity setPreview(final boolean preview) {
+    isPreview = preview;
+    return this;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public ClusterVariableEntity setScope(final String scope) {
+    this.scope = scope;
+    return this;
+  }
+
+  public String getFullValue() {
+    return fullValue;
+  }
+
+  public ClusterVariableEntity setFullValue(final String fullValue) {
+    this.fullValue = fullValue;
+    return this;
+  }
+
+  @Override
+  public String getId() {
+    return clusterVariableId;
+  }
+
+  @Override
+  public ClusterVariableEntity setId(final String id) {
+    clusterVariableId = id;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ClusterVariableEntity setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public ClusterVariableEntity setValue(final String value) {
+    this.value = value;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        clusterVariableId,
+        name,
+        value,
+        fullValue,
+        isPreview,
+        scope,
+        resourceId,
+        Arrays.hashCode(sortValues));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ClusterVariableEntity that = (ClusterVariableEntity) o;
+    return isPreview == that.isPreview
+        && Objects.equals(clusterVariableId, that.clusterVariableId)
+        && Objects.equals(name, that.name)
+        && Objects.equals(value, that.value)
+        && Objects.equals(fullValue, that.fullValue)
+        && Objects.equals(scope, that.scope)
+        && Objects.equals(resourceId, that.resourceId)
+        && Objects.deepEquals(sortValues, that.sortValues);
+  }
+
+  @Override
+  public String toString() {
+    return "ClusterVariableEntity{"
+        + "clusterVariableId='"
+        + clusterVariableId
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", value='"
+        + value
+        + '\''
+        + ", fullValue='"
+        + fullValue
+        + '\''
+        + ", isPreview="
+        + isPreview
+        + ", scope='"
+        + scope
+        + '\''
+        + ", resourceId='"
+        + resourceId
+        + '\''
+        + ", sortValues="
+        + Arrays.toString(sortValues)
+        + '}';
+  }
+
+  public Object[] getSortValues() {
+    return sortValues;
+  }
+
+  public ClusterVariableEntity setSortValues(final Object[] sortValues) {
+    this.sortValues = sortValues;
+    return this;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public ClusterVariableEntity setResourceId(final String resourceId) {
+    this.resourceId = resourceId;
+    return this;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableScope.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableScope.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.clustervariable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum ClusterVariableScope {
+  GLOBAL,
+  TENANT,
+  UNSPECIFIED;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableScope.class);
+
+  public static ClusterVariableScope fromProtocol(final String scope) {
+    return switch (scope) {
+      case "GLOBAL" -> GLOBAL;
+      case "TENANT" -> TENANT;
+      default -> {
+        LOGGER.error(
+            "Unknown cluster variable scope received from protocol: {}. Defaulting to UNSPECIFIED.",
+            scope);
+        yield UNSPECIFIED;
+      }
+    };
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableScope.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableScope.java
@@ -12,20 +12,21 @@ import org.slf4j.LoggerFactory;
 
 public enum ClusterVariableScope {
   GLOBAL,
-  TENANT,
-  UNSPECIFIED;
-
+  TENANT;
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableScope.class);
 
   public static ClusterVariableScope fromProtocol(final String scope) {
     return switch (scope) {
       case "GLOBAL" -> GLOBAL;
       case "TENANT" -> TENANT;
+      // This should never happen, as any other scope would be rejected by the processor before
+      // mutating the state, as the safety check, but we need a default case for the switch
+      // expression
       default -> {
         LOGGER.error(
-            "Unknown cluster variable scope received from protocol: {}. Defaulting to UNSPECIFIED.",
+            "Unknown cluster variable scope received from protocol: {}. Defaulting to GLOBAL.",
             scope);
-        yield UNSPECIFIED;
+        yield GLOBAL;
       }
     };
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableScope.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableScope.java
@@ -15,10 +15,11 @@ public enum ClusterVariableScope {
   TENANT;
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableScope.class);
 
-  public static ClusterVariableScope fromProtocol(final String scope) {
+  public static ClusterVariableScope fromProtocol(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableScope scope) {
     return switch (scope) {
-      case "GLOBAL" -> GLOBAL;
-      case "TENANT" -> TENANT;
+      case GLOBAL -> GLOBAL;
+      case TENANT -> TENANT;
       // This should never happen, as any other scope would be rejected by the processor before
       // mutating the state, as the safety check, but we need a default case for the switch
       // expression

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
@@ -1,0 +1,30 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "scope": {
+        "type": "keyword"
+      },
+      "resourceId": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "fullValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "isPreview": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
@@ -11,7 +11,7 @@
       "scope": {
         "type": "keyword"
       },
-      "resourceId": {
+      "tenantId": {
         "type": "keyword"
       },
       "value": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
@@ -1,0 +1,30 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "scope": {
+        "type": "keyword"
+      },
+      "resourceId": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "fullValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "isPreview": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
@@ -11,7 +11,7 @@
       "scope": {
         "type": "keyword"
       },
-      "resourceId": {
+      "tenantId": {
         "type": "keyword"
       },
       "value": {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -219,8 +219,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new ClusterVariableDeletedHandler(
-                indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
-                configuration.getIndex().getVariableSizeThreshold()),
+                indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName()),
             new VariableHandler(
                 indexDescriptors.get(VariableTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.errorhandling.ErrorHandler;
 import io.camunda.exporter.errorhandling.ErrorHandlers;
 import io.camunda.exporter.handlers.AuthorizationCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.AuthorizationDeletedHandler;
+import io.camunda.exporter.handlers.ClusterVariableHandler;
 import io.camunda.exporter.handlers.CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler;
 import io.camunda.exporter.handlers.CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.DecisionEvaluationHandler;
@@ -84,6 +85,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
@@ -212,6 +214,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewVariableFromVariableHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+            new ClusterVariableHandler(
+                indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
+                configuration.getIndex().getVariableSizeThreshold()),
             new VariableHandler(
                 indexDescriptors.get(VariableTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -17,7 +17,8 @@ import io.camunda.exporter.errorhandling.ErrorHandler;
 import io.camunda.exporter.errorhandling.ErrorHandlers;
 import io.camunda.exporter.handlers.AuthorizationCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.AuthorizationDeletedHandler;
-import io.camunda.exporter.handlers.ClusterVariableHandler;
+import io.camunda.exporter.handlers.ClusterVariableCreatedHandler;
+import io.camunda.exporter.handlers.ClusterVariableDeletedHandler;
 import io.camunda.exporter.handlers.CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler;
 import io.camunda.exporter.handlers.CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.DecisionEvaluationHandler;
@@ -214,7 +215,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewVariableFromVariableHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
-            new ClusterVariableHandler(
+            new ClusterVariableCreatedHandler(
+                indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
+                configuration.getIndex().getVariableSizeThreshold()),
+            new ClusterVariableDeletedHandler(
                 indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new VariableHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandler.java
@@ -45,7 +45,8 @@ public class ClusterVariableCreatedHandler
 
   @Override
   public boolean handlesRecord(final Record<ClusterVariableRecordValue> record) {
-    return SUPPORTED_INTENT.equals(record.getIntent());
+    return getHandledValueType().equals(record.getValueType())
+        && SUPPORTED_INTENT.equals(record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandler.java
@@ -69,12 +69,7 @@ public class ClusterVariableCreatedHandler
       final Record<ClusterVariableRecordValue> record, final ClusterVariableEntity entity) {
     final var recordValue = record.getValue();
     entity
-        .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope().name()))
-        .setId(
-            ClusterVariableIndex.generateID(
-                recordValue.getName(),
-                recordValue.getTenantId(),
-                ClusterVariableScope.fromProtocol(recordValue.getScope().toString())))
+        .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope().toString()))
         .setName(recordValue.getName());
 
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClusterVariableDeletedHandler
+    implements ExportHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableDeletedHandler.class);
+  private static final ClusterVariableIntent SUPPORTED_INTENT = ClusterVariableIntent.DELETED;
+  private final String indexName;
+  private final int variableSizeThreshold;
+
+  public ClusterVariableDeletedHandler(final String indexName, final int variableSizeThreshold) {
+    this.indexName = indexName;
+    this.variableSizeThreshold = variableSizeThreshold;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.CLUSTER_VARIABLE;
+  }
+
+  @Override
+  public Class<ClusterVariableEntity> getEntityType() {
+    return ClusterVariableEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ClusterVariableRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && SUPPORTED_INTENT.equals(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ClusterVariableRecordValue> record) {
+    final var recordValue = record.getValue();
+    return List.of(
+        ClusterVariableIndex.generateID(
+            recordValue.getName(),
+            recordValue.getTenantId(),
+            ClusterVariableScope.fromProtocol(recordValue.getScope().toString())));
+  }
+
+  @Override
+  public ClusterVariableEntity createNewEntity(final String id) {
+    return new ClusterVariableEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ClusterVariableRecordValue> record, final ClusterVariableEntity entity) {
+    final var recordValue = record.getValue();
+    entity
+        .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope().name()))
+        .setId(
+            ClusterVariableIndex.generateID(
+                recordValue.getName(),
+                recordValue.getTenantId(),
+                ClusterVariableScope.fromProtocol(recordValue.getScope().toString())))
+        .setName(recordValue.getName());
+
+    if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
+      entity.setTenantId(recordValue.getTenantId());
+    }
+
+    if (recordValue.getValue().length() > variableSizeThreshold) {
+      entity.setValue(recordValue.getValue().substring(0, variableSizeThreshold));
+      entity.setFullValue(recordValue.getValue());
+      entity.setPreview(true);
+    } else {
+      entity.setValue(recordValue.getValue());
+      entity.setFullValue(null);
+      entity.setPreview(false);
+    }
+  }
+
+  @Override
+  public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.delete(indexName, entity.getId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
@@ -67,29 +67,7 @@ public class ClusterVariableDeletedHandler
   @Override
   public void updateEntity(
       final Record<ClusterVariableRecordValue> record, final ClusterVariableEntity entity) {
-    final var recordValue = record.getValue();
-    entity
-        .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope().name()))
-        .setId(
-            ClusterVariableIndex.generateID(
-                recordValue.getName(),
-                recordValue.getTenantId(),
-                ClusterVariableScope.fromProtocol(recordValue.getScope().toString())))
-        .setName(recordValue.getName());
-
-    if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
-      entity.setTenantId(recordValue.getTenantId());
-    }
-
-    if (recordValue.getValue().length() > variableSizeThreshold) {
-      entity.setValue(recordValue.getValue().substring(0, variableSizeThreshold));
-      entity.setFullValue(recordValue.getValue());
-      entity.setPreview(true);
-    } else {
-      entity.setValue(recordValue.getValue());
-      entity.setFullValue(null);
-      entity.setPreview(false);
-    }
+    // no-op since the entity will be deleted
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
@@ -9,28 +9,22 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
+import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
-import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ClusterVariableDeletedHandler
     implements ExportHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableDeletedHandler.class);
   private static final ClusterVariableIntent SUPPORTED_INTENT = ClusterVariableIntent.DELETED;
   private final String indexName;
-  private final int variableSizeThreshold;
 
-  public ClusterVariableDeletedHandler(final String indexName, final int variableSizeThreshold) {
+  public ClusterVariableDeletedHandler(final String indexName) {
     this.indexName = indexName;
-    this.variableSizeThreshold = variableSizeThreshold;
   }
 
   @Override
@@ -53,10 +47,11 @@ public class ClusterVariableDeletedHandler
   public List<String> generateIds(final Record<ClusterVariableRecordValue> record) {
     final var recordValue = record.getValue();
     return List.of(
-        ClusterVariableIndex.generateID(
+        ClusterVariableUtil.generateID(
             recordValue.getName(),
             recordValue.getTenantId(),
-            ClusterVariableScope.fromProtocol(recordValue.getScope().toString())));
+            io.camunda.search.entities.ClusterVariableScope.valueOf(
+                recordValue.getScope().name())));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableHandler.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class ClusterVariableHandler
+    implements ExportHandler<ClusterVariableEntity, ClusterVariableRecordValue> {
+
+  private static final Set<ClusterVariableIntent> SUPPORTED_INTENTS =
+      EnumSet.of(ClusterVariableIntent.CREATED, ClusterVariableIntent.DELETED);
+  private final String indexName;
+  private final int variableSizeThreshold;
+
+  public ClusterVariableHandler(final String indexName, final int variableSizeThreshold) {
+    this.indexName = indexName;
+    this.variableSizeThreshold = variableSizeThreshold;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.CLUSTER_VARIABLE;
+  }
+
+  @Override
+  public Class<ClusterVariableEntity> getEntityType() {
+    return ClusterVariableEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ClusterVariableRecordValue> record) {
+    return SUPPORTED_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ClusterVariableRecordValue> record) {
+    final var recordValue = record.getValue();
+    switch (recordValue.getScope()) {
+      case GLOBAL -> {
+        return List.of(recordValue.getName());
+      }
+      case TENANT -> {
+        return List.of(String.format("%s-%s", recordValue.getName(), recordValue.getTenantId()));
+      }
+      default ->
+          throw new IllegalArgumentException(
+              "Cluster variable with unspecified scope can not be exported");
+    }
+  }
+
+  @Override
+  public ClusterVariableEntity createNewEntity(final String id) {
+    return new ClusterVariableEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ClusterVariableRecordValue> record, final ClusterVariableEntity entity) {
+    final var recordValue = record.getValue();
+
+    switch (recordValue.getScope()) {
+      case GLOBAL -> entity.setScope("GLOBAL").setId(recordValue.getName());
+      case TENANT ->
+          entity
+              .setScope("TENANT")
+              .setResourceId(recordValue.getTenantId())
+              .setId(String.format("%s-%s", recordValue.getName(), recordValue.getTenantId()));
+      default ->
+          throw new IllegalArgumentException(
+              "Cluster variable with unspecified scope can not be exported");
+    }
+
+    entity.setName(recordValue.getName());
+
+    if (recordValue.getValue().length() > variableSizeThreshold) {
+      entity.setValue(recordValue.getValue().substring(0, variableSizeThreshold));
+      entity.setFullValue(recordValue.getValue());
+      entity.setPreview(true);
+    } else {
+      entity.setValue(recordValue.getValue());
+      entity.setFullValue(null);
+      entity.setPreview(false);
+    }
+  }
+
+  @Override
+  public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandlerTest.java
@@ -173,7 +173,7 @@ public class ClusterVariableCreatedHandlerTest {
     assertThat(clusterVariableEntity.getScope())
         .isEqualTo(
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
-                clusterVariableRecordValue.getScope().toString()));
+                clusterVariableRecordValue.getScope()));
     assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
     assertThat(clusterVariableEntity.isPreview()).isFalse();
     assertThat(clusterVariableEntity.getFullValue()).isNull();
@@ -206,7 +206,7 @@ public class ClusterVariableCreatedHandlerTest {
     assertThat(clusterVariableEntity.getScope())
         .isEqualTo(
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
-                clusterVariableRecordValue.getScope().toString()));
+                clusterVariableRecordValue.getScope()));
     assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
     assertThat(clusterVariableEntity.isPreview()).isFalse();
     assertThat(clusterVariableEntity.getFullValue()).isNull();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandlerTest.java
@@ -169,8 +169,6 @@ public class ClusterVariableCreatedHandlerTest {
     underTest.updateEntity(variableRecord, clusterVariableEntity);
 
     // then
-    assertThat(clusterVariableEntity.getId())
-        .isEqualTo(clusterVariableRecordValue.getName() + "-GLOBAL");
     assertThat(clusterVariableEntity.getName()).isEqualTo(clusterVariableRecordValue.getName());
     assertThat(clusterVariableEntity.getScope())
         .isEqualTo(
@@ -202,12 +200,6 @@ public class ClusterVariableCreatedHandlerTest {
     underTest.updateEntity(variableRecord, clusterVariableEntity);
 
     // then
-    assertThat(clusterVariableEntity.getId())
-        .isEqualTo(
-            "%s-%s-TENANT"
-                .formatted(
-                    clusterVariableRecordValue.getName(),
-                    clusterVariableRecordValue.getTenantId()));
     assertThat(clusterVariableEntity.getName()).isEqualTo(clusterVariableRecordValue.getName());
     assertThat(clusterVariableEntity.getTenantId())
         .isEqualTo(clusterVariableRecordValue.getTenantId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
@@ -117,48 +117,4 @@ public class ClusterVariableDeletedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
     verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
   }
-
-  @Test
-  void shouldUpdateGlobalClusterEntityFromRecord() {
-    final ClusterVariableRecordValue value =
-        ImmutableClusterVariableRecordValue.builder()
-            .from(factory.generateObject(ClusterVariableRecordValue.class))
-            .withScope(ClusterVariableScope.GLOBAL)
-            .build();
-    final Record<ClusterVariableRecordValue> record =
-        factory.generateRecord(
-            ValueType.CLUSTER_VARIABLE,
-            r -> r.withIntent(ClusterVariableIntent.DELETED).withValue(value));
-    final ClusterVariableEntity entity = new ClusterVariableEntity();
-    underTest.updateEntity(record, entity);
-    assertThat(entity.getId()).isEqualTo(value.getName() + "-GLOBAL");
-    assertThat(entity.getName()).isEqualTo(value.getName());
-    assertThat(entity.getScope())
-        .isEqualTo(
-            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
-                value.getScope().toString()));
-  }
-
-  @Test
-  void shouldUpdateTenantClusterEntityFromRecord() {
-    final ClusterVariableRecordValue value =
-        ImmutableClusterVariableRecordValue.builder()
-            .from(factory.generateObject(ClusterVariableRecordValue.class))
-            .withScope(ClusterVariableScope.TENANT)
-            .withTenantId("tenantId")
-            .build();
-    final Record<ClusterVariableRecordValue> record =
-        factory.generateRecord(
-            ValueType.CLUSTER_VARIABLE,
-            r -> r.withIntent(ClusterVariableIntent.DELETED).withValue(value));
-    final ClusterVariableEntity entity = new ClusterVariableEntity();
-    underTest.updateEntity(record, entity);
-    assertThat(entity.getId()).isEqualTo(value.getName() + "-" + value.getTenantId() + "-TENANT");
-    assertThat(entity.getName()).isEqualTo(value.getName());
-    assertThat(entity.getTenantId()).isEqualTo(value.getTenantId());
-    assertThat(entity.getScope())
-        .isEqualTo(
-            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
-                value.getScope().toString()));
-  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
@@ -29,9 +29,8 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 public class ClusterVariableDeletedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "clusterVariable";
-  private final int variableSizeThreshold = 10;
   private final ClusterVariableDeletedHandler underTest =
-      new ClusterVariableDeletedHandler(indexName, variableSizeThreshold);
+      new ClusterVariableDeletedHandler(indexName);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+public class ClusterVariableDeletedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "clusterVariable";
+  private final int variableSizeThreshold = 10;
+  private final ClusterVariableDeletedHandler underTest =
+      new ClusterVariableDeletedHandler(indexName, variableSizeThreshold);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.CLUSTER_VARIABLE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(ClusterVariableEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"DELETED"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecord(final ClusterVariableIntent intent) {
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent));
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"DELETED"},
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final ClusterVariableIntent intent) {
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent));
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIdsForGlobalClusterVariable() {
+    final ClusterVariableRecordValue value =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .build();
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.DELETED).withValue(value));
+    final var idList = underTest.generateIds(record);
+    assertThat(idList).containsExactly(value.getName() + "-GLOBAL");
+  }
+
+  @Test
+  void shouldGenerateIdsForTenantClusterVariable() {
+    final ClusterVariableRecordValue value =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.TENANT)
+            .withTenantId("tenantId")
+            .build();
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.DELETED).withValue(value));
+    final var idList = underTest.generateIds(record);
+    assertThat(idList).containsExactly(value.getName() + "-" + value.getTenantId() + "-TENANT");
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    final var result = underTest.createNewEntity("id");
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldDeleteEntityOnFlush() {
+    final ClusterVariableEntity inputEntity =
+        new ClusterVariableEntity()
+            .setId("id")
+            .setName("key")
+            .setValue("value")
+            .setTenantId("tenantId")
+            .setScope(
+                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+    underTest.flush(inputEntity, mockRequest);
+    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+  }
+
+  @Test
+  void shouldUpdateGlobalClusterEntityFromRecord() {
+    final ClusterVariableRecordValue value =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .build();
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.DELETED).withValue(value));
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+    assertThat(entity.getId()).isEqualTo(value.getName() + "-GLOBAL");
+    assertThat(entity.getName()).isEqualTo(value.getName());
+    assertThat(entity.getScope())
+        .isEqualTo(
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
+                value.getScope().toString()));
+  }
+
+  @Test
+  void shouldUpdateTenantClusterEntityFromRecord() {
+    final ClusterVariableRecordValue value =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.TENANT)
+            .withTenantId("tenantId")
+            .build();
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.DELETED).withValue(value));
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+    assertThat(entity.getId()).isEqualTo(value.getName() + "-" + value.getTenantId() + "-TENANT");
+    assertThat(entity.getName()).isEqualTo(value.getName());
+    assertThat(entity.getTenantId()).isEqualTo(value.getTenantId());
+    assertThat(entity.getScope())
+        .isEqualTo(
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
+                value.getScope().toString()));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableHandlerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+public class ClusterVariableHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "clusterVariable";
+  private final int variableSizeThreshold = 10;
+  private final ClusterVariableHandler underTest =
+      new ClusterVariableHandler(indexName, variableSizeThreshold);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.CLUSTER_VARIABLE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(ClusterVariableEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATE", "DELETE", "UPDATE", "UPDATED"},
+      mode = Mode.EXCLUDE)
+  void shouldHandleRecord(final ClusterVariableIntent intent) {
+    // given
+    final Record<ClusterVariableRecordValue> decisionRecord =
+        factory.generateRecord(ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(decisionRecord)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATED", "DELETED"},
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final ClusterVariableIntent intent) {
+    // given
+    final Record<ClusterVariableRecordValue> decisionRecord =
+        factory.generateRecord(ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(decisionRecord)).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIdsForGlobalClusterVariable() {
+    // given
+    final ClusterVariableRecordValue clusterVariableRecordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .build();
+
+    final Record<ClusterVariableRecordValue> clusterVariableRecordValueRecord =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(clusterVariableRecordValue));
+
+    // when
+    final var idList = underTest.generateIds(clusterVariableRecordValueRecord);
+
+    // then
+    assertThat(idList).containsExactly(clusterVariableRecordValue.getName());
+  }
+
+  @Test
+  void shouldGenerateIdsForGlobalTenantVariable() {
+    // given
+    final ClusterVariableRecordValue clusterVariableRecordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.TENANT)
+            .withTenantId("tenantId")
+            .build();
+
+    final Record<ClusterVariableRecordValue> clusterVariableRecordValueRecord =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(clusterVariableRecordValue));
+
+    // when
+    final var idList = underTest.generateIds(clusterVariableRecordValueRecord);
+
+    // then
+    assertThat(idList)
+        .containsExactly(
+            clusterVariableRecordValue.getName() + "-" + clusterVariableRecordValue.getTenantId());
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final ClusterVariableEntity inputEntity =
+        new ClusterVariableEntity()
+            .setId("id")
+            .setName("key")
+            .setValue("value")
+            .setResourceId("tenantId")
+            .setScope("TENANT");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+
+  @Test
+  void shouldUpdateGlobalClusterEntityFromRecord() {
+    // given
+    final ClusterVariableRecordValue clusterVariableRecordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withValue("v".repeat(variableSizeThreshold))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .build();
+
+    final Record<ClusterVariableRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(clusterVariableRecordValue));
+
+    // when
+    final ClusterVariableEntity clusterVariableEntity = new ClusterVariableEntity();
+    underTest.updateEntity(variableRecord, clusterVariableEntity);
+
+    // then
+    assertThat(clusterVariableEntity.getId()).isEqualTo(clusterVariableRecordValue.getName());
+    assertThat(clusterVariableEntity.getName()).isEqualTo(clusterVariableRecordValue.getName());
+    assertThat(clusterVariableEntity.getScope())
+        .isEqualTo(clusterVariableRecordValue.getScope().toString());
+    assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
+    assertThat(clusterVariableEntity.isPreview()).isFalse();
+    assertThat(clusterVariableEntity.getFullValue()).isNull();
+  }
+
+  @Test
+  void shouldUpdateTenantClusterEntityFromRecord() {
+    // given
+    final ClusterVariableRecordValue clusterVariableRecordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withValue("v".repeat(variableSizeThreshold))
+            .withScope(ClusterVariableScope.TENANT)
+            .withTenantId("tenantId")
+            .build();
+
+    final Record<ClusterVariableRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(clusterVariableRecordValue));
+
+    // when
+    final ClusterVariableEntity clusterVariableEntity = new ClusterVariableEntity();
+    underTest.updateEntity(variableRecord, clusterVariableEntity);
+
+    // then
+    assertThat(clusterVariableEntity.getId())
+        .isEqualTo(
+            "%s-%s"
+                .formatted(
+                    clusterVariableRecordValue.getName(),
+                    clusterVariableRecordValue.getTenantId()));
+    assertThat(clusterVariableEntity.getName()).isEqualTo(clusterVariableRecordValue.getName());
+    assertThat(clusterVariableEntity.getResourceId())
+        .isEqualTo(clusterVariableRecordValue.getTenantId());
+    assertThat(clusterVariableEntity.getScope())
+        .isEqualTo(clusterVariableRecordValue.getScope().toString());
+    assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
+    assertThat(clusterVariableEntity.isPreview()).isFalse();
+    assertThat(clusterVariableEntity.getFullValue()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordWithFullValue() {
+
+    // given
+    final ClusterVariableRecordValue clusterVariableRecordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withValue("v".repeat(variableSizeThreshold + 1))
+            .withTenantId("tenantId")
+            .build();
+
+    final Record<ClusterVariableRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(clusterVariableRecordValue));
+
+    // when
+    final ClusterVariableEntity clusterVariableEntity = new ClusterVariableEntity();
+    underTest.updateEntity(variableRecord, clusterVariableEntity);
+
+    // then
+    assertThat(clusterVariableEntity.getValue()).isEqualTo("v".repeat(variableSizeThreshold));
+    assertThat(clusterVariableEntity.getFullValue())
+        .isEqualTo("v".repeat(variableSizeThreshold + 1));
+    assertThat(clusterVariableEntity.isPreview()).isTrue();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.exporter.rdbms.cache.RdbmsBatchOperationCacheLoader;
 import io.camunda.exporter.rdbms.cache.RdbmsProcessCacheLoader;
+import io.camunda.exporter.rdbms.handlers.ClusterVariableExportHandler;
 import io.camunda.exporter.rdbms.handlers.CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.handlers.CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.handlers.DecisionDefinitionExportHandler;
@@ -171,6 +172,9 @@ public class RdbmsExporterWrapper implements Exporter {
         new FlowNodeExportHandler(rdbmsWriter.getFlowNodeInstanceWriter(), processCache));
     builder.withHandler(
         ValueType.VARIABLE, new VariableExportHandler(rdbmsWriter.getVariableWriter()));
+    builder.withHandler(
+        ValueType.CLUSTER_VARIABLE,
+        new ClusterVariableExportHandler(rdbmsWriter.getClusterVariableWriter()));
     builder.withHandler(
         ValueType.USER_TASK,
         new UserTaskExportHandler(rdbmsWriter.getUserTaskWriter(), processCache));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.rdbms.handlers;
 
+import static io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL;
+
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
@@ -42,12 +44,16 @@ public class ClusterVariableExportHandler
   }
 
   private ClusterVariableDbModel map(final Record<ClusterVariableRecordValue> record) {
-    final ClusterVariableRecordValue value = record.getValue();
-    return new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
-        .name(value.getName())
-        .value(value.getValue())
-        .scope(ClusterVariableScope.valueOf(record.getValue().getScope().name()))
-        .tenantId(value.getTenantId())
-        .build();
+    final var value = record.getValue();
+    final var builder =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+            .name(value.getName())
+            .value(value.getValue());
+    if (value.getScope() == GLOBAL) {
+      builder.scope(ClusterVariableScope.GLOBAL).tenantId(null);
+    } else {
+      builder.scope(ClusterVariableScope.TENANT).tenantId(value.getTenantId());
+    }
+    return builder.build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -10,7 +10,9 @@ package io.camunda.exporter.rdbms.handlers;
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 
@@ -25,8 +27,9 @@ public class ClusterVariableExportHandler
 
   @Override
   public boolean canExport(final Record<ClusterVariableRecordValue> record) {
-    return record.getIntent() == ClusterVariableIntent.CREATED
-        || record.getIntent() == ClusterVariableIntent.DELETED;
+    return record.getValueType() == ValueType.CLUSTER_VARIABLE
+        && (record.getIntent() == ClusterVariableIntent.CREATED
+            || record.getIntent() == ClusterVariableIntent.DELETED);
   }
 
   @Override
@@ -43,8 +46,8 @@ public class ClusterVariableExportHandler
     return new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
         .name(value.getName())
         .value(value.getValue())
-        .scope(value.getScope().name())
-        .resourceId(value.getTenantId())
+        .scope(ClusterVariableScope.valueOf(record.getValue().getScope().name()))
+        .tenantId(value.getTenantId())
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+
+public class ClusterVariableExportHandler
+    implements RdbmsExportHandler<ClusterVariableRecordValue> {
+
+  private final ClusterVariableWriter clusterVariableWriter;
+
+  public ClusterVariableExportHandler(final ClusterVariableWriter clusterVariableWriter) {
+    this.clusterVariableWriter = clusterVariableWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<ClusterVariableRecordValue> record) {
+    return record.getIntent() == ClusterVariableIntent.CREATED
+        || record.getIntent() == ClusterVariableIntent.DELETED;
+  }
+
+  @Override
+  public void export(final Record<ClusterVariableRecordValue> record) {
+    if (record.getIntent() == ClusterVariableIntent.CREATED) {
+      clusterVariableWriter.create(map(record));
+    } else if (record.getIntent() == ClusterVariableIntent.DELETED) {
+      clusterVariableWriter.delete(map(record));
+    }
+  }
+
+  private ClusterVariableDbModel map(final Record<ClusterVariableRecordValue> record) {
+    final ClusterVariableRecordValue value = record.getValue();
+    return new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+        .name(value.getName())
+        .value(value.getValue())
+        .scope(value.getScope().name())
+        .resourceId(value.getTenantId())
+        .build();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -50,13 +50,11 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
   /**
    * Returns the current value of the variable.
    *
-   * <p>The returned object is deserialized based on the stored format. It may be a {@link String},
-   * {@link Number}, {@link Boolean}, {@link java.util.Map}, {@link java.util.List}, or another
-   * serializable type.
+   * <p>The returned object is deserialized based on the stored format.
    *
-   * @return the variable value
+   * @return the variable value as String (never {@code null})
    */
-  Object getValue();
+  String getValue();
 
   /**
    * Returns the scope in which this variable is defined.


### PR DESCRIPTION
This pull request introduces support for cluster-level variables in the RDBMS schema and service layers. The main changes include adding a new `CLUSTER_VARIABLE` table to the database schema, implementing the necessary Java domain, service, and mapper classes to read and write cluster variables, and updating the main service and writer classes to expose cluster variable functionality.

**Database schema changes:**

* Added a new `CLUSTER_VARIABLE` table to the RDBMS schema, including columns for variable ID, name, type, values, preview flag, resource ID, and scope. Also added an index on `RESOURCE_ID` and Oracle-specific handling for large VARCHAR columns.

**Service and domain layer additions:**

* Introduced `ClusterVariableDbQuery` for querying cluster variables, and `ClusterVariableDbReader` for reading cluster variables from the database, including support for filtering, sorting, paging, and access checks. [[1]](diffhunk://#diff-4c83772ebc36537c90d6f8e22d6a561519afe9111e69e07d6ee31fbb9b4d1b08R1-R89) [[2]](diffhunk://#diff-8592766487dfbb6fa0cbe624dd0cd812c14a4e9f31a467a06ab46082a361d41fR1-R90)
* Added `ClusterVariableMapper` interface for MyBatis mapping of cluster variable queries and mutations.
* Defined `ClusterVariableSearchColumn` enum for cluster variable entity column mapping.

**Integration with main service and writer classes:**

* Updated `RdbmsService` and `RdbmsWriter` classes to include and expose cluster variable reader and writer functionality, including constructor and getter updates. [[1]](diffhunk://#diff-c1a576aeb5cf9e81ae3648856c860c9749b0a4a1556381b3fe1e2452f799cb50R13) [[2]](diffhunk://#diff-c1a576aeb5cf9e81ae3648856c860c9749b0a4a1556381b3fe1e2452f799cb50R59) [[3]](diffhunk://#diff-c1a576aeb5cf9e81ae3648856c860c9749b0a4a1556381b3fe1e2452f799cb50R90) [[4]](diffhunk://#diff-c1a576aeb5cf9e81ae3648856c860c9749b0a4a1556381b3fe1e2452f799cb50R121) [[5]](diffhunk://#diff-c1a576aeb5cf9e81ae3648856c860c9749b0a4a1556381b3fe1e2452f799cb50R190-R193) [[6]](diffhunk://#diff-24b0a420399262a06e830e6c925c13c00fb8046f172da4c8d2226313e1fcf99cR13) [[7]](diffhunk://#diff-24b0a420399262a06e830e6c925c13c00fb8046f172da4c8d2226313e1fcf99cR30) [[8]](diffhunk://#diff-24b0a420399262a06e830e6c925c13c00fb8046f172da4c8d2226313e1fcf99cR72) [[9]](diffhunk://#diff-24b0a420399262a06e830e6c925c13c00fb8046f172da4c8d2226313e1fcf99cL105-R109) [[10]](diffhunk://#diff-24b0a420399262a06e830e6c925c13c00fb8046f172da4c8d2226313e1fcf99cR147) [[11]](diffhunk://#diff-24b0a420399262a06e830e6c925c13c00fb8046f172da4c8d2226313e1fcf99cR212-R215)

**Factory updates:**

* Modified `RdbmsWriterFactory` to accept and manage the new `ClusterVariableMapper` for writer instantiation. [[1]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfR13) [[2]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfR53) [[3]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfL72-R75) [[4]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfR95)

**Minor schema formatting:**

* Reformatted index creation statements for readability in the schema changelog file. [[1]](diffhunk://#diff-e66e70df05eeb3cc91d208ef1e7e433e30f92a6a9f30806a2aa1edae2a228b29L443-R449) [[2]](diffhunk://#diff-e66e70df05eeb3cc91d208ef1e7e433e30f92a6a9f30806a2aa1edae2a228b29L706-R709)


## Related issues

closes https://github.com/camunda/camunda/issues/39062
