### PR TITLE
[Backport stable/8.8] ci: upsize fossa analyze job

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -29,7 +29,7 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: gcp-core-8-default
+    runs-on: gcp-core-16-default
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
     timeout-minutes: 31
     strategy:


### PR DESCRIPTION
# Description
Backport of #40854 to `stable/8.8`.

relates to camunda/team-infrastructure#888