### PR TITLE
[Backport stable/8.7] perf: avoid blocking IO for RocksDB

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -119,6 +119,7 @@ public final class ZeebeRocksDbFactory<
 
     final var dbOptions =
         DBOptions.getDBOptionsFromProps(props)
+            .setAvoidUnnecessaryBlockingIO(true)
             .setErrorIfExists(false)
             .setCreateIfMissing(true)
             .setParanoidChecks(true)


### PR DESCRIPTION
# Description
Backport of #40201 to `stable/8.7`.

relates to #39932