### PR TITLE
refactor: NodeIdProvider config is used for static nodeId setting

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -163,8 +163,7 @@ public class Cluster implements Cloneable {
   }
 
   public void setNodeId(final int nodeId) {
-    final var staticConfig = nodeIdProvider.staticConfig();
-    staticConfig.setNodeId(nodeId);
+    nodeIdProvider.staticConfig().setNodeId(nodeId);
   }
 
   public int getPartitionCount() {

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
 
-import io.camunda.configuration.DynamicNodeIdConfig.Type;
+import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import java.util.Collections;
@@ -87,7 +87,7 @@ public class Cluster implements Cloneable {
    * assigned a static {@link #nodeId}.
    */
   @NestedConfigurationProperty
-  private DynamicNodeIdConfig dynamicNodeId = new DynamicNodeIdConfig();
+  private NodeIdProvider dynamicNodeId = new NodeIdProvider();
 
   /** The number of partitions in the cluster. */
   private int partitionCount = 1;
@@ -131,11 +131,11 @@ public class Cluster implements Cloneable {
   @NestedConfigurationProperty
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
 
-  public DynamicNodeIdConfig getDynamicNodeId() {
+  public NodeIdProvider getDynamicNodeId() {
     return dynamicNodeId;
   }
 
-  public void setDynamicNodeId(final DynamicNodeIdConfig dynamicNodeId) {
+  public void setDynamicNodeId(final NodeIdProvider dynamicNodeId) {
     this.dynamicNodeId = dynamicNodeId;
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -159,11 +159,11 @@ public class Cluster implements Cloneable {
   }
 
   public Integer getNodeId() {
-    return nodeIdProvider.staticConfig().getNodeId();
+    return nodeIdProvider.fixed().getNodeId();
   }
 
   public void setNodeId(final int nodeId) {
-    nodeIdProvider.staticConfig().setNodeId(nodeId);
+    nodeIdProvider.fixed().setNodeId(nodeId);
   }
 
   public int getPartitionCount() {

--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -15,9 +15,9 @@ public class NodeIdProvider {
 
   /**
    * Set the {@link Type} of the implementation for the provider of dynamic node id. {@link
-   * Type#STATIC} refers to no provider.
+   * Type#FIXED} refers to no provider.
    */
-  private Type type = Type.STATIC;
+  private Type type = Type.FIXED;
 
   /** Configuration to use S3 for dynamic node id. */
   private S3 s3 = new S3();
@@ -27,7 +27,7 @@ public class NodeIdProvider {
    * because it's a reserved keyword in java. However, the getter is called `getStatic`, so this
    * field is bound as if it was name `static`.
    */
-  private final StaticConfig staticConfig = new StaticConfig();
+  private final Fixed fixed = new Fixed();
 
   public Type getType() {
     return type;
@@ -62,9 +62,9 @@ public class NodeIdProvider {
     return s3;
   }
 
-  public StaticConfig staticConfig() {
-    assertType(Type.STATIC);
-    return staticConfig;
+  public Fixed fixed() {
+    assertType(Type.FIXED);
+    return fixed;
   }
 
   /**
@@ -72,8 +72,8 @@ public class NodeIdProvider {
    * that it's called `getStatic` and not `getStaticConfig` since we want to bind it to the property
    * "static", not "static-config"
    */
-  StaticConfig getStatic() {
-    return staticConfig;
+  Fixed getFixed() {
+    return fixed;
   }
 
   private void assertType(final Type expected) {
@@ -221,7 +221,7 @@ public class NodeIdProvider {
     }
   }
 
-  public static final class StaticConfig {
+  public static final class Fixed {
     private int nodeId;
 
     public int getNodeId() {
@@ -244,7 +244,7 @@ public class NodeIdProvider {
   }
 
   public enum Type {
-    STATIC,
+    FIXED,
     S3;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -13,8 +13,6 @@ import java.util.Set;
 
 public class NodeIdProvider {
 
-  static final String PREFIX = Cluster.PREFIX + ".node-id-provider";
-
   /**
    * Set the {@link Type} of the implementation for the provider of dynamic node id. {@link
    * Type#STATIC} refers to no provider.
@@ -224,12 +222,11 @@ public class NodeIdProvider {
   }
 
   public static final class StaticConfig {
-    static final String PREFIX = NodeIdProvider.PREFIX + ".static";
     private int nodeId;
 
     public int getNodeId() {
       return UnifiedConfigurationHelper.validateLegacyConfiguration(
-          PREFIX + ".node-id",
+          Cluster.PREFIX + ".node-id",
           nodeId,
           Integer.class,
           UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,

--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-public class DynamicNodeIdConfig {
+public class NodeIdProvider {
 
   /**
    * Set the {@link Type} of the implementation for the provider of dynamic node id. {@link

--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -9,18 +9,27 @@ package io.camunda.configuration;
 
 import java.time.Duration;
 import java.util.Optional;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import java.util.Set;
 
 public class NodeIdProvider {
 
+  static final String PREFIX = Cluster.PREFIX + ".node-id-provider";
+
   /**
    * Set the {@link Type} of the implementation for the provider of dynamic node id. {@link
-   * Type#NONE} refers to no provider.
+   * Type#STATIC} refers to no provider.
    */
-  private Type type = Type.NONE;
+  private Type type = Type.STATIC;
 
   /** Configuration to use S3 for dynamic node id. */
-  private @NestedConfigurationProperty S3 s3 = new S3();
+  private S3 s3 = new S3();
+
+  /**
+   * This field is bound to "static" as property name. Unfortunately it cannot be called static
+   * because it's a reserved keyword in java. However, the getter is called `getStatic`, so this
+   * field is bound as if it was name `static`.
+   */
+  private final StaticConfig staticConfig = new StaticConfig();
 
   public Type getType() {
     return type;
@@ -51,13 +60,33 @@ public class NodeIdProvider {
    * @throws IllegalStateException if the type is not S3
    */
   public S3 s3() {
-    if (type != Type.S3) {
-      throw new IllegalStateException(
-          "Cannot access S3 configuration when dynamic node ID type is "
-              + type
-              + ". Use s3() method to access S3 configuration, which validates the type.");
-    }
+    assertType(Type.S3);
     return s3;
+  }
+
+  public StaticConfig staticConfig() {
+    assertType(Type.STATIC);
+    return staticConfig;
+  }
+
+  /**
+   * Getter for spring configuration binding, do not use it, as it does not check the type. Note
+   * that it's called `getStatic` and not `getStaticConfig` since we want to bind it to the property
+   * "static", not "static-config"
+   */
+  StaticConfig getStatic() {
+    return staticConfig;
+  }
+
+  private void assertType(final Type expected) {
+    if (type != expected) {
+      throw new IllegalStateException(
+          "Cannot access "
+              + expected
+              + " configuration in NodeIdProvider configuration, type is "
+              + type
+              + ".");
+    }
   }
 
   public static class S3 {
@@ -194,8 +223,31 @@ public class NodeIdProvider {
     }
   }
 
+  public static final class StaticConfig {
+    static final String PREFIX = NodeIdProvider.PREFIX + ".static";
+    private int nodeId;
+
+    public int getNodeId() {
+      return UnifiedConfigurationHelper.validateLegacyConfiguration(
+          PREFIX + ".node-id",
+          nodeId,
+          Integer.class,
+          UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+          Set.of(Cluster.LEGACY_NODE_ID_PROPERTY));
+    }
+
+    public void setNodeId(final int nodeId) {
+      this.nodeId = nodeId;
+    }
+
+    @Override
+    public String toString() {
+      return "StaticConfig{" + "nodeId=" + nodeId + '}';
+    }
+  }
+
   public enum Type {
-    NONE,
+    STATIC,
     S3;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -287,7 +287,7 @@ public class BrokerBasedPropertiesOverride {
     final var cluster = unifiedConfiguration.getCamunda().getCluster().withBrokerProperties();
 
     override.getCluster().setInitialContactPoints(cluster.getInitialContactPoints());
-    if (cluster.getNodeIdProvider().getType() == Type.STATIC) {
+    if (cluster.getNodeIdProvider().getType() == Type.FIXED) {
       override.getCluster().setNodeId(cluster.getNodeId());
     }
     override.getCluster().setPartitionsCount(cluster.getPartitionCount());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -24,6 +24,7 @@ import io.camunda.configuration.InternalApi;
 import io.camunda.configuration.KeyStore;
 import io.camunda.configuration.Membership;
 import io.camunda.configuration.Metrics;
+import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.PrimaryStorage;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.Rdbms;
@@ -286,7 +287,9 @@ public class BrokerBasedPropertiesOverride {
     final var cluster = unifiedConfiguration.getCamunda().getCluster().withBrokerProperties();
 
     override.getCluster().setInitialContactPoints(cluster.getInitialContactPoints());
-    override.getCluster().setNodeId(cluster.getNodeId());
+    if (cluster.getNodeIdProvider().getType() == Type.STATIC) {
+      override.getCluster().setNodeId(cluster.getNodeId());
+    }
     override.getCluster().setPartitionsCount(cluster.getPartitionCount());
     override.getCluster().setReplicationFactor(cluster.getReplicationFactor());
     override.getCluster().setClusterSize(cluster.getSize());

--- a/configuration/src/test/java/io/camunda/configuration/ClusterDynamicNodeIdTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterDynamicNodeIdTest.java
@@ -10,8 +10,8 @@ package io.camunda.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.configuration.DynamicNodeIdConfig.S3;
-import io.camunda.configuration.DynamicNodeIdConfig.Type;
+import io.camunda.configuration.NodeIdProvider.S3;
+import io.camunda.configuration.NodeIdProvider.Type;
 import java.time.Duration;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
@@ -42,7 +42,7 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldSetWithOnlyRequiredProperties() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, DynamicNodeIdConfig::getType);
+      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, NodeIdProvider::getType);
       assertThat(cluster.getDynamicNodeId().s3())
           .returns("bucketExample", S3::getBucketName)
           .returns(Duration.ofSeconds(10), S3::getLeaseDuration);
@@ -72,7 +72,7 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldSetWithAllProperties() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, DynamicNodeIdConfig::getType);
+      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, NodeIdProvider::getType);
       assertThat(cluster.getDynamicNodeId().s3())
           .returns("bucketExample", S3::getBucketName)
           .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
@@ -96,7 +96,7 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldDefaultToNoneType() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, DynamicNodeIdConfig::getType);
+      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, NodeIdProvider::getType);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldSetTypeToNone() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, DynamicNodeIdConfig::getType);
+      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, NodeIdProvider::getType);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
@@ -23,13 +23,13 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig({UnifiedConfiguration.class, UnifiedConfigurationHelper.class})
 @ActiveProfiles("broker")
-public class ClusterDynamicNodeIdTest {
+public class ClusterNodeIdProviderTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.cluster.dynamic-node-id.type=s3",
-        "camunda.cluster.dynamic-node-id.s3.bucketName=bucketExample",
-        "camunda.cluster.dynamic-node-id.s3.leaseDuration=PT10s",
+        "camunda.cluster.node-id-provider.type=s3",
+        "camunda.cluster.node-id-provider.s3.bucketName=bucketExample",
+        "camunda.cluster.node-id-provider.s3.leaseDuration=PT10s",
       })
   class WithOnlyRequiredProperties {
 
@@ -42,8 +42,8 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldSetWithOnlyRequiredProperties() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, NodeIdProvider::getType);
-      assertThat(cluster.getDynamicNodeId().s3())
+      assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
+      assertThat(cluster.getNodeIdProvider().s3())
           .returns("bucketExample", S3::getBucketName)
           .returns(Duration.ofSeconds(10), S3::getLeaseDuration);
     }
@@ -52,14 +52,14 @@ public class ClusterDynamicNodeIdTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.cluster.dynamic-node-id.type=s3",
-        "camunda.cluster.dynamic-node-id.s3.bucketName=bucketExample",
-        "camunda.cluster.dynamic-node-id.s3.leaseDuration=PT10s",
-        "camunda.cluster.dynamic-node-id.s3.task-id=example-task-id",
-        "camunda.cluster.dynamic-node-id.s3.endpoint=https://s3.example.com",
-        "camunda.cluster.dynamic-node-id.s3.region=us-east-1",
-        "camunda.cluster.dynamic-node-id.s3.accessKey=myAccessKey",
-        "camunda.cluster.dynamic-node-id.s3.secretKey=mySecretKey",
+        "camunda.cluster.node-id-provider.type=s3",
+        "camunda.cluster.node-id-provider.s3.bucketName=bucketExample",
+        "camunda.cluster.node-id-provider.s3.leaseDuration=PT10s",
+        "camunda.cluster.node-id-provider.s3.task-id=example-task-id",
+        "camunda.cluster.node-id-provider.s3.endpoint=https://s3.example.com",
+        "camunda.cluster.node-id-provider.s3.region=us-east-1",
+        "camunda.cluster.node-id-provider.s3.accessKey=myAccessKey",
+        "camunda.cluster.node-id-provider.s3.secretKey=mySecretKey",
       })
   class WithAllProperties {
 
@@ -72,8 +72,8 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldSetWithAllProperties() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, NodeIdProvider::getType);
-      assertThat(cluster.getDynamicNodeId().s3())
+      assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
+      assertThat(cluster.getNodeIdProvider().s3())
           .returns("bucketExample", S3::getBucketName)
           .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
           .returns(Optional.of("example-task-id"), S3::getTaskId)
@@ -96,20 +96,21 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldDefaultToNoneType() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, NodeIdProvider::getType);
+      assertThat(cluster.getNodeIdProvider()).returns(Type.STATIC, NodeIdProvider::getType);
     }
 
     @Test
     void shouldThrowExceptionWhenAccessingS3Config() {
       final var cluster = camunda.getCluster();
-      assertThatThrownBy(() -> cluster.getDynamicNodeId().s3())
+      assertThatThrownBy(() -> cluster.getNodeIdProvider().s3())
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot access S3 configuration when dynamic node ID type is NONE");
+          .hasMessageContaining(
+              "Cannot access S3 configuration when dynamic node ID type is STATIC");
     }
   }
 
   @Nested
-  @TestPropertySource(properties = {"camunda.cluster.dynamic-node-id.type=none"})
+  @TestPropertySource(properties = {"camunda.cluster.node-id-provider.type=static"})
   class WithTypeSetToNone {
 
     private final Camunda camunda;
@@ -121,15 +122,16 @@ public class ClusterDynamicNodeIdTest {
     @Test
     void shouldSetTypeToNone() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, NodeIdProvider::getType);
+      assertThat(cluster.getNodeIdProvider()).returns(Type.STATIC, NodeIdProvider::getType);
     }
 
     @Test
     void shouldThrowExceptionWhenAccessingS3Config() {
       final var cluster = camunda.getCluster();
-      assertThatThrownBy(() -> cluster.getDynamicNodeId().s3())
+      assertThatThrownBy(() -> cluster.getNodeIdProvider().s3())
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot access S3 configuration when dynamic node ID type is NONE");
+          .hasMessageContaining(
+              "Cannot access S3 configuration when dynamic node ID type is STATIC");
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
@@ -99,7 +99,7 @@ public class ClusterNodeIdProviderTest {
     @Test
     void shouldDefaultToStaticType() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getNodeIdProvider()).returns(Type.STATIC, NodeIdProvider::getType);
+      assertThat(cluster.getNodeIdProvider()).returns(Type.FIXED, NodeIdProvider::getType);
     }
 
     @Test
@@ -108,24 +108,24 @@ public class ClusterNodeIdProviderTest {
       assertThatThrownBy(() -> cluster.getNodeIdProvider().s3())
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining(
-              "Cannot access S3 configuration in NodeIdProvider configuration, type is STATIC.");
+              "Cannot access S3 configuration in NodeIdProvider configuration, type is FIXED.");
     }
   }
 
   @Nested
-  @TestPropertySource(properties = {"camunda.cluster.node-id-provider.type=static"})
-  class WithTypeSetToStatic {
+  @TestPropertySource(properties = {"camunda.cluster.node-id-provider.type=fixed"})
+  class WithTypeSetToFixed {
 
     private final Camunda camunda;
 
-    WithTypeSetToStatic(@Autowired final Camunda camunda) {
+    WithTypeSetToFixed(@Autowired final Camunda camunda) {
       this.camunda = camunda;
     }
 
     @Test
     void shouldSetTypeToStatic() {
       final var cluster = camunda.getCluster();
-      assertThat(cluster.getNodeIdProvider()).returns(Type.STATIC, NodeIdProvider::getType);
+      assertThat(cluster.getNodeIdProvider()).returns(Type.FIXED, NodeIdProvider::getType);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ClusterNodeIdProviderTest {
       assertThatThrownBy(() -> cluster.getNodeIdProvider().s3())
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining(
-              "Cannot access S3 configuration in NodeIdProvider configuration, type is STATIC.");
+              "Cannot access S3 configuration in NodeIdProvider configuration, type is FIXED.");
     }
   }
 
@@ -150,19 +150,19 @@ public class ClusterNodeIdProviderTest {
 
     @Test
     void shouldRemapNodeIdToStaticNodeId() {
-      // Verify the property is remapped to the static node ID
+      // Verify the property is remapped to the fixed node ID
       assertThat(camunda.getCluster().getNodeId()).isEqualTo(42);
-      assertThat(camunda.getCluster().getNodeIdProvider().staticConfig().getNodeId()).isEqualTo(42);
+      assertThat(camunda.getCluster().getNodeIdProvider().fixed().getNodeId()).isEqualTo(42);
     }
   }
 
   @Nested
   @TestPropertySource(properties = {"camunda.cluster.node-id=99"})
-  class WithStaticNodeIdProperty {
+  class WithFixedNodeIdProperty {
     final Camunda camunda;
 
     @Autowired
-    WithStaticNodeIdProperty(final Camunda camunda) {
+    WithFixedNodeIdProperty(final Camunda camunda) {
       this.camunda = camunda;
     }
 
@@ -170,7 +170,7 @@ public class ClusterNodeIdProviderTest {
     void shouldReadFromStaticNodeIdProperty() {
       // Verify the new property location works
       assertThat(camunda.getCluster().getNodeId()).isEqualTo(99);
-      assertThat(camunda.getCluster().getNodeIdProvider().staticConfig().getNodeId()).isEqualTo(99);
+      assertThat(camunda.getCluster().getNodeIdProvider().fixed().getNodeId()).isEqualTo(99);
     }
   }
 
@@ -188,7 +188,7 @@ public class ClusterNodeIdProviderTest {
     void shouldReadFromLegacyProperty() {
       // Verify backward compatibility with the legacy property
       assertThat(camunda.getCluster().getNodeId()).isEqualTo(7);
-      assertThat(camunda.getCluster().getNodeIdProvider().staticConfig().getNodeId()).isEqualTo(7);
+      assertThat(camunda.getCluster().getNodeIdProvider().fixed().getNodeId()).isEqualTo(7);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
@@ -17,70 +17,73 @@ import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig({UnifiedConfiguration.class, UnifiedConfigurationHelper.class})
-@ActiveProfiles("broker")
 public class ClusterNodeIdProviderTest {
   @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.cluster.node-id-provider.type=s3",
-        "camunda.cluster.node-id-provider.s3.bucketName=bucketExample",
-        "camunda.cluster.node-id-provider.s3.leaseDuration=PT10s",
-      })
-  class WithOnlyRequiredProperties {
+  class WithS3Type {
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.cluster.node-id-provider.type=s3",
+          "camunda.cluster.node-id-provider.s3.bucketName=bucketExample",
+          "camunda.cluster.node-id-provider.s3.leaseDuration=PT10s",
+        })
+    class WithOnlyRequiredProperties {
 
-    private final Camunda camunda;
+      private final Camunda camunda;
 
-    WithOnlyRequiredProperties(@Autowired final Camunda camunda) {
-      this.camunda = camunda;
+      WithOnlyRequiredProperties(@Autowired final Camunda camunda) {
+        this.camunda = camunda;
+      }
+
+      @Test
+      void shouldSetWithOnlyRequiredProperties() {
+        final var cluster = camunda.getCluster();
+        assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
+        assertThat(cluster.getNodeIdProvider().s3())
+            .returns("bucketExample", S3::getBucketName)
+            .returns(Duration.ofSeconds(10), S3::getLeaseDuration);
+      }
     }
 
-    @Test
-    void shouldSetWithOnlyRequiredProperties() {
-      final var cluster = camunda.getCluster();
-      assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
-      assertThat(cluster.getNodeIdProvider().s3())
-          .returns("bucketExample", S3::getBucketName)
-          .returns(Duration.ofSeconds(10), S3::getLeaseDuration);
-    }
-  }
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.cluster.node-id-provider.type=s3",
+          "camunda.cluster.node-id-provider.s3.bucketName=bucketExample",
+          "camunda.cluster.node-id-provider.s3.leaseDuration=PT10s",
+          "camunda.cluster.node-id-provider.s3.task-id=example-task-id",
+          "camunda.cluster.node-id-provider.s3.endpoint=https://s3.example.com",
+          "camunda.cluster.node-id-provider.s3.region=us-east-1",
+          "camunda.cluster.node-id-provider.s3.accessKey=myAccessKey",
+          "camunda.cluster.node-id-provider.s3.secretKey=mySecretKey",
+        })
+    class WithAllProperties {
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.cluster.node-id-provider.type=s3",
-        "camunda.cluster.node-id-provider.s3.bucketName=bucketExample",
-        "camunda.cluster.node-id-provider.s3.leaseDuration=PT10s",
-        "camunda.cluster.node-id-provider.s3.task-id=example-task-id",
-        "camunda.cluster.node-id-provider.s3.endpoint=https://s3.example.com",
-        "camunda.cluster.node-id-provider.s3.region=us-east-1",
-        "camunda.cluster.node-id-provider.s3.accessKey=myAccessKey",
-        "camunda.cluster.node-id-provider.s3.secretKey=mySecretKey",
-      })
-  class WithAllProperties {
+      private final Camunda camunda;
 
-    private final Camunda camunda;
+      WithAllProperties(@Autowired final Camunda camunda) {
+        this.camunda = camunda;
+      }
 
-    WithAllProperties(@Autowired final Camunda camunda) {
-      this.camunda = camunda;
-    }
+      @Test
+      void shouldSetWithAllProperties() {
+        final var cluster = camunda.getCluster();
+        assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
+        assertThat(cluster.getNodeIdProvider().s3())
+            .returns("bucketExample", S3::getBucketName)
+            .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
+            .returns(Optional.of("example-task-id"), S3::getTaskId)
+            .returns(Optional.of("https://s3.example.com"), S3::getEndpoint)
+            .returns(Optional.of("us-east-1"), S3::getRegion)
+            .returns(Optional.of("myAccessKey"), S3::getAccessKey)
+            .returns(Optional.of("mySecretKey"), S3::getSecretKey);
 
-    @Test
-    void shouldSetWithAllProperties() {
-      final var cluster = camunda.getCluster();
-      assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
-      assertThat(cluster.getNodeIdProvider().s3())
-          .returns("bucketExample", S3::getBucketName)
-          .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
-          .returns(Optional.of("example-task-id"), S3::getTaskId)
-          .returns(Optional.of("https://s3.example.com"), S3::getEndpoint)
-          .returns(Optional.of("us-east-1"), S3::getRegion)
-          .returns(Optional.of("myAccessKey"), S3::getAccessKey)
-          .returns(Optional.of("mySecretKey"), S3::getSecretKey);
+        assertThatThrownBy(cluster::getNodeId).isInstanceOf(IllegalStateException.class);
+      }
     }
   }
 
@@ -94,7 +97,7 @@ public class ClusterNodeIdProviderTest {
     }
 
     @Test
-    void shouldDefaultToNoneType() {
+    void shouldDefaultToStaticType() {
       final var cluster = camunda.getCluster();
       assertThat(cluster.getNodeIdProvider()).returns(Type.STATIC, NodeIdProvider::getType);
     }
@@ -105,22 +108,22 @@ public class ClusterNodeIdProviderTest {
       assertThatThrownBy(() -> cluster.getNodeIdProvider().s3())
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining(
-              "Cannot access S3 configuration when dynamic node ID type is STATIC");
+              "Cannot access S3 configuration in NodeIdProvider configuration, type is STATIC.");
     }
   }
 
   @Nested
   @TestPropertySource(properties = {"camunda.cluster.node-id-provider.type=static"})
-  class WithTypeSetToNone {
+  class WithTypeSetToStatic {
 
     private final Camunda camunda;
 
-    WithTypeSetToNone(@Autowired final Camunda camunda) {
+    WithTypeSetToStatic(@Autowired final Camunda camunda) {
       this.camunda = camunda;
     }
 
     @Test
-    void shouldSetTypeToNone() {
+    void shouldSetTypeToStatic() {
       final var cluster = camunda.getCluster();
       assertThat(cluster.getNodeIdProvider()).returns(Type.STATIC, NodeIdProvider::getType);
     }
@@ -131,7 +134,61 @@ public class ClusterNodeIdProviderTest {
       assertThatThrownBy(() -> cluster.getNodeIdProvider().s3())
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining(
-              "Cannot access S3 configuration when dynamic node ID type is STATIC");
+              "Cannot access S3 configuration in NodeIdProvider configuration, type is STATIC.");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.cluster.node-id=42"})
+  class WithNodeIdProperty {
+    final Camunda camunda;
+
+    @Autowired
+    WithNodeIdProperty(final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldRemapNodeIdToStaticNodeId() {
+      // Verify the property is remapped to the static node ID
+      assertThat(camunda.getCluster().getNodeId()).isEqualTo(42);
+      assertThat(camunda.getCluster().getNodeIdProvider().staticConfig().getNodeId()).isEqualTo(42);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.cluster.node-id-provider.static.node-id=99"})
+  class WithStaticNodeIdProperty {
+    final Camunda camunda;
+
+    @Autowired
+    WithStaticNodeIdProperty(final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldReadFromStaticNodeIdProperty() {
+      // Verify the new property location works
+      assertThat(camunda.getCluster().getNodeId()).isEqualTo(99);
+      assertThat(camunda.getCluster().getNodeIdProvider().staticConfig().getNodeId()).isEqualTo(99);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.broker.cluster.nodeId=7"})
+  class WithLegacyNodeIdProperty {
+    final Camunda camunda;
+
+    @Autowired
+    WithLegacyNodeIdProperty(final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldReadFromLegacyProperty() {
+      // Verify backward compatibility with the legacy property
+      assertThat(camunda.getCluster().getNodeId()).isEqualTo(7);
+      assertThat(camunda.getCluster().getNodeIdProvider().staticConfig().getNodeId()).isEqualTo(7);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
@@ -157,7 +157,7 @@ public class ClusterNodeIdProviderTest {
   }
 
   @Nested
-  @TestPropertySource(properties = {"camunda.cluster.node-id-provider.static.node-id=99"})
+  @TestPropertySource(properties = {"camunda.cluster.node-id=99"})
   class WithStaticNodeIdProperty {
     final Camunda camunda;
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -53,7 +53,7 @@ public class NodeIdProviderConfiguration {
   /** Create the S3NodeReposiotry as a separate bean so it's lifecycle is managed by spring */
   public S3NodeIdRepository s3NodeIdRepository() {
     return switch (cluster.getNodeIdProvider().getType()) {
-      case STATIC -> null;
+      case FIXED -> null;
       case S3 -> {
         final var clientConfig = makeS3ClientConfig(cluster.getNodeIdProvider().s3());
         final var config =
@@ -71,7 +71,7 @@ public class NodeIdProviderConfiguration {
       final BrokerShutdownHelper shutdownHelper) {
     final var nodeIdProvider =
         switch (cluster.getNodeIdProvider().getType()) {
-          case STATIC -> {
+          case FIXED -> {
             final var nodeId = cluster.getNodeId();
             yield NodeIdProvider.staticProvider(nodeId);
           }
@@ -122,7 +122,7 @@ public class NodeIdProviderConfiguration {
       final BrokerBasedConfiguration brokerBasedConfiguration) {
     final var initializer =
         switch (cluster.getNodeIdProvider().getType()) {
-          case STATIC -> new ConfiguredDataDirectoryProvider();
+          case FIXED -> new ConfiguredDataDirectoryProvider();
           case S3 -> new NodeIdBasedDataDirectoryProvider(nodeIdProvider);
         };
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -52,14 +52,14 @@ public class NodeIdProviderConfiguration {
   @Bean
   /** Create the S3NodeReposiotry as a separate bean so it's lifecycle is managed by spring */
   public S3NodeIdRepository s3NodeIdRepository() {
-    return switch (cluster.getDynamicNodeId().getType()) {
-      case NONE -> null;
+    return switch (cluster.getNodeIdProvider().getType()) {
+      case STATIC -> null;
       case S3 -> {
-        final var clientConfig = makeS3ClientConfig(cluster.getDynamicNodeId().s3());
+        final var clientConfig = makeS3ClientConfig(cluster.getNodeIdProvider().s3());
         final var config =
             new S3NodeIdRepository.Config(
-                cluster.getDynamicNodeId().s3().getBucketName(),
-                cluster.getDynamicNodeId().s3().getLeaseDuration());
+                cluster.getNodeIdProvider().s3().getBucketName(),
+                cluster.getNodeIdProvider().s3().getLeaseDuration());
         yield S3NodeIdRepository.of(clientConfig, config, Clock.systemUTC());
       }
     };
@@ -70,13 +70,13 @@ public class NodeIdProviderConfiguration {
       final Optional<NodeIdRepository> nodeIdRepository,
       final BrokerShutdownHelper shutdownHelper) {
     final var nodeIdProvider =
-        switch (cluster.getDynamicNodeId().getType()) {
-          case NONE -> {
+        switch (cluster.getNodeIdProvider().getType()) {
+          case STATIC -> {
             final var nodeId = cluster.getNodeId();
             yield NodeIdProvider.staticProvider(nodeId);
           }
           case S3 -> {
-            final var config = cluster.getDynamicNodeId().s3();
+            final var config = cluster.getNodeIdProvider().s3();
             if (nodeIdRepository.isEmpty()) {
               throw new IllegalStateException(
                   "DynamicNodeIdProvider configured to use S3: missing s3 node id repository");

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -121,8 +121,8 @@ public class NodeIdProviderConfiguration {
       final NodeIdProvider nodeIdProvider,
       final BrokerBasedConfiguration brokerBasedConfiguration) {
     final var initializer =
-        switch (cluster.getDynamicNodeId().getType()) {
-          case NONE -> new ConfiguredDataDirectoryProvider();
+        switch (cluster.getNodeIdProvider().getType()) {
+          case STATIC -> new ConfiguredDataDirectoryProvider();
           case S3 -> new NodeIdBasedDataDirectoryProvider(nodeIdProvider);
         };
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker;
 
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.configuration.Cluster;
-import io.camunda.configuration.DynamicNodeIdConfig.S3;
+import io.camunda.configuration.NodeIdProvider.S3;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.dynamic.nodeid.ConfiguredDataDirectoryProvider;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -52,12 +52,12 @@ public class DynamicNodeIdIT {
   private static final int CLUSTER_SIZE = 3;
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Duration LEASE_DURATION = Duration.ofSeconds(10);
-  private static final String TASK_ID_PROPERTY = "camunda.cluster.dynamic-node-id.s3.taskId";
+  private static final String TASK_ID_PROPERTY = "camunda.cluster.node-id-provider.s3.taskId";
 
   @TestZeebe
   private final TestCluster testCluster =
       TestCluster.builder()
-          .withName("dynamic-node-id-test")
+          .withName("node-id-provider-test")
           .withBrokersCount(CLUSTER_SIZE)
           .withPartitionsCount(1)
           .withReplicationFactor(CLUSTER_SIZE)
@@ -70,21 +70,21 @@ public class DynamicNodeIdIT {
                           "none",
                           "camunda.cluster.size",
                           CLUSTER_SIZE,
-                          "camunda.cluster.dynamic-node-id.type",
+                          "camunda.cluster.node-id-provider.type",
                           "s3",
                           TASK_ID_PROPERTY,
                           UUID.randomUUID().toString(),
-                          "camunda.cluster.dynamic-node-id.s3.bucketName",
+                          "camunda.cluster.node-id-provider.s3.bucketName",
                           BUCKET_NAME,
-                          "camunda.cluster.dynamic-node-id.s3.leaseDuration",
+                          "camunda.cluster.node-id-provider.s3.leaseDuration",
                           LEASE_DURATION,
-                          "camunda.cluster.dynamic-node-id.s3.endpoint",
+                          "camunda.cluster.node-id-provider.s3.endpoint",
                           S3.getEndpoint(),
-                          "camunda.cluster.dynamic-node-id.s3.region",
+                          "camunda.cluster.node-id-provider.s3.region",
                           S3.getRegion(),
-                          "camunda.cluster.dynamic-node-id.s3.accessKey",
+                          "camunda.cluster.node-id-provider.s3.accessKey",
                           S3.getAccessKey(),
-                          "camunda.cluster.dynamic-node-id.s3.secretKey",
+                          "camunda.cluster.node-id-provider.s3.secretKey",
                           S3.getSecretKey())))
           .build();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -59,7 +59,7 @@ public class HealthCheckIT {
   private static final String BUCKET_NAME = UUID.randomUUID().toString();
   private static final int CLUSTER_SIZE = 3;
   private static final Duration LEASE_DURATION = Duration.ofSeconds(5);
-  private static final String TASK_ID_PROPERTY = "camunda.cluster.dynamic-node-id.s3.taskId";
+  private static final String TASK_ID_PROPERTY = "camunda.cluster.node-id-provider.s3.taskId";
   private static final ProxyRegistry PROXY_REGISTRY = new ProxyRegistry(TOXIPROXY);
   private static URI toxiproxyS3Endpoint;
   private static ContainerProxy proxy;
@@ -76,23 +76,23 @@ public class HealthCheckIT {
           // S3 repository properties
           .withAdditionalProperties(
               Map.of(
-                  "camunda.cluster.dynamic-node-id.type",
+                  "camunda.cluster.node-id-provider.type",
                   "s3",
                   TASK_ID_PROPERTY,
                   UUID.randomUUID().toString(),
-                  "camunda.cluster.dynamic-node-id.s3.bucketName",
+                  "camunda.cluster.node-id-provider.s3.bucketName",
                   BUCKET_NAME,
-                  "camunda.cluster.dynamic-node-id.s3.leaseDuration",
+                  "camunda.cluster.node-id-provider.s3.leaseDuration",
                   LEASE_DURATION,
-                  "camunda.cluster.dynamic-node-id.s3.endpoint",
+                  "camunda.cluster.node-id-provider.s3.endpoint",
                   toxiproxyS3Endpoint,
-                  "camunda.cluster.dynamic-node-id.s3.region",
+                  "camunda.cluster.node-id-provider.s3.region",
                   S3.getRegion(),
-                  "camunda.cluster.dynamic-node-id.s3.accessKey",
+                  "camunda.cluster.node-id-provider.s3.accessKey",
                   S3.getAccessKey(),
-                  "camunda.cluster.dynamic-node-id.s3.secretKey",
+                  "camunda.cluster.node-id-provider.s3.secretKey",
                   S3.getSecretKey(),
-                  "camunda.cluster.dynamic-node-id.s3.apiCallTimeout",
+                  "camunda.cluster.node-id-provider.s3.apiCallTimeout",
                   LEASE_DURATION.dividedBy(2).toString()));
 
   @BeforeAll

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -57,7 +57,6 @@ public class HealthCheckIT {
 
   @AutoClose private static S3Client s3Client;
   private static final String BUCKET_NAME = UUID.randomUUID().toString();
-  private static final int CLUSTER_SIZE = 3;
   private static final Duration LEASE_DURATION = Duration.ofSeconds(5);
   private static final String TASK_ID_PROPERTY = "camunda.cluster.node-id-provider.s3.taskId";
   private static final ProxyRegistry PROXY_REGISTRY = new ProxyRegistry(TOXIPROXY);
@@ -71,11 +70,6 @@ public class HealthCheckIT {
               Map.of(
                   "camunda.data.secondary-storage.type",
                   "none",
-                  "camunda.cluster.size",
-                  CLUSTER_SIZE))
-          // S3 repository properties
-          .withAdditionalProperties(
-              Map.of(
                   "camunda.cluster.node-id-provider.type",
                   "s3",
                   TASK_ID_PROPERTY,


### PR DESCRIPTION
## Description
As suggested in [this PR comment](https://github.com/camunda/camunda/pull/40518#discussion_r2510629705) the default `NodeIdProvider.Type` is now `STATIC` and a new `Static` class has been created to hold the `nodeId`.

The `getNodeId/setNodeId` method in `Cluster` have been kept for backward compatibility.
Because `Type.STATIC` is the default, there's no need to override the `Type` when doing `setNodeId`, since the type should not be overridden.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40751 
