### PR TITLE
ci: create GH release after Docker image releases

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -267,134 +267,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  # GitHub release job creates a GitHub release with artifacts, changelog, and proper versioning.
-  # Flags impact:
-  # - With dryRun=true: Skips creating the actual GitHub release (only prepares artifacts and changelog)
-  # - With releaseProcessDryRun=true: Creates a draft GitHub release for E2E testing and manual inspection
-  # - Uses RELEASE_TAG for versioning (prefixed with 'dryrun-' when releaseProcessDryRun=true)
-  # The job generates changelog, checksums artifacts, and determines pre-release status
-  github:
-    needs: release
-    name: Github Release
-    runs-on: ubuntu-latest
-    # Minor releases take more time since a lot of issues are included in the changelog
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_BRANCH }}
-          fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
-      - name: Install Zeebe changelog tool
-        run: |
-          gh release download --repo camunda/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
-          tar -xzvf zeebe-changelog_*
-          chmod +x zcl
-      - name: Identify previous release version
-        id: prev_version
-        if: ${{ !inputs.dryRun }}
-        uses: camunda/infra-global-github-actions/previous-version@main
-        with:
-          version: "${{ inputs.releaseVersion }}"
-          verbose: 'false'
-      - name: Generate Changelog
-        id: gen-changelog
-        if: ${{ !inputs.dryRun }}
-        run: |
-          # We set some bash properties to better fail/debug this script
-          #
-          # * https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
-          # * https://explainshell.com/explain?cmd=set+-euox+pipefail
-          #
-          set -euox pipefail
-
-          # Default changelog value
-          changelog="Release ${{ inputs.releaseVersion }}"
-
-          # Add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
-          #
-          # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
-          # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type
-          ZCL_FROM_REV="${{ steps.prev_version.outputs.previous_version }}"
-          ZCL_TARGET_REV="${{ env.RELEASE_TAG }}"
-
-          # The following command will add labels to the issues on GitHub.
-          # You can verify this step by looking at closed issues. They should now be tagged with the release.
-          ./zcl add-labels \
-          --token=${{ secrets.GITHUB_TOKEN }} \
-          --from="$ZCL_FROM_REV" \
-          --target="$ZCL_TARGET_REV" \
-          --label="version:$ZCL_TARGET_REV" \
-          --org camunda --repo camunda
-
-          # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
-          changelog=$(./zcl generate \
-          --token=${{ secrets.GITHUB_TOKEN }} \
-          --label="version:$ZCL_TARGET_REV" \
-          --org camunda --repo camunda)
-
-          # With multiline strings the output needs to be set differently.
-          #
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
-          #
-          {
-            echo 'CHANGELOG<<EOF'
-            echo "$changelog"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
-          # To show the changelog also as step summary
-          echo "$changelog" >> "$GITHUB_STEP_SUMMARY"
-      - name: Download Release Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: release-artifacts-${{ inputs.releaseVersion }}
-          path: release-artifacts
-      - name: Create Artifact Checksums
-        id: checksum
-        working-directory: ./release-artifacts
-        run: |
-          for filename in *; do
-            checksumFile="${filename}.sha1sum"
-            sha1sum "${filename}" > "${checksumFile}"
-            sha1sumResult=$?
-            if [ ! -f "${checksumFile}" ]; then
-              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
-              exit 1
-            fi
-          done
-      - name: Determine if Pre-Release
-        id: pre-release
-        run: |
-          shopt -s nocasematch # set matching to case insensitive
-          PRE_RELEASE=false
-          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT).*$ ]]; then
-            PRE_RELEASE=true
-          fi
-          shopt -u nocasematch # reset it
-          echo "result=${PRE_RELEASE}" >> "$GITHUB_OUTPUT"
-      - name: Create Github release
-        uses: ncipollo/release-action@v1
-        if: ${{ !inputs.dryRun }}
-        with:
-          name: ${{ env.RELEASE_TAG }}
-          artifacts: "release-artifacts/*"
-          artifactErrorsFailBuild: true
-          draft: ${{ inputs.releaseProcessDryRun }}
-          makeLatest: ${{ inputs.isLatest }}
-          body: ${{ steps.gen-changelog.outputs.changelog }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ steps.pre-release.outputs.result }}
-          tag: ${{ env.RELEASE_TAG }}
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
   # Docker image release jobs build and publish multi-platform Docker images for each Camunda component.
   # All Docker jobs follow the same pattern: build locally, verify, then sync to DockerHub.
   # Flags impact:
@@ -780,6 +652,134 @@ jobs:
       build: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
     secrets: inherit
