### PR TITLE
Prototype: Configure RocksDB memory per broker and not per partition

### DIFF
--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -235,6 +235,11 @@
       <artifactId>camunda-search-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -128,12 +128,9 @@ public final class PartitionManagerImpl
     // allocate a quarter of the block cache to the write buffer manager, value to be
     // discussed/tuned
     final long wbmLimitBytes = blockCacheBytes / 4;
-    // capacity (blockCacheBytes)
-    // numShardBits (-1 = default), automatically picks a shard count based on your system and
-    // capacity
-    // strictCapacityLimit (true)
-    // highPriPoolRatio (0.5)
-    final LRUCache sharedCache = new LRUCache(blockCacheBytes, -1, true, 0.5);
+
+
+    final LRUCache sharedCache = new LRUCache(blockCacheBytes, 8, false, 0.15);
     final WriteBufferManager sharedWbm = new WriteBufferManager(wbmLimitBytes, sharedCache);
 
     zeebePartitionFactory =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -80,6 +80,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.ToLongFunction;
+import org.rocksdb.LRUCache;
+import org.rocksdb.WriteBufferManager;
 
 public final class ZeebePartitionFactory {
 
@@ -102,6 +104,8 @@ public final class ZeebePartitionFactory {
   private final SecurityConfiguration securityConfig;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
+  private final LRUCache lruCache;
+  private final WriteBufferManager writeBufferManager;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -120,7 +124,9 @@ public final class ZeebePartitionFactory {
       final FeatureFlags featureFlags,
       final SecurityConfiguration securityConfig,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final LRUCache lruCache,
+      final WriteBufferManager writeBufferManager) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -138,6 +144,8 @@ public final class ZeebePartitionFactory {
     this.securityConfig = securityConfig;
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+    this.lruCache = lruCache;
+    this.writeBufferManager = writeBufferManager;
   }
 
   public ZeebePartition constructPartition(
@@ -145,7 +153,9 @@ public final class ZeebePartitionFactory {
       final FileBasedSnapshotStore snapshotStore,
       final DynamicPartitionConfig initialPartitionConfig,
       final BrokerHealthCheckService brokerHealthCheckService,
-      final MeterRegistry partitionMeterRegistry) {
+      final MeterRegistry partitionMeterRegistry,
+      final LRUCache lruCache,
+      final WriteBufferManager writeBufferManager) {
     final var communicationService = clusterServices.getCommunicationService();
     final var membershipService = clusterServices.getMembershipService();
     final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);
@@ -158,7 +168,9 @@ public final class ZeebePartitionFactory {
             databaseCfg.createRocksDbConfiguration(),
             consistencyChecks.getSettings(),
             new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), partitionId),
-            () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)));
+            () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)),
+            lruCache,
+            writeBufferManager);
     final StateController stateController =
         createStateController(raftPartition, zeebeFactory, snapshotStore, snapshotStore);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -153,9 +153,7 @@ public final class ZeebePartitionFactory {
       final FileBasedSnapshotStore snapshotStore,
       final DynamicPartitionConfig initialPartitionConfig,
       final BrokerHealthCheckService brokerHealthCheckService,
-      final MeterRegistry partitionMeterRegistry,
-      final LRUCache lruCache,
-      final WriteBufferManager writeBufferManager) {
+      final MeterRegistry partitionMeterRegistry) {
     final var communicationService = clusterServices.getCommunicationService();
     final var membershipService = clusterServices.getMembershipService();
     final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -31,11 +31,17 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.rocksdb.LRUCache;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBufferManager;
 
 final class TestState {
-
   private static final int BATCH_INSERT_SIZE = 10_000;
   private static final int KEY_VALUE_SIZE = 8096;
+
+  static {
+    RocksDB.loadLibrary();
+  }
 
   TestContext generateContext(final long sizeInBytes) throws Exception {
     final var meterRegistry = new SimpleMeterRegistry();
@@ -82,11 +88,14 @@ final class TestState {
   }
 
   private ZeebeRocksDbFactory<ZbColumnFamilies> createDbFactory() {
+    final LRUCache lruCache = new LRUCache(200 * 1024 * 1024);
     return new ZeebeRocksDbFactory<>(
         new RocksDbConfiguration(),
         new ConsistencyChecksSettings(false, false),
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        SimpleMeterRegistry::new);
+        SimpleMeterRegistry::new,
+        lruCache,
+        new WriteBufferManager(100 * 1024 * 1024, lruCache));
   }
 
   private void insertData(final List<ColumnFamily<DbString, DbString>> columns) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStepTest.java
@@ -31,16 +31,25 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
+import org.rocksdb.LRUCache;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBufferManager;
 
 public class MigrationTransitionStepTest {
+  static {
+    RocksDB.loadLibrary();
+  }
 
   @TempDir Path tempDir;
+  final LRUCache lruCache = new LRUCache(200 * 1024 * 1024);
   ZeebeRocksDbFactory<?> factory =
       new ZeebeRocksDbFactory<ZbColumnFamilies>(
           new RocksDbConfiguration(),
           new ConsistencyChecksSettings(),
           new AccessMetricsConfiguration(Kind.NONE, 1),
-          SimpleMeterRegistry::new);
+          SimpleMeterRegistry::new,
+          lruCache,
+          new WriteBufferManager(100 * 1024 * 1024, lruCache));
 
   @AutoClose ZeebeDb zeebeDb;
   TestPartitionTransitionContext context;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -39,6 +39,7 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 import org.rocksdb.TableFormatConfig;
+import org.rocksdb.WriteBufferManager;
 
 public final class ZeebeRocksDbFactory<
         ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue & ScopedColumnFamily>
@@ -57,7 +58,9 @@ public final class ZeebeRocksDbFactory<
       final RocksDbConfiguration rocksDbConfiguration,
       final ConsistencyChecksSettings consistencyChecksSettings,
       final AccessMetricsConfiguration metricsConfiguration,
-      final Supplier<MeterRegistry> meterRegistryFactory) {
+      final Supplier<MeterRegistry> meterRegistryFactory,
+      final LRUCache lruCache,
+      final WriteBufferManager writeBufferManager) {
     this.rocksDbConfiguration = Objects.requireNonNull(rocksDbConfiguration);
     this.consistencyChecksSettings = Objects.requireNonNull(consistencyChecksSettings);
     metrics = metricsConfiguration;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -322,7 +322,7 @@ public final class ZeebeRocksDbFactory<
     return props;
   }
 
-    closeables.add(cache);
+  private TableFormatConfig createTableFormatConfig(final List<AutoCloseable> closeables) {
     final var filter = new BloomFilter(10, false);
     closeables.add(filter);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
