### PR TITLE
feat: update `adHocSubProcessElements` variable

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionsTest.java
@@ -165,7 +165,7 @@ public class ProcessInstanceMigrationPreconditionsTest {
     final DeployedProcess deployedProcess =
         processState.getProcessByKeyAndTenant(processDefinitionKey, "<default>");
 
-    // when/then - should return true for the multi-instance body wrapping non ad-hoc subprocess
+    // when/then - should return false for the multi-instance body wrapping non ad-hoc subprocess
     assertThat(isAdHocRelatedProcess(deployedProcess, "task")).isFalse();
   }
 }


### PR DESCRIPTION
## Description

Handles ad-hoc subprocess migration by updating the `adHocSubProcessElements` variable to reflect the target process definition.

When an ad-hoc subprocess is migrated to a different process definition version, the `adHocSubProcessElements` variable, which contains metadata about available ad-hoc activities, must be updated to match the target definition.

This ensures that the metadata accurately reflects the available activities in the new process definition, preventing stale references to activities that may have been added, removed, or modified.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40737
