### PR TITLE
Only resolve ACTIVE incidents in batch incident resolution

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
@@ -39,7 +39,8 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class BatchOperationResolveIncidentTest {
 
-  static final int AMOUNT_OF_INCIDENTS = 3;
+  static final int AMOUNT_OF_MI_INCIDENTS = 5;
+  static final int AMOUNT_OF_INCIDENTS = 3 + AMOUNT_OF_MI_INCIDENTS;
 
   private static CamundaClient camundaClient;
 
@@ -48,24 +49,30 @@ public class BatchOperationResolveIncidentTest {
     Objects.requireNonNull(camundaClient);
 
     final var processes =
-        List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");
+        List.of(
+            "service_tasks_v1.bpmn",
+            "service_tasks_v2.bpmn",
+            "incident_process_v1.bpmn",
+            "multi_instance_incident.bpmn");
     processes.forEach(
         process -> deployResource(camundaClient, String.format("process/%s", process)));
 
-    waitForProcessesToBeDeployed(camundaClient, 3);
+    waitForProcessesToBeDeployed(camundaClient, 4);
 
     startProcessInstance(camundaClient, "service_tasks_v1");
     startProcessInstance(camundaClient, "service_tasks_v2", Map.of("path", 222));
     startProcessInstance(camundaClient, "incident_process_v1");
     startProcessInstance(camundaClient, "incident_process_v1");
     startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(
+        camundaClient, "multi-instance-incident", Map.of("items", AMOUNT_OF_MI_INCIDENTS));
 
-    waitForProcessInstancesToStart(camundaClient, 5);
+    waitForProcessInstancesToStart(camundaClient, 6);
   }
 
   @BeforeEach
   void beforeEach() {
-    waitUntilProcessInstanceHasIncidents(camundaClient, 3);
+    waitUntilProcessInstanceHasIncidents(camundaClient, 4);
     waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
@@ -7,34 +7,32 @@
  */
 package io.camunda.it.client;
 
+import static io.camunda.it.task.UserTaskIT.startProcessInstance;
 import static io.camunda.it.util.TestHelper.deployResource;
-import static io.camunda.it.util.TestHelper.getScopedVariables;
-import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
-import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
 import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
-import static io.camunda.it.util.TestHelper.waitUntilScopedProcessInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
@@ -44,83 +42,65 @@ public class BatchOperationResolveIncidentTest {
   static final int AMOUNT_OF_INCIDENTS = 3;
 
   private static CamundaClient camundaClient;
-  String testScopeId;
-  final List<Process> deployedProcesses = new ArrayList<>();
-  final List<Long> activeIncidents = new ArrayList<>();
 
-  @BeforeEach
-  public void beforeEach(final TestInfo testInfo) {
+  @BeforeAll
+  static void before() {
     Objects.requireNonNull(camundaClient);
-    testScopeId =
-        testInfo.getTestMethod().map(Method::toString).orElse(UUID.randomUUID().toString());
 
     final var processes =
         List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");
     processes.forEach(
-        process ->
-            deployedProcesses.addAll(
-                deployResource(camundaClient, String.format("process/%s", process))
-                    .getProcesses()));
+        process -> deployResource(camundaClient, String.format("process/%s", process)));
 
     waitForProcessesToBeDeployed(camundaClient, 3);
 
-    final var processInstances = new ArrayList<Long>();
-    processInstances.add(
-        startScopedProcessInstance(camundaClient, "service_tasks_v1", testScopeId)
-            .getProcessInstanceKey());
-    processInstances.add(
-        startScopedProcessInstance(
-                camundaClient, "service_tasks_v2", testScopeId, Map.of("path", 222))
-            .getProcessInstanceKey());
-    processInstances.add(
-        startScopedProcessInstance(camundaClient, "incident_process_v1", testScopeId)
-            .getProcessInstanceKey());
-    processInstances.add(
-        startScopedProcessInstance(camundaClient, "incident_process_v1", testScopeId)
-            .getProcessInstanceKey());
-    processInstances.add(
-        startScopedProcessInstance(camundaClient, "incident_process_v1", testScopeId)
-            .getProcessInstanceKey());
+    startProcessInstance(camundaClient, "service_tasks_v1");
+    startProcessInstance(camundaClient, "service_tasks_v2", Map.of("path", 222));
+    startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(camundaClient, "incident_process_v1");
 
-    waitForScopedProcessInstancesToStart(camundaClient, testScopeId, 5);
-    waitUntilScopedProcessInstanceHasIncidents(camundaClient, testScopeId, AMOUNT_OF_INCIDENTS);
-    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
-
-    activeIncidents.addAll(
-        camundaClient.newIncidentSearchRequest().send().join().items().stream()
-            .map(Incident::getIncidentKey)
-            .toList());
+    waitForProcessInstancesToStart(camundaClient, 5);
   }
 
-  @AfterEach
-  void afterEach() {
-    deployedProcesses.clear();
-    activeIncidents.clear();
+  @BeforeEach
+  void beforeEach() {
+    waitUntilProcessInstanceHasIncidents(camundaClient, 3);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
   }
 
   @Test
-  void shouldResolveIncidentsWithBatch() throws InterruptedException {
+  void shouldResolveIncidentsWithBatch() {
+    // given
+    final var activeIncidentKeys =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(f -> f.state(IncidentState.ACTIVE))
+            .send()
+            .join()
+            .items()
+            .stream()
+            .map(Incident::getIncidentKey)
+            .toList();
+
     // when
-    final var result =
+    final Future<CreateBatchOperationResponse> result =
         camundaClient
             .newCreateBatchOperationCommand()
             .resolveIncident()
-            .filter(f -> f.variables(getScopedVariables(testScopeId)))
-            .send()
-            .join();
-    final var batchOperationKey = result.getBatchOperationKey();
+            .filter(f -> f.hasIncident(true))
+            .send();
 
-    // then
-    assertThat(result).isNotNull();
-
-    // and wait if batch has correct amount of items. (To fail fast if not)
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 3);
-
-    // and
-    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 3, 0);
-
-    // and
-    waitUntilIncidentsAreResolved(camundaClient, activeIncidents.size());
+    // then each incident should be resolved and in an item, with each item completed
+    final var batchOperationKey =
+        assertThat(result)
+            .succeedsWithin(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+            .actual()
+            .getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchOperationKey, AMOUNT_OF_INCIDENTS);
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, AMOUNT_OF_INCIDENTS, 0);
+    waitUntilIncidentsAreResolved(camundaClient, activeIncidentKeys);
 
     // and
     final var itemsObj =
@@ -131,9 +111,89 @@ public class BatchOperationResolveIncidentTest {
             .join();
     final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
 
-    assertThat(itemsObj.items()).hasSize(3);
+    assertThat(itemKeys).hasSize(AMOUNT_OF_INCIDENTS);
+    assertThat(itemKeys).containsExactlyInAnyOrderElementsOf(activeIncidentKeys);
     assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
         .containsExactly(BatchOperationItemState.COMPLETED);
-    assertThat(itemKeys).containsExactlyInAnyOrder(activeIncidents.toArray(Long[]::new));
+  }
+
+  @Test
+  void shouldResolveActiveIncidentsOnlyWithBatch() {
+    // given we resolve all incidents once
+    final var firstActiveIncidentKeys =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(f -> f.state(IncidentState.ACTIVE))
+            .send()
+            .join()
+            .items()
+            .stream()
+            .map(Incident::getIncidentKey)
+            .toList();
+    final Future<CreateBatchOperationResponse> firstResult =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .resolveIncident()
+            .filter(f -> f.hasIncident(true))
+            .send();
+    final var firstBatchOperationKey =
+        assertThat(firstResult)
+            .succeedsWithin(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+            .actual()
+            .getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, firstBatchOperationKey, AMOUNT_OF_INCIDENTS);
+    waitForBatchOperationCompleted(camundaClient, firstBatchOperationKey, AMOUNT_OF_INCIDENTS, 0);
+    waitUntilIncidentsAreResolved(camundaClient, firstActiveIncidentKeys);
+
+    // and we fetch the newly created incidents
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
+    final var activeIncidentKeys =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(f -> f.state(IncidentState.ACTIVE))
+            .send()
+            .join()
+            .items()
+            .stream()
+            .map(Incident::getIncidentKey)
+            .toList();
+    assertThat(activeIncidentKeys)
+        .hasSize(AMOUNT_OF_INCIDENTS)
+        .doesNotContainAnyElementsOf(firstActiveIncidentKeys);
+
+    // when
+    final Future<CreateBatchOperationResponse> result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .resolveIncident()
+            .filter(f -> f.hasIncident(true))
+            .send();
+
+    // then we should only have the original amount of items for the operation, not duplicated (or
+    // more)
+    final var batchOperationKey =
+        assertThat(result)
+            .succeedsWithin(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+            .actual()
+            .getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchOperationKey, AMOUNT_OF_INCIDENTS);
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, AMOUNT_OF_INCIDENTS, 0);
+    waitUntilIncidentsAreResolved(camundaClient, activeIncidentKeys);
+
+    // and
+    final var itemsObj =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.batchOperationKey(batchOperationKey))
+            .send()
+            .join();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
+
+    assertThat(itemKeys).hasSize(AMOUNT_OF_INCIDENTS);
+    assertThat(itemKeys).containsExactlyInAnyOrderElementsOf(activeIncidentKeys);
+    assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
+        .containsExactly(BatchOperationItemState.COMPLETED);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -360,30 +360,6 @@ public final class TestHelper {
    * Waits for process instances to start which are having a process variable {@link *
    * #VAR_TEST_SCOPE_ID}.
    *
-   * @param camundaClient ... CamundaClient
-   * @param expectedIncidents
-   */
-  public static void waitUntilScopedProcessInstanceHasIncidents(
-      final CamundaClient camundaClient, final String scopeId, final int expectedIncidents) {
-    Awaitility.await("should wait until scoped incidents are exists")
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
-        .ignoreExceptions() // Ignore exceptions and continue retrying
-        .untilAsserted(
-            () -> {
-              final var result =
-                  camundaClient
-                      .newProcessInstanceSearchRequest()
-                      .filter(f -> f.variables(getScopedVariables(scopeId)).hasIncident(true))
-                      .send()
-                      .join();
-              assertThat(result.page().totalItems()).isEqualTo(expectedIncidents);
-            });
-  }
-
-  /**
-   * Waits for process instances to start which are having a process variable {@link *
-   * #VAR_TEST_SCOPE_ID}.
-   *
    * @param camundaClient CamundaClient
    * @param processInstanceKey the key of the process instance to check
    * @param variableName the name of the variable to check
@@ -782,7 +758,7 @@ public final class TestHelper {
   }
 
   public static void waitUntilProcessInstanceHasIncidents(
-      final CamundaClient camundaClient, final int expectedIncidents) {
+      final CamundaClient camundaClient, final int expectedInstancesWithIncidents) {
     Awaitility.await("should wait until incidents are exists")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -794,7 +770,7 @@ public final class TestHelper {
                       .filter(f -> f.hasIncident(true))
                       .send()
                       .join();
-              assertThat(result.page().totalItems()).isEqualTo(expectedIncidents);
+              assertThat(result.page().totalItems()).isEqualTo(expectedInstancesWithIncidents);
             });
   }
 
@@ -871,6 +847,24 @@ public final class TestHelper {
                       .send()
                       .join();
               assertThat(result.page().totalItems()).isEqualTo(expectedIncidents);
+            });
+  }
+
+  public static void waitUntilIncidentsAreResolved(
+      final CamundaClient camundaClient, final List<Long> incidentKeys) {
+    Awaitility.await("should wait until incidents are resolved")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newIncidentSearchRequest()
+                      .filter(
+                          f -> f.state(IncidentState.RESOLVED).incidentKey(k -> k.in(incidentKeys)))
+                      .send()
+                      .join();
+              assertThat(result.page().totalItems()).isEqualTo(incidentKeys.size());
             });
   }
 

--- a/qa/acceptance-tests/src/test/resources/process/multi_instance_incident.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/multi_instance_incident.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="6169c24" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="multi-instance-incident" name="Multi-instance incident" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a32fvn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a32fvn" sourceRef="StartEvent_1" targetRef="MultiInstanceJobWithIncident" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_17pv1bd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_17pv1bd" sourceRef="MultiInstanceJobWithIncident" targetRef="EndEvent_1" />
+    <bpmn:serviceTask id="MultiInstanceJobWithIncident">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="=jobType" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a32fvn</bpmn:incoming>
+      <bpmn:outgoing>Flow_17pv1bd</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=for i in 1..items return i" inputElement="" outputCollection="" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multi-instance-incident">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10ju7yv_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ekih8p_di" bpmnElement="MultiInstanceJobWithIncident">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1a32fvn_di" bpmnElement="Flow_1a32fvn">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17pv1bd_di" bpmnElement="Flow_17pv1bd">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProvider.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.batchoperation.itemprovider;
 
 import com.google.common.collect.Lists;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPageBuilders;
@@ -89,6 +90,7 @@ public class IncidentItemProvider implements ItemProvider {
           new IncidentFilter.Builder()
               .processInstanceKeyOperations(
                   FilterUtil.mapDefaultToOperation(processInstanceKeysBatch))
+              .states(IncidentState.ACTIVE.name())
               .build();
       incidents.addAll(fetchIncidentItems(filter, pageSize));
     }


### PR DESCRIPTION
## Description

Only considers ACTIVE incidents when resolving incidents in a batch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40822 
