### PR TITLE
feat: enable add, move & cancel flownode with parent scope

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -32,6 +32,7 @@ import {
   hasChildPlaceholders,
 } from 'modules/utils/instanceHistoryModification';
 import {
+  getSelectedRunningInstanceCount,
   selectAdHocSubProcessInnerInstance,
   selectFlowNode,
 } from 'modules/utils/flowNodeSelection';
@@ -260,6 +261,10 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
             modificationsStore.finishAddingToken(
               processInstanceXmlData.businessObjects,
               flowNodeInstance.flowNodeId,
+              flowNodeInstance.id,
+            );
+          } else if (modificationsStore.state.status === 'moving-token') {
+            modificationsStore.setAncestorFlowNodeKeyForMoveOperation(
               flowNodeInstance.id,
             );
           } else {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/index.tsx
@@ -263,6 +263,10 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
               flowNodeInstance.flowNodeId,
               flowNodeInstance.id,
             );
+          } else if (modificationsStore.state.status === 'moving-token') {
+            modificationsStore.setAncestorFlowNodeKeyForMoveOperation(
+              flowNodeInstance.id,
+            );
           } else {
             tracking.track({eventName: 'instance-history-item-clicked'});
             if (isAdHocSubProcessInnerInstance) {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -273,7 +273,6 @@ const TopPanel: React.FC = observer(() => {
     return 'content';
   };
 
-  console.log(modificationsStore.state.status);
   const {data: totalRunningInstancesByFlowNode} =
     useTotalRunningInstancesByFlowNode();
 

--- a/operate/client/src/modules/bpmn-js/utils/isMoveModificationTarget.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMoveModificationTarget.ts
@@ -8,7 +8,6 @@
 
 import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import isNil from 'lodash/isNil';
-import {isWithinMultiInstance} from './isWithinMultiInstance';
 import {isAttachedToAnEventBasedGateway} from './isAttachedToAnEventBasedGateway';
 import {hasType} from './hasType';
 
@@ -17,7 +16,6 @@ const isMoveModificationTarget = (
 ) => {
   return (
     !isNil(businessObject) &&
-    !isWithinMultiInstance(businessObject) &&
     !isAttachedToAnEventBasedGateway(businessObject) &&
     !hasType({businessObject, types: ['bpmn:StartEvent', 'bpmn:BoundaryEvent']})
   );

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -41,13 +41,7 @@ const useFlowNodes = () => {
 
 const useAppendableFlowNodes = () => {
   return useFlowNodes()
-    .filter(
-      (flowNode) =>
-        flowNode.isMoveModificationTarget &&
-        ((IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED &&
-          modificationsStore.state.status !== 'moving-token') ||
-          !flowNode.hasMultipleScopes),
-    )
+    .filter((flowNode) => flowNode.isMoveModificationTarget)
     .map(({id}) => id);
 };
 

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -87,6 +87,7 @@ type State = {
     | 'enabled'
     | 'adding-token'
     | 'moving-token'
+    | 'canceling-token'
     | 'disabled'
     | 'applying-modifications';
   modifications: Modification[];
@@ -98,6 +99,7 @@ type State = {
     | undefined;
   sourceFlowNodeIdForMoveOperation: string | null;
   sourceFlowNodeInstanceKeyForMoveOperation: string | null;
+  ancestorFlowNodeInstanceKeyForMoveOperation: string | null;
   sourceFlowNodeIdForAddOperation: string | null;
 };
 
@@ -106,6 +108,7 @@ const DEFAULT_STATE: State = {
   modifications: [],
   sourceFlowNodeIdForMoveOperation: null,
   sourceFlowNodeInstanceKeyForMoveOperation: null,
+  ancestorFlowNodeInstanceKeyForMoveOperation: null,
   sourceFlowNodeIdForAddOperation: null,
   lastRemovedModification: undefined,
 };
@@ -213,6 +216,12 @@ class Modifications {
 
   setSourceFlowNodeIdForMoveOperation = (sourceFlowNodeId: string | null) => {
     this.state.sourceFlowNodeIdForMoveOperation = sourceFlowNodeId;
+  };
+  setAncestorFlowNodeKeyForMoveOperation = (
+    ancestorFlowNodeInstanceKey: string | null,
+  ) => {
+    this.state.ancestorFlowNodeInstanceKeyForMoveOperation =
+      ancestorFlowNodeInstanceKey;
   };
 
   setSourceFlowNodeInstanceKeyForMoveOperation = (
@@ -514,6 +523,7 @@ class Modifications {
               : {fromFlowNodeInstanceKey: payload.flowNodeInstanceKey}),
             toFlowNodeId: targetFlowNode.id,
             newTokensCount: scopeIds.length,
+            ancestorElementInstanceKey: payload.ancestorElement?.instanceKey,
             variables:
               Object.keys(allVariables).length > 0 ? allVariables : undefined,
           },
@@ -625,6 +635,7 @@ class Modifications {
     visibleAffectedTokenCount,
     businessObjects,
     bpmnProcessId,
+    ancestorElementInstanceKey,
   }: {
     sourceFlowNodeId: string;
     sourceFlowNodeInstanceKey?: string;
@@ -634,6 +645,7 @@ class Modifications {
     visibleAffectedTokenCount: number;
     businessObjects: BusinessObjects;
     bpmnProcessId?: string;
+    ancestorElementInstanceKey?: string;
   }) => {
     modificationsStore.addModification({
       type: 'token',
@@ -656,6 +668,10 @@ class Modifications {
         },
         affectedTokenCount,
         visibleAffectedTokenCount,
+        ancestorElement: {
+          instanceKey: ancestorElementInstanceKey ?? '',
+          flowNodeId: '',
+        },
         scopeIds: Array.from({
           length: newScopeCount,
         }).map(() => generateUniqueID()),

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -34,6 +34,7 @@ const finishMovingToken = (
   businessObjects: BusinessObjects,
   bpmnProcessId?: string,
   targetFlowNodeId?: string,
+  ancestorElementInstanceKey?: string,
 ) => {
   tracking.track({
     eventName: 'move-token',
@@ -68,6 +69,7 @@ const finishMovingToken = (
       newScopeCount,
       businessObjects,
       bpmnProcessId,
+      ancestorElementInstanceKey,
     });
   }
 

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -28,7 +28,10 @@ const hasMultipleScopes = (
     return true;
   }
 
-  if (parentFlowNode.$parent?.$type !== 'bpmn:SubProcess') {
+  if (
+    parentFlowNode.$parent?.$type !== 'bpmn:SubProcess' &&
+    parentFlowNode.$parent?.$type !== 'bpmn:AdHocSubProcess'
+  ) {
     return false;
   }
 


### PR DESCRIPTION
## Description

This PR enables process instance modification operations (add, move, and potentially cancel) for flow nodes with parent scopes. The key enhancement is support for flow nodes within multi-instance containers or nested subprocesses, where multiple parent scope instances may exist.

### Key Changes
- Extended BPMN element type support to include `AdHocSubProcess` alongside `SubProcess` for scope detection
- Removed the restriction preventing move modifications to flow nodes within multi-instance containers
- Added ancestor element tracking to enable proper scope resolution when moving or adding tokens in nested structures
- Updated UI to guide users to select parent instances from the Instance History tree when working with flow nodes that have multiple parent scopes

## Related issues

closes #40430
