### PR TITLE
[Do not merge] Identify which tests are not short-circuiting the `RecordingExporter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         shell: bash
         run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
+          ./mvnw -B -T 2 --no-snapshot-updates -fn
           -D forkCount=7
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -9,6 +9,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  <!--  Temp addition to ensure tests in this module are ran by CI -->
 
   <parent>
     <groupId>io.camunda</groupId>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+<!--  Temp addition to ensure tests in this module are ran by CI -->
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  <!--  Temp addition to ensure tests in this module are ran by CI -->
 
   <parent>
     <groupId>io.camunda</groupId>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -9,6 +9,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  <!--  Temp addition to ensure tests in this module are ran by CI -->
 
   <parent>
     <groupId>io.camunda</groupId>

--- a/zeebe/test-util/pom.xml
+++ b/zeebe/test-util/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+  <!--  Temp addition to ensure tests in this module are ran by CI -->
 
   <parent>
     <groupId>io.camunda</groupId>

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -668,7 +668,10 @@ public final class RecordingExporter implements Exporter {
         while (isEmpty() && endTime > now) {
           final long waitTime = endTime - now;
           try {
-            IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
+            final boolean isConditionMetInTime = IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
+            if (!isConditionMetInTime) {
+              throw new IllegalStateException("EXPORTER IS NOT LIMITED!!!");
+            }
           } catch (final InterruptedException ignored) {
             // ignored
           }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I have made the `RecordingExporter` fail the test if it isn't short-circuited within the maximum wait time. Those tests don't limit the exporter properly. I will let the CI run and use the result to collect which tests need to be changed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #39892
