### PR TITLE
refactor: record archiver duration even on failures

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -82,10 +82,9 @@ public abstract class ArchiverJob implements BackgroundTask {
         // measure the time it takes all in all, including searching, reindexing, deletion
         // There is some overhead with the scheduling at the executor, but this
         // should be negligible
-        .thenComposeAsync(
-            count -> {
+        .whenCompleteAsync(
+            (count, error) -> {
               exporterMetrics.measureArchivingDuration(timer);
-              return CompletableFuture.completedFuture(count);
             },
             executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Executor;
 final class TestRepository extends NoopArchiverRepository {
   final List<DocumentMove> moves = new ArrayList<>();
   ArchiveBatch batch;
+  boolean shouldFailOnMove = false;
 
   public CompletableFuture<ArchiveBatch> getNextBatch() {
     return CompletableFuture.completedFuture(batch);
@@ -53,6 +54,9 @@ final class TestRepository extends NoopArchiverRepository {
       final String idFieldName,
       final List<String> ids,
       final Executor executor) {
+    if (shouldFailOnMove) {
+      return CompletableFuture.failedFuture(new RuntimeException("Simulated archiving failure"));
+    }
     moves.add(new DocumentMove(sourceIndexName, destinationIndexName, idFieldName, ids, executor));
     return CompletableFuture.completedFuture(null);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I noticed that when the reindexing operations times out , the total archiver duration in grafana does not reflect the total duration of the archiving operation

<img width="1452" height="649" alt="image" src="https://github.com/user-attachments/assets/3dd7bb68-e4b5-4af8-92fe-1c831d7e2ff4" />

* Changed the completion handler in `ArchiverJob.execute()` from `thenComposeAsync` to `whenCompleteAsync`, so that archiving duration metrics are recorded regardless of success or failure.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
