### PR TITLE
fix: flaky 8.7 nightly test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_variables_for_completion.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_variables_for_completion.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_with_variables_to_complete" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_with_variables">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -16,9 +16,13 @@ test.beforeAll(async () => {
   await deploy([
     './resources/usertask_with_variables.bpmn',
     './resources/usertask_without_variables.bpmn',
+    './resources/usertask_with_variables_for_completion.bpmn',
   ]);
   await createInstances('usertask_without_variables', 1, 1);
-  await createInstances('usertask_with_variables', 1, 4, {
+  await createInstances('usertask_with_variables', 1, 3, {
+    testData: 'something',
+  });
+  await createInstances('usertask_with_variables_to_complete', 1, 1, {
     testData: 'something',
   });
 });
@@ -171,7 +175,7 @@ test.describe('variables page', () => {
     taskPanelPage,
   }) => {
     await taskPanelPage.filterBy('Unassigned');
-    await taskPanelPage.openTask('usertask_with_variables');
+    await taskPanelPage.openTask('usertask_with_variables_to_complete');
 
     await expect(taskDetailsPage.addVariableButton).toBeHidden();
     await expect(taskDetailsPage.assignToMeButton).toBeVisible();
@@ -194,7 +198,7 @@ test.describe('variables page', () => {
     await page.reload();
 
     await taskPanelPage.filterBy('Completed');
-    await taskPanelPage.openTask('usertask_with_variables');
+    await taskPanelPage.openTask('usertask_with_variables_to_complete');
 
     await expect(page.getByText('newVariableName')).toBeVisible();
     await expect(page.getByText('newVariableValue')).toBeVisible();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The failure of `new variable still exists after refresh if task is completed` was caused by test data conflicts with another test. This PR introduces unique test data to isolate and stabilize the test.


🧪 [Test run](https://github.com/camunda/camunda/actions/runs/19324470438)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
