### PR TITLE
test: fix configuration being updated after init

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -47,7 +47,7 @@ final class PartitionJoinTest {
               clusterCfg.setClusterSize(1);
               clusterCfg.setNodeId(0);
               clusterCfg.setPartitionsCount(2);
-              clusterCfg.setReplicationFactor(3);
+              clusterCfg.setReplicationFactor(1);
             });
 
     final var initialContactPoint =
@@ -102,8 +102,8 @@ final class PartitionJoinTest {
   Broker buildBroker(final Path tmp, final Consumer<BrokerCfg> configure) {
     final var brokerCfg = new BrokerCfg();
     assignSocketAddresses(brokerCfg);
-    brokerCfg.init(tmp.toAbsolutePath().toString());
     configure.accept(brokerCfg);
+    brokerCfg.init(tmp.toAbsolutePath().toString());
     final var atomixCluster = TestClusterFactory.createAtomixCluster(brokerCfg, meterRegistry);
     final var actorScheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerCfg);
     final var brokerClient =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -218,8 +218,8 @@ final class PartitionLeaveTest {
   private static Broker buildBroker(final Path tmp, final Consumer<BrokerCfg> configure) {
     final var brokerCfg = new BrokerCfg();
     assignSocketAddresses(brokerCfg);
-    brokerCfg.init(tmp.toAbsolutePath().toString());
     configure.accept(brokerCfg);
+    brokerCfg.init(tmp.toAbsolutePath().toString());
     final var actorScheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerCfg);
     final var atomixCluster = TestClusterFactory.createAtomixCluster(brokerCfg, METER_REGISTRY);
     final var brokerClient =


### PR DESCRIPTION
## Description
Configuration was modified after calling `brokerCfg.init(` which could cause issues in validation

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
