### PR TITLE
feat: handle drd fields for decisions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionDefinitionFilter.java
@@ -37,6 +37,12 @@ public interface DecisionDefinitionFilter extends SearchRequestFilter {
   /** Filter by decision requirements key. */
   DecisionDefinitionFilter decisionRequirementsKey(final long value);
 
+  /** Filter by dmn decision requirements name. */
+  DecisionDefinitionFilter decisionRequirementsName(final String value);
+
+  /** Filter by decision requirements version. */
+  DecisionDefinitionFilter decisionRequirementsVersion(final int value);
+
   /** Filter by tenant id. */
   DecisionDefinitionFilter tenantId(final String value);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinition.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinition.java
@@ -17,4 +17,8 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.response.Decision;
 
-public interface DecisionDefinition extends Decision {}
+public interface DecisionDefinition extends Decision {
+  String getDecisionRequirementsName();
+
+  int getDecisionRequirementsVersion();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionDefinitionSort.java
@@ -37,6 +37,12 @@ public interface DecisionDefinitionSort extends SearchRequestSort<DecisionDefini
   /** Sort by decision requirements key. */
   DecisionDefinitionSort decisionRequirementsKey();
 
+  /** Sort by dmn decision requirements name. */
+  DecisionDefinitionSort decisionRequirementsName();
+
+  /** Sort by decision requirements version. */
+  DecisionDefinitionSort decisionRequirementsVersion();
+
   /** Sort by tenant id. */
   DecisionDefinitionSort tenantId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionDefinitionFilterImpl.java
@@ -67,6 +67,18 @@ public class DecisionDefinitionFilterImpl
   }
 
   @Override
+  public DecisionDefinitionFilter decisionRequirementsName(final String value) {
+    filter.setDecisionRequirementsName(value);
+    return this;
+  }
+
+  @Override
+  public DecisionDefinitionFilter decisionRequirementsVersion(final int value) {
+    filter.setDecisionRequirementsVersion(value);
+    return this;
+  }
+
+  @Override
   public DecisionDefinitionFilter tenantId(final String value) {
     filter.setTenantId(value);
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionDefinitionImpl.java
@@ -21,12 +21,14 @@ import java.util.Objects;
 
 public final class DecisionDefinitionImpl implements DecisionDefinition {
 
-  private final String dmnDecisionId;
-  private final String dmnDecisionName;
+  private final String decisionDefinitionId;
+  private final String name;
   private final int version;
-  private final long decisionKey;
-  private final String dmnDecisionRequirementsId;
+  private final long decisionDefinitionKey;
+  private final String decisionRequirementsId;
   private final long decisionRequirementsKey;
+  private final String decisionRequirementsName;
+  private final int decisionRequirementsVersion;
   private final String tenantId;
 
   public DecisionDefinitionImpl(final DecisionDefinitionResult item) {
@@ -37,34 +39,40 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
         Long.parseLong(item.getDecisionDefinitionKey()),
         item.getDecisionRequirementsId(),
         Long.parseLong(item.getDecisionRequirementsKey()),
+        item.getDecisionRequirementsName(),
+        item.getDecisionRequirementsVersion(),
         item.getTenantId());
   }
 
   public DecisionDefinitionImpl(
-      final String dmnDecisionId,
-      final String dmnDecisionName,
+      final String decisionDefinitionId,
+      final String name,
       final int version,
-      final long decisionKey,
-      final String dmnDecisionRequirementsId,
+      final long decisionDefinitionKey,
+      final String decisionRequirementsId,
       final long decisionRequirementsKey,
+      final String decisionRequirementsName,
+      final int decisionRequirementsVersion,
       final String tenantId) {
-    this.dmnDecisionId = dmnDecisionId;
-    this.dmnDecisionName = dmnDecisionName;
+    this.decisionDefinitionId = decisionDefinitionId;
+    this.name = name;
     this.version = version;
-    this.decisionKey = decisionKey;
-    this.dmnDecisionRequirementsId = dmnDecisionRequirementsId;
+    this.decisionDefinitionKey = decisionDefinitionKey;
+    this.decisionRequirementsId = decisionRequirementsId;
     this.decisionRequirementsKey = decisionRequirementsKey;
+    this.decisionRequirementsName = decisionRequirementsName;
+    this.decisionRequirementsVersion = decisionRequirementsVersion;
     this.tenantId = tenantId;
   }
 
   @Override
   public String getDmnDecisionId() {
-    return dmnDecisionId;
+    return decisionDefinitionId;
   }
 
   @Override
   public String getDmnDecisionName() {
-    return dmnDecisionName;
+    return name;
   }
 
   @Override
@@ -74,12 +82,12 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
 
   @Override
   public long getDecisionKey() {
-    return decisionKey;
+    return decisionDefinitionKey;
   }
 
   @Override
   public String getDmnDecisionRequirementsId() {
-    return dmnDecisionRequirementsId;
+    return decisionRequirementsId;
   }
 
   @Override
@@ -93,14 +101,26 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
   }
 
   @Override
+  public String getDecisionRequirementsName() {
+    return decisionRequirementsName;
+  }
+
+  @Override
+  public int getDecisionRequirementsVersion() {
+    return decisionRequirementsVersion;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
-        dmnDecisionId,
-        dmnDecisionName,
+        decisionDefinitionId,
+        name,
         version,
-        decisionKey,
-        dmnDecisionRequirementsId,
+        decisionDefinitionKey,
+        decisionRequirementsId,
         decisionRequirementsKey,
+        decisionRequirementsName,
+        decisionRequirementsVersion,
         tenantId);
   }
 
@@ -112,34 +132,41 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final DecisionDefinitionImpl decisionDefinition = (DecisionDefinitionImpl) o;
-    return version == decisionDefinition.version
-        && decisionKey == decisionDefinition.decisionKey
-        && decisionRequirementsKey == decisionDefinition.decisionRequirementsKey
-        && Objects.equals(dmnDecisionId, decisionDefinition.dmnDecisionId)
-        && Objects.equals(dmnDecisionName, decisionDefinition.dmnDecisionName)
-        && Objects.equals(dmnDecisionRequirementsId, decisionDefinition.dmnDecisionRequirementsId)
-        && Objects.equals(tenantId, decisionDefinition.tenantId);
+    final DecisionDefinitionImpl that = (DecisionDefinitionImpl) o;
+    return version == that.version
+        && decisionDefinitionKey == that.decisionDefinitionKey
+        && decisionRequirementsKey == that.decisionRequirementsKey
+        && decisionRequirementsVersion == that.decisionRequirementsVersion
+        && Objects.equals(decisionDefinitionId, that.decisionDefinitionId)
+        && Objects.equals(name, that.name)
+        && Objects.equals(decisionRequirementsId, that.decisionRequirementsId)
+        && Objects.equals(decisionRequirementsName, that.decisionRequirementsName)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override
   public String toString() {
     return "DecisionDefinitionImpl{"
-        + "dmnDecisionId='"
-        + dmnDecisionId
+        + "decisionDefinitionId='"
+        + decisionDefinitionId
         + '\''
-        + ", dmnDecisionName='"
-        + dmnDecisionName
+        + ", name='"
+        + name
         + '\''
         + ", version="
         + version
-        + ", decisionKey="
-        + decisionKey
-        + ", dmnDecisionRequirementsId='"
-        + dmnDecisionRequirementsId
+        + ", decisionDefinitionKey="
+        + decisionDefinitionKey
+        + ", decisionRequirementsId='"
+        + decisionRequirementsId
         + '\''
         + ", decisionRequirementsKey="
         + decisionRequirementsKey
+        + ", decisionRequirementsName='"
+        + decisionRequirementsName
+        + '\''
+        + ", decisionRequirementsVersion="
+        + decisionRequirementsVersion
         + ", tenantId='"
         + tenantId
         + '\''

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/DecisionDefinitionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/DecisionDefinitionSortImpl.java
@@ -52,6 +52,16 @@ public class DecisionDefinitionSortImpl extends SearchRequestSortBase<DecisionDe
   }
 
   @Override
+  public DecisionDefinitionSort decisionRequirementsName() {
+    return field("decisionRequirementsName");
+  }
+
+  @Override
+  public DecisionDefinitionSort decisionRequirementsVersion() {
+    return field("decisionRequirementsVersion");
+  }
+
+  @Override
   public DecisionDefinitionSort tenantId() {
     return field("tenantId");
   }

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -72,6 +72,9 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   @NestedConfigurationProperty private Cache processCache = new Cache(databaseName(), "process");
 
+  @NestedConfigurationProperty
+  private Cache decisionRequirementsCache = new Cache(databaseName(), "decisionRequirements");
+
   @NestedConfigurationProperty private Cache formCache = new Cache(databaseName(), "form");
 
   @NestedConfigurationProperty private PostExport postExport = new PostExport(databaseName());
