### PR TITLE
feat: introduce parameter for returning full variable values

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1864,7 +1864,9 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *  .filter((f) -> f.variableKey(variableKey))
    *  .sort((s) -> s.value().asc())
    *  .page((p) -> p.limit(100))
+   *  .truncateValues(false)
    *  .send();
+   * </pre>
    *
    * @return a builder for the variable search request
    */
@@ -1879,9 +1881,10 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *  camundaClient
    * .newVariableGetRequest(variableKey)
    * .send();
+   * </pre>
    *
-   *  @param variableKey the key of the variable
-   *  @return a builder for the request to get a variable
+   * @param variableKey the key of the variable
+   * @return a builder for the request to get a variable
    */
   VariableGetRequest newVariableGetRequest(long variableKey);
 
@@ -1889,16 +1892,18 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * Executes a search request to query variables related to a user task.
    *
    * <pre>
-   *   long variableKey = ...;
+   *   long userTaskKey = ...;
    *
    *  camundaClient
-   *   .newUserTaskVariableSearchRequest(variableKey)
+   *   .newUserTaskVariableSearchRequest(userTaskKey)
    *   .sort((s) -> s.value().asc())
    *   .page((p) -> p.limit(100))
+   *   .truncateValues(false)
    *   .send();
+   * </pre>
    *
-   *  @param userTaskKey the key of the user task
-   *  @return a builder for the user task variable search request
+   * @param userTaskKey the key of the user task
+   * @return a builder for the user task variable search request
    */
   UserTaskVariableSearchRequest newUserTaskVariableSearchRequest(long userTaskKey);
 
@@ -1917,7 +1922,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *   .fileName("file.txt")
    *   .timeToLive(Duration.ofDays(1))
    *   .send();
-   *   </pre>
+   * </pre>
    *
    * @return a builder for the command
    */

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/UserTaskVariableSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/UserTaskVariableSearchRequest.java
@@ -21,4 +21,15 @@ import io.camunda.client.api.search.sort.VariableSort;
 
 public interface UserTaskVariableSearchRequest
     extends TypedSearchRequest<UserTaskVariableFilter, VariableSort, UserTaskVariableSearchRequest>,
