### PR TITLE
ci: downsize Zeebe performance tests

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -178,8 +178,8 @@ jobs:
 
   performance-tests:
     name: "Performance"
-    runs-on: gcp-perf-core-16-default
-    timeout-minutes: 20
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"


### PR DESCRIPTION
## Description

[New visibility into runner resource usage revealed](https://camunda.slack.com/archives/C071KP5BTHB/p1762941816500959) that the performance-tests job does not utilize many resources on its currently 16 core runner (at most 30% CPU and 20% RAM consumption).

This PR proposes to downsize to a smaller runner, to achieve higher relative resource usage and lower costs:

* old runner: https://github.com/camunda/camunda/actions/runs/19295628622/job/55176797453
* new runner: https://github.com/camunda/camunda/actions/runs/19294365901/job/55176341107?pr=40832


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
