### PR TITLE
ci: upsize fossa analyze job

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -29,7 +29,7 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: gcp-core-8-default
+    runs-on: gcp-core-16-default
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
     timeout-minutes: 31
     strategy:


### PR DESCRIPTION
## Description

This PR schedules FOSSA analyze job on a bigger runner. This job gets evicted multiple time a day because of memory overconsumption.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

[Slack thread](https://camunda.slack.com/archives/C071KP5BTHB/p1762941816500959)
https://github.com/camunda/team-infrastructure/issues/888
