### PR TITLE
feat: Update logic for pushing docker images and tagging latest

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -333,20 +333,32 @@ jobs:
           revision: ${{ needs.release.outputs.releaseTagRevision }}
           version: ${{ inputs.releaseVersion }}
           platforms: ${{ env.PLATFORMS }}
-      - name: Sync Docker Image to DockerHub
+      - name: Sync Zeebe Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ steps.build-zeebe-docker.outputs.image }}
-      - name: Sync Latest Docker Image to DockerHub
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ steps.build-zeebe-docker.outputs.image }}
+      - name: Sync Zeebe Latest Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:latest \
-            ${{ steps.build-zeebe-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ steps.build-zeebe-docker.outputs.image }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -423,17 +435,29 @@ jobs:
       - name: Sync Operate Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ steps.build-operate-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ steps.build-operate-docker.outputs.image }}
       - name: Sync Latest Operate Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:latest \
-            ${{ steps.build-operate-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ steps.build-operate-docker.outputs.image }} 
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -510,17 +534,29 @@ jobs:
       - name: Sync Tasklist Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ steps.build-tasklist-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ steps.build-tasklist-docker.outputs.image }}
       - name: Sync Latest Tasklist Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:latest \
-            ${{ steps.build-tasklist-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ steps.build-tasklist-docker.outputs.image }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -604,17 +640,29 @@ jobs:
       - name: Sync Camunda Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ steps.build-camunda-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ steps.build-camunda-docker.outputs.image }}
       - name: Sync Latest Camunda Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.DOCKER_IMAGE }}:latest \
-            ${{ steps.build-camunda-docker.outputs.image }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ steps.build-camunda-docker.outputs.image }}
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Reason of the change:
During the release of `8.8.3` and we faced an issue when the `docker buildx imagetools create` command resulted in `400` error but unfortunately we were unable to identify the root cause. For details see the [incident](https://camunda.slack.com/archives/C09RJKQDPB2)

## Applied changes:
- Usage of GHA [nick-fields/retry](https://github.com/nick-fields/retry) which is suggested in [suggested](https://github.com/camunda/github-actions-recipes?tab=readme-ov-file#retry-a-command-via-nick-fieldsretry-usages-in-camunda) in the github-actions-recipes readme
- With the GHA setting a number of retries to 3
- Running the docker command in debug mode by using `-D` flag.

## Test
Created a test GHA in an internal repository and tested the logic with test imag. Logic is the same, building the multi arch image, putting into local registry then sync it with an other registry.

The workflow file is available [here](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19296359443/workflow) the test run is [here](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19296359443/job/55179194500)

Test workflow[ contains a failure on purpose](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19296359443/job/55179194500#step:11:1) to test the retry mechanism.