### PR TITLE
[CPT] (Restore) Generate git properties

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <version.java>8</version.java>
+    <maven-commit-id-plugin-version>9.0.2</maven-commit-id-plugin-version>
     <!-- Camunda Docker image properties. CI overrides the properties to use the current image. -->
     <io.camunda.process.test.camundaDockerImageName>camunda/camunda</io.camunda.process.test.camundaDockerImageName>
     <io.camunda.process.test.camundaDockerImageVersion>${project.version}</io.camunda.process.test.camundaDockerImageVersion>
@@ -274,6 +275,30 @@
               </relocations>
 
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>${maven-commit-id-plugin-version}</version>
+        <configuration>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <includeOnlyProperties>
+            <includeOnlyProperty>^git.branch$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+        </configuration>
+        <executions>
+          <execution>
+            <id>collect-git-info</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Description

The generation of the Git properties was removed accidentally with https://github.com/camunda/camunda/commit/a46a6f506fef435e374b0a5e6bbe36c9a12e24a8. We need to bring it back.

Backport changes from https://github.com/camunda/camunda/pull/39734 to skip the frontend build.

## Related issues

closes https://github.com/camunda/camunda/issues/40603