### PR TITLE
fix: remove timestamp from checkpoint record

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -17,11 +17,11 @@ public class CheckpointBackupConfirmedApplier {
     this.checkpointState = checkpointState;
   }
 
-  public void apply(final CheckpointRecord checkpointRecord) {
+  public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
     checkpointState.setLatestBackupInfo(
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
-        checkpointRecord.getCheckpointTimestamp(),
+        checkpointTimestamp,
         checkpointRecord.getCheckpointType());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -37,7 +37,7 @@ public class CheckpointConfirmBackupProcessor {
     final var latestBackupId = checkpointState.getLatestBackupId();
     if (latestBackupId < checkpointId) {
       LOG.debug("Confirming backup for checkpoint {}", checkpointId);
-      backupConfirmedApplier.apply(checkpointRecord);
+      backupConfirmedApplier.apply(checkpointRecord, record.getTimestamp());
       resultBuilder.appendRecord(
           record.getKey(),
           checkpointRecord,

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -92,7 +92,7 @@ public final class CheckpointCreateProcessor {
     // Checkpoint should be created even if we don't take a backup for checkpoint-consistency
     appendCheckpointCreatedEvent(record, resultBuilder, followupRecord);
 
-    checkpointCreatedApplier.apply(followupRecord);
+    checkpointCreatedApplier.apply(followupRecord, record.getTimestamp());
 
     // Handle client response based on scaling state
     if (scalingInProgress) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -29,11 +29,11 @@ public final class CheckpointCreatedEventApplier {
     this.metrics = metrics;
   }
 
-  public void apply(final CheckpointRecord checkpointRecord) {
+  public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
     checkpointState.setLatestCheckpointInfo(
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
-        checkpointRecord.getCheckpointTimestamp(),
+        checkpointTimestamp,
         checkpointRecord.getCheckpointType());
     checkpointListeners.forEach(
         listener -> listener.onNewCheckpointCreated(checkpointState.getLatestCheckpointId()));

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -122,9 +122,12 @@ public final class CheckpointRecordsProcessor
     }
     final CheckpointIntent intent = (CheckpointIntent) record.getIntent();
     switch (intent) {
-      case CREATED -> checkpointCreatedEventApplier.apply((CheckpointRecord) record.getValue());
+      case CREATED ->
+          checkpointCreatedEventApplier.apply(
+              (CheckpointRecord) record.getValue(), record.getTimestamp());
       case CONFIRMED_BACKUP ->
-          checkpointBackupConfirmedApplier.apply((CheckpointRecord) record.getValue());
+          checkpointBackupConfirmedApplier.apply(
+              (CheckpointRecord) record.getValue(), record.getTimestamp());
       default -> {
         // Don't apply intents CREATE and IGNORED
       }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -216,12 +216,10 @@ final class CheckpointRecordsProcessorTest {
     // given
     final long checkpointId = 1;
     final long checkpointPosition = 10;
-    final long timestamp = Instant.now().toEpochMilli();
     final CheckpointRecord value =
         new CheckpointRecord()
             .setCheckpointId(checkpointId)
             .setCheckpointPosition(checkpointPosition)
-            .setCheckpointTimestamp(timestamp)
             .setCheckpointType(CheckpointType.MARKER);
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(
@@ -238,7 +236,7 @@ final class CheckpointRecordsProcessorTest {
     // state is updated
     assertThat(state.getLatestCheckpointId()).isEqualTo(checkpointId);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(checkpointPosition);
-    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(timestamp);
+    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(record.getTimestamp());
     assertThat(state.getLatestCheckpointType()).isEqualTo(CheckpointType.MARKER);
   }
 
@@ -369,12 +367,10 @@ final class CheckpointRecordsProcessorTest {
 
     final var newCheckpointId = 10;
     final var newCheckpointPosition = 100;
-    final var timestampNew = Instant.now().toEpochMilli();
     final var value =
         new CheckpointRecord()
             .setCheckpointId(newCheckpointId)
             .setCheckpointPosition(newCheckpointPosition)
-            .setCheckpointTimestamp(timestampNew)
             .setCheckpointType(CheckpointType.SCHEDULED_BACKUP);
     final var record =
         new MockTypedCheckpointRecord(
@@ -395,7 +391,7 @@ final class CheckpointRecordsProcessorTest {
         .returns(value, Event::value);
     assertThat(state.getLatestBackupId()).isEqualTo(newCheckpointId);
     assertThat(state.getLatestBackupPosition()).isEqualTo(newCheckpointPosition);
-    assertThat(state.getLatestBackupTimestamp()).isEqualTo(timestampNew);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(record.getTimestamp());
     assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
   }
 
@@ -483,13 +479,11 @@ final class CheckpointRecordsProcessorTest {
     // given
     final var backupId = 15;
     final var backupPosition = 150;
-    final var timestamp = Instant.now().toEpochMilli();
     final var value =
         new CheckpointRecord()
             .setCheckpointId(backupId)
             .setCheckpointPosition(backupPosition)
-            .setCheckpointType(CheckpointType.MANUAL_BACKUP)
-            .setCheckpointTimestamp(timestamp);
+            .setCheckpointType(CheckpointType.MANUAL_BACKUP);
     final var record =
         new MockTypedCheckpointRecord(
             backupPosition + 1,
@@ -504,7 +498,7 @@ final class CheckpointRecordsProcessorTest {
     // then - backup state is updated
     assertThat(state.getLatestBackupId()).isEqualTo(backupId);
     assertThat(state.getLatestBackupPosition()).isEqualTo(backupPosition);
-    assertThat(state.getLatestBackupTimestamp()).isEqualTo(timestamp);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(record.getTimestamp());
     assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
   }
 
@@ -642,7 +636,7 @@ final class CheckpointRecordsProcessorTest {
     // then - backup state is updated
     assertThat(state.getLatestBackupId()).isEqualTo(backupId);
     assertThat(state.getLatestBackupPosition()).isEqualTo(backupPosition);
-    assertThat(state.getLatestBackupTimestamp()).isEqualTo(-1L);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(record.getTimestamp());
     assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-checkpoint-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-checkpoint-template.json
@@ -25,9 +25,6 @@
             "checkpointPosition": {
               "type": "long"
             },
-            "checkpointTimestamp": {
-              "type": "long"
-            },
             "checkpointType": {
               "type": "keyword"
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-checkpoint-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-checkpoint-template.json
@@ -25,9 +25,6 @@
             "checkpointPosition": {
               "type": "long"
             },
-            "checkpointTimestamp": {
-              "type": "long"
-            },
             "checkpointType": {
               "type": "keyword"
             }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -36,7 +36,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Nested;
@@ -351,7 +350,6 @@ final class BulkIndexRequestTest {
                       .withValue(
                           new CheckpointRecord()
                               .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
-                              .setCheckpointTimestamp(Instant.now().toEpochMilli())
                               .setCheckpointId(100)
                               .setCheckpointPosition(100L)));
 
@@ -365,11 +363,9 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(
-              source -> ((Map<String, Object>) source).get("checkpointType"),
-              source -> ((Map<String, Object>) source).get("checkpointTimestamp"))
-          .describedAs("Expect that the records are serialized without type and timestamp")
-          .containsAll(Set.of(Tuple.tuple(null, null)));
+          .extracting(source -> ((Map<String, Object>) source).get("checkpointType"))
+          .describedAs("Expect that the records are serialized without type")
+          .containsExactly(new Object[] {null});
     }
 
     @Test
@@ -383,7 +379,6 @@ final class BulkIndexRequestTest {
                       .withValue(
                           new CheckpointRecord()
                               .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
-                              .setCheckpointTimestamp(timestamp.toEpochMilli())
                               .setCheckpointId(100)
                               .setCheckpointPosition(100L)));
 
@@ -397,13 +392,9 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(
-              source -> ((Map<String, Object>) source).get("checkpointType"),
-              source -> ((Map<String, Object>) source).get("checkpointTimestamp"))
-          .describedAs("Expect that the records are serialized with type and timestamp")
-          .containsAll(
-              Set.of(
-                  Tuple.tuple(CheckpointType.SCHEDULED_BACKUP.name(), timestamp.toEpochMilli())));
+          .extracting(source -> ((Map<String, Object>) source).get("checkpointType"))
+          .describedAs("Expect that the records are serialized with type")
+          .containsExactly(CheckpointType.SCHEDULED_BACKUP.name());
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
@@ -17,22 +17,18 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
 
   private static final String CHECKPOINT_ID_KEY = "id";
   private static final String CHECKPOINT_POSITION_KEY = "position";
-  private static final String CHECKPOINT_TIMESTAMP_KEY = "timestamp";
   private static final String CHECKPOINT_TYPE_KEY = "type";
 
   private final LongProperty checkpointIdProperty = new LongProperty(CHECKPOINT_ID_KEY, -1L);
   private final LongProperty checkpointPositionProperty =
       new LongProperty(CHECKPOINT_POSITION_KEY, -1L);
-  private final LongProperty checkpointTimestampProperty =
-      new LongProperty(CHECKPOINT_TIMESTAMP_KEY, -1L);
   private final EnumProperty<CheckpointType> checkpointTypeProperty =
       new EnumProperty<>(CHECKPOINT_TYPE_KEY, CheckpointType.class, CheckpointType.MANUAL_BACKUP);
 
   public CheckpointRecord() {
-    super(4);
+    super(3);
     declareProperty(checkpointIdProperty)
         .declareProperty(checkpointPositionProperty)
-        .declareProperty(checkpointTimestampProperty)
         .declareProperty(checkpointTypeProperty);
   }
 
@@ -53,16 +49,6 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
 
   public CheckpointRecord setCheckpointType(final CheckpointType checkpointType) {
     checkpointTypeProperty.setValue(checkpointType);
-    return this;
-  }
-
-  @Override
-  public long getCheckpointTimestamp() {
-    return checkpointTimestampProperty.getValue();
-  }
-
-  public CheckpointRecord setCheckpointTimestamp(final long checkpointTimestamp) {
-    checkpointTimestampProperty.setValue(checkpointTimestamp);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2150,20 +2150,17 @@ final class JsonSerializableToJsonTest {
                 new CheckpointRecord()
                     .setCheckpointId(1L)
                     .setCheckpointPosition(10L)
-                    .setCheckpointTimestamp(TIMESTAMP.toEpochMilli())
                     .setCheckpointType(CheckpointType.SCHEDULED_BACKUP),
         """
         {
           "checkpointId":1,
           "checkpointPosition":10,
-          "checkpointTimestamp":%d,
           "checkpointType":"SCHEDULED_BACKUP"
         }
         """
-            .formatted(TIMESTAMP.toEpochMilli())
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
-      //////////////////////// Checkpoint record without timestamp and type ///////////////////////
+      //////////////////////// Checkpoint record without type ///////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Checkpoint record without timestamp",
@@ -2173,7 +2170,6 @@ final class JsonSerializableToJsonTest {
           {
             "checkpointId":1,
             "checkpointPosition":10,
-            "checkpointTimestamp":-1,
             "checkpointType":"MANUAL_BACKUP"
           }
           """

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CheckpointRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CheckpointRecord.golden
@@ -17,22 +17,18 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
 
   private static final String CHECKPOINT_ID_KEY = "id";
   private static final String CHECKPOINT_POSITION_KEY = "position";
-  private static final String CHECKPOINT_TIMESTAMP_KEY = "timestamp";
   private static final String CHECKPOINT_TYPE_KEY = "type";
 
   private final LongProperty checkpointIdProperty = new LongProperty(CHECKPOINT_ID_KEY, -1L);
   private final LongProperty checkpointPositionProperty =
       new LongProperty(CHECKPOINT_POSITION_KEY, -1L);
-  private final LongProperty checkpointTimestampProperty =
-      new LongProperty(CHECKPOINT_TIMESTAMP_KEY, -1L);
   private final EnumProperty<CheckpointType> checkpointTypeProperty =
       new EnumProperty<>(CHECKPOINT_TYPE_KEY, CheckpointType.class, CheckpointType.MANUAL_BACKUP);
 
   public CheckpointRecord() {
-    super(4);
+    super(3);
     declareProperty(checkpointIdProperty)
         .declareProperty(checkpointPositionProperty)
-        .declareProperty(checkpointTimestampProperty)
         .declareProperty(checkpointTypeProperty);
   }
 
@@ -53,16 +49,6 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
 
   public CheckpointRecord setCheckpointType(final CheckpointType checkpointType) {
     checkpointTypeProperty.setValue(checkpointType);
-    return this;
-  }
-
-  @Override
-  public long getCheckpointTimestamp() {
-    return checkpointTimestampProperty.getValue();
-  }
-
-  public CheckpointRecord setCheckpointTimestamp(final long checkpointTimestamp) {
-    checkpointTimestampProperty.setValue(checkpointTimestamp);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointRecordValue.java
@@ -38,9 +38,4 @@ public interface CheckpointRecordValue extends RecordValue {
    * @return the type of the checkpoint
    */
   CheckpointType getCheckpointType();
-
-  /**
-   * @return the timestamp of the checkpoint
-   */
-  long getCheckpointTimestamp();
 }


### PR DESCRIPTION
The checkpoint state timestamp is better to be derived from the `Record` timestamp which is provided by the sequencer. 

The `CheckpointRecord` timestamp is removed and instead have this value derived from the wrapping record when persisting the Checkpoint/Backup state.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
