### PR TITLE
fix: Keycloak migration, refer to groups by name 

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/TenantMigrationHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.migration.identity.handler.sm;
 
-import static io.camunda.migration.identity.MigrationUtil.normalizeGroupID;
-
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
@@ -182,15 +180,13 @@ public class TenantMigrationHandler extends MigrationHandler<Tenant> {
     tenantGroups.forEach(
         group -> {
           try {
-            final var normalizedGroupId = normalizeGroupID(group);
             final var tenantMember =
-                new TenantMemberRequest(tenantId, normalizedGroupId, EntityType.GROUP);
+                new TenantMemberRequest(tenantId, group.name(), EntityType.GROUP);
             retryOnBackpressure(
                 () -> tenantService.addMember(tenantMember).join(),
                 "Failed to assign group with name: " + group.name() + " to tenant: " + tenantId);
             assignedGroupCount.incrementAndGet();
-            logger.debug(
-                "Group with name '{}' assigned to tenant '{}'.", normalizedGroupId, tenantId);
+            logger.debug("Group with name '{}' assigned to tenant '{}'.", group.name(), tenantId);
           } catch (final Exception e) {
             if (!isConflictError(e)) {
               throw new MigrationException(

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandlerTest.java
@@ -128,7 +128,7 @@ public class GroupMigrationHandlerTest {
     verify(authorizationServices, times(3)).createAuthorization(request.capture());
     final List<CreateAuthorizationRequest> requests = request.getAllValues();
     MatcherAssert.assertThat(requests, Matchers.hasSize(3));
-    MatcherAssert.assertThat(requests.getFirst().ownerId(), Matchers.is("normal_group"));
+    MatcherAssert.assertThat(requests.getFirst().ownerId(), Matchers.is("Normal Group"));
     MatcherAssert.assertThat(
         requests.getFirst().ownerType(), Matchers.is(AuthorizationOwnerType.GROUP));
     MatcherAssert.assertThat(requests.getFirst().resourceId(), Matchers.is("process"));
@@ -142,7 +142,7 @@ public class GroupMigrationHandlerTest {
             PermissionType.READ_PROCESS_INSTANCE,
             PermissionType.UPDATE_PROCESS_INSTANCE,
             PermissionType.CREATE_PROCESS_INSTANCE));
-    MatcherAssert.assertThat(requests.get(1).ownerId(), Matchers.is("normal_group"));
+    MatcherAssert.assertThat(requests.get(1).ownerId(), Matchers.is("Normal Group"));
     MatcherAssert.assertThat(
         requests.get(1).ownerType(), Matchers.is(AuthorizationOwnerType.GROUP));
     MatcherAssert.assertThat(requests.get(1).resourceId(), Matchers.is("*"));
@@ -154,7 +154,7 @@ public class GroupMigrationHandlerTest {
             PermissionType.READ_DECISION_DEFINITION,
             PermissionType.READ_DECISION_INSTANCE,
             PermissionType.DELETE_DECISION_INSTANCE));
-    MatcherAssert.assertThat(requests.get(2).ownerId(), Matchers.is("normal_group"));
+    MatcherAssert.assertThat(requests.get(2).ownerId(), Matchers.is("Normal Group"));
     MatcherAssert.assertThat(
         requests.get(2).ownerType(), Matchers.is(AuthorizationOwnerType.GROUP));
     MatcherAssert.assertThat(requests.get(2).resourceId(), Matchers.is("process"));
@@ -264,12 +264,12 @@ public class GroupMigrationHandlerTest {
     // given
     // groups
     final String longGroupName = "a".repeat(300);
-    final String groupNameWithUnsupportedChars = "Group@Name#With$Special%Chars";
+    final String groupNameWithSpecialChars = "Group@Name With$Special%Chars";
     when(managementIdentityClient.fetchGroups(anyInt()))
         .thenReturn(
             List.of(
                 new Group("id1", longGroupName),
-                new Group("id2", groupNameWithUnsupportedChars),
+                new Group("id2", groupNameWithSpecialChars),
                 new Group("id3", "Normal Group")))
         .thenReturn(List.of());
     when(managementIdentityClient.fetchGroupRoles(any()))
@@ -300,12 +300,12 @@ public class GroupMigrationHandlerTest {
         .extracting(
             RoleMemberRequest::roleId, RoleMemberRequest::entityId, RoleMemberRequest::entityType)
         .containsExactlyInAnyOrder(
-            tuple("role_1", "a".repeat(256), EntityType.GROUP),
-            tuple("role@name_with_special_chars", "a".repeat(256), EntityType.GROUP),
-            tuple("role_2", "group@name_with_special_chars", EntityType.GROUP),
-            tuple("role_3", "group@name_with_special_chars", EntityType.GROUP),
-            tuple("role_1", "normal_group", EntityType.GROUP),
-            tuple("role_2", "normal_group", EntityType.GROUP));
+            tuple("role_1", longGroupName, EntityType.GROUP),
+            tuple("role@name_with_special_chars", longGroupName, EntityType.GROUP),
+            tuple("role_2", groupNameWithSpecialChars, EntityType.GROUP),
+            tuple("role_3", groupNameWithSpecialChars, EntityType.GROUP),
+            tuple("role_1", "Normal Group", EntityType.GROUP),
+            tuple("role_2", "Normal Group", EntityType.GROUP));
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
@@ -132,7 +132,7 @@ public class KeycloakTenantMigrationHandlerTest {
             tuple("tenant1", "username1", EntityType.USER),
             tuple("tenant1", "username2", EntityType.USER),
             // Groups for tenant1
-            tuple("tenant1", "group_1", EntityType.GROUP),
+            tuple("tenant1", "Group 1", EntityType.GROUP),
             // Clients for tenant1
             tuple("tenant1", "Client1", EntityType.CLIENT),
             tuple("tenant1", "Client2", EntityType.CLIENT),
@@ -140,13 +140,13 @@ public class KeycloakTenantMigrationHandlerTest {
             tuple("tenant2", "username3", EntityType.USER),
             tuple("tenant2", "username4", EntityType.USER),
             // Groups for tenant2
-            tuple("tenant2", "group_2", EntityType.GROUP),
+            tuple("tenant2", "Group 2", EntityType.GROUP),
             // Clients for tenant2
             tuple("tenant2", "Client3", EntityType.CLIENT),
             // Users for default tenant
             tuple("<default>", "username4", EntityType.USER),
             // Groups for default tenant
-            tuple("<default>", "group_3", EntityType.GROUP),
+            tuple("<default>", "Group 3", EntityType.GROUP),
             // Clients for default tenant
             tuple("<default>", "Client4", EntityType.CLIENT));
   }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractKeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractKeycloakIdentityMigrationIT.java
@@ -32,9 +32,11 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
@@ -80,7 +82,7 @@ public abstract class AbstractKeycloakIdentityMigrationIT {
           // create groups
           .withEnv("KEYCLOAK_GROUPS_0_NAME", "groupA")
           .withEnv("KEYCLOAK_GROUPS_1_NAME", "groupB")
-          .withEnv("KEYCLOAK_GROUPS_2_NAME", "groupC")
+          .withEnv("KEYCLOAK_GROUPS_2_NAME", "group C")
           // create users and assign them to groups and roles
           .withEnv("KEYCLOAK_USERS_0_EMAIL", "user0@email.com")
           .withEnv("KEYCLOAK_USERS_0_FIRST-NAME", "user0")
@@ -98,7 +100,7 @@ public abstract class AbstractKeycloakIdentityMigrationIT {
           .withEnv("KEYCLOAK_USERS_1_LAST-NAME", "user1")
           .withEnv("KEYCLOAK_USERS_1_USERNAME", "user1")
           .withEnv("KEYCLOAK_USERS_1_PASSWORD", "password")
-          .withEnv("KEYCLOAK_USERS_1_GROUPS_0", "groupC")
+          .withEnv("KEYCLOAK_USERS_1_GROUPS_0", "group C")
           .withEnv("KEYCLOAK_USERS_1_ROLES_0", "Zeebe")
           // assign authorizations to groups
           .withEnv("IDENTITY_AUTHORIZATIONS_0_GROUP_NAME", "groupA")
@@ -301,7 +303,9 @@ public abstract class AbstractKeycloakIdentityMigrationIT {
                 new URI(
                     "%s%s"
                         .formatted(
-                            externalIdentityUrl(IDENTITY_88), "/api/groups?search=" + groupName)))
+                            externalIdentityUrl(IDENTITY_88),
+                            "/api/groups?search="
+                                + URLEncoder.encode(groupName, StandardCharsets.UTF_8))))
             .GET()
             .header("Authorization", getManagementIdentityBearerToken())
             .build();

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -288,7 +288,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
               final var authorizations = client.newAuthorizationSearchRequest().send().join();
               assertThat(authorizations.items())
                   .extracting(Authorization::getOwnerId)
-                  .contains("groupa", "groupb");
+                  .contains("groupA", "groupB");
             });
 
     // then
@@ -303,7 +303,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
             a -> new HashSet<>(a.getPermissionTypes()))
         .contains(
             tuple(
-                "groupa",
+                "groupA",
                 OwnerType.GROUP,
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
@@ -311,7 +311,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
                     PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
-                "groupb",
+                "groupB",
                 OwnerType.GROUP,
                 ResourceType.DECISION_DEFINITION,
                 Set.of(
@@ -326,10 +326,10 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
     // given
     // we need to add the group-role memberships here via API calls, because there is no support to
     // do that via configuration
-    addGroupToRoleInManagementIdentity("groupc", "Zeebe");
-    addGroupToRoleInManagementIdentity("groupb", "Tasklist");
-    addGroupToRoleInManagementIdentity("groupb", "Operate");
-    addGroupToRoleInManagementIdentity("groupa", "Identity");
+    addGroupToRoleInManagementIdentity("group C", "Zeebe");
+    addGroupToRoleInManagementIdentity("groupB", "Tasklist");
+    addGroupToRoleInManagementIdentity("groupB", "Operate");
+    addGroupToRoleInManagementIdentity("groupA", "Identity");
 
     // when
     migration.start();
@@ -340,26 +340,26 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
         .untilAsserted(
             () -> {
               final var groups = client.newGroupsByRoleSearchRequest("zeebe").send().join();
-              assertThat(groups.items()).extracting(RoleGroup::getGroupId).contains("groupc");
+              assertThat(groups.items()).extracting(RoleGroup::getGroupId).contains("group C");
             });
 
     // then
     assertThat(migration.getExitCode()).isEqualTo(0);
 
     final var zeebeGroups = client.newGroupsByRoleSearchRequest("zeebe").send().join().items();
-    assertThat(zeebeGroups).extracting(RoleGroup::getGroupId).containsExactlyInAnyOrder("groupc");
+    assertThat(zeebeGroups).extracting(RoleGroup::getGroupId).containsExactlyInAnyOrder("group C");
     final var operateGroups = client.newGroupsByRoleSearchRequest("operate").send().join().items();
-    assertThat(operateGroups).extracting(RoleGroup::getGroupId).containsExactlyInAnyOrder("groupb");
+    assertThat(operateGroups).extracting(RoleGroup::getGroupId).containsExactlyInAnyOrder("groupB");
     final var tasklistGroups =
         client.newGroupsByRoleSearchRequest("tasklist").send().join().items();
     assertThat(tasklistGroups)
         .extracting(RoleGroup::getGroupId)
-        .containsExactlyInAnyOrder("groupb");
+        .containsExactlyInAnyOrder("groupB");
     final var identityGroups =
         client.newGroupsByRoleSearchRequest("identity").send().join().items();
     assertThat(identityGroups)
         .extracting(RoleGroup::getGroupId)
-        .containsExactlyInAnyOrder("groupa");
+        .containsExactlyInAnyOrder("groupA");
   }
 
   @Test
@@ -580,11 +580,11 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
     final var tenant1Groups = searchGroupsInTenant(restAddress, "tenant1");
     assertThat(tenant1Groups.items())
         .extracting(TenantGroup::groupId)
-        .containsExactlyInAnyOrder("groupa");
+        .containsExactlyInAnyOrder("groupA");
     final var tenant2Groups = searchGroupsInTenant(restAddress, "TenanT2");
     assertThat(tenant2Groups.items())
         .extracting(TenantGroup::groupId)
-        .containsExactlyInAnyOrder("groupb");
+        .containsExactlyInAnyOrder("groupB");
     final var tenant1Clients = searchClientsInTenant(restAddress, "tenant1");
     assertThat(tenant1Clients.items())
         .extracting(TenantClient::clientId)


### PR DESCRIPTION
## Description

Previously names were normalized to valid ids like done for the SaaS migration.
This is not the right approach for Self-Managed Keycloak though, as there
groups are not managed as entities within the OC. Instead the name managed in Keycloak
needs to be used as foreign key to grant groups authorizations or role/tenant membership.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40780
