### PR TITLE
[Backport stable/8.6] ci: create GH release after Docker image releases

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -256,131 +256,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  github:
-    needs: release
-    name: Github Release
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_BRANCH }}
-          fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
-      - name: Install Zeebe changelog tool
-        run: |
-          gh release download --repo camunda/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
-          tar -xzvf zeebe-changelog_*
-          chmod +x zcl
-      - name: Generate Changelog for patch release
-        id: gen-changelog
-        run: |
-          # We set some bash properties to better fail/debug this script
-          #
-          # * https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
-          # * https://explainshell.com/explain?cmd=set+-euox+pipefail
-          #
-          set -euox pipefail
-
-          # Default changelog value
-          changelog="Release ${{ inputs.releaseVersion }}"
-          isDraftRelease="true"
-
-          # Right now we only support patch releases for generating the changelog
-          # as it is the easiest to automate and the most repetitive work to do on a release
-          if [[ "${{ inputs.releaseVersion }}" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
-          then
-            # Next, add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
-            #
-            # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
-            # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
-            #
-            # PATCH: the tag for the previous patch version on the same minor branch. e.g. if you're releasing 1.2.3, then ZCL_FROM_REV=1.2.2.
-
-            # To find the previous patch version we extract the patch version and subtract by one
-            patchVersion=$(echo ${{ inputs.releaseVersion }} | sed 's/8\.[1-9][0-9]*\.//')
-            majorMinor=$(echo ${{ inputs.releaseVersion }} | sed 's/\.[1-9][0-9]*$//')
-            ZCL_FROM_REV="$majorMinor".$(( patchVersion - 1 ))
-            ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
-
-            # The following command will add labels to the issues on GitHub.
-            # You can verify this step by looking at closed issues. They should now be tagged with the release.
-            ./zcl add-labels \
-            --token=${{ secrets.GITHUB_TOKEN }} \
-            --from=$ZCL_FROM_REV \
-            --target=$ZCL_TARGET_REV \
-            --label="version:$ZCL_TARGET_REV" \
-            --org camunda --repo zeebe
-
-            # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
-            changelog=$(./zcl generate \
-            --token=${{ secrets.GITHUB_TOKEN }} \
-            --label="version:$ZCL_TARGET_REV" \
-            --org camunda --repo zeebe)
-            isDraftRelease="false"
-          fi
-
-          # With multiline strings the output needs to be set differently.
-          #
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
-          #
-          echo 'CHANGELOG<<EOF' >> $GITHUB_OUTPUT
-          echo "$changelog" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-          echo "isDraftRelease=$isDraftRelease" >> "$GITHUB_OUTPUT"
-
-          # To show the changelog also as step summary
-          echo "$changelog" >> $GITHUB_STEP_SUMMARY
-      - name: Download Release Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: release-artifacts-${{ inputs.releaseVersion }}
-          path: release-artifacts
-      - name: Create Artifact Checksums
-        id: checksum
-        working-directory: ./release-artifacts
-        run: |
-          for filename in *; do
-            checksumFile="${filename}.sha1sum"
-            sha1sum "${filename}" > "${checksumFile}"
-            sha1sumResult=$?
-            if [ ! -f "${checksumFile}" ]; then
-              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
-              exit 1
-            fi
-          done
-      - name: Determine if Pre-Release
-        id: pre-release
-        run: |
-          shopt -s nocasematch # set matching to case insensitive
-          PRE_RELEASE=false
-          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
-            PRE_RELEASE=true
-          fi
-          shopt -u nocasematch # reset it
-          echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
-      - name: Create Github release
-        uses: ncipollo/release-action@v1
-        if: ${{ !inputs.dryRun }}
-        with:
-          name: ${{ env.RELEASE_TAG }}
-          artifacts: "release-artifacts/*"
-          artifactErrorsFailBuild: true
-          draft: ${{ inputs.releaseProcessDryRun || steps.gen-changelog.outputs.isDraftRelease }}
-          makeLatest: ${{ inputs.isLatest }}
-          body: ${{ steps.gen-changelog.outputs.changelog }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ steps.pre-release.outputs.result }}
-          tag: ${{ env.RELEASE_TAG }}
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
   zeebe-docker:
     needs: release
     name: Zeebe docker Image Release
@@ -716,6 +591,131 @@ jobs:
           docker buildx imagetools create \
             --tag ${{ env.DOCKER_IMAGE }}:latest \
             ${{ steps.build-camunda-docker.outputs.image }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  github:
+    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
+    name: Github Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
+      - name: Install Zeebe changelog tool
+        run: |
+          gh release download --repo camunda/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
+          tar -xzvf zeebe-changelog_*
+          chmod +x zcl
+      - name: Generate Changelog for patch release
+        id: gen-changelog
+        run: |
+          # We set some bash properties to better fail/debug this script
+          #
+          # * https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+          # * https://explainshell.com/explain?cmd=set+-euox+pipefail
+          #
+          set -euox pipefail
+
+          # Default changelog value
+          changelog="Release ${{ inputs.releaseVersion }}"
+          isDraftRelease="true"
+
+          # Right now we only support patch releases for generating the changelog
+          # as it is the easiest to automate and the most repetitive work to do on a release
+          if [[ "${{ inputs.releaseVersion }}" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
+          then
+            # Next, add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
+            #
+            # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
+            # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
+            #
+            # PATCH: the tag for the previous patch version on the same minor branch. e.g. if you're releasing 1.2.3, then ZCL_FROM_REV=1.2.2.
+
+            # To find the previous patch version we extract the patch version and subtract by one
+            patchVersion=$(echo ${{ inputs.releaseVersion }} | sed 's/8\.[1-9][0-9]*\.//')
+            majorMinor=$(echo ${{ inputs.releaseVersion }} | sed 's/\.[1-9][0-9]*$//')
+            ZCL_FROM_REV="$majorMinor".$(( patchVersion - 1 ))
+            ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
+
+            # The following command will add labels to the issues on GitHub.
+            # You can verify this step by looking at closed issues. They should now be tagged with the release.
+            ./zcl add-labels \
+            --token=${{ secrets.GITHUB_TOKEN }} \
+            --from=$ZCL_FROM_REV \
+            --target=$ZCL_TARGET_REV \
+            --label="version:$ZCL_TARGET_REV" \
+            --org camunda --repo zeebe
+
+            # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
+            changelog=$(./zcl generate \
+            --token=${{ secrets.GITHUB_TOKEN }} \
+            --label="version:$ZCL_TARGET_REV" \
+            --org camunda --repo zeebe)
+            isDraftRelease="false"
+          fi
+
+          # With multiline strings the output needs to be set differently.
+          #
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          #
+          echo 'CHANGELOG<<EOF' >> $GITHUB_OUTPUT
+          echo "$changelog" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "isDraftRelease=$isDraftRelease" >> "$GITHUB_OUTPUT"
+
+          # To show the changelog also as step summary
+          echo "$changelog" >> $GITHUB_STEP_SUMMARY
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts-${{ inputs.releaseVersion }}
+          path: release-artifacts
+      - name: Create Artifact Checksums
+        id: checksum
+        working-directory: ./release-artifacts
+        run: |
+          for filename in *; do
+            checksumFile="${filename}.sha1sum"
+            sha1sum "${filename}" > "${checksumFile}"
+            sha1sumResult=$?
+            if [ ! -f "${checksumFile}" ]; then
+              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
+              exit 1
+            fi
+          done
+      - name: Determine if Pre-Release
+        id: pre-release
+        run: |
+          shopt -s nocasematch # set matching to case insensitive
+          PRE_RELEASE=false
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
+            PRE_RELEASE=true
+          fi
+          shopt -u nocasematch # reset it
+          echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        if: ${{ !inputs.dryRun }}
+        with:
+          name: ${{ env.RELEASE_TAG }}
+          artifacts: "release-artifacts/*"
+          artifactErrorsFailBuild: true
+          draft: ${{ inputs.releaseProcessDryRun || steps.gen-changelog.outputs.isDraftRelease }}
+          makeLatest: ${{ inputs.isLatest }}
+          body: ${{ steps.gen-changelog.outputs.changelog }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ steps.pre-release.outputs.result }}
+          tag: ${{ env.RELEASE_TAG }}
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
# Description
Backport of #40801 to `stable/8.6`.

relates to 