### PR TITLE
Unflake tests by awaiting for all authorizations during identity setup

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -63,7 +63,6 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -647,17 +646,23 @@ public final class EngineRule extends ExternalResource {
   }
 
   public void awaitIdentitySetup() {
-    final var totalAmountOfAuthorizationsCreated =
-        AuthorizationResourceType.getUserProvidedResourceTypes().size();
+    final var identitySetup =
+        RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).getFirst();
 
+    /*
+     * We'll need to await for the identity setup to be completed before proceeding, but it's not
+     * easy to know what to wait for. The INITIALIZED event is written before all the follow-up
+     * commands are processed, so we can't wait just for that. Instead, we need to wait for all the
+     * authorizations to be created on all partitions as well.
+     */
+    final int totalAmountOfAuthorizationsCreated =
+        identitySetup.getValue().getAuthorizations().size();
     if (partitionCount > 1) {
-      RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).await();
       RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
           .withDistributionIntent(AuthorizationIntent.CREATE)
           .skip(totalAmountOfAuthorizationsCreated - 1)
           .await();
     } else {
-      RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).await();
       RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
           .skip(totalAmountOfAuthorizationsCreated - 1)
           .await();


### PR DESCRIPTION


## Description

<!-- Describe the goal and purpose of this PR. -->

This unflakes the `BroadcastSignalMultiplePartitionsTest.shouldRejectBroadcastForOneUnauthorizedProcess` test (and likely other tests as well) by correctly awaiting for the identity setup to complete.

### Context

In the test it tries to create a process instance using the DEFAULT user (which is supposed to have the admin role). However, this is rejected because the user does not have the correct permissions, even though it's supposed to be an admin.

```
2 R CREA     CREATE       #086->#085     -1 new <process "id-7fe9..98600d1"> (default start)  (no vars) !FORBIDDEN (Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, id-7fe9e9c6-bc79-4c9f-bd77-12e2598600d1]')
```

The problem is that the identity setup may not yet have finished setting up the admin role. This particularly concerns multi-partition setups.

```
2 R CREA     CREATE       #086->#085     -1 new <process "id-7fe9..98600d1"> (default start)  (no vars) !FORBIDDEN (Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, id-7fe9e9c6-bc79-4c9f-bd77-12e2598600d1]')
2 C AUTH     CREATE       #087->  -1 P1K041 ROLE "admin" can [CANCEL_PROCESS_INSTANCE, READ_PROCESS_INSTANCE, CREATE_PROCESS_INSTANCE, UPDATE_PROCESS_INSTANCE, UPDATE_USER_TASK, MODIFY_PROCESS_INSTANCE, DELETE_PROCESS_INSTANCE, READ_USER_TASK, READ_PROCESS_DEFINITION] PROCESS_DEFINITION "*"
```

The reason is that we didn't wait until all authorizations were created, but only until a subset of them were. The mistake was that we considered the number of resource types to be equivalent to the number of authorizations, but that's not the reality. Instead, each of the default roles has authorizations. The admin role already has an authorization for each resource type, and so does the readonly admin. The RPA role has just two authorizations, and so on.

We can simply check the INITIALIZED event for the number of authorizations that had to be created.

Note that it would be better if the INITIALIZED event would follow the full creation and distribution of all the identity entities (users, roles, etc). For now, this just unflakes some tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40333
