### PR TITLE
ci: exclude version 8.5 from daily QA

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # List all `stable/8.*` branches
           # Sort them in desc order
-          # Exclude versions that don't require daily QA - for example, 8.4 in extended support
+          # Exclude versions that don't require daily QA - for example, 8.5 in extended support
           # Remove the `origin/` prefix
           # Transform to json-formatted objects with branch and generation_template fields
           # Transform them to json-formatted array of those objects
@@ -40,6 +40,7 @@ jobs:
             git ls-remote origin "refs/heads/stable/8.*" | awk '{print $2}' | sed 's|refs/heads/||' \
               | sort -Vr \
               | grep -v '^stable/8.4$' \
+              | grep -v '^stable/8.5$' \
               | while read -r branch; do
                   version="${branch#stable/}"
                   printf '{"branch":"%s","generation_template":"Camunda %s+gen1"}\n' "$branch" "$version"
@@ -48,8 +49,6 @@ jobs:
                   map(
                     if .branch == "stable/8.8" then
                       .generation_template = "Camunda 8.8-SNAPSHOT"
-                    elif .branch == "stable/8.5" then
-                      .generation_template = "Camunda 8.5+gen27"
                     else
                       .
                     end


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

There's no need to run the QA daily against versions that are in extended support. With 8.5 in extended support, we can exclude it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

See: https://camunda.slack.com/archives/C013MEVQ4M9/p1762873409449279?thread_ts=1762826685.161969&cid=C013MEVQ4M9