### PR TITLE
fix: Add support for sorting Authorization records by `resourceId`

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
@@ -12,7 +12,8 @@ import io.camunda.search.entities.AuthorizationEntity;
 public enum AuthorizationSearchColumn implements SearchColumn<AuthorizationEntity> {
   OWNER_ID("ownerId"),
   OWNER_TYPE("ownerType"),
-  RESOURCE_TYPE("resourceType");
+  RESOURCE_TYPE("resourceType"),
+  RESOURCE_ID("resourceId");
 
   private final String property;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
@@ -83,6 +83,22 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceType).reversed());
   }
 
+  @TestTemplate
+  public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().asc(),
+        Comparator.comparing(AuthorizationEntity::resourceId));
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().desc(),
+        Comparator.comparing(AuthorizationEntity::resourceId).reversed());
+  }
+
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<AuthorizationSort>> sortBuilder,

--- a/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
@@ -28,7 +28,7 @@ public record AuthorizationQuery(
 
   @Override
   public List<SearchSortOptions> retainValidSortings(final List<SearchSortOptions> sorting) {
-    final var fieldNames = List.of("ownerId", "ownerType", "resourceIds", "resourceType");
+    final var fieldNames = List.of("ownerId", "ownerType", "resourceId", "resourceType");
     return sorting.stream().filter(s -> fieldNames.contains(s.field().field())).toList();
   }
 


### PR DESCRIPTION
## Description

This PR fixes a bug where sorting authorizations by `resourceId` was not properly supported across storage backends.

### Additional issue discovered - ES/OS:
- While fixing the RDBMS issue, discovered that ES/OS backends also didn't properly support `resourceId` sorting.
  - The API accepted `resourceId` as a sort parameter but silently ignored it, leading to incorrect sorting behavior.

### Changes made

#### RDBMS implementation:
- Added `RESOURCE_ID("resourceId")` to `AuthorizationSearchColumn` enum to avoid `IllegalArgumentException: Unknown sortField: resourceId` exception.

#### ES/OS implementation:
- Fixed `resourceId` field name in authorization sort validation (from `"resourceIds"` to `"resourceId"`).

**Tests:**
- Added tests to `AuthorizationSpecificFilterIT` to verify sorting by `resourceId` works correctly, covering both ascending and descending sort orders (RDBMS).
- Added test to `AuthorizationIntegrationTest` that verifies sorting by `resourceId` properly works across all storage backends (RDBMS, ES, OS).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40799 
