### PR TITLE
feat: Clean up connectors-application.properties

### DIFF
--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,6 +1,1 @@
-zeebe.client.broker.gateway-address=http://127.0.0.1:26500
-zeebe.client.security.plaintext=true
-camunda.operate.client.url=http://localhost:8080
-camunda.operate.client.username=demo
-camunda.operate.client.password=demo
 server.port=8086


### PR DESCRIPTION
Removed Zeebe and Camunda Operate client configurations.

## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes non-required properties from the `connectors-application.properties`. 

It still needs to be verified whether the `zeebe.` properties need a replacement, but Operate is not part of the game anymore.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
