### PR TITLE
[Backport release-8.9.0-alpha1] Patch Spring Boot to 3.5.7 to fix CVE-2025-59250

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -552,7 +552,7 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>4.0.2</version>
+      <version>4.0.4</version>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -103,7 +103,7 @@
     <version.rest-assured>5.5.5</version.rest-assured>
     <version.spring>6.2.11</version.spring>
     <version.spring-security>6.5.5</version.spring-security>
-    <version.spring-boot>3.5.6</version.spring-boot>
+    <version.spring-boot>3.5.7</version.spring-boot>
     <version.tomcat>10.1.48</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
# Description
Backport of #40711 to `release-8.9.0-alpha1`.

relates to #40709