### PR TITLE
fix: credentials provider silent fail

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CredentialsProviderConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CredentialsProviderConfiguration.java
@@ -101,17 +101,7 @@ public class CredentialsProviderConfiguration {
                 camundaClientProperties.getAuth().getClientAssertion().getKeystoreKeyPassword());
 
     maybeConfigureIdentityProviderSSLConfig(credBuilder, camundaClientProperties);
-    try {
-      return credBuilder.build();
-    } catch (final Exception e) {
-      LOG.warn(
-          "Failed to configure oidc credential provider, falling back to use no authentication, cause: {}",
-          e.getMessage());
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(e.getMessage(), e);
-      }
-      return new NoopCredentialsProvider();
-    }
+    return credBuilder.build();
   }
 
   private void maybeConfigureIdentityProviderSSLConfig(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes a try/catch block around the building of the credentials provider.

Originally, this was introduced as until 8.7, the spring boot starter technically knew only 1 way to configure it, so using the noop credentials provider was the fallback.

Starting from 8.8, this is controlled by the `camunda.client.auth.method` which can be set or is discovered by the client. There is not more need to set up the credentials provider and silently fall back to another one.

Instead, a faulty configuration should lead to an error at startup.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