@@ -148,6 +151,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setProcessCache(final Cache processCache) {
     this.processCache = processCache;
+  }
+
+  public Cache getDecisionRequirementsCache() {
+    return decisionRequirementsCache;
+  }
+
+  public void setDecisionRequirementsCache(final Cache decisionRequirementsCache) {
+    this.decisionRequirementsCache = decisionRequirementsCache;
   }
 
   public Cache getFormCache() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -795,6 +795,10 @@ public class BrokerBasedPropertiesOverride {
     setArg(
         args, "batchOperationCache.maxCacheSize", database.getBatchOperationCache().getMaxSize());
     setArg(args, "processCache.maxCacheSize", database.getProcessCache().getMaxSize());
+    setArg(
+        args,
+        "decisionRequirementsCache.maxCacheSize",
+        database.getDecisionRequirementsCache().getMaxSize());
     setArg(args, "formCache.maxCacheSize", database.getFormCache().getMaxSize());
 
     setArg(args, "postExport.batchSize", database.getPostExport().getBatchSize());

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -81,6 +81,7 @@ public class SecondaryStorageElasticsearchTest {
 
   private static final int EXPECTED_BATCH_OPERATION_CACHE_MAX_SIZE = 5_000;
   private static final int EXPECTED_PROCESS_CACHE_MAX_SIZE = 15_000;
+  private static final int EXPECTED_DECISIONREQUIREMENTS_CACHE_MAX_SIZE = 8_000;
   private static final int EXPECTED_FORM_CACHE_MAX_SIZE = 20_000;
 
   private static final int EXPECTED_POST_EXPORT_BATCH_SIZE = 200;
@@ -726,6 +727,8 @@ public class SecondaryStorageElasticsearchTest {
             + EXPECTED_BATCH_OPERATION_CACHE_MAX_SIZE,
         "camunda.data.secondary-storage.elasticsearch.process-cache.max-size="
             + EXPECTED_PROCESS_CACHE_MAX_SIZE,
+        "camunda.data.secondary-storage.elasticsearch.decisionRequirements-cache.max-size="
+            + EXPECTED_DECISIONREQUIREMENTS_CACHE_MAX_SIZE,
         "camunda.data.secondary-storage.elasticsearch.form-cache.max-size="
             + EXPECTED_FORM_CACHE_MAX_SIZE,
       })
@@ -749,6 +752,8 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_BATCH_OPERATION_CACHE_MAX_SIZE);
       assertThat(exporterConfiguration.getProcessCache().getMaxCacheSize())
           .isEqualTo(EXPECTED_PROCESS_CACHE_MAX_SIZE);
+      assertThat(exporterConfiguration.getDecisionRequirementsCache().getMaxCacheSize())
+          .isEqualTo(EXPECTED_DECISIONREQUIREMENTS_CACHE_MAX_SIZE);
       assertThat(exporterConfiguration.getFormCache().getMaxCacheSize())
           .isEqualTo(EXPECTED_FORM_CACHE_MAX_SIZE);
     }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -80,6 +80,7 @@ public class SecondaryStorageOpensearchTest {
 
   private static final int EXPECTED_BATCH_OPERATION_CACHE_MAX_SIZE = 5_000;
   private static final int EXPECTED_PROCESS_CACHE_MAX_SIZE = 15_000;
+  private static final int EXPECTED_DECISIONREQUIREMENTS_CACHE_MAX_SIZE = 8_000;
   private static final int EXPECTED_FORM_CACHE_MAX_SIZE = 20_000;
 
   private static final int EXPECTED_POST_EXPORT_BATCH_SIZE = 200;
@@ -628,6 +629,8 @@ public class SecondaryStorageOpensearchTest {
             + EXPECTED_BATCH_OPERATION_CACHE_MAX_SIZE,
         "camunda.data.secondary-storage.opensearch.process-cache.max-size="
             + EXPECTED_PROCESS_CACHE_MAX_SIZE,
+        "camunda.data.secondary-storage.opensearch.decision-requirements-cache.max-size="
+            + EXPECTED_DECISIONREQUIREMENTS_CACHE_MAX_SIZE,
         "camunda.data.secondary-storage.opensearch.form-cache.max-size="
             + EXPECTED_FORM_CACHE_MAX_SIZE,
       })
@@ -651,6 +654,8 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_BATCH_OPERATION_CACHE_MAX_SIZE);
       assertThat(exporterConfiguration.getProcessCache().getMaxCacheSize())
           .isEqualTo(EXPECTED_PROCESS_CACHE_MAX_SIZE);
+      assertThat(exporterConfiguration.getDecisionRequirementsCache().getMaxCacheSize())
+          .isEqualTo(EXPECTED_DECISIONREQUIREMENTS_CACHE_MAX_SIZE);
       assertThat(exporterConfiguration.getFormCache().getMaxCacheSize())
           .isEqualTo(EXPECTED_FORM_CACHE_MAX_SIZE);
     }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -277,6 +277,8 @@
       <column name="VERSION" type="SMALLINT"/>
       <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT"/>
       <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(255)"/>
+      <column name="DECISION_REQUIREMENTS_NAME" type="VARCHAR(255)"/>
+      <column name="DECISION_REQUIREMENTS_VERSION" type="SMALLINT"/>
     </createTable>
 
     <createIndex tableName="${prefix}DECISION_DEFINITION" indexName="${prefix}IDX_DECISION_DEFINITION_ID">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionDefinitionSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionDefinitionSearchColumn.java
@@ -16,7 +16,9 @@ public enum DecisionDefinitionSearchColumn implements SearchColumn<DecisionDefin
   VERSION("version"),
   TENANT_ID("tenantId"),
   DECISION_REQUIREMENTS_KEY("decisionRequirementsKey"),
-  DECISION_REQUIREMENTS_ID("decisionRequirementsId");
+  DECISION_REQUIREMENTS_ID("decisionRequirementsId"),
+  DECISION_REQUIREMENTS_NAME("decisionRequirementsName"),
+  DECISION_REQUIREMENTS_VERSION("decisionRequirementsVersion");
 
   private final String property;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionDefinitionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionDefinitionDbModel.java
