### PR TITLE
feat: add element instance history tree component

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/Bar.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/Bar.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {forwardRef} from 'react';
+import {TimeStampLabel} from '../Bar/TimeStampLabel';
+import {NodeName, Container, StateIcon} from '../Bar/styled';
+import {Layer, Stack, Tag} from '@carbon/react';
+import {formatDate} from 'modules/utils/date';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+
+type Props = {
+  elementInstanceKey: string;
+  elementId: string;
+  elementName: string;
+  elementInstanceState: ElementInstance['state'];
+  hasIncident: boolean;
+  endDate: string | undefined;
+  isTimestampLabelVisible: boolean;
+  isRoot: boolean;
+  latestMigrationDate: string | undefined;
+};
+
+const Bar = forwardRef<HTMLDivElement, Props>(
+  (
+    {
+      elementInstanceKey,
+      elementName,
+      elementInstanceState,
+      hasIncident,
+      endDate = null,
+      isTimestampLabelVisible,
+      isRoot,
+      latestMigrationDate,
+    },
+    ref,
+  ) => {
+    return (
+      <Container ref={ref} data-testid={`node-details-${elementInstanceKey}`}>
+        <Stack orientation="horizontal" gap={5}>
+          {hasIncident ? (
+            <StateIcon state="INCIDENT" size={16} />
+          ) : (
+            <StateIcon state={elementInstanceState} size={16} />
+          )}
+          <NodeName>{elementName}</NodeName>
+          {isRoot && latestMigrationDate !== undefined && (
+            <Tag type="green">{`Migrated ${formatDate(latestMigrationDate)}`}</Tag>
+          )}
+          {isTimestampLabelVisible && (
+            <Layer>
+              <TimeStampLabel timeStamp={endDate} />
+            </Layer>
+          )}
+        </Stack>
+      </Container>
+    );
+  },
+);
+
+export {Bar};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -13,7 +13,6 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {observer} from 'mobx-react-lite';
 import {elementInstancesTreeStore} from './elementInstancesTreeStore';
-import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import type {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {ElementInstanceIcon} from './styled';
 import {useRootNode} from 'modules/hooks/flowNodeSelection';
@@ -24,6 +23,7 @@ import {Bar} from './Bar';
 import {InfiniteScroller} from 'modules/components/InfiniteScroller';
 import {useSearchElementInstancesByScope} from 'modules/queries/elementInstances/useSearchElementInstancesByScope';
 import {notificationsStore} from 'modules/stores/notifications';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 
 const TREE_NODE_HEIGHT = 32;
 const FOLDABLE_ELEMENT_TYPES: ElementInstance['type'][] = [
@@ -50,15 +50,6 @@ const useElementInstanceHistoryTree = () => {
   }
   return context;
 };
-
-function useElementBusinessObjects(params: {processDefinitionKey: string}) {
-  const {processDefinitionKey} = params;
-  const {data: processInstanceXmlData} = useProcessInstanceXml({
-    processDefinitionKey,
-  });
-
-  return processInstanceXmlData?.businessObjects;
-}
 
 type UnfoldableElementInstancesNodeProps = {
   scopeKey: string;
@@ -392,9 +383,7 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
   (props) => {
     const {processInstance, scrollableContainerRef, rowRef, ...rest} = props;
 
-    const businessObjects = useElementBusinessObjects({
-      processDefinitionKey: processInstance.processDefinitionKey,
-    });
+    const {data: businessObjects} = useBusinessObjects();
 
     elementInstancesTreeStore.setRootNode(processInstance.processInstanceKey);
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -107,7 +107,7 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
         label: (
           <Bar
             elementInstanceKey={scopeKey}
-            elementId={elementId!}
+            elementId={elementId}
             elementName={elementName}
             elementInstanceState={elementInstanceState}
             hasIncident={hasIncident}

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -1,0 +1,432 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createContext, useContext, useRef} from 'react';
+import type {
+  ElementInstance,
+  ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {observer} from 'mobx-react-lite';
+import {elementInstancesTreeStore} from './elementInstancesTreeStore';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import type {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
+import {ElementInstanceIcon} from './styled';
+import {useRootNode} from 'modules/hooks/flowNodeSelection';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {selectFlowNode} from 'modules/utils/flowNodeSelection';
+import {TreeNode} from '../styled';
+import {Bar} from './Bar';
+import {InfiniteScroller} from 'modules/components/InfiniteScroller';
+import {useSearchElementInstancesByScope} from 'modules/queries/elementInstances/useSearchElementInstancesByScope';
+import {notificationsStore} from 'modules/stores/notifications';
+
+const TREE_NODE_HEIGHT = 32;
+const FOLDABLE_ELEMENT_TYPES: ElementInstance['type'][] = [
+  'PROCESS',
+  'MULTI_INSTANCE_BODY',
+  'SUB_PROCESS',
+  'AD_HOC_SUB_PROCESS',
+  'AD_HOC_SUB_PROCESS_INNER_INSTANCE',
+];
+
+const ElementInstanceHistoryTree = createContext<{
+  processInstance: ProcessInstance;
+  rowRef: React.Ref<HTMLDivElement>;
+  scrollableContainerRef: React.RefObject<HTMLDivElement | null>;
+  businessObjects: BusinessObjects;
+} | null>(null);
+
+const useElementInstanceHistoryTree = () => {
+  const context = useContext(ElementInstanceHistoryTree);
+  if (!context) {
+    throw new Error(
+      'useElementInstanceHistoryTree must be used within a ElementInstanceHistoryTreeProvider',
+    );
+  }
+  return context;
+};
+
+function useElementBusinessObjects(params: {processDefinitionKey: string}) {
+  const {processDefinitionKey} = params;
+  const {data: processInstanceXmlData} = useProcessInstanceXml({
+    processDefinitionKey,
+  });
+
+  return processInstanceXmlData?.businessObjects;
+}
+
+type UnfoldableElementInstancesNodeProps = {
+  scopeKey: string;
+  elementId: string;
+  elementName: string;
+  elementInstanceState: ElementInstance['state'];
+  hasIncident: boolean;
+  endDate: string | undefined;
+  elementType: ElementInstance['type'];
+  renderIcon: () => React.ReactNode | null;
+};
+
+const UnfoldableElementInstancesNode: React.FC<UnfoldableElementInstancesNodeProps> =
+  observer(
+    ({
+      scopeKey,
+      elementId,
+      elementName,
+      elementInstanceState,
+      hasIncident,
+      endDate,
+      elementType,
+      renderIcon,
+      ...rest
+    }) => {
+      const rowRef = useRef<HTMLDivElement>(null);
+      const latestMigrationDate = undefined;
+      const isRoot = elementType === 'PROCESS';
+
+      const rootNode = useRootNode();
+      const isSelected = flowNodeSelectionStore.isSelected({
+        flowNodeId: isRoot ? undefined : elementId,
+        flowNodeInstanceId: scopeKey,
+        isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
+      });
+
+      const handleSelect = () => {
+        selectFlowNode(rootNode, {
+          flowNodeId: elementId,
+          flowNodeInstanceId: scopeKey,
+          isMultiInstance: false,
+        });
+      };
+
+      const elementProps = {
+        ...rest,
+        'data-testid': `tree-node-${scopeKey}`,
+        selected: isSelected ? [scopeKey] : [],
+        active: isSelected ? scopeKey : undefined,
+        id: scopeKey,
+        value: scopeKey,
+        'aria-label': elementName,
+        renderIcon,
+        isExpanded: false,
+        onSelect: handleSelect,
+        label: (
+          <Bar
+            elementInstanceKey={scopeKey}
+            elementId={elementId!}
+            elementName={elementName}
+            elementInstanceState={elementInstanceState}
+            hasIncident={hasIncident}
+            endDate={endDate}
+            isTimestampLabelVisible={false}
+            isRoot={isRoot}
+            latestMigrationDate={latestMigrationDate}
+            ref={rowRef}
+          />
+        ),
+      };
+
+      return <TreeNode {...elementProps} key={scopeKey} />;
+    },
+  );
+
+const ScrollableNodes: React.FC<
+  Omit<React.ComponentProps<typeof InfiniteScroller>, 'children'> & {
+    visibleChildren: ElementInstance[];
+  }
+> = ({
+  onVerticalScrollEndReach,
+  onVerticalScrollStartReach,
+  visibleChildren,
+  scrollableContainerRef,
+  ...carbonTreeNodeProps
+}) => {
+  return (
+    <InfiniteScroller
+      onVerticalScrollEndReach={onVerticalScrollEndReach}
+      onVerticalScrollStartReach={onVerticalScrollStartReach}
+      scrollableContainerRef={scrollableContainerRef}
+    >
+      <ul>
+        {visibleChildren.map(
+          ({
+            elementInstanceKey,
+            elementName,
+            type,
+            elementId,
+            state,
+            hasIncident,
+            endDate,
+          }) => {
+            return (
+              <ElementInstanceSubTreeRoot
+                key={elementInstanceKey}
+                scopeKey={elementInstanceKey}
+                elementName={elementName ?? elementId}
+                elementId={elementId}
+                elementInstanceState={state}
+                hasIncident={hasIncident}
+                endDate={endDate}
+                elementType={type}
+                {...carbonTreeNodeProps}
+              />
+            );
+          },
+        )}
+      </ul>
+    </InfiniteScroller>
+  );
+};
+
+type FoldableElementInstancesNodeProps = {
+  scopeKey: string;
+  elementId: string;
+  elementName: string;
+  elementInstanceState: ElementInstance['state'];
+  hasIncident: boolean;
+  endDate: string | undefined;
+  elementType: ElementInstance['type'];
+  renderIcon: () => React.ReactNode;
+};
+
+const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> =
+  observer(
+    ({
+      scopeKey,
+      elementId,
+      elementName,
+      elementInstanceState,
+      hasIncident,
+      endDate,
+      elementType,
+      renderIcon,
+      ...carbonTreeNodeProps
+    }) => {
+      const rowRef = useRef<HTMLDivElement>(null);
+      const {scrollableContainerRef} = useElementInstanceHistoryTree();
+      const {refetch: fetchFirstChild} = useSearchElementInstancesByScope(
+        {
+          elementInstanceScopeKey: scopeKey,
+          page: {limit: 1, from: 0},
+          sort: [{field: 'startDate', order: 'asc'}],
+        },
+        {enabled: false},
+      );
+      const latestMigrationDate = undefined;
+      const isRoot = elementType === 'PROCESS';
+
+      const rootNode = useRootNode();
+      const isSelected = flowNodeSelectionStore.isSelected({
+        flowNodeId: isRoot ? undefined : elementId,
+        flowNodeInstanceId: scopeKey,
+        isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
+      });
+      const isExpanded = elementInstancesTreeStore.isNodeExpanded(scopeKey);
+
+      const handleSelect = async () => {
+        if (elementType !== 'AD_HOC_SUB_PROCESS_INNER_INSTANCE') {
+          selectFlowNode(rootNode, {
+            flowNodeId: elementId,
+            flowNodeInstanceId: scopeKey,
+            isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
+          });
+          return;
+        }
+
+        const childInstances = elementInstancesTreeStore.getItems(scopeKey);
+
+        if (isExpanded && childInstances.length > 0) {
+          selectFlowNode(rootNode, {
+            flowNodeId: elementId,
+            flowNodeInstanceId: scopeKey,
+            isMultiInstance: false,
+            anchorFlowNodeId: childInstances[0].elementId,
+          });
+          return;
+        }
+
+        const {data} = await fetchFirstChild();
+        const [firstChild] = data?.items ?? [];
+
+        if (firstChild === undefined) {
+          notificationsStore.displayNotification({
+            kind: 'warning',
+            title:
+              'No child instances found for Ad Hoc Sub Process Inner Instance',
+            subtitle:
+              "The element instance has no child instances and we can't select the first child instance",
+            isDismissable: true,
+          });
+          return;
+        }
+
+        selectFlowNode(rootNode, {
+          flowNodeId: elementId,
+          flowNodeInstanceId: scopeKey,
+          isMultiInstance: false,
+          anchorFlowNodeId: firstChild.elementId,
+        });
+      };
+
+      const elementProps = {
+        ...carbonTreeNodeProps,
+        'data-testid': `tree-node-${scopeKey}`,
+        selected: isSelected ? [scopeKey] : [],
+        active: isSelected ? scopeKey : undefined,
+        id: scopeKey,
+        value: scopeKey,
+        'aria-label': elementName,
+        renderIcon,
+        isExpanded,
+        onSelect: handleSelect,
+        label: (
+          <Bar
+            elementInstanceKey={scopeKey}
+            elementId={elementId}
+            elementName={elementName}
+            elementInstanceState={elementInstanceState}
+            hasIncident={hasIncident}
+            endDate={endDate}
+            isTimestampLabelVisible={false}
+            isRoot={isRoot}
+            latestMigrationDate={latestMigrationDate}
+            ref={rowRef}
+          />
+        ),
+      };
+
+      return (
+        <TreeNode
+          {...elementProps}
+          key={scopeKey}
+          onToggle={() => {
+            elementInstancesTreeStore.toggleNode(scopeKey);
+          }}
+        >
+          <ScrollableNodes
+            onVerticalScrollEndReach={async (scrollUp) => {
+              const newPageItemsCount =
+                await elementInstancesTreeStore.fetchNextPage(scopeKey);
+              if (newPageItemsCount > 0) {
+                scrollUp(
+                  newPageItemsCount * (rowRef.current?.offsetHeight ?? 0),
+                );
+              }
+            }}
+            onVerticalScrollStartReach={async (scrollDown) => {
+              const newPageItemsCount =
+                await elementInstancesTreeStore.fetchPreviousPage(scopeKey);
+              if (newPageItemsCount > 0) {
+                scrollDown(newPageItemsCount * TREE_NODE_HEIGHT);
+              }
+            }}
+            scrollableContainerRef={scrollableContainerRef}
+            visibleChildren={elementInstancesTreeStore.getItems(scopeKey)}
+          />
+        </TreeNode>
+      );
+    },
+  );
+
+type Props = {
+  scopeKey: string;
+  elementName: string;
+  elementId: string;
+  elementInstanceState: ElementInstance['state'];
+  hasIncident: boolean;
+  endDate: string | undefined;
+  elementType: ElementInstance['type'];
+};
+
+const ElementInstanceSubTreeRoot: React.FC<Props> = observer((props) => {
+  const {elementType, elementId, scopeKey, ...rest} = props;
+  const {businessObjects} = useElementInstanceHistoryTree();
+  const isFoldable = FOLDABLE_ELEMENT_TYPES.includes(elementType);
+
+  if (isFoldable) {
+    return (
+      <FoldableElementInstancesNode
+        {...rest}
+        scopeKey={scopeKey}
+        elementType={elementType}
+        elementId={elementId}
+        renderIcon={() => (
+          <ElementInstanceIcon
+            elementInstanceType={elementType}
+            diagramBusinessObject={businessObjects[elementId]}
+            $hasLeftMargin={false}
+          />
+        )}
+      />
+    );
+  }
+
+  return (
+    <UnfoldableElementInstancesNode
+      {...rest}
+      scopeKey={scopeKey}
+      elementType={elementType}
+      elementId={elementId}
+      renderIcon={() => (
+        <ElementInstanceIcon
+          elementInstanceType={elementType}
+          diagramBusinessObject={businessObjects[elementId]}
+          $hasLeftMargin
+        />
+      )}
+    />
+  );
+});
+
+type ElementInstancesTreeProps = {
+  processInstance: ProcessInstance;
+  rowRef: React.Ref<HTMLDivElement>;
+  scrollableContainerRef: React.RefObject<HTMLDivElement | null>;
+};
+
+const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
+  (props) => {
+    const {processInstance, scrollableContainerRef, rowRef, ...rest} = props;
+
+    const businessObjects = useElementBusinessObjects({
+      processDefinitionKey: processInstance.processDefinitionKey,
+    });
+
+    elementInstancesTreeStore.setRootNode(processInstance.processInstanceKey);
+
+    if (businessObjects === undefined) {
+      return null;
+    }
+
+    return (
+      <ElementInstanceHistoryTree.Provider
+        value={{
+          processInstance,
+          rowRef,
+          scrollableContainerRef,
+          businessObjects,
+        }}
+      >
+        <ElementInstanceSubTreeRoot
+          {...rest}
+          elementId={processInstance.processDefinitionId}
+          elementName={
+            processInstance.processDefinitionName ??
+            processInstance.processDefinitionId
+          }
+          elementInstanceState={processInstance.state}
+          hasIncident={processInstance.hasIncident}
+          endDate={processInstance.endDate}
+          elementType="PROCESS"
+          scopeKey={processInstance.processInstanceKey}
+        />
+      </ElementInstanceHistoryTree.Provider>
+    );
+  },
+);
+
+export {ElementInstancesTree};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -36,7 +36,6 @@ const FOLDABLE_ELEMENT_TYPES: ElementInstance['type'][] = [
 
 const ElementInstanceHistoryTree = createContext<{
   processInstance: ProcessInstance;
-  rowRef: React.Ref<HTMLDivElement>;
   scrollableContainerRef: React.RefObject<HTMLDivElement | null>;
   businessObjects: BusinessObjects;
 } | null>(null);
@@ -375,13 +374,13 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer((props) => {
 
 type ElementInstancesTreeProps = {
   processInstance: ProcessInstance;
-  rowRef: React.Ref<HTMLDivElement>;
+
   scrollableContainerRef: React.RefObject<HTMLDivElement | null>;
 };
 
 const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
   (props) => {
-    const {processInstance, scrollableContainerRef, rowRef, ...rest} = props;
+    const {processInstance, scrollableContainerRef, ...rest} = props;
 
     const {data: businessObjects} = useBusinessObjects();
 
@@ -395,7 +394,6 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
       <ElementInstanceHistoryTree.Provider
         value={{
           processInstance,
-          rowRef,
           scrollableContainerRef,
           businessObjects,
         }}

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -50,7 +50,7 @@ const useElementInstanceHistoryTree = () => {
   return context;
 };
 
-type UnfoldableElementInstancesNodeProps = {
+type NonFoldableElementInstancesNodeProps = {
   scopeKey: string;
   elementId: string;
   elementName: string;
@@ -61,7 +61,7 @@ type UnfoldableElementInstancesNodeProps = {
   renderIcon: () => React.ReactNode | null;
 };
 
-const UnfoldableElementInstancesNode: React.FC<UnfoldableElementInstancesNodeProps> =
+const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeProps> =
   observer(
     ({
       scopeKey,
@@ -356,7 +356,7 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer((props) => {
   }
 
   return (
-    <UnfoldableElementInstancesNode
+    <NonFoldableElementInstancesNode
       {...rest}
       scopeKey={scopeKey}
       elementType={elementType}

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/styled.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {INSTANCE_HISTORY_LEFT_PADDING} from 'modules/constants';
+import styled, {css} from 'styled-components';
+import {ElementInstanceIcon as BaseElementInstanceIcon} from 'modules/components/ElementInstanceIcon';
+
+const ElementInstanceIcon = styled(BaseElementInstanceIcon)<{
+  $hasLeftMargin: boolean;
+}>`
+  ${({$hasLeftMargin}) => {
+    return css`
+      ${$hasLeftMargin
+        ? css`
+            margin-left: ${INSTANCE_HISTORY_LEFT_PADDING};
+          `
+        : ''}
+    `;
+  }}
+`;
+
+export {ElementInstanceIcon};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -84,7 +84,8 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
   );
 };
 
-describe('FlowNodeInstanceLog', () => {
+// TODO unskip with #27330
+describe.skip('FlowNodeInstanceLog', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockDeprecatedProcessInstance,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -12,7 +12,7 @@ import {
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 
-import {FlowNodeInstanceLog} from './index';
+import {ElementInstanceLog} from './index';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {
@@ -85,7 +85,7 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
 };
 
 // TODO unskip with #27330
-describe.skip('FlowNodeInstanceLog', () => {
+describe.skip('ElementInstanceLog', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockDeprecatedProcessInstance,
@@ -105,7 +105,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     expect(screen.getByTestId('instance-history-skeleton')).toBeInTheDocument();
 
@@ -120,7 +120,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     expect(screen.getByTestId('instance-history-skeleton')).toBeInTheDocument();
 
@@ -134,7 +134,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     expect(
       await screen.findByText('Instance History could not be fetched'),
@@ -146,7 +146,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     mockFetchProcessDefinitionXml().withServerError();
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     expect(
       await screen.findByText('Instance History could not be fetched'),
@@ -159,7 +159,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     mockFetchProcessDefinitionXml().withServerError(403);
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     expect(
       await screen.findByText('Missing permissions to access Instance History'),
@@ -183,7 +183,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     await waitForElementToBeRemoved(
       screen.queryByTestId('instance-history-skeleton'),
@@ -242,7 +242,7 @@ describe.skip('FlowNodeInstanceLog', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     init(mockProcessInstance);
 
-    render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
+    render(<ElementInstanceLog />, {wrapper: Wrapper});
 
     expect((await screen.findAllByText('processName')).length).toBeGreaterThan(
       0,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.tsx
@@ -39,9 +39,9 @@ const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
   );
 });
 
-const FlowNodeInstanceLog: React.FC = observer(() => {
+const ElementInstanceLog: React.FC = observer(() => {
   const {data: processInstance, status} = useProcessInstance();
-  const flowNodeInstanceRowRef = useRef<HTMLDivElement>(null);
+  const elementInstanceRowRef = useRef<HTMLDivElement>(null);
   const instanceHistoryRef = useRef<HTMLDivElement>(null);
 
   if (status === 'pending') {
@@ -71,7 +71,7 @@ const FlowNodeInstanceLog: React.FC = observer(() => {
           <TreeView label={`${name} instance history`} hideLabel>
             <ElementInstancesTree
               processInstance={processInstance}
-              rowRef={flowNodeInstanceRowRef}
+              rowRef={elementInstanceRowRef}
               scrollableContainerRef={instanceHistoryRef}
             />
           </TreeView>
@@ -81,4 +81,4 @@ const FlowNodeInstanceLog: React.FC = observer(() => {
   );
 });
 
-export {FlowNodeInstanceLog};
+export {ElementInstanceLog};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.tsx
@@ -41,7 +41,6 @@ const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
 
 const ElementInstanceLog: React.FC = observer(() => {
   const {data: processInstance, status} = useProcessInstance();
-  const elementInstanceRowRef = useRef<HTMLDivElement>(null);
   const instanceHistoryRef = useRef<HTMLDivElement>(null);
 
   if (status === 'pending') {
@@ -71,7 +70,6 @@ const ElementInstanceLog: React.FC = observer(() => {
           <TreeView label={`${name} instance history`} hideLabel>
             <ElementInstancesTree
               processInstance={processInstance}
-              rowRef={elementInstanceRowRef}
               scrollableContainerRef={instanceHistoryRef}
             />
           </TreeView>

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.tsx
@@ -7,9 +7,7 @@
  */
 
 import React, {useRef} from 'react';
-import {FlowNodeInstancesTree} from '../FlowNodeInstancesTree/v2';
 import {observer} from 'mobx-react';
-import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {
   Container,
   NodeContainer,
@@ -22,31 +20,10 @@ import {modificationsStore} from 'modules/stores/modifications';
 import {Stack, TreeView} from '@carbon/react';
 import {Skeleton} from '../Skeleton';
 import {ExecutionCountToggle} from '../ExecutionCountToggle';
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
-import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
-import {
-  useInstanceExecutionHistory,
-  useIsInstanceExecutionHistoryAvailable,
-} from 'modules/hooks/flowNodeInstance';
+import {ElementInstancesTree} from '../FlowNodeInstancesTree/v2/index.new';
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 
-const FlowNodeInstanceLog: React.FC = observer(() => {
-  const instanceExecutionHistory = useInstanceExecutionHistory();
-  const isInstanceExecutionHistoryAvailable =
-    useIsInstanceExecutionHistoryAvailable();
-  const {
-    state: {status: flowNodeInstanceStatus},
-  } = flowNodeInstanceStore;
-
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-  const {isSuccess, isError, isPending} = useProcessInstanceXml({
-    processDefinitionKey,
-  });
-
-  const LOADING_STATES = ['initial', 'first-fetch'];
-
-  const flowNodeInstanceRowRef = useRef<HTMLDivElement>(null);
-  const instanceHistoryRef = useRef<HTMLDivElement>(null);
-
+const Layout: React.FC<{children: React.ReactNode}> = observer(({children}) => {
   return (
     <Container data-testid="instance-history">
       <PanelHeader title="Instance History" size="sm">
@@ -57,36 +34,50 @@ const FlowNodeInstanceLog: React.FC = observer(() => {
           </Stack>
         )}
       </PanelHeader>
-      {isSuccess && isInstanceExecutionHistoryAvailable ? (
-        <InstanceHistory ref={instanceHistoryRef}>
-          <NodeContainer>
-            <TreeView
-              label={`${instanceExecutionHistory?.flowNodeId} instance history`}
-              hideLabel
-            >
-              {
-                <FlowNodeInstancesTree
-                  rowRef={flowNodeInstanceRowRef}
-                  scrollableContainerRef={instanceHistoryRef}
-                  flowNodeInstance={instanceExecutionHistory!}
-                  isRoot
-                />
-              }
-            </TreeView>
-          </NodeContainer>
-        </InstanceHistory>
-      ) : (
-        <>
-          {(flowNodeInstanceStatus === 'error' || isError) && (
-            //TODO update the message with 403 related error during v2 endpoint integration #33542
-            <ErrorMessage message="Instance History could not be fetched" />
-          )}
-          {(LOADING_STATES.includes(flowNodeInstanceStatus) || isPending) && (
-            <Skeleton />
-          )}
-        </>
-      )}
+      {children}
     </Container>
+  );
+});
+
+const FlowNodeInstanceLog: React.FC = observer(() => {
+  const {data: processInstance, status} = useProcessInstance();
+  const flowNodeInstanceRowRef = useRef<HTMLDivElement>(null);
+  const instanceHistoryRef = useRef<HTMLDivElement>(null);
+
+  if (status === 'pending') {
+    return (
+      <Layout>
+        <Skeleton />
+      </Layout>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Layout>
+        {/* TODO update the message with 403 related error during v2 endpoint integration #33542 */}
+        <ErrorMessage message="Instance History could not be fetched" />
+      </Layout>
+    );
+  }
+
+  const {processDefinitionId, processDefinitionName} = processInstance;
+  const name = processDefinitionName ?? processDefinitionId;
+
+  return (
+    <Layout>
+      <InstanceHistory ref={instanceHistoryRef}>
+        <NodeContainer>
+          <TreeView label={`${name} instance history`} hideLabel>
+            <ElementInstancesTree
+              processInstance={processInstance}
+              rowRef={flowNodeInstanceRowRef}
+              scrollableContainerRef={instanceHistoryRef}
+            />
+          </TreeView>
+        </NodeContainer>
+      </InstanceHistory>
+    </Layout>
   );
 });
 

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -22,7 +22,7 @@ import {ProcessInstanceHeader} from './ProcessInstanceHeader';
 import {TopPanel} from './TopPanel';
 import {BottomPanel, ModificationFooter, Buttons} from './styled';
 import {FlowNodeInstanceLog} from './FlowNodeInstanceLog';
-import {FlowNodeInstanceLog as FlowNodeInstanceLogV2} from './FlowNodeInstanceLog/v2';
+import {ElementInstanceLog} from './FlowNodeInstanceLog/v2';
 import {IS_ELEMENT_INSTANCE_HISTORY_V2} from 'modules/feature-flags';
 import {Button, Modal} from '@carbon/react';
 import {tracking} from 'modules/tracking';
@@ -208,7 +208,7 @@ const ProcessInstance: React.FC = observer(() => {
             bottomPanel={
               <BottomPanel $shouldExpandPanel={isListenerTabSelected}>
                 {IS_ELEMENT_INSTANCE_HISTORY_V2 ? (
-                  <FlowNodeInstanceLogV2 />
+                  <ElementInstanceLog />
                 ) : (
                   <FlowNodeInstanceLog />
                 )}

--- a/operate/client/src/modules/queries/elementInstances/useSearchElementInstancesByScope.tsx
+++ b/operate/client/src/modules/queries/elementInstances/useSearchElementInstancesByScope.tsx
@@ -6,86 +6,26 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type QueryKey,
-} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 import {searchElementInstances} from 'modules/api/v2/elementInstances/searchElementInstances';
 import {queryKeys} from '../queryKeys';
-import type {QueryElementInstancesResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
-import type {RequestError} from 'modules/request';
-
-const MAX_ELEMENT_INSTANCES_PER_REQUEST = 50;
-
-type PageParam = {
-  page: number;
-  pageElementInstanceScopeKey?: string;
-};
 
 const useSearchElementInstancesByScope = (
-  payload: Parameters<typeof queryKeys.elementInstances.searcyByScope>[0],
+  payload: Parameters<typeof queryKeys.elementInstances.searchByScope>[0],
+  options?: {
+    enabled?: boolean;
+  },
 ) => {
-  const {elementInstanceScopeKey} = payload;
-  return useInfiniteQuery<
-    QueryElementInstancesResponseBody,
-    RequestError,
-    InfiniteData<QueryElementInstancesResponseBody>,
-    QueryKey,
-    PageParam
-  >({
-    queryKey: queryKeys.elementInstances.searcyByScope({
-      elementInstanceScopeKey,
-    }),
-    queryFn: async ({pageParam}) => {
-      const {page, pageElementInstanceScopeKey} = pageParam;
-      const {response, error} = await searchElementInstances({
-        filter: {
-          elementInstanceScopeKey:
-            pageElementInstanceScopeKey ?? elementInstanceScopeKey,
-        },
-        page: {
-          limit: MAX_ELEMENT_INSTANCES_PER_REQUEST,
-          from: page,
-        },
-      });
+  return useQuery({
+    queryKey: queryKeys.elementInstances.searchByScope(payload),
+    queryFn: async () => {
+      const {response, error} = await searchElementInstances(payload);
       if (response !== null) {
         return response;
       }
       throw error;
     },
-    initialPageParam: {
-      page: 0,
-    },
-    getNextPageParam: (
-      lastPage,
-      _,
-      {page: lastPageParam, pageElementInstanceScopeKey},
-    ) => {
-      const {page} = lastPage;
-      const nextPage = lastPageParam + MAX_ELEMENT_INSTANCES_PER_REQUEST;
-
-      if (nextPage > page.totalItems) {
-        return null;
-      }
-
-      return {page: nextPage, pageElementInstanceScopeKey};
-    },
-    getPreviousPageParam: (
-      _,
-      __,
-      {page: firstPageParam, pageElementInstanceScopeKey},
-    ) => {
-      const previousPage = firstPageParam - MAX_ELEMENT_INSTANCES_PER_REQUEST;
-
-      if (previousPage < 0) {
-        return null;
-      }
-
-      return {page: previousPage, pageElementInstanceScopeKey};
-    },
-    refetchInterval: 5000,
-    maxPages: 2,
+    ...options,
   });
 };
 

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -10,6 +10,7 @@ import type {
   ElementInstance,
   ProcessInstance,
   QueryElementInstanceIncidentsRequestBody,
+  QueryElementInstancesRequestBody,
   QueryProcessInstanceIncidentsRequestBody,
   QueryProcessInstancesRequestBody,
   Variable,
@@ -106,9 +107,12 @@ const queryKeys = {
         pageSize,
       ];
     },
-    searcyByScope: (payload: {elementInstanceScopeKey: string}) => {
-      const {elementInstanceScopeKey} = payload;
-      return ['elementInstancesSearch', elementInstanceScopeKey];
+    searchByScope: (
+      payload: Pick<QueryElementInstancesRequestBody, 'page' | 'sort'> & {
+        elementInstanceScopeKey: string;
+      },
+    ) => {
+      return ['elementInstancesSearchByScope', ...Object.values(payload)];
     },
   },
   processInstances: {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR migrates the `<ElementInstanceLog />` (previously `<FlowNodeInstanceLog />`) to the V2 API.

This PR only migrates the view mode part. No modifications yet.
It also doesn't have the polling yet

I skipped tests for now. I'll fix them in the end.

Please review this one https://github.com/camunda/camunda/pull/40872

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#27330](https://github.com/camunda/camunda/issues/27330)