-        FinalSearchRequestStep<Variable> {}
+        FinalSearchRequestStep<Variable> {
+
+  /**
+   * <pre>
+   * Sets {@code truncateValues=false} in the search request to return full variable values. By
+   * default, truncated values are returned.
+   *
+   * @return the builder for the search request
+   * </pre>
+   */
+  UserTaskVariableSearchRequest withFullValues();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/VariableSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/VariableSearchRequest.java
@@ -21,4 +21,15 @@ import io.camunda.client.api.search.sort.VariableSort;
 
 public interface VariableSearchRequest
     extends TypedSearchRequest<VariableFilter, VariableSort, VariableSearchRequest>,
-        FinalSearchRequestStep<Variable> {}
+        FinalSearchRequestStep<Variable> {
+
+  /**
+   * <pre>
+   * Sets {@code truncateValues=false} in the search request to return full variable values. By
+   * default, truncated values are returned.
+   *
+   * @return the builder for the search request
+   * </pre>
+   */
+  VariableSearchRequest withFullValues();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UserTaskVariableSearchRequestImpl.java
@@ -34,6 +34,8 @@ import io.camunda.client.impl.search.response.SearchResponseMapper;
 import io.camunda.client.protocol.rest.UserTaskVariableSearchQueryRequest;
 import io.camunda.client.protocol.rest.VariableSearchQueryResult;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -47,6 +49,7 @@ public class UserTaskVariableSearchRequestImpl
   private final RequestConfig.Builder httpRequestConfig;
   private final JsonMapper jsonMapper;
   private final long userTaskKey;
+  private boolean withFullValues = false;
 
   public UserTaskVariableSearchRequestImpl(
       final HttpClient httpClient, final JsonMapper jsonMapper, final long userTaskKey) {
@@ -66,8 +69,14 @@ public class UserTaskVariableSearchRequestImpl
   @Override
   public CamundaFuture<SearchResponse<Variable>> send() {
     final HttpCamundaFuture<SearchResponse<Variable>> result = new HttpCamundaFuture<>();
+
+    final Map<String, String> queryParams = new HashMap<>();
+    if (withFullValues) {
+      queryParams.put("truncateValues", String.valueOf(false));
+    }
     httpClient.post(
         String.format("/user-tasks/%d/variables/search", userTaskKey),
+        queryParams,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         VariableSearchQueryResult.class,
@@ -109,6 +118,12 @@ public class UserTaskVariableSearchRequestImpl
   @Override
   public UserTaskVariableSearchRequest page(final Consumer<SearchRequestPage> fn) {
     return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public UserTaskVariableSearchRequest withFullValues() {
+    withFullValues = true;
+    return this;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/VariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/VariableSearchRequestImpl.java
@@ -34,6 +34,8 @@ import io.camunda.client.impl.search.response.SearchResponseMapper;
 import io.camunda.client.protocol.rest.VariableSearchQuery;
 import io.camunda.client.protocol.rest.VariableSearchQueryResult;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -46,6 +48,7 @@ public class VariableSearchRequestImpl
   private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
+  private boolean withFullValues = false;
 
   public VariableSearchRequestImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
     request = new VariableSearchQuery();
@@ -63,8 +66,13 @@ public class VariableSearchRequestImpl
   @Override
   public CamundaFuture<SearchResponse<Variable>> send() {
     final HttpCamundaFuture<SearchResponse<Variable>> result = new HttpCamundaFuture<>();
+    final Map<String, String> queryParams = new HashMap<>();
+    if (withFullValues) {
+      queryParams.put("truncateValues", String.valueOf(false));
+    }
     httpClient.post(
         "/variables/search",
+        queryParams,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         VariableSearchQueryResult.class,
@@ -106,6 +114,12 @@ public class VariableSearchRequestImpl
   @Override
   public VariableSearchRequest page(final Consumer<SearchRequestPage> fn) {
     return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public VariableSearchRequest withFullValues() {
+    withFullValues = true;
+    return this;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/variable/SearchVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/variable/SearchVariableTest.java
@@ -17,10 +17,12 @@ package io.camunda.client.variable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.tomakehurst.wiremock.http.QueryParameter;
 import io.camunda.client.protocol.rest.BasicStringFilterProperty;
 import io.camunda.client.protocol.rest.VariableFilter;
 import io.camunda.client.protocol.rest.VariableSearchQuery;
 import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +125,29 @@ public class SearchVariableTest extends ClientRestTest {
     // then
     final VariableSearchQuery request = gatewayService.getLastRequest(VariableSearchQuery.class);
     assertThat(request.getFilter().getIsTruncated()).isEqualTo(true);
+  }
+
+  @Test
+  void shouldSearchVariablesWithoutParamsByDefault() {
+    // when
+    client.newVariableSearchRequest().send().join();
+
+    // then
+    final QueryParameter param =
+        RestGatewayService.getLastRequest().getQueryParams().get("truncateValues");
+    assertThat(param).isNull();
+  }
+
+  @Test
+  void shouldSearchVariablesWithoutTruncating() {
+    // when
+    client.newVariableSearchRequest().withFullValues().send().join();
+
+    // then
+    final QueryParameter param =
+        RestGatewayService.getLastRequest().getQueryParams().get("truncateValues");
+    assertThat(param.isSingleValued()).isTrue();
+    assertThat(param.firstValue()).isEqualTo("false");
   }
 
   @Test

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -96,6 +96,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -289,7 +289,7 @@ paths:
         - User task
       operationId: searchUserTaskVariables
       summary: Search user task variables
-      description: Search for user task variables based on given criteria.
+      description: Search for user task variables based on given criteria. By default, long variable values in the response are truncated.
       parameters:
         - name: userTaskKey
           in: path
@@ -297,6 +297,12 @@ paths:
           description: The key of the user task.
           schema:
             $ref: 'keys.yaml#/components/schemas/UserTaskKey'
+        - name: truncateValues
+          in: query
+          required: false
+          description: When true (default), long variable values in the response are truncated. When false, full variable values are returned.
+          schema:
+            type: boolean
       requestBody:
         required: false
         content:

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -8,7 +8,14 @@ paths:
         - Variable
       operationId: searchVariables
       summary: Search variables
-      description: Search for process and local variables based on given criteria.
+      description: Search for process and local variables based on given criteria. By default, long variable values in the response are truncated.
+      parameters:
+        - name: truncateValues
+          in: query
+          required: false
+          description: When true (default), long variable values in the response are truncated. When false, full variable values are returned.
+          schema:
+            type: boolean
       requestBody:
         required: false
         content:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @CamundaRestController
 @RequiresSecondaryStorage
@@ -41,18 +42,21 @@ public class VariableController {
 
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<Object> searchVariables(
-      @RequestBody(required = false) final VariableSearchQuery query) {
+      @RequestBody(required = false) final VariableSearchQuery query,
+      @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
+          final boolean truncateValues) {
     return SearchQueryRequestMapper.toVariableQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, truncateValues));
   }
 
-  private ResponseEntity<Object> search(final VariableQuery query) {
+  private ResponseEntity<Object> search(final VariableQuery query, final boolean truncateValues) {
     try {
       final var result =
           variableServices
               .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .search(query);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toVariableSearchQueryResponse(result));
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -1151,29 +1151,30 @@ public final class SearchQueryResponseMapper {
   }
 
   public static VariableSearchQueryResult toVariableSearchQueryResponse(
-      final SearchQueryResult<VariableEntity> result) {
+      final SearchQueryResult<VariableEntity> result, final boolean truncateValues) {
     final var page = toSearchQueryPageResponse(result);
     return new VariableSearchQueryResult()
         .page(page)
         .items(
             ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toVariables)
+                .map(entity -> toVariables(entity, truncateValues))
                 .orElseGet(Collections::emptyList));
   }
 
   private static List<VariableSearchResult> toVariables(
-      final List<VariableEntity> variableEntities) {
-    return variableEntities.stream().map(SearchQueryResponseMapper::toVariable).toList();
+      final List<VariableEntity> variableEntities, final boolean truncateValues) {
+    return variableEntities.stream().map(entity -> toVariable(entity, truncateValues)).toList();
   }
 
-  private static VariableSearchResult toVariable(final VariableEntity variableEntity) {
+  private static VariableSearchResult toVariable(
+      final VariableEntity variableEntity, final boolean truncateValues) {
     return new VariableSearchResult()
         .variableKey(KeyUtil.keyToString(variableEntity.variableKey()))
         .name(variableEntity.name())
-        .value(variableEntity.value())
+        .value(!truncateValues ? getFullValueIfPresent(variableEntity) : variableEntity.value())
         .processInstanceKey(KeyUtil.keyToString(variableEntity.processInstanceKey()))
         .tenantId(variableEntity.tenantId())
-        .isTruncated(variableEntity.isPreview())
+        .isTruncated(truncateValues && variableEntity.isPreview())
         .scopeKey(KeyUtil.keyToString(variableEntity.scopeKey()));
   }
 
@@ -1181,10 +1182,14 @@ public final class SearchQueryResponseMapper {
     return new VariableResult()
         .variableKey(KeyUtil.keyToString(variableEntity.variableKey()))
         .name(variableEntity.name())
-        .value(variableEntity.isPreview() ? variableEntity.fullValue() : variableEntity.value())
+        .value(getFullValueIfPresent(variableEntity))
         .processInstanceKey(KeyUtil.keyToString(variableEntity.processInstanceKey()))
         .tenantId(variableEntity.tenantId())
         .scopeKey(KeyUtil.keyToString(variableEntity.scopeKey()));
+  }
+
+  private static String getFullValueIfPresent(final VariableEntity variableEntity) {
+    return variableEntity.isPreview() ? variableEntity.fullValue() : variableEntity.value();
   }
 
   public static AuthorizationSearchResult toAuthorizationSearchQueryResponse(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -97,6 +97,37 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               }
           }""";
 
+  private static final String EXPECTED_UNTRUNCATED_SEARCH_RESPONSE =
+      """
+          {
+              "items": [
+                  {
+                        "variableKey": "0",
+                        "name": "n",
+                        "value": "v",
+                        "scopeKey": "2",
+                        "processInstanceKey": "3",
+                        "tenantId": "<default>",
+                        "isTruncated": false
+                  },
+                  {
+                        "variableKey": "1",
+                        "name": "ne",
+                        "value": "ve",
+                        "scopeKey": "2",
+                        "processInstanceKey": "3",
+                        "tenantId": "<default>",
+                        "isTruncated": false
+                  }
+              ],
+              "page": {
+                  "totalItems": 2,
+                  "startCursor": "0",
+                  "endCursor": "1",
+                  "hasMoreTotalItems": false
+              }
+          }""";
+
   private static final String VARIABLE_TASKS_SEARCH_URL = "/v2/variables/search";
   private static final SearchQueryResult<VariableEntity> SEARCH_QUERY_RESULT =
       new Builder<VariableEntity>()
@@ -147,6 +178,23 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .contentType(APPLICATION_JSON)
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(variableServices).search(new VariableQuery.Builder().build());
+  }
+
+  @Test
+  void shouldSearchVariablesWithFullValues() {
+    // when / then
+    webClient
+        .post()
+        .uri(VARIABLE_TASKS_SEARCH_URL + "?truncateValues=false")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_UNTRUNCATED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).search(new VariableQuery.Builder().build());
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- added new `truncateValues` boolean parameter to user task variable and variables search requests
- added test coverage for returning full variables on those search requests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/39189
