### PR TITLE
feat: allow CoverageReportUtilTest to run without a real frontend artifact

### DIFF
--- a/testing/camunda-process-test-java/src/test/resources/coverage/index.html
+++ b/testing/camunda-process-test-java/src/test/resources/coverage/index.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Coverage Report</title>
+</head>
+<body>
+<script>
+  window.COVERAGE_DATA = {{ COVERAGE_DATA }};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allows `CoverageReportUtilTest` to run without a real frontend artifact. Java's classpath resolution will prefer `src/test/resources` over `src/main/resources` during test execution, so by creating minimal test resources, we decouple the unit tests from the production frontend build.

related to https://github.com/camunda/camunda/pull/40432
