### PR TITLE
Configure node-id based data directory when dynamic node id provider is configured

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -45,6 +46,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
       "io.camunda.zeebe.shared",
     })
 @Profile("broker")
+@DependsOn(
+    "dataDirectoryProvider") // ensure that the data directory is set up before starting the broker
 public class BrokerModuleConfiguration implements CloseableSilently {
   private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/ConfiguredDataDirectoryProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/ConfiguredDataDirectoryProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A data directory provider that returns the configured data directory as-is without any
+ * modification.
+ */
+public class ConfiguredDataDirectoryProvider implements DataDirectoryProvider {
+
+  @Override
+  public CompletableFuture<Path> initialize(final Path baseDataDirectory) {
+    return CompletableFuture.completedFuture(baseDataDirectory);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/DataDirectoryProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/DataDirectoryProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+public interface DataDirectoryProvider {
+
+  /**
+   * Computes and returns the data directory path based on the base directory. The implementation
+   * may also perform initialization of the data directory.
+   */
+  CompletableFuture<Path> initialize(final Path baseDirectory);
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdBasedDataDirectoryProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdBasedDataDirectoryProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A data directory provider that appends the node ID to the configured data directory. This is
+ * useful in dynamic node ID scenarios where multiple nodes share the same base directory and need
+ * to be isolated by their node ID.
+ */
+public class NodeIdBasedDataDirectoryProvider implements DataDirectoryProvider {
+
+  private final NodeIdProvider nodeIdProvider;
+
+  public NodeIdBasedDataDirectoryProvider(final NodeIdProvider nodeIdProvider) {
+    this.nodeIdProvider = nodeIdProvider;
+  }
+
+  @Override
+  public CompletableFuture<Path> initialize(final Path baseDataDirectory) {
+    final NodeInstance nodeInstance = nodeIdProvider.currentNodeInstance();
+    if (nodeInstance == null) {
+      return CompletableFuture.failedFuture(
+          new IllegalStateException("Node instance is not available"));
+    }
+    final int nodeId = nodeInstance.id();
+    final Path dataDirectory = baseDataDirectory.resolve(String.valueOf(nodeId));
+    return CompletableFuture.completedFuture(dataDirectory);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdBasedDataDirectoryProviderTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdBasedDataDirectoryProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NodeIdBasedDataDirectoryProviderTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void shouldAppendNodeIdToBaseDirectory() {
+    // given
+    final int nodeId = 5;
+    final NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.currentNodeInstance()).thenReturn(new NodeInstance(nodeId));
+
+    final Path baseDirectory = tempDir.resolve("base");
+    final DataDirectoryProvider initializer = new NodeIdBasedDataDirectoryProvider(nodeIdProvider);
+
+    // when
+    final CompletableFuture<Path> result = initializer.initialize(baseDirectory);
+
+    // then
+    assertThat(result).isCompleted();
+    assertThat(result.join()).isEqualTo(baseDirectory.resolve(String.valueOf(nodeId)));
+  }
+
+  @Test
+  void shouldFailWhenNodeInstanceIsNull() {
+    // given
+    final NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.currentNodeInstance()).thenReturn(null);
+
+    final Path baseDirectory = tempDir.resolve("base");
+    final DataDirectoryProvider initializer = new NodeIdBasedDataDirectoryProvider(nodeIdProvider);
+
+    // when
+    final CompletableFuture<Path> result = initializer.initialize(baseDirectory);
+
+    // then
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Node instance is not available");
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/PreConfiguredDataDirectoryProviderTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/PreConfiguredDataDirectoryProviderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PreConfiguredDataDirectoryProviderTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void shouldReturnConfiguredDirectory() {
+    // given
+    final Path dataDirectory = tempDir.resolve("data");
+    final DataDirectoryProvider initializer = new ConfiguredDataDirectoryProvider();
+
+    // when
+    final CompletableFuture<Path> result = initializer.initialize(dataDirectory);
+
+    // then
+    assertThat(result).isCompleted();
+    assertThat(result.join()).isEqualTo(dataDirectory);
+  }
+}


### PR DESCRIPTION
## Description

This PR configured data directory using node id if the dynamic node id provider is configured. This is added to the node-id-provider module because it only matters for dynamic node id. When the versioning is added, the provider will be extended to add versioned directory and bootstrapping from previous version.

The bean is added as a dependency to `BrokerModuleConfiguration` to ensure that Broker is only started after the directory is set up.

## Related issues

closes #40475 
