### PR TITLE
feat: add element instance history tree store

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
@@ -63,7 +63,7 @@ const mockSecondPageItems: ElementInstance[] = Array.from(
   (_, i) =>
     createMockElementInstance({
       elementInstanceKey: `${2251799813685730 + i}`,
-      elementId: `task_${i + 50}`,
+      elementId: `task_${i + 100}`,
       startDate: `2023-01-01T11:${String(i).padStart(2, '0')}:00.000Z`,
     }),
 );
@@ -469,7 +469,7 @@ describe('elementInstancesTreeStore', () => {
       mockProcessInstanceKey,
     );
     expect(secondItems.length).toBe(100);
-    expect(secondItems[0].elementId).toBe('task_50');
+    expect(secondItems[0].elementId).toBe('task_100');
   });
 
   it('should return 0 when reaching end of list', async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
@@ -1,0 +1,646 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {elementInstancesTreeStore} from './elementInstancesTreeStore';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import type {
+  ElementInstance,
+  QueryElementInstancesResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockProcessInstanceKey = '2251799813685625';
+const mockChildScopeKey1 = '2251799813685630';
+const mockChildScopeKey2 = '2251799813685640';
+const mockGrandchildScopeKey = '2251799813685650';
+
+const createMockElementInstance = (
+  overrides: Partial<ElementInstance> = {},
+): ElementInstance => ({
+  elementInstanceKey: '2251799813685630',
+  elementId: 'task_1',
+  elementName: 'Task 1',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2023-01-01T10:00:00.000Z',
+  processDefinitionKey: '2251799813685623',
+  processDefinitionId: 'test-process',
+  processInstanceKey: mockProcessInstanceKey,
+  hasIncident: false,
+  tenantId: '<default>',
+  ...overrides,
+});
+
+const createMockResponse = (
+  items: ElementInstance[],
+  totalItems: number,
+): QueryElementInstancesResponseBody => ({
+  items,
+  page: {
+    totalItems,
+  },
+});
+
+const mockFirstPageItems: ElementInstance[] = Array.from(
+  {length: 100},
+  (_, i) =>
+    createMockElementInstance({
+      elementInstanceKey: `${2251799813685630 + i}`,
+      elementId: `task_${i}`,
+      startDate: `2023-01-01T10:${String(i).padStart(2, '0')}:00.000Z`,
+    }),
+);
+
+const mockFirstPageResponse = createMockResponse(mockFirstPageItems, 150);
+
+const mockSecondPageItems: ElementInstance[] = Array.from(
+  {length: 100},
+  (_, i) =>
+    createMockElementInstance({
+      elementInstanceKey: `${2251799813685730 + i}`,
+      elementId: `task_${i + 50}`,
+      startDate: `2023-01-01T11:${String(i).padStart(2, '0')}:00.000Z`,
+    }),
+);
+
+const mockSecondPageResponse = createMockResponse(mockSecondPageItems, 150);
+
+const mockPreviousPageItems: ElementInstance[] = Array.from(
+  {length: 50},
+  (_, i) =>
+    createMockElementInstance({
+      elementInstanceKey: `${2251799813685530 + i}`,
+      elementId: `task_prev_${i}`,
+      startDate: `2023-01-01T09:${String(i).padStart(2, '0')}:00.000Z`,
+    }),
+);
+
+const mockPreviousPageResponse = createMockResponse(mockPreviousPageItems, 150);
+
+const mockChildInstances: ElementInstance[] = [
+  createMockElementInstance({
+    elementInstanceKey: mockChildScopeKey1,
+    elementId: 'subprocess_1',
+    elementName: 'Sub Process 1',
+    type: 'SUB_PROCESS',
+  }),
+  createMockElementInstance({
+    elementInstanceKey: mockChildScopeKey2,
+    elementId: 'subprocess_2',
+    elementName: 'Sub Process 2',
+    type: 'SUB_PROCESS',
+  }),
+];
+
+const mockChildResponse = createMockResponse(mockChildInstances, 2);
+
+const mockEmptyResponse = createMockResponse([], 0);
+
+describe('elementInstancesTreeStore', () => {
+  afterEach(() => {
+    elementInstancesTreeStore.reset();
+  });
+
+  it('should initialize store with empty state', async () => {
+    expect(elementInstancesTreeStore.state.rootScopeKey).toBe(null);
+    expect(elementInstancesTreeStore.state.nodes.size).toBe(0);
+    expect(elementInstancesTreeStore.state.expandedNodes.size).toBe(0);
+  });
+
+  it('should set root node and fetch first 2 pages automatically', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    expect(elementInstancesTreeStore.state.rootScopeKey).toBe(
+      mockProcessInstanceKey,
+    );
+    expect(elementInstancesTreeStore.state.nodes.size).toBe(1);
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockProcessInstanceKey),
+    ).toBe(true);
+
+    const items = elementInstancesTreeStore.getItems(mockProcessInstanceKey);
+    expect(items.length).toBe(100);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.totalItems).toBe(150);
+  });
+
+  it('should mark root node as expanded after setting root', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockProcessInstanceKey),
+    ).toBe(true);
+  });
+
+  it('should not reset state when setting same root node twice', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const firstCallItems = elementInstancesTreeStore.getItems(
+      mockProcessInstanceKey,
+    );
+
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    expect(elementInstancesTreeStore.state.nodes.size).toBe(1);
+
+    const secondCallItems = elementInstancesTreeStore.getItems(
+      mockProcessInstanceKey,
+    );
+    expect(secondCallItems).toBe(firstCallItems);
+  });
+
+  it('should expand node and fetch children when not already expanded', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockChildResponse);
+
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(true);
+    expect(elementInstancesTreeStore.state.nodes.has(mockChildScopeKey1)).toBe(
+      true,
+    );
+
+    const items = elementInstancesTreeStore.getItems(mockChildScopeKey1);
+    expect(items.length).toBe(2);
+  });
+
+  it('should not fetch again when expanding already expanded node', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockChildResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    const itemsBefore = elementInstancesTreeStore.getItems(mockChildScopeKey1);
+
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    const itemsAfter = elementInstancesTreeStore.getItems(mockChildScopeKey1);
+    expect(itemsAfter).toBe(itemsBefore);
+  });
+
+  it('should fetch 2 pages (100 items) when expanding node', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    const items = elementInstancesTreeStore.getItems(mockChildScopeKey1);
+    expect(items.length).toBe(100);
+  });
+
+  it('should set loading status when expanding node', async () => {
+    mockSearchElementInstances().withSuccess(mockChildResponse);
+
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    const nodeData =
+      elementInstancesTreeStore.state.nodes.get(mockChildScopeKey1);
+    expect(nodeData?.status).toBe('loaded');
+  });
+
+  it('should set error status when expansion fails', async () => {
+    mockSearchElementInstances().withServerError(500);
+
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(true);
+
+    const nodeData =
+      elementInstancesTreeStore.state.nodes.get(mockChildScopeKey1);
+    expect(nodeData).toBeUndefined();
+  });
+
+  it('should collapse node and remove from expandedNodes set', async () => {
+    mockSearchElementInstances().withSuccess(mockEmptyResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(true);
+
+    elementInstancesTreeStore.collapseNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(false);
+  });
+
+  it('should remove collapsed node data from memory', async () => {
+    mockSearchElementInstances().withSuccess(mockEmptyResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(elementInstancesTreeStore.state.nodes.has(mockChildScopeKey1)).toBe(
+      true,
+    );
+
+    elementInstancesTreeStore.collapseNode(mockChildScopeKey1);
+
+    expect(elementInstancesTreeStore.getItems(mockChildScopeKey1)).toHaveLength(
+      0,
+    );
+  });
+
+  it('should recursively collapse all child nodes', async () => {
+    const parentWithChildResponse = createMockResponse(
+      [
+        createMockElementInstance({
+          elementInstanceKey: mockChildScopeKey1,
+          elementId: 'child_scope',
+        }),
+      ],
+      1,
+    );
+
+    const childWithGrandchildResponse = createMockResponse(
+      [
+        createMockElementInstance({
+          elementInstanceKey: mockGrandchildScopeKey,
+          elementId: 'grandchild_scope',
+        }),
+      ],
+      1,
+    );
+
+    const grandchildResponse = createMockResponse([], 0);
+
+    mockSearchElementInstances().withSuccess(parentWithChildResponse);
+    await elementInstancesTreeStore.expandNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(childWithGrandchildResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    mockSearchElementInstances().withSuccess(grandchildResponse);
+    await elementInstancesTreeStore.expandNode(mockGrandchildScopeKey);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockProcessInstanceKey),
+    ).toBe(true);
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(true);
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockGrandchildScopeKey),
+    ).toBe(true);
+
+    elementInstancesTreeStore.collapseNode(mockProcessInstanceKey);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockProcessInstanceKey),
+    ).toBe(false);
+    expect(
+      elementInstancesTreeStore.getItems(mockProcessInstanceKey),
+    ).toHaveLength(0);
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(false);
+    expect(elementInstancesTreeStore.getItems(mockChildScopeKey1)).toHaveLength(
+      0,
+    );
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockGrandchildScopeKey),
+    ).toBe(false);
+    expect(elementInstancesTreeStore.getItems(mockChildScopeKey1)).toHaveLength(
+      0,
+    );
+  });
+
+  it('should preserve sibling nodes when collapsing one branch', async () => {
+    const parentWithTwoChildrenResponse = createMockResponse(
+      [
+        createMockElementInstance({
+          elementInstanceKey: mockChildScopeKey1,
+          elementId: 'child_scope_1',
+        }),
+        createMockElementInstance({
+          elementInstanceKey: mockChildScopeKey2,
+          elementId: 'child_scope_2',
+        }),
+      ],
+      2,
+    );
+
+    mockSearchElementInstances().withSuccess(parentWithTwoChildrenResponse);
+    await elementInstancesTreeStore.expandNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockEmptyResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    mockSearchElementInstances().withSuccess(mockEmptyResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey2);
+
+    elementInstancesTreeStore.collapseNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(false);
+    expect(elementInstancesTreeStore.state.nodes.has(mockChildScopeKey1)).toBe(
+      false,
+    );
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey2),
+    ).toBe(true);
+    expect(elementInstancesTreeStore.state.nodes.has(mockChildScopeKey2)).toBe(
+      true,
+    );
+  });
+
+  it('should expand node when toggling collapsed node', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockChildResponse);
+
+    await elementInstancesTreeStore.toggleNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(true);
+    expect(elementInstancesTreeStore.state.nodes.has(mockChildScopeKey1)).toBe(
+      true,
+    );
+    expect(elementInstancesTreeStore.getItems(mockChildScopeKey1)).toHaveLength(
+      2,
+    );
+  });
+
+  it('should collapse node when toggling expanded node', async () => {
+    mockSearchElementInstances().withSuccess(mockEmptyResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(true);
+
+    elementInstancesTreeStore.toggleNode(mockChildScopeKey1);
+
+    expect(
+      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
+    ).toBe(false);
+    expect(elementInstancesTreeStore.state.nodes.has(mockChildScopeKey1)).toBe(
+      false,
+    );
+  });
+
+  it('should fetch next page with correct offset and limit', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.windowStart).toBe(0);
+    expect(nodeData?.pageMetadata.windowEnd).toBe(50);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    const updatedNodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(updatedNodeData?.pageMetadata.windowStart).toBe(50);
+    expect(updatedNodeData?.pageMetadata.windowEnd).toBe(100);
+  });
+
+  it('should return count of new items when fetching next page', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+
+    const count = await elementInstancesTreeStore.fetchNextPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(50);
+  });
+
+  it('should update window metadata after fetching next page', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.windowStart).toBe(50);
+    expect(nodeData?.pageMetadata.windowEnd).toBe(100);
+  });
+
+  it('should replace items with new 2-page window', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const firstItems = elementInstancesTreeStore.getItems(
+      mockProcessInstanceKey,
+    );
+    expect(firstItems.length).toBe(100);
+    expect(firstItems[0].elementId).toBe('task_0');
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    const secondItems = elementInstancesTreeStore.getItems(
+      mockProcessInstanceKey,
+    );
+    expect(secondItems.length).toBe(100);
+    expect(secondItems[0].elementId).toBe('task_50');
+  });
+
+  it('should return 0 when reaching end of list', async () => {
+    const endResponse = createMockResponse(mockFirstPageItems, 50);
+    mockSearchElementInstances().withSuccess(endResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.windowEnd).toBe(50);
+    expect(nodeData?.pageMetadata.totalItems).toBe(50);
+
+    const count = await elementInstancesTreeStore.fetchNextPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(0);
+  });
+
+  it('should return -1 when next page fetch fails', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withServerError(500);
+
+    const count = await elementInstancesTreeStore.fetchNextPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(-1);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.status).toBe('error');
+  });
+
+  it('should fetch previous page with correct offset and limit', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.windowStart).toBe(50);
+
+    mockSearchElementInstances().withSuccess(mockPreviousPageResponse);
+
+    await elementInstancesTreeStore.fetchPreviousPage(mockProcessInstanceKey);
+
+    const updatedNodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(updatedNodeData?.pageMetadata.windowStart).toBe(0);
+    expect(updatedNodeData?.pageMetadata.windowEnd).toBe(50);
+  });
+
+  it('should return count of new items when fetching previous page', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockPreviousPageResponse);
+
+    const count = await elementInstancesTreeStore.fetchPreviousPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(50);
+  });
+
+  it('should update window metadata after fetching previous page', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.windowStart).toBe(50);
+    expect(nodeData?.pageMetadata.windowEnd).toBe(100);
+
+    mockSearchElementInstances().withSuccess(mockPreviousPageResponse);
+
+    await elementInstancesTreeStore.fetchPreviousPage(mockProcessInstanceKey);
+
+    const updatedNodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(updatedNodeData?.pageMetadata.windowStart).toBe(0);
+    expect(updatedNodeData?.pageMetadata.windowEnd).toBe(50);
+  });
+
+  it('should return 0 when at beginning of list', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.pageMetadata.windowStart).toBe(0);
+
+    const count = await elementInstancesTreeStore.fetchPreviousPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(0);
+  });
+
+  it('should return -1 when previous page fetch fails', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockSecondPageResponse);
+    await elementInstancesTreeStore.fetchNextPage(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withServerError(500);
+
+    const count = await elementInstancesTreeStore.fetchPreviousPage(
+      mockProcessInstanceKey,
+    );
+
+    expect(count).toBe(-1);
+
+    const nodeData = elementInstancesTreeStore.state.nodes.get(
+      mockProcessInstanceKey,
+    );
+    expect(nodeData?.status).toBe('error');
+  });
+
+  it('should get items for existing node', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    const items = elementInstancesTreeStore.getItems(mockProcessInstanceKey);
+
+    expect(items).toHaveLength(100);
+    expect(items).toEqual(mockFirstPageItems);
+  });
+
+  it('should return empty array for non-existent node', async () => {
+    const items = elementInstancesTreeStore.getItems('non-existent-key');
+
+    expect(items).toHaveLength(0);
+    expect(items).toEqual([]);
+  });
+
+  it('should reset all state when reset is called', async () => {
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+    await elementInstancesTreeStore.setRootNode(mockProcessInstanceKey);
+
+    mockSearchElementInstances().withSuccess(mockChildResponse);
+    await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
+
+    expect(elementInstancesTreeStore.state.rootScopeKey).not.toBe(null);
+    expect(elementInstancesTreeStore.state.nodes.size).toBeGreaterThan(0);
+    expect(elementInstancesTreeStore.state.expandedNodes.size).toBeGreaterThan(
+      0,
+    );
+
+    elementInstancesTreeStore.reset();
+
+    expect(elementInstancesTreeStore.state.rootScopeKey).toBe(null);
+    expect(elementInstancesTreeStore.state.nodes.size).toBe(0);
+    expect(elementInstancesTreeStore.state.expandedNodes.size).toBe(0);
+  });
+});

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
@@ -227,7 +227,16 @@ describe('elementInstancesTreeStore', () => {
 
     const nodeData =
       elementInstancesTreeStore.state.nodes.get(mockChildScopeKey1);
-    expect(nodeData).toBeUndefined();
+
+    expect(nodeData).toEqual({
+      items: [],
+      pageMetadata: {
+        totalItems: 0,
+        windowStart: 0,
+        windowEnd: 0,
+      },
+      status: 'error',
+    });
   });
 
   it('should collapse node and remove from expandedNodes set', async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.test.ts
@@ -243,15 +243,15 @@ describe('elementInstancesTreeStore', () => {
     mockSearchElementInstances().withSuccess(mockEmptyResponse);
     await elementInstancesTreeStore.expandNode(mockChildScopeKey1);
 
-    expect(
-      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
-    ).toBe(true);
+    expect(elementInstancesTreeStore.isNodeExpanded(mockChildScopeKey1)).toBe(
+      true,
+    );
 
     elementInstancesTreeStore.collapseNode(mockChildScopeKey1);
 
-    expect(
-      elementInstancesTreeStore.state.expandedNodes.has(mockChildScopeKey1),
-    ).toBe(false);
+    expect(elementInstancesTreeStore.isNodeExpanded(mockChildScopeKey1)).toBe(
+      false,
+    );
   });
 
   it('should remove collapsed node data from memory', async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.ts
@@ -57,20 +57,22 @@ class ElementInstancesTreeStore {
   };
 
   setRootNode = async (processInstanceKey: string) => {
-    if (this.state.rootScopeKey !== processInstanceKey) {
-      this.state.abortControllers.forEach((controller) => {
-        controller.abort();
-      });
-      this.state.abortControllers.clear();
-
-      this.state.nodes.clear();
-      this.state.expandedNodes.clear();
-      this.state.rootScopeKey = processInstanceKey;
-
-      this.state.expandedNodes.add(processInstanceKey);
-
-      await this.fetchFirstPage(processInstanceKey);
+    if (this.state.rootScopeKey === processInstanceKey) {
+      return;
     }
+
+    this.state.abortControllers.forEach((controller) => {
+      controller.abort();
+    });
+    this.state.abortControllers.clear();
+
+    this.state.nodes.clear();
+    this.state.expandedNodes.clear();
+    this.state.rootScopeKey = processInstanceKey;
+
+    this.state.expandedNodes.add(processInstanceKey);
+
+    await this.fetchFirstPage(processInstanceKey);
   };
 
   expandNode = async (scopeKey: string) => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {makeAutoObservable} from 'mobx';
+import {searchElementInstances} from 'modules/api/v2/elementInstances/searchElementInstances';
+import {logger} from 'modules/logger';
+
+const PAGE_SIZE = 50;
+
+type PageMetadata = {
+  totalItems: number;
+  windowStart: number;
+  windowEnd: number;
+};
+
+type NodeData = {
+  items: ElementInstance[];
+  pageMetadata: PageMetadata;
+  status: 'idle' | 'loading' | 'error' | 'loaded';
+};
+
+type State = {
+  rootScopeKey: string | null;
+  nodes: Map<string, NodeData>;
+  expandedNodes: Set<string>;
+};
+
+class ElementInstancesTreeStore {
+  state: State = {
+    rootScopeKey: null,
+    nodes: new Map(),
+    expandedNodes: new Set(),
+  };
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  setRootNode = async (processInstanceKey: string) => {
+    if (this.state.rootScopeKey !== processInstanceKey) {
+      this.state.nodes.clear();
+      this.state.expandedNodes.clear();
+      this.state.rootScopeKey = processInstanceKey;
+
+      await this.fetchFirstPage(processInstanceKey);
+
+      this.state.expandedNodes.add(processInstanceKey);
+    }
+  };
+
+  expandNode = async (scopeKey: string) => {
+    if (this.state.expandedNodes.has(scopeKey)) {
+      return;
+    }
+
+    this.state.expandedNodes.add(scopeKey);
+
+    if (!this.state.nodes.has(scopeKey)) {
+      await this.fetchFirstPage(scopeKey);
+    }
+  };
+
+  private fetchFirstPage = async (scopeKey: string) => {
+    this.setNodeStatus(scopeKey, 'loading');
+
+    const {response, error} = await searchElementInstances({
+      filter: {elementInstanceScopeKey: scopeKey},
+      page: {limit: PAGE_SIZE * 2, from: 0},
+      sort: [{field: 'startDate', order: 'asc'}],
+    });
+
+    if (response !== null) {
+      this.state.nodes.set(scopeKey, {
+        items: response.items,
+        pageMetadata: {
+          totalItems: response.page.totalItems,
+          windowStart: 0,
+          windowEnd: PAGE_SIZE,
+        },
+        status: 'loaded',
+      });
+    } else {
+      this.setNodeStatus(scopeKey, 'error');
+      logger.error('Failed to fetch element instances', error);
+    }
+  };
+
+  collapseNode = (scopeKey: string) => {
+    this.state.expandedNodes.delete(scopeKey);
+
+    this.collapseAndRemoveDescendants(scopeKey);
+
+    this.state.nodes.delete(scopeKey);
+  };
+
+  toggleNode = async (scopeKey: string) => {
+    if (this.isNodeExpanded(scopeKey)) {
+      this.collapseNode(scopeKey);
+    } else {
+      await this.expandNode(scopeKey);
+    }
+  };
+
+  private collapseAndRemoveDescendants = (parentScopeKey: string) => {
+    const nodeData = this.state.nodes.get(parentScopeKey);
+
+    if (!nodeData) {
+      return;
+    }
+
+    nodeData.items.forEach((item) => {
+      const childKey = item.elementInstanceKey;
+
+      if (this.state.expandedNodes.has(childKey)) {
+        this.state.expandedNodes.delete(childKey);
+      }
+
+      if (this.state.nodes.has(childKey)) {
+        this.collapseAndRemoveDescendants(childKey);
+        this.state.nodes.delete(childKey);
+      }
+    });
+  };
+
+  fetchNextPage = async (scopeKey: string): Promise<number> => {
+    const nodeData = this.state.nodes.get(scopeKey);
+
+    if (!nodeData) {
+      logger.error('Cannot fetch next page: node not found');
+      return -1;
+    }
+
+    const nextWindowStart = nodeData.pageMetadata.windowEnd;
+    const nextWindowEnd = nextWindowStart + PAGE_SIZE;
+
+    if (nextWindowStart >= nodeData.pageMetadata.totalItems) {
+      return 0;
+    }
+
+    this.setNodeStatus(scopeKey, 'loading');
+
+    const {response, error} = await searchElementInstances({
+      filter: {elementInstanceScopeKey: scopeKey},
+      page: {limit: PAGE_SIZE * 2, from: nextWindowStart},
+      sort: [{field: 'startDate', order: 'asc'}],
+    });
+
+    if (response !== null) {
+      this.state.nodes.set(scopeKey, {
+        items: response.items,
+        pageMetadata: {
+          totalItems: response.page.totalItems,
+          windowStart: nextWindowStart,
+          windowEnd: nextWindowEnd,
+        },
+        status: 'loaded',
+      });
+
+      return Math.max(0, response.items.length - PAGE_SIZE);
+    } else {
+      this.setNodeStatus(scopeKey, 'error');
+      logger.error('Failed to fetch next page', error);
+      return -1;
+    }
+  };
+
+  fetchPreviousPage = async (scopeKey: string): Promise<number> => {
+    const nodeData = this.state.nodes.get(scopeKey);
+
+    if (!nodeData) {
+      logger.error('Cannot fetch previous page: node not found');
+      return -1;
+    }
+
+    const prevWindowEnd = nodeData.pageMetadata.windowStart;
+    const prevWindowStart = Math.max(0, prevWindowEnd - PAGE_SIZE);
+
+    if (prevWindowStart < 0 || nodeData.pageMetadata.windowStart === 0) {
+      return 0;
+    }
+
+    this.setNodeStatus(scopeKey, 'loading');
+
+    const {response, error} = await searchElementInstances({
+      filter: {elementInstanceScopeKey: scopeKey},
+      page: {limit: PAGE_SIZE * 2, from: prevWindowStart},
+      sort: [{field: 'startDate', order: 'asc'}],
+    });
+
+    if (response !== null) {
+      this.state.nodes.set(scopeKey, {
+        items: response.items,
+        pageMetadata: {
+          totalItems: response.page.totalItems,
+          windowStart: prevWindowStart,
+          windowEnd: prevWindowEnd,
+        },
+        status: 'loaded',
+      });
+
+      return Math.min(PAGE_SIZE, response.items.length);
+    } else {
+      this.setNodeStatus(scopeKey, 'error');
+      logger.error('Failed to fetch previous page', error);
+      return -1;
+    }
+  };
+
+  private setNodeStatus = (scopeKey: string, status: NodeData['status']) => {
+    const nodeData = this.state.nodes.get(scopeKey);
+    if (nodeData) {
+      this.state.nodes.set(scopeKey, {
+        ...nodeData,
+        status,
+      });
+    }
+  };
+
+  isNodeExpanded = (scopeKey: string): boolean => {
+    return this.state.expandedNodes.has(scopeKey);
+  };
+
+  getItems = (scopeKey: string): ElementInstance[] => {
+    return this.state.nodes.get(scopeKey)?.items ?? [];
+  };
+
+  reset = () => {
+    this.state.rootScopeKey = null;
+    this.state.nodes.clear();
+    this.state.expandedNodes.clear();
+  };
+}
+
+const elementInstancesTreeStore = new ElementInstancesTreeStore();
+export {elementInstancesTreeStore};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/elementInstancesTreeStore.ts
@@ -289,6 +289,16 @@ class ElementInstancesTreeStore {
         ...nodeData,
         status,
       });
+    } else {
+      this.state.nodes.set(scopeKey, {
+        items: [],
+        pageMetadata: {
+          totalItems: 0,
+          windowStart: 0,
+          windowEnd: 0,
+        },
+        status,
+      });
     }
   };
 

--- a/operate/client/src/modules/api/v2/elementInstances/searchElementInstances.ts
+++ b/operate/client/src/modules/api/v2/elementInstances/searchElementInstances.ts
@@ -15,11 +15,13 @@ import {requestWithThrow} from 'modules/request';
 
 const searchElementInstances = async (
   payload: QueryElementInstancesRequestBody,
+  signal?: AbortSignal,
 ) => {
   return requestWithThrow<QueryElementInstancesResponseBody>({
     url: endpoints.queryElementInstances.getUrl(),
     method: endpoints.queryElementInstances.method,
     body: payload,
+    signal,
   });
 };
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As mentioned some weeks ago due to some limitations on the Tanstack infinite query imperative APIs I had and due to the complexity of doing a proper virtualization of the tree while I had to keep using Mobx here.

This store is inspired by the existing one but it's not 100% the same. I trimmed some fat of it and the V2 API is not fully compatible with the old one.

I also decided to colocate the store file in the same folder instead of having it inside modules to coupling with other stores.

The polling will come later

I'm only creating the store with some tests. The PR is big but the store is not that large. Most of the diff comes from the tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#27330](https://github.com/camunda/camunda/issues/27330)
