### PR TITLE
test: disable flaky shouldLogRestOverGrpcWarning sdk test

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessorLoggingTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertiesPostProcessorLoggingTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.spring.client.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,7 @@ public class PropertiesPostProcessorLoggingTest {
   class RestOverGrpcWarning {
 
     @Test
+    @Disabled("https://github.com/camunda/camunda/issues/40841")
     void shouldLogRestOverGrpcWarning(final CapturedOutput output) {
       assertThat(output)
           .contains(


### PR DESCRIPTION
## Description

It's not a crucial test, this stops the bleeding for now while we can investigate the cause on a dedicated branch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #40841