@@ -16,7 +16,9 @@ public record DecisionDefinitionDbModel(
     String tenantId,
     int version,
     String decisionRequirementsId,
-    Long decisionRequirementsKey) {
+    Long decisionRequirementsKey,
+    String decisionRequirementsName,
+    int decisionRequirementsVersion) {
 
   // create a builder for this record extending ObjectBuilder
   public static class DecisionDefinitionDbModelBuilder
@@ -29,6 +31,8 @@ public record DecisionDefinitionDbModel(
     private int version;
     private String decisionRequirementsId;
     private Long decisionRequirementsKey;
+    private String decisionRequirementsName;
+    private int decisionRequirementsVersion;
 
     public DecisionDefinitionDbModelBuilder decisionDefinitionKey(
         final Long decisionDefinitionKey) {
@@ -69,6 +73,18 @@ public record DecisionDefinitionDbModel(
       return this;
     }
 
+    public DecisionDefinitionDbModelBuilder decisionRequirementsName(
+        final String decisionRequirementsName) {
+      this.decisionRequirementsName = decisionRequirementsName;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder decisionRequirementsVersion(
+        final int decisionRequirementsVersion) {
+      this.decisionRequirementsVersion = decisionRequirementsVersion;
+      return this;
+    }
+
     @Override
     public DecisionDefinitionDbModel build() {
       return new DecisionDefinitionDbModel(
@@ -78,7 +94,9 @@ public record DecisionDefinitionDbModel(
           tenantId,
           version,
           decisionRequirementsId,
-          decisionRequirementsKey);
+          decisionRequirementsKey,
+          decisionRequirementsName,
+          decisionRequirementsVersion);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -25,7 +25,9 @@
     TENANT_ID,
     VERSION,
     DECISION_REQUIREMENTS_KEY,
-    DECISION_REQUIREMENTS_ID
+    DECISION_REQUIREMENTS_ID,
+    DECISION_REQUIREMENTS_NAME,
+    DECISION_REQUIREMENTS_VERSION
     FROM ${prefix}DECISION_DEFINITION
     <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
     ) t
@@ -96,6 +98,22 @@
           #{value}
         </foreach>
       </if>
+      <if
+        test="filter.decisionRequirementsNames != null and !filter.decisionRequirementsNames.isEmpty()">
+        AND DECISION_REQUIREMENTS_NAME IN
+        <foreach collection="filter.decisionRequirementsNames" item="value" open="(" separator=", "
+          close=")">
+          #{value}
+        </foreach>
+      </if>
+      <if
+        test="filter.decisionRequirementsVersions != null and !filter.decisionRequirementsVersions.isEmpty()">
+        AND DECISION_REQUIREMENTS_VERSION IN
+        <foreach collection="filter.decisionRequirementsVersions" item="value" open="(" separator=", "
+          close=")">
+          #{value}
+        </foreach>
+      </if>
     </where>
   </sql>
 
@@ -107,13 +125,15 @@
       <arg column="VERSION" javaType="java.lang.Integer"/>
       <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"/>
       <arg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
+      <arg column="DECISION_REQUIREMENTS_NAME" javaType="java.lang.String"/>
+      <arg column="DECISION_REQUIREMENTS_VERSION" javaType="java.lang.Integer"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
     </constructor>
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel">
-    INSERT INTO ${prefix}DECISION_DEFINITION (DECISION_DEFINITION_KEY, DECISION_DEFINITION_ID, NAME, TENANT_ID, VERSION, DECISION_REQUIREMENTS_ID, DECISION_REQUIREMENTS_KEY)
+    INSERT INTO ${prefix}DECISION_DEFINITION (DECISION_DEFINITION_KEY, DECISION_DEFINITION_ID, NAME, TENANT_ID, VERSION, DECISION_REQUIREMENTS_ID, DECISION_REQUIREMENTS_KEY, DECISION_REQUIREMENTS_NAME, DECISION_REQUIREMENTS_VERSION)
     VALUES (#{decisionDefinitionKey}, #{decisionDefinitionId}, #{name},
-            #{tenantId}, #{version}, #{decisionRequirementsId}, #{decisionRequirementsKey})
+            #{tenantId}, #{version}, #{decisionRequirementsId}, #{decisionRequirementsKey}, #{decisionRequirementsName}, #{decisionRequirementsVersion})
   </insert>
 </mapper>

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1070,6 +1070,9 @@
         #   processCache:
         #     maxCacheSize: 10000
         #
+        #   decisionRequirementsCache:
+        #     maxCacheSize: 10000
+        #
         #   formCache:
         #     maxCacheSize: 10000
         #

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -983,6 +983,9 @@
         #   processCache:
         #     maxCacheSize: 10000
         #
+        #   decisionRequirementsCache:
+        #     maxCacheSize: 10000
+        #
         #   formCache:
         #     maxCacheSize: 10000
         #

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Decision;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
@@ -84,7 +85,7 @@ class DecisionAuthorizationIT {
 
     // then
     assertThat(decisionDefinitions).hasSize(1);
-    assertThat(decisionDefinitions.stream().map(p -> p.getDmnDecisionId()).toList())
+    assertThat(decisionDefinitions.stream().map(Decision::getDmnDecisionId).toList())
         .containsOnly(DECISION_DEFINITION_ID_1);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -58,6 +58,10 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionRequirementsId());
     assertThat(instance.decisionRequirementsKey())
         .isEqualTo(decisionDefinition.decisionRequirementsKey());
+    assertThat(instance.decisionRequirementsName())
+        .isEqualTo(decisionDefinition.decisionRequirementsName());
+    assertThat(instance.decisionRequirementsVersion())
+        .isEqualTo(decisionDefinition.decisionRequirementsVersion());
   }
 
   @TestTemplate
@@ -97,6 +101,10 @@ public class DecisionDefinitionIT {
         .isEqualTo(decisionDefinition.decisionRequirementsId());
     assertThat(instance.decisionRequirementsKey())
         .isEqualTo(decisionDefinition.decisionRequirementsKey());
+    assertThat(instance.decisionRequirementsName())
+        .isEqualTo(decisionDefinition.decisionRequirementsName());
+    assertThat(instance.decisionRequirementsVersion())
+        .isEqualTo(decisionDefinition.decisionRequirementsVersion());
   }
 
   @TestTemplate
@@ -219,6 +227,8 @@ public class DecisionDefinitionIT {
                     .tenantIds(decisionDefinition.tenantId())
                     .decisionRequirementsIds(decisionDefinition.decisionRequirementsId())
                     .decisionRequirementsKeys(decisionDefinition.decisionRequirementsKey())
+                    .decisionRequirementsNames(decisionDefinition.decisionRequirementsName())
+                    .decisionRequirementsVersions(decisionDefinition.decisionRequirementsVersion())
                     .build(),
                 DecisionDefinitionSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
@@ -120,6 +120,40 @@ public class DecisionDefinitionSortIT {
   }
 
   @TestTemplate
+  public void shouldSortByRequirementsNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsName().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsName));
+  }
+
+  @TestTemplate
+  public void shouldSortByRequirementsNameDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsName().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsName).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByRequirementsVersionAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsVersion().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsVersion));
+  }
+
+  @TestTemplate
+  public void shouldSortByRequirementsVersionDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsVersion().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsVersion).reversed());
+  }
+
+  @TestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
@@ -65,6 +65,8 @@ public class DecisionDefinitionSpecificFilterIT {
                     .version(1337)
                     .decisionRequirementsKey(1338L)
                     .decisionRequirementsId("requirements-1338")
+                    .decisionRequirementsName("requirements-name-1338")
+                    .decisionRequirementsVersion(1338)
                     .tenantId("sorting-tenant1")));
 
     final var searchResult =
@@ -89,6 +91,10 @@ public class DecisionDefinitionSpecificFilterIT {
         new DecisionDefinitionFilter.Builder().decisionRequirementsIds("requirements-1338").build(),
         new DecisionDefinitionFilter.Builder().decisionRequirementsKeys(1338L).build(),
         new DecisionDefinitionFilter.Builder().versions(1337).build(),
+        new DecisionDefinitionFilter.Builder()
+            .decisionRequirementsNames("requirements-name-1338")
+            .build(),
+        new DecisionDefinitionFilter.Builder().decisionRequirementsVersions(1338).build(),
         new DecisionDefinitionFilter.Builder().tenantIds("sorting-tenant1").build());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
