### PR TITLE
fix: open variable JSON modal for completed process instances

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/VariablesTable.tsx
@@ -95,7 +95,12 @@ const VariablesTable: React.FC<Props> = ({
 
                   if (!isProcessInstanceRunning) {
                     if (isTruncated) {
-                      return <ViewFullVariableButton variableName={name} />;
+                      return (
+                        <ViewFullVariableButton
+                          variableName={name}
+                          variableKey={variableKey}
+                        />
+                      );
                     }
                     return null;
                   }
@@ -112,7 +117,10 @@ const VariablesTable: React.FC<Props> = ({
                       }}
                       fallback={
                         isTruncated ? (
-                          <ViewFullVariableButton variableName={name} />
+                          <ViewFullVariableButton
+                            variableName={name}
+                            variableKey={variableKey}
+                          />
                         ) : null
                       }
                     >

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ViewFullVariableButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ViewFullVariableButton/index.test.tsx
@@ -12,22 +12,40 @@ import {
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {ViewFullVariableButton} from './index';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
+import {createvariable} from 'modules/testUtils';
+
+const createWrapper = () => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
 
 describe('<ViewFullVariableButton />', () => {
   it('should load full value', async () => {
-    vi.useFakeTimers({shouldAdvanceTime: true});
-    const mockOnClick = vi.fn(function mock(): Promise<null | string> {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve('foo'), 0);
-      });
-    });
     const mockVariableName = 'foo-variable';
+    const mockVariableKey = 'variable-key-123';
+    const mockVariableValue = '{"foo": "bar", "test": 123}';
+
+    mockGetVariable().withSuccess(
+      createvariable({
+        variableKey: mockVariableKey,
+        name: mockVariableName,
+        value: mockVariableValue,
+      }),
+    );
 
     const {user} = render(
       <ViewFullVariableButton
-        onClick={mockOnClick}
         variableName={mockVariableName}
+        variableKey={mockVariableKey}
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(
@@ -40,17 +58,14 @@ describe('<ViewFullVariableButton />', () => {
       screen.getByTestId('variable-operation-spinner'),
     ).toBeInTheDocument();
 
-    vi.runOnlyPendingTimers();
-
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('variable-operation-spinner'),
     );
 
-    expect(mockOnClick).toHaveBeenCalled();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', {name: `Full value of ${mockVariableName}`}),
     ).toBeInTheDocument();
-    vi.useRealTimers();
+    expect(screen.getByText(/"foo": "bar"/)).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ViewFullVariableButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ViewFullVariableButton/index.tsx
@@ -11,15 +11,22 @@ import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {Button} from '@carbon/react';
 import {Popup} from '@carbon/react/icons';
 import {Operations} from '../Operations';
+import {useVariable} from 'modules/queries/variables/useVariable';
 
 type Props = {
-  onClick?: () => Promise<string | null>;
   variableName: string;
+  variableKey: string;
 };
 
-const ViewFullVariableButton: React.FC<Props> = ({onClick, variableName}) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [variableValue, setVariableValue] = useState<null | string>(null);
+const ViewFullVariableButton: React.FC<Props> = ({
+  variableName,
+  variableKey,
+}) => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const {data, isLoading} = useVariable(variableKey, {
+    enabled: isModalVisible,
+  });
+  const variableValue = data?.value;
 
   return (
     <>
@@ -33,21 +40,16 @@ const ViewFullVariableButton: React.FC<Props> = ({onClick, variableName}) => {
           iconDescription={`View full value of ${variableName}`}
           tooltipPosition="left"
           onClick={async () => {
-            setIsLoading(true);
-            const result = onClick ? await onClick() : null;
-            setVariableValue(result ?? null);
-            setIsLoading(false);
+            setIsModalVisible(true);
           }}
         />
       </Operations>
-      {variableValue !== null && (
+      {variableValue !== undefined && (
         <JSONEditorModal
-          value={variableValue!}
-          isVisible={variableValue !== null}
+          value={variableValue}
+          isVisible={isModalVisible}
           readOnly
-          onClose={() => {
-            setVariableValue(null);
-          }}
+          onClose={() => setIsModalVisible(false)}
           title={`Full value of ${variableName}`}
         />
       )}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Changes: Fetch full variable on "view full variable" button click.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40859 