+
+  # GitHub release job creates a GitHub release with artifacts, changelog, and proper versioning.
+  # Flags impact:
+  # - With dryRun=true: Skips creating the actual GitHub release (only prepares artifacts and changelog)
+  # - With releaseProcessDryRun=true: Creates a draft GitHub release for E2E testing and manual inspection
+  # - Uses RELEASE_TAG for versioning (prefixed with 'dryrun-' when releaseProcessDryRun=true)
+  # The job generates changelog, checksums artifacts, and determines pre-release status
+  github:
+    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
+    name: Github Release
+    runs-on: ubuntu-latest
+    # Minor releases take more time since a lot of issues are included in the changelog
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
+      - name: Install Zeebe changelog tool
+        run: |
+          gh release download --repo camunda/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
+          tar -xzvf zeebe-changelog_*
+          chmod +x zcl
+      - name: Identify previous release version
+        id: prev_version
+        if: ${{ !inputs.dryRun }}
+        uses: camunda/infra-global-github-actions/previous-version@main
+        with:
+          version: "${{ inputs.releaseVersion }}"
+          verbose: 'false'
+      - name: Generate Changelog
+        id: gen-changelog
+        if: ${{ !inputs.dryRun }}
+        run: |
+          # We set some bash properties to better fail/debug this script
+          #
+          # * https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+          # * https://explainshell.com/explain?cmd=set+-euox+pipefail
+          #
+          set -euox pipefail
+
+          # Default changelog value
+          changelog="Release ${{ inputs.releaseVersion }}"
+
+          # Add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
+          #
+          # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
+          # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type
+          ZCL_FROM_REV="${{ steps.prev_version.outputs.previous_version }}"
+          ZCL_TARGET_REV="${{ env.RELEASE_TAG }}"
+
+          # The following command will add labels to the issues on GitHub.
+          # You can verify this step by looking at closed issues. They should now be tagged with the release.
+          ./zcl add-labels \
+          --token=${{ secrets.GITHUB_TOKEN }} \
+          --from="$ZCL_FROM_REV" \
+          --target="$ZCL_TARGET_REV" \
+          --label="version:$ZCL_TARGET_REV" \
+          --org camunda --repo camunda
+
+          # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
+          changelog=$(./zcl generate \
+          --token=${{ secrets.GITHUB_TOKEN }} \
+          --label="version:$ZCL_TARGET_REV" \
+          --org camunda --repo camunda)
+
+          # With multiline strings the output needs to be set differently.
+          #
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          #
+          {
+            echo 'CHANGELOG<<EOF'
+            echo "$changelog"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+          # To show the changelog also as step summary
+          echo "$changelog" >> "$GITHUB_STEP_SUMMARY"
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts-${{ inputs.releaseVersion }}
+          path: release-artifacts
+      - name: Create Artifact Checksums
+        id: checksum
+        working-directory: ./release-artifacts
+        run: |
+          for filename in *; do
+            checksumFile="${filename}.sha1sum"
+            sha1sum "${filename}" > "${checksumFile}"
+            sha1sumResult=$?
+            if [ ! -f "${checksumFile}" ]; then
+              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
+              exit 1
+            fi
+          done
+      - name: Determine if Pre-Release
+        id: pre-release
+        run: |
+          shopt -s nocasematch # set matching to case insensitive
+          PRE_RELEASE=false
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT).*$ ]]; then
+            PRE_RELEASE=true
+          fi
+          shopt -u nocasematch # reset it
+          echo "result=${PRE_RELEASE}" >> "$GITHUB_OUTPUT"
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        if: ${{ !inputs.dryRun }}
+        with:
+          name: ${{ env.RELEASE_TAG }}
+          artifacts: "release-artifacts/*"
+          artifactErrorsFailBuild: true
+          draft: ${{ inputs.releaseProcessDryRun }}
+          makeLatest: ${{ inputs.isLatest }}
+          body: ${{ steps.gen-changelog.outputs.changelog }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ steps.pre-release.outputs.result }}
+          tag: ${{ env.RELEASE_TAG }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   # This job waits for the existing FOSSA scan (triggered by check-licenses.yml on tag push)
   # then creates releases and generates attribution/SBOM reports for single-app only


### PR DESCRIPTION
## Description

As noticed with https://github.com/camunda/camunda/actions/runs/19132047552/attempts/1 and https://app.incident.io/camunda/incidents/3784 the uploads of Docker images to DockerHub is not always reliable.

I propose only creating the GH release once all Docker images are uploaded successfully to DockerHub. This has two advantages:

* users looking at GitHub don't get the impression prematurely that all artifacts are available
    * this property can later be used for upgrade tests in the monorepo, they currently fail while a release is ongoing because they rely on Git tags to identify available artifacts -> now they could switch to use GH releases info
* we need to revert fewer artifacts in case of foundational problems with DockerHub API errors

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