@@ -23,6 +23,7 @@ public final class DecisionDefinitionFixtures extends CommonFixtures {
     final var decisionDefinitionKey = nextKey();
     final var decisionRequirementsKey = nextKey();
     final var version = RANDOM.nextInt(1000);
+    final var decisionRequirementsVersion = RANDOM.nextInt(1000);
     final var builder =
         new DecisionDefinitionDbModelBuilder()
             .decisionDefinitionKey(decisionDefinitionKey)
@@ -31,6 +32,8 @@ public final class DecisionDefinitionFixtures extends CommonFixtures {
             .version(version)
             .decisionRequirementsKey(decisionRequirementsKey)
             .decisionRequirementsId("decision-requirements-" + decisionRequirementsKey)
+            .decisionRequirementsName("decision-requirements-name-" + decisionRequirementsKey)
+            .decisionRequirementsVersion(decisionRequirementsVersion)
             .tenantId("tenant-" + decisionDefinitionKey);
 
     return builderFunction.apply(builder).build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.api.response.Decision;
+import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
@@ -74,7 +74,10 @@ public class DecisionDefinitionTenancyIT {
     final var result = camundaClient.newDecisionDefinitionSearchRequest().send().join();
     // then
     assertThat(result.items()).hasSize(2);
-    assertThat(result.items().stream().map(Decision::getTenantId).collect(Collectors.toSet()))
+    assertThat(
+            result.items().stream()
+                .map(DecisionDefinition::getTenantId)
+                .collect(Collectors.toSet()))
         .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
   }
 
@@ -85,7 +88,10 @@ public class DecisionDefinitionTenancyIT {
     final var result = camundaClient.newDecisionDefinitionSearchRequest().send().join();
     // then
     assertThat(result.items()).hasSize(1);
-    assertThat(result.items().stream().map(Decision::getTenantId).collect(Collectors.toSet()))
+    assertThat(
+            result.items().stream()
+                .map(DecisionDefinition::getTenantId)
+                .collect(Collectors.toSet()))
         .containsExactlyInAnyOrder(TENANT_A);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionDefinitionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionDefinitionEntityTransformer.java
@@ -25,6 +25,8 @@ public class DecisionDefinitionEntityTransformer
         source.getVersion(),
         source.getDecisionRequirementsId(),
         source.getDecisionRequirementsKey(),
+        source.getDecisionRequirementsName(),
+        source.getDecisionRequirementsVersion(),
         source.getTenantId());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionFilterTransformer.java
@@ -15,6 +15,8 @@ import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_NAME;
+import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_VERSION;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.VERSION;
@@ -45,6 +47,8 @@ public final class DecisionDefinitionFilterTransformer
         intTerms(VERSION, filter.versions()),
         stringTerms(DECISION_REQUIREMENTS_ID, filter.decisionRequirementsIds()),
         longTerms(DECISION_REQUIREMENTS_KEY, filter.decisionRequirementsKeys()),
+        stringTerms(DECISION_REQUIREMENTS_NAME, filter.decisionRequirementsNames()),
+        intTerms(DECISION_REQUIREMENTS_VERSION, filter.decisionRequirementsVersions()),
         stringTerms(TENANT_ID, filter.tenantIds()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionDefinitionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionDefinitionFieldSortingTransformer.java
@@ -11,6 +11,8 @@ import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_NAME;
+import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_VERSION;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.VERSION;
@@ -26,6 +28,8 @@ public class DecisionDefinitionFieldSortingTransformer implements FieldSortingTr
       case "version" -> VERSION;
       case "decisionRequirementsId" -> DECISION_REQUIREMENTS_ID;
       case "decisionRequirementsKey" -> DECISION_REQUIREMENTS_KEY;
+      case "decisionRequirementsName" -> DECISION_REQUIREMENTS_NAME;
+      case "decisionRequirementsVersion" -> DECISION_REQUIREMENTS_VERSION;
       case "tenantId" -> TENANT_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionQueryTransformerTest.java
@@ -143,6 +143,46 @@ public final class DecisionDefinitionQueryTransformerTest extends AbstractTransf
   }
 
   @Test
+  public void shouldQueryByDecisionRequirementsName() {
+    // given
+    final var decisionDefinitionFilter =
+        FilterBuilders.decisionDefinition(f -> f.decisionRequirementsNames("drName"));
+
+    // when
+    final var searchRequest = transformQuery(decisionDefinitionFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("decisionRequirementsName");
+              assertThat(t.value().stringValue()).isEqualTo("drName");
+            });
+  }
+
+  @Test
+  public void shouldQueryByDecisionRequirementsVersion() {
+    // given
+    final var decisionDefinitionFilter =
+        FilterBuilders.decisionDefinition(f -> f.decisionRequirementsVersions(2));
+
+    // when
+    final var searchRequest = transformQuery(decisionDefinitionFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("decisionRequirementsVersion");
+              assertThat(t.value().intValue()).isEqualTo(2);
+            });
+  }
+
+  @Test
   public void shouldQueryByTenantId() {
     // given
     final var decisionDefinitionFilter = FilterBuilders.decisionDefinition(f -> f.tenantIds("foo"));

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionDefinitionEntity.java
@@ -17,5 +17,7 @@ public record DecisionDefinitionEntity(
     Integer version,
     String decisionRequirementsId,
     Long decisionRequirementsKey,
+    String decisionRequirementsName,
+    Integer decisionRequirementsVersion,
     String tenantId)
     implements TenantOwnedEntity {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
@@ -22,6 +22,8 @@ public record DecisionDefinitionFilter(
     List<Integer> versions,
     List<String> decisionRequirementsIds,
     List<Long> decisionRequirementsKeys,
+    List<String> decisionRequirementsNames,
+    List<Integer> decisionRequirementsVersions,
     List<String> tenantIds)
     implements FilterBase {
 
@@ -33,6 +35,8 @@ public record DecisionDefinitionFilter(
     private List<Integer> versions;
     private List<String> decisionRequirementsIds;
     private List<Long> decisionRequirementsKeys;
+    private List<String> decisionRequirementsNames;
+    private List<Integer> decisionRequirementsVersions;
     private List<String> tenantIds;
 
     public Builder decisionDefinitionKeys(final List<Long> values) {
@@ -89,6 +93,24 @@ public record DecisionDefinitionFilter(
       return decisionRequirementsKeys(collectValuesAsList(values));
     }
 
+    public Builder decisionRequirementsNames(final List<String> values) {
+      decisionRequirementsNames = addValuesToList(decisionRequirementsNames, values);
+      return this;
+    }
+
+    public Builder decisionRequirementsNames(final String... values) {
+      return decisionRequirementsNames(collectValuesAsList(values));
+    }
+
+    public Builder decisionRequirementsVersions(final List<Integer> values) {
+      decisionRequirementsVersions = addValuesToList(decisionRequirementsVersions, values);
+      return this;
+    }
+
+    public Builder decisionRequirementsVersions(final Integer... values) {
+      return decisionRequirementsVersions(collectValuesAsList(values));
+    }
+
     public Builder tenantIds(final List<String> values) {
       tenantIds = addValuesToList(tenantIds, values);
       return this;
@@ -107,6 +129,8 @@ public record DecisionDefinitionFilter(
           Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsIds, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionRequirementsNames, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionRequirementsVersions, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DecisionDefinitionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DecisionDefinitionSort.java
@@ -56,6 +56,16 @@ public record DecisionDefinitionSort(List<FieldSorting> orderings) implements So
       return this;
     }
 
+    public Builder decisionRequirementsName() {
+      currentOrdering = new FieldSorting("decisionRequirementsName", null);
+      return this;
+    }
+
+    public Builder decisionRequirementsVersion() {
+      currentOrdering = new FieldSorting("decisionRequirementsVersion", null);
+      return this;
+    }
+
     public Builder tenantId() {
       currentOrdering = new FieldSorting("tenantId", null);
       return this;

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
@@ -9,6 +9,7 @@ package io.camunda.search.test.utils;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
@@ -55,6 +56,12 @@ public abstract class SearchDBExtension implements BeforeAllCallback, AfterAllCa
       "idxtestprocess" + RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
 
   public static final ProcessIndex PROCESS_INDEX = new ProcessIndex(IDX_PROCESS_PREFIX, true);
+
+  public static final String IDX_DECISIONREQUIREMENTS_PREFIX =
+      "idxtestdrd" + RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
+
+  public static final DecisionRequirementsIndex DECISIONREQUIREMENTS_INDEX =
+      new DecisionRequirementsIndex(IDX_DECISIONREQUIREMENTS_PREFIX, true);
 
   public static final String IDX_FORM_PREFIX =
       "idxtestform" + RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/DecisionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/DecisionIndex.java
@@ -23,6 +23,8 @@ public class DecisionIndex extends AbstractIndexDescriptor implements Prio4Backu
   public static final String VERSION = "version";
   public static final String DECISION_REQUIREMENTS_ID = "decisionRequirementsId";
   public static final String DECISION_REQUIREMENTS_KEY = "decisionRequirementsKey";
+  public static final String DECISION_REQUIREMENTS_NAME = "decisionRequirementsName";
+  public static final String DECISION_REQUIREMENTS_VERSION = "decisionRequirementsVersion";
 
   public DecisionIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionDefinitionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionDefinitionEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.dmn.definition;
 
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -22,6 +23,13 @@ public class DecisionDefinitionEntity
   @BeforeVersion880 private int version;
   @BeforeVersion880 private String decisionRequirementsId;
   @BeforeVersion880 private long decisionRequirementsKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String decisionRequirementsName;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private int decisionRequirementsVersion;
+
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
@@ -89,6 +97,26 @@ public class DecisionDefinitionEntity
     return this;
   }
 
+  public String getDecisionRequirementsName() {
+    return decisionRequirementsName;
+  }
+
+  public DecisionDefinitionEntity setDecisionRequirementsName(
+      final String decisionRequirementsName) {
+    this.decisionRequirementsName = decisionRequirementsName;
+    return this;
+  }
+
+  public int getDecisionRequirementsVersion() {
+    return decisionRequirementsVersion;
+  }
+
+  public DecisionDefinitionEntity setDecisionRequirementsVersion(
+      final int decisionRequirementsVersion) {
+    this.decisionRequirementsVersion = decisionRequirementsVersion;
+    return this;
+  }
+
   @Override
   public String getTenantId() {
     return tenantId;
@@ -109,6 +137,8 @@ public class DecisionDefinitionEntity
         version,
         decisionRequirementsId,
         decisionRequirementsKey,
+        decisionRequirementsName,
+        decisionRequirementsVersion,
         tenantId);
   }
 
@@ -128,6 +158,8 @@ public class DecisionDefinitionEntity
         && Objects.equals(decisionId, that.decisionId)
         && Objects.equals(name, that.name)
         && Objects.equals(decisionRequirementsId, that.decisionRequirementsId)
+        && Objects.equals(decisionRequirementsName, that.decisionRequirementsName)
+        && decisionRequirementsVersion == that.decisionRequirementsVersion
         && Objects.equals(tenantId, that.tenantId);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-decision.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-decision.json
@@ -27,6 +27,12 @@
       "decisionRequirementsKey": {
         "type": "long"
       },
+      "decisionRequirementsName": {
+        "type": "keyword"
+      },
+      "decisionRequirementsVersion": {
+        "type": "long"
+      },
       "tenantId": {
         "type": "keyword"
       }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/operate-decision.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/operate-decision.json
@@ -27,6 +27,12 @@
       "decisionRequirementsKey": {
         "type": "long"
       },
+      "decisionRequirementsName": {
+        "type": "keyword"
+      },
+      "decisionRequirementsVersion": {
+        "type": "long"
+      },
       "tenantId": {
         "type": "keyword"
       }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/decisionRequirements/CachedDecisionRequirementsEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/decisionRequirements/CachedDecisionRequirementsEntity.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.cache.decisionRequirements;
+
+public record CachedDecisionRequirementsEntity(long key, String name, int version) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -117,6 +117,7 @@ import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
@@ -141,6 +142,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   private ExporterEntityCacheImpl<String, CachedBatchOperationEntity> batchOperationCache;
   private ExporterEntityCacheImpl<String, CachedFormEntity> formCache;
   private ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache;
+  private ExporterEntityCacheImpl<Long, CachedDecisionRequirementsEntity> decisionRequirementsCache;
 
   @Override
   public void init(
@@ -167,6 +169,13 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             entityCacheProvider.getProcessCacheLoader(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
             new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry));
+
+    decisionRequirementsCache =
+        new ExporterEntityCacheImpl<>(
+            configuration.getDecisionRequirementsCache().getMaxCacheSize(),
+            entityCacheProvider.getDecisionRequirementsCacheLoader(
+                indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
+            new CaffeineCacheStatsCounter(NAMESPACE, "decisionRequirements", meterRegistry));
 
     formCache =
         new ExporterEntityCacheImpl<>(
@@ -207,7 +216,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new GroupEntityRemovedHandler(
                 indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
             new GroupDeletedHandler(indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
-            new DecisionHandler(indexDescriptors.get(DecisionIndex.class).getFullQualifiedName()),
+            new DecisionHandler(
+                indexDescriptors.get(DecisionIndex.class).getFullQualifiedName(),
+                decisionRequirementsCache),
             new ListViewProcessInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
             new ListViewFlowNodeFromIncidentHandler(
@@ -227,7 +238,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(VariableTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new DecisionRequirementsHandler(
-                indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName(),
+                decisionRequirementsCache),
             new PostImporterQueueFromIncidentHandler(
                 indexDescriptors.get(PostImporterQueueTemplate.class).getFullQualifiedName()),
             new FlowNodeInstanceFromIncidentHandler(
@@ -368,6 +380,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       processCache.clear();
       processCache = null;
     }
+    if (decisionRequirementsCache != null) {
+      decisionRequirementsCache.clear();
+      decisionRequirementsCache = null;
+    }
   }
 
   @Override
@@ -407,6 +423,12 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   @Override
   public ExporterEntityCacheImpl<Long, CachedProcessEntity> getProcessCache() {
     return processCache;
+  }
+
+  @Override
+  public ExporterEntityCacheImpl<Long, CachedDecisionRequirementsEntity>
+      getDecisionRequirementsCache() {
+    return decisionRequirementsCache;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
@@ -75,6 +76,13 @@ public interface ExporterResourceProvider {
    * @return {@link ExporterEntityCacheImpl} of {@link CachedProcessEntity}
    */
   ExporterEntityCacheImpl<Long, CachedProcessEntity> getProcessCache();
+
+  /**
+   * Returns the reference to the Decision Cache
+   *
+   * @return {@link ExporterEntityCacheImpl} of {@link CachedDecisionRequirementsEntity}
+   */
+  ExporterEntityCacheImpl<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCache();
 
   /**
    * Returns the reference to the Form Cache

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.batchoperation.ElasticSearchBatchOperationCacheLoader;
+import io.camunda.exporter.cache.decision.ElasticSearchDecisionRequirementsCacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.ElasticSearchProcessCacheLoader;
@@ -24,6 +25,7 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import java.io.IOException;
 
@@ -80,6 +82,13 @@ class ElasticsearchAdapter implements ClientAdapter {
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName) {
       return new ElasticSearchProcessCacheLoader(client, processIndexName);
+    }
+
+    @Override
+    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
+        final String decisionRequirementsIndexName) {
+      return new ElasticSearchDecisionRequirementsCacheLoader(
+          client, decisionRequirementsIndexName);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.batchoperation.OpenSearchBatchOperationCacheLoader;
+import io.camunda.exporter.cache.decision.OpenSearchDecisionRequirementsCacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.OpenSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.OpenSearchProcessCacheLoader;
@@ -22,6 +23,7 @@ import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -80,6 +82,12 @@ class OpensearchAdapter implements ClientAdapter {
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName) {
       return new OpenSearchProcessCacheLoader(client, processIndexName);
+    }
+
+    @Override
+    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
+        final String decisionRequirementsIndexName) {
+      return new OpenSearchDecisionRequirementsCacheLoader(client, decisionRequirementsIndexName);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 
 public interface ExporterEntityCacheProvider {
@@ -18,6 +19,9 @@ public interface ExporterEntityCacheProvider {
       String batchOperationIndexName);
 
   CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(String processIndexName);
+
+  CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
+      String decisionIndexName);
 
   CacheLoader<String, CachedFormEntity> getFormCacheLoader(String formIndexName);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/decision/ElasticSearchDecisionRequirementsCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/decision/ElasticSearchDecisionRequirementsCacheLoader.java
@@ -40,9 +40,11 @@ public class ElasticSearchDecisionRequirementsCacheLoader
                     .id(String.valueOf(decisionRequirementsKey)),
             DecisionRequirementsEntity.class);
     if (response.found()) {
-      final DecisionRequirementsEntity decisionEntity = response.source();
+      final DecisionRequirementsEntity decisionRequirementsEntity = response.source();
       return new CachedDecisionRequirementsEntity(
-          decisionEntity.getKey(), decisionEntity.getName(), decisionEntity.getVersion());
+          decisionRequirementsEntity.getKey(),
+          decisionRequirementsEntity.getName(),
+          decisionRequirementsEntity.getVersion());
     } else {
       LOG.debug("DecisionRequirements '{}' not found in Elasticsearch", decisionRequirementsKey);
       return null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/decision/ElasticSearchDecisionRequirementsCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/decision/ElasticSearchDecisionRequirementsCacheLoader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache.decision;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticSearchDecisionRequirementsCacheLoader
+    implements CacheLoader<Long, CachedDecisionRequirementsEntity> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticSearchDecisionRequirementsCacheLoader.class);
+
+  private final ElasticsearchClient client;
+  private final String decisionRequirementsIndexName;
+
+  public ElasticSearchDecisionRequirementsCacheLoader(
+      final ElasticsearchClient client, final String decisionRequirementsIndexName) {
+    this.client = client;
+    this.decisionRequirementsIndexName = decisionRequirementsIndexName;
+  }
+
+  @Override
+  public CachedDecisionRequirementsEntity load(final Long decisionRequirementsKey)
+      throws Exception {
+    final var response =
+        client.get(
+            request ->
+                request
+                    .index(decisionRequirementsIndexName)
+                    .id(String.valueOf(decisionRequirementsKey)),
+            DecisionRequirementsEntity.class);
+    if (response.found()) {
+      final DecisionRequirementsEntity decisionEntity = response.source();
+      return new CachedDecisionRequirementsEntity(
+          decisionEntity.getKey(), decisionEntity.getName(), decisionEntity.getVersion());
+    } else {
+      LOG.debug("DecisionRequirements '{}' not found in Elasticsearch", decisionRequirementsKey);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/decision/OpenSearchDecisionRequirementsCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/decision/OpenSearchDecisionRequirementsCacheLoader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache.decision;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenSearchDecisionRequirementsCacheLoader
+    implements CacheLoader<Long, CachedDecisionRequirementsEntity> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OpenSearchDecisionRequirementsCacheLoader.class);
+
+  private final OpenSearchClient client;
+  private final String decisionRequirementsIndexName;
+
+  public OpenSearchDecisionRequirementsCacheLoader(
+      final OpenSearchClient client, final String decisionRequirementsIndexName) {
+    this.client = client;
+    this.decisionRequirementsIndexName = decisionRequirementsIndexName;
+  }
+
+  @Override
+  public CachedDecisionRequirementsEntity load(final Long decisionRequirementsKey)
+      throws Exception {
+    final var response =
+        client.get(
+            request ->
+                request
+                    .index(decisionRequirementsIndexName)
+                    .id(String.valueOf(decisionRequirementsKey)),
+            DecisionRequirementsEntity.class);
+    if (response.found()) {
+      final var decisionEntity = response.source();
+      return new CachedDecisionRequirementsEntity(
+          decisionEntity.getKey(), decisionEntity.getName(), decisionEntity.getVersion());
+    } else {
+      LOG.debug("DecisionRequirements '{}' not found in Opensearch", decisionRequirementsKey);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
@@ -135,6 +135,14 @@ public final class ConfigValidator {
               + processCacheMaxCacheSize);
     }
 
+    final int decisionRequirementsCacheMaxCacheSize =
+        configuration.getDecisionRequirementsCache().getMaxCacheSize();
+    if (decisionRequirementsCacheMaxCacheSize < 1) {
+      throw new ExporterException(
+          "CamundaExporter decisionRequirementsCache.maxCacheSize must be >= 1. Current value: "
+              + decisionRequirementsCacheMaxCacheSize);
+    }
+
     final int batchOperationCacheMaxCacheSize =
         configuration.getBatchOperationCache().getMaxCacheSize();
     if (batchOperationCacheMaxCacheSize < 1) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -19,6 +19,7 @@ public class ExporterConfiguration {
   private HistoryConfiguration history = new HistoryConfiguration();
   private CacheConfiguration batchOperationCache = new CacheConfiguration();
   private CacheConfiguration processCache = new CacheConfiguration();
+  private CacheConfiguration decisionRequirementsCache = new CacheConfiguration();
   private CacheConfiguration formCache = new CacheConfiguration();
   private PostExportConfiguration postExport = new PostExportConfiguration();
   private IncidentNotifierConfiguration notifier = new IncidentNotifierConfiguration();
@@ -63,6 +64,14 @@ public class ExporterConfiguration {
 
   public void setProcessCache(final CacheConfiguration processCache) {
     this.processCache = processCache;
+  }
+
+  public CacheConfiguration getDecisionRequirementsCache() {
+    return decisionRequirementsCache;
+  }
+
+  public void setDecisionRequirementsCache(final CacheConfiguration decisionRequirementsCache) {
+    this.decisionRequirementsCache = decisionRequirementsCache;
   }
 
   public CacheConfiguration getFormCache() {
@@ -130,6 +139,8 @@ public class ExporterConfiguration {
         + batchOperationCache
         + ", processCache="
         + processCache
+        + ", decisionRequirementsCache="
+        + decisionRequirementsCache
         + ", formCache="
         + formCache
         + ", postExport="

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
@@ -11,6 +11,8 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -23,9 +25,14 @@ public class DecisionHandler
 
   private static final Set<String> STATES = Set.of(ProcessIntent.CREATED.name());
   private final String indexName;
+  private final ExporterEntityCache<Long, CachedDecisionRequirementsEntity>
+      decisionRequirementsCache;
 
-  public DecisionHandler(final String indexName) {
+  public DecisionHandler(
+      final String indexName,
+      final ExporterEntityCache<Long, CachedDecisionRequirementsEntity> decisionRequirementsCache) {
     this.indexName = indexName;
+    this.decisionRequirementsCache = decisionRequirementsCache;
   }
 
   @Override
@@ -66,6 +73,9 @@ public class DecisionHandler
         .setDecisionId(decision.getDecisionId())
         .setDecisionRequirementsId(decision.getDecisionRequirementsId())
         .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+        .setDecisionRequirementsName(getRequirementsName(decision.getDecisionRequirementsKey()))
+        .setDecisionRequirementsVersion(
+            getRequirementsVersion(decision.getDecisionRequirementsKey()))
         .setTenantId(tenantOrDefault(decision.getTenantId()));
   }
 
@@ -77,5 +87,19 @@ public class DecisionHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  private String getRequirementsName(final long decisionRequirementsKey) {
+    return decisionRequirementsCache
+        .get(decisionRequirementsKey)
+        .map(CachedDecisionRequirementsEntity::name)
+        .orElse(null);
+  }
+
+  private int getRequirementsVersion(final long decisionRequirementsKey) {
+    return decisionRequirementsCache
+        .get(decisionRequirementsKey)
+        .map(CachedDecisionRequirementsEntity::version)
+        .orElse(0);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -222,8 +222,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         .orElse(bpmnProcessId);
   }
 
-  private String getVersionTag(final long processDefinitionJey) {
-    return processCache.get(processDefinitionJey).map(CachedProcessEntity::versionTag).orElse(null);
+  private String getVersionTag(final long processDefinitionKey) {
+    return processCache.get(processDefinitionKey).map(CachedProcessEntity::versionTag).orElse(null);
   }
 
   public TreePath createTreePath(final Record<ProcessInstanceRecordValue> record) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -24,6 +24,7 @@ import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -82,6 +83,12 @@ final class CamundaExporterTest {
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName) {
+      return k -> null;
+    }
+
+    @Override
+    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
+        final String decisionIndexName) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/DecisionRequirementsCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/DecisionRequirementsCacheIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import static io.camunda.search.test.utils.SearchDBExtension.DECISIONREQUIREMENTS_INDEX;
+import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import io.camunda.exporter.DefaultExporterResourceProvider;
+import io.camunda.exporter.cache.decision.ElasticSearchDecisionRequirementsCacheLoader;
+import io.camunda.exporter.cache.decision.OpenSearchDecisionRequirementsCacheLoader;
+import io.camunda.search.schema.config.IndexConfiguration;
+import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache.CacheLoaderFailedException;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DecisionRequirementsCacheIT {
+  @RegisterExtension private static final SearchDBExtension SEARCH_DB = SearchDBExtension.create();
+
+  @BeforeEach
+  void setup() {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      new ElasticsearchEngineClient(SEARCH_DB.esClient(), SEARCH_DB.objectMapper())
+          .createIndex(DECISIONREQUIREMENTS_INDEX, new IndexConfiguration());
+    }
+    new OpensearchEngineClient(SEARCH_DB.osClient(), SEARCH_DB.objectMapper())
+        .createIndex(DECISIONREQUIREMENTS_INDEX, new IndexConfiguration());
+  }
+
+  @AfterEach
+  void cleanup() throws IOException {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      SEARCH_DB
+          .esClient()
+          .indices()
+          .delete(req -> req.index(DECISIONREQUIREMENTS_INDEX.getFullQualifiedName()));
+    }
+    SEARCH_DB
+        .osClient()
+        .indices()
+        .delete(req -> req.index(DECISIONREQUIREMENTS_INDEX.getFullQualifiedName()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideDRDCache")
+  void shouldReturnEmptyOptionalIfDrdDoesNotExist(final DRDCacheArgument drdCacheArgument) {
+    // when
+    final var decisionRequirement = drdCacheArgument.drdCache().get(1L);
+
+    // then
+    assertThat(decisionRequirement).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideDRDCache")
+  void shouldLoadDrdEntityFromBackend(final DRDCacheArgument drdCacheArgument) {
+    // given
+    final var drdEntity =
+        new DecisionRequirementsEntity()
+            .setId("3")
+            .setKey(3L)
+            .setDecisionRequirementsId("drd-id")
+            .setName("testdrd")
+            .setVersion(2);
+    drdCacheArgument.indexer().accept(drdEntity);
+
+    // when
+    final var drd = drdCacheArgument.drdCache.get(3L);
+
+    // then
+    final var expectedCachedDrdEntity = new CachedDecisionRequirementsEntity(3L, "testdrd", 2);
+    assertThat(drd).isPresent().get().isEqualTo(expectedCachedDrdEntity);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideFailingDRDCache")
+  void shouldThrowExceptionIfQueryToElasticFailed(final DRDCacheArgument drdCacheArgument) {
+    // given
+    final var failingDrdCache = drdCacheArgument.drdCache();
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> failingDrdCache.get(1L))
+        .isInstanceOf(CacheLoaderFailedException.class);
+  }
+
+  static Stream<Arguments> provideDRDCache() {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      return Stream.of(
+          Arguments.of(
+              Named.of(
+                  "ElasticSearch",
+                  getESDRDCache(
+                      SearchDBExtension.DECISIONREQUIREMENTS_INDEX.getFullQualifiedName()))),
+          Arguments.of(
+              Named.of(
+                  "OpenSearch",
+                  getOSDRDCache(
+                      SearchDBExtension.DECISIONREQUIREMENTS_INDEX.getFullQualifiedName()))));
+    } else {
+      return Stream.of(
+          Arguments.of(
+              Named.of(
+                  "OpenSearch",
+                  getOSDRDCache(
+                      SearchDBExtension.DECISIONREQUIREMENTS_INDEX.getFullQualifiedName()))));
+    }
+  }
+
+  static Stream<Arguments> provideFailingDRDCache() {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      return Stream.of(
+          Arguments.of(Named.of("ElasticSearch", getESDRDCache("invalid-index-name"))),
+          Arguments.of(Named.of("OpenSearch", getOSDRDCache("invalid-index-name"))));
+    } else {
+      return Stream.of(Arguments.of(Named.of("OpenSearch", getOSDRDCache("invalid-index-name"))));
+    }
+  }
+
+  static DRDCacheArgument getESDRDCache(final String indexName) {
+    return new DRDCacheArgument(
+        new ExporterEntityCacheImpl<>(
+            10,
+            new ElasticSearchDecisionRequirementsCacheLoader(SEARCH_DB.esClient(), indexName),
+            new CaffeineCacheStatsCounter(
+                DefaultExporterResourceProvider.NAMESPACE, "ES", new SimpleMeterRegistry())),
+        DecisionRequirementsCacheIT::indexInElasticSearch);
+  }
+
+  static DRDCacheArgument getOSDRDCache(final String indexName) {
+    return new DRDCacheArgument(
+        new ExporterEntityCacheImpl<>(
+            10,
+            new OpenSearchDecisionRequirementsCacheLoader(SEARCH_DB.osClient(), indexName),
+            new CaffeineCacheStatsCounter(
+                DefaultExporterResourceProvider.NAMESPACE, "OS", new SimpleMeterRegistry())),
+        DecisionRequirementsCacheIT::indexInOpenSearch);
+  }
+
+  private static void indexInElasticSearch(
+      final DecisionRequirementsEntity decisionRequirementsEntity) {
+    try {
+      SEARCH_DB
+          .esClient()
+          .index(
+              request ->
+                  request
+                      .index(DECISIONREQUIREMENTS_INDEX.getFullQualifiedName())
+                      .id(decisionRequirementsEntity.getId())
+                      .document(decisionRequirementsEntity));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void indexInOpenSearch(
+      final DecisionRequirementsEntity decisionRequirementsEntity) {
+    try {
+      SEARCH_DB
+          .osClient()
+          .index(
+              request ->
+                  request
+                      .index(DECISIONREQUIREMENTS_INDEX.getFullQualifiedName())
+                      .id(decisionRequirementsEntity.getId())
+                      .document(decisionRequirementsEntity));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  record DRDCacheArgument(
+      ExporterEntityCache<Long, CachedDecisionRequirementsEntity> drdCache,
+      Consumer<DecisionRequirementsEntity> indexer) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestDecisionRequirementsCache.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestDecisionRequirementsCache.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class TestDecisionRequirementsCache
+    implements ExporterEntityCache<Long, CachedDecisionRequirementsEntity> {
+  private final HashMap<Long, CachedDecisionRequirementsEntity> cache = new HashMap<>();
+
+  @Override
+  public Optional<CachedDecisionRequirementsEntity> get(final Long entityKey) {
+    return Optional.ofNullable(cache.get(entityKey));
+  }
+
+  @Override
+  public Map<Long, CachedDecisionRequirementsEntity> getAll(final Iterable<Long> keys) {
+    final Map<Long, CachedDecisionRequirementsEntity> map = new HashMap<>();
+    keys.forEach(k -> map.put(k, get(k).orElse(null)));
+    return map;
+  }
+
+  @Override
+  public void put(final Long entityKey, final CachedDecisionRequirementsEntity processEntity) {
+    cache.put(entityKey, processEntity);
+  }
+
+  @Override
+  public void remove(final Long entityKey) {
+    cache.remove(entityKey);
+  }
+
+  @Override
+  public void clear() {
+    cache.clear();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
@@ -248,6 +248,19 @@ public class ConfigValidatorTest {
 
   @ParameterizedTest(name = "{0}")
   @ValueSource(ints = {-1, 0})
+  void shouldForbidNonPositiveMaxDecisionRequirementsCacheSize(final int maxCacheSize) {
+    // given
+    config.getDecisionRequirementsCache().setMaxCacheSize(maxCacheSize);
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(config))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining(
+            "CamundaExporter decisionRequirementsCache.maxCacheSize must be >= 1.");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(ints = {-1, 0})
   void shouldForbidNonPositiveMaxBatchOperationCacheSize(final int maxCacheSize) {
     // given
     config.getBatchOperationCache().setMaxCacheSize(maxCacheSize);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -10,8 +10,10 @@ package io.camunda.exporter.handlers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.cache.TestDecisionRequirementsCache;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
@@ -27,7 +29,10 @@ final class DecisionHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-decision";
-  private final DecisionHandler underTest = new DecisionHandler(indexName);
+  private final TestDecisionRequirementsCache decisionRequirementsCache =
+      new TestDecisionRequirementsCache();
+  private final DecisionHandler underTest =
+      new DecisionHandler(indexName, decisionRequirementsCache);
 
   @Test
   void testGetHandledValueType() {
@@ -148,5 +153,45 @@ final class DecisionHandlerTest {
         .isEqualTo("decisionRequirementsId");
     assertThat(decisionDefinitionEntity.getDecisionRequirementsKey()).isEqualTo(222L);
     assertThat(decisionDefinitionEntity.getTenantId()).isEqualTo("tenantId");
+  }
+
+  @Test
+  void shouldUpdateEntityFromCache() {
+    // given
+    final long decisionKey = 123;
+    final long decisionRequirementsKey = 222;
+    final String decisionRequirementsName = "decisionRequirementsName";
+    final int decisionRequirementsVersion = 4;
+
+    final DecisionRecordValue decisionRecordValue =
+        ImmutableDecisionRecordValue.builder()
+            .from(factory.generateObject(DecisionRecordValue.class))
+            .withDecisionKey(decisionKey)
+            .withDecisionRequirementsId("decisionRequirementsId")
+            .withDecisionRequirementsKey(decisionRequirementsKey)
+            .build();
+
+    final Record<DecisionRecordValue> decisionRecord =
+        factory.generateRecord(
+            ValueType.DECISION,
+            r -> r.withIntent(DecisionIntent.CREATED).withValue(decisionRecordValue));
+
+    final CachedDecisionRequirementsEntity cachedDRD =
+        new CachedDecisionRequirementsEntity(
+            decisionRequirementsKey, decisionRequirementsName, decisionRequirementsVersion);
+    decisionRequirementsCache.put(decisionRequirementsKey, cachedDRD);
+
+    // when
+    final DecisionDefinitionEntity decisionDefinitionEntity = new DecisionDefinitionEntity();
+    underTest.updateEntity(decisionRecord, decisionDefinitionEntity);
+
+    // then
+    assertThat(decisionDefinitionEntity.getKey()).isEqualTo(decisionKey);
+    assertThat(decisionDefinitionEntity.getDecisionRequirementsKey())
+        .isEqualTo(decisionRequirementsKey);
+    assertThat(decisionDefinitionEntity.getDecisionRequirementsName())
+        .isEqualTo(decisionRequirementsName);
+    assertThat(decisionDefinitionEntity.getDecisionRequirementsVersion())
+        .isEqualTo(decisionRequirementsVersion);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
@@ -12,9 +12,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.cache.TestDecisionRequirementsCache;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
@@ -29,8 +31,11 @@ import org.junit.jupiter.api.Test;
 final class DecisionRequirementsHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = DecisionRequirementsIndex.INDEX_NAME;
+  private final TestDecisionRequirementsCache decisionRequirementsCache =
+      new TestDecisionRequirementsCache();
 
-  private final DecisionRequirementsHandler underTest = new DecisionRequirementsHandler(indexName);
+  private final DecisionRequirementsHandler underTest =
+      new DecisionRequirementsHandler(indexName, decisionRequirementsCache);
 
   @Test
   void testGetHandledValueType() {
@@ -145,6 +150,38 @@ final class DecisionRequirementsHandlerTest {
 
     // then
     verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+
+  @Test
+  void shouldUpdateDecisionRequirementsCache() {
+    // given
+    final long expectedKey = 123;
+    final String expectedName = "name";
+    final int expectedVersion = 2;
+    final DecisionRequirementsRecordValue recordValue =
+        ImmutableDecisionRequirementsRecordValue.builder()
+            .from(factory.generateObject(DecisionRequirementsRecordValue.class))
+            .withDecisionRequirementsKey(expectedKey)
+            .withDecisionRequirementsName(expectedName)
+            .withDecisionRequirementsVersion(expectedVersion)
+            .build();
+
+    final Record<DecisionRequirementsRecordValue> decisionRequirementsRecord =
+        factory.generateRecord(
+            ValueType.DECISION_REQUIREMENTS,
+            r -> r.withIntent(DecisionRequirementsIntent.CREATED).withValue(recordValue));
+
+    // when
+    final DecisionRequirementsEntity entity = new DecisionRequirementsEntity();
+    underTest.updateEntity(decisionRequirementsRecord, entity);
+
+    // then
+    assertThat(decisionRequirementsCache.get(recordValue.getDecisionRequirementsKey()))
+        .isPresent()
+        .get()
+        .extracting(
+            CachedDecisionRequirementsEntity::name, CachedDecisionRequirementsEntity::version)
+        .containsExactly(expectedName, expectedVersion);
   }
 
   private Record<DecisionRequirementsRecordValue> generateRecord(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
@@ -19,6 +19,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
@@ -72,6 +73,12 @@ public class TestExporterResourceProvider implements ExporterResourceProvider {
 
   @Override
   public ExporterEntityCacheImpl<Long, CachedProcessEntity> getProcessCache() {
+    return null;
+  }
+
+  @Override
+  public ExporterEntityCacheImpl<Long, CachedDecisionRequirementsEntity>
+      getDecisionRequirementsCache() {
     return null;
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -33,6 +33,7 @@ public class ExporterConfiguration {
 
   // caches
   private CacheConfiguration processCache = new CacheConfiguration();
+  private CacheConfiguration decisionRequirementsCache = new CacheConfiguration();
   private CacheConfiguration batchOperationCache = new CacheConfiguration();
 
   public Duration getFlushInterval() {
@@ -92,6 +93,14 @@ public class ExporterConfiguration {
     this.processCache = processCache;
   }
 
+  public CacheConfiguration getDecisionRequirementsCache() {
+    return decisionRequirementsCache;
+  }
+
+  public void setDecisionRequirementsCache(final CacheConfiguration decisionRequirementsCache) {
+    this.decisionRequirementsCache = decisionRequirementsCache;
+  }
+
   public CacheConfiguration getBatchOperationCache() {
     return batchOperationCache;
   }
@@ -130,6 +139,13 @@ public class ExporterConfiguration {
       errors.add(
           String.format(
               "processCache.maxSize must be greater than 0 but was %d", processCache.getMaxSize()));
+    }
+
+    if (decisionRequirementsCache.getMaxSize() < 1) {
+      errors.add(
+          String.format(
+              "decisionRequirementsCache.maxSize must be greater than 0 but was %d",
+              decisionRequirementsCache.getMaxSize()));
     }
 
     if (batchOperationCache.getMaxSize() < 1) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsDecisionRequirementsCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsDecisionRequirementsCacheLoader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RdbmsDecisionRequirementsCacheLoader
+    implements CacheLoader<Long, CachedDecisionRequirementsEntity> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RdbmsDecisionRequirementsCacheLoader.class);
+  private final DecisionRequirementsDbReader reader;
+
+  public RdbmsDecisionRequirementsCacheLoader(final DecisionRequirementsDbReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public CachedDecisionRequirementsEntity load(final @NotNull Long decisionRequirementsKey)
+      throws Exception {
+    final var response = reader.findOne(decisionRequirementsKey);
+    if (response.isPresent()) {
+      final var dre = response.get();
+      return new CachedDecisionRequirementsEntity(
+          dre.decisionRequirementsKey(), dre.name(), dre.version());
+    }
+    LOG.debug("DecisionRequirements '{}' not found in RDBMS", decisionRequirementsKey);
+    return null;
+  }
+
+  @Override
+  public @NotNull Map<Long, CachedDecisionRequirementsEntity> loadAll(
+      final @NotNull Set<? extends Long> decisionRequirementsKeys) {
+    final var query =
+        DecisionRequirementsQuery.of(
+            b -> b.filter(f -> f.decisionRequirementsKeys(List.copyOf(decisionRequirementsKeys))));
+    final var response = reader.search(query);
+    return response.items().stream()
+        .collect(
+            Collectors.toMap(
+                DecisionRequirementsEntity::decisionRequirementsKey,
+                dre ->
+                    new CachedDecisionRequirementsEntity(
+                        dre.decisionRequirementsKey(), dre.name(), dre.version())));
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -171,6 +171,8 @@ components:
             - version
             - decisionRequirementsId
             - decisionRequirementsKey
+            - decisionRequirementsName
+            - decisionRequirementsVersion
             - tenantId
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
@@ -222,6 +224,12 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKey'
           description: The assigned key of the decision requirements graph that the decision definition is part of.
+        decisionRequirementsName:
+          type: string
+          description: The DMN name of the decision requirements that the decision definition is part of.
+        decisionRequirementsVersion:
+          type: integer
+          description: The assigned version of the decision requirements that the decision definition is part of.
 
     DecisionDefinitionSearchQueryResult:
       type: object
@@ -262,6 +270,12 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKey'
           description: The assigned key of the decision requirements graph that the decision definition is part of.
+        decisionRequirementsName:
+          type: string
+          description: The DMN name of the decision requirements that the decision definition is part of.
+        decisionRequirementsVersion:
+          type: integer
+          description: The assigned version of the decision requirements that the decision definition is part of.
 
     DecisionEvaluationInstruction:
       x-polymorphic-schema: true

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -579,6 +579,10 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getDecisionRequirementsKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::decisionRequirementsKeys);
+      ofNullable(filter.getDecisionRequirementsName())
+          .ifPresent(builder::decisionRequirementsNames);
+      ofNullable(filter.getDecisionRequirementsVersion())
+          .ifPresent(builder::decisionRequirementsVersions);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -891,7 +891,9 @@ public final class SearchQueryResponseMapper {
         .version(d.version())
         .decisionDefinitionId(d.decisionDefinitionId())
         .decisionRequirementsKey(KeyUtil.keyToString(d.decisionRequirementsKey()))
-        .decisionRequirementsId(d.decisionRequirementsId());
+        .decisionRequirementsId(d.decisionRequirementsId())
+        .decisionRequirementsName(d.decisionRequirementsName())
+        .decisionRequirementsVersion(d.decisionRequirementsVersion());
   }
 
   public static DecisionRequirementsResult toDecisionRequirements(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -559,6 +559,8 @@ public class SearchQuerySortRequestMapper {
         case VERSION -> builder.version();
         case DECISION_REQUIREMENTS_ID -> builder.decisionRequirementsId();
         case DECISION_REQUIREMENTS_KEY -> builder.decisionRequirementsKey();
+        case DECISION_REQUIREMENTS_NAME -> builder.decisionRequirementsName();
+        case DECISION_REQUIREMENTS_VERSION -> builder.decisionRequirementsVersion();
         case TENANT_ID -> builder.tenantId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -54,7 +54,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                       "name": "name",
                       "version": 1,
                       "decisionRequirementsId": "drId",
-                      "decisionRequirementsKey": "2"
+                      "decisionRequirementsKey": "2",
+                      "decisionRequirementsName": "drN",
+                      "decisionRequirementsVersion": 2
                   }
               ],
               "page": {
@@ -68,7 +70,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   static final SearchQueryResult<DecisionDefinitionEntity> SEARCH_QUERY_RESULT =
       new Builder<DecisionDefinitionEntity>()
           .total(1L)
-          .items(List.of(new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "t")))
+          .items(
+              List.of(
+                  new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "drN", 2, "t")))
           .startCursor("f")
           .endCursor("v")
           .build();
@@ -148,7 +152,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                 "version": 1,
                 "decisionRequirementsId": "drId",
                 "decisionRequirementsKey": "2",
-                "decisionDefinitionId": "dId"
+                "decisionDefinitionId": "dId",
+                "decisionRequirementsName": "drN",
+                "decisionRequirementsVersion": 2
               }
             }""";
 
@@ -179,6 +185,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                         .decisionRequirementsIds("drId")
                         .decisionRequirementsKeys(2L)
                         .decisionDefinitionIds("dId")
+                        .decisionRequirementsNames("drN")
+                        .decisionRequirementsVersions(2)
                         .build())
                 .build());
   }
@@ -212,6 +220,12 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                     },
                     {
                          "field": "decisionRequirementsId"
+                    },
+                    {
+                         "field": "decisionRequirementsName"
+                    },
+                    {
+                         "field": "decisionRequirementsVersion"
                     },
                     {
                          "field": "tenantId"
@@ -250,6 +264,10 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                         .asc()
                         .decisionRequirementsId()
                         .asc()
+                        .decisionRequirementsName()
+                        .asc()
+                        .decisionRequirementsVersion()
+                        .asc()
                         .tenantId()
                         .asc()
                         .build())
@@ -275,7 +293,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "type": "about:blank",
               "title": "Bad Request",
               "status": 400,
-              "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [decisionDefinitionKey, decisionDefinitionId, name, version, decisionRequirementsId, decisionRequirementsKey, tenantId]",
+              "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [decisionDefinitionKey, decisionDefinitionId, name, version, decisionRequirementsId, decisionRequirementsKey, decisionRequirementsName, decisionRequirementsVersion, tenantId]",
               "instance": "%s"
             }"""
             .formatted(DECISION_DEFINITIONS_SEARCH_URL);
@@ -415,7 +433,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
     // given
     final Long decisionDefinitionKey = 1L;
     final DecisionDefinitionEntity decisionDefinitionEntity =
-        new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "t");
+        new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "drN", 2, "t");
     when(decisionDefinitionServices.getByKey(decisionDefinitionKey))
         .thenReturn(decisionDefinitionEntity);
     final var expectedResponse =
@@ -427,7 +445,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "name": "name",
               "version": 1,
               "decisionRequirementsId": "drId",
-              "decisionRequirementsKey": "2"
+              "decisionRequirementsKey": "2",
+              "decisionRequirementsName": "drN",
+              "decisionRequirementsVersion": 2
             }""";
     // when/then
     webClient


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Add decision requirements name and version to the decision index
- Add cache for decision requirements since decision records do not contain the associated drd version and name
- Return decision requirements name and version in V2 API responses and add filter and sorting options
- Updated Camunda Client requests and responses to use the new fields

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/20767
