### PR TITLE
feat: implement backup range index

### DIFF
--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -128,6 +128,25 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!--  Ensure non-jqwik junit5 tests can be run -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -56,4 +56,16 @@ public interface BackupDescriptor {
    * @return the type of the checkpoint that triggered the backup
    */
   CheckpointType checkpointType();
+
+  /**
+   * When continuous backups are enabled, this points to the previous backup in the chain if there
+   * is one.
+   */
+  BackupIdentifier previousBackup();
+
+  /**
+   * When continuous backups are enabled, this points to the next backup in the chain, if there is
+   * one. This is set only when the next backup is created.
+   */
+  BackupIdentifier nextBackup();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/RangeIndex.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/RangeIndex.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * This maintains an index of backup ranges, allowing efficient tracking of contiguous backups. It
+ * supports adding and removing backups, as well as looking up which range a backup belongs to.
+ *
+ * @implSpec
+ *     <ul>
+ *       <li>Ranges that only contain a single backup are allowed to support merging of indices.
+ *           This is required for backup stores which maintain separate indices for each node.
+ *     </ul>
+ *
+ * @implNote Maintains two sorted sets of ranges, one sorted by the first backup and one sorted by
+ *     the last backup. This allows efficient lookup of ranges by backup id, as well as efficient
+ *     iteration in both ascending and descending order. By construction, the index is guaranteed to
+ *     only have a single range for each first and last backup.
+ */
+public final class RangeIndex {
+  private final TreeSet<Range> rangesByFirstBackup =
+      new TreeSet<>(
+          Comparator.comparing(
+              Range::firstBackup, Comparator.comparingLong(BackupIdentifier::checkpointId)));
+
+  private final TreeSet<Range> rangesByLastBackup =
+      new TreeSet<>(
+          Comparator.comparing(
+              Range::lastBackup, Comparator.comparingLong(BackupIdentifier::checkpointId)));
+
+  /** Returns the ranges in descending order by the last backup, the "best" range first. */
+  public SortedSet<Range> descendingRanges() {
+    return Collections.unmodifiableSortedSet(rangesByLastBackup.reversed());
+  }
+
+  /** Returns the ranges in ascending order by the first backup, the "oldest" range first. */
+  public SortedSet<Range> ascendingRanges() {
+    return Collections.unmodifiableSortedSet(rangesByFirstBackup);
+  }
+
+  /**
+   * Adds a backup to the range index, potentially merging existing ranges.
+   *
+   * @apiNote If this backup is already contained in an existing range, the previous and next
+   *     backups in the descriptor must not contradict the existing range. For Example, you cannot
+   *     have an existing range [1, 3] and add backup 2 with previousBackup=null. Usage of this
+   *     method must ensure that such contradictions do not occur. In practice, this is guaranteed
+   *     because `nextBackup` is never known for new backups and `previousBackup` is always known
+   *     and correct because checkpoint creation is linear.
+   * @throws IllegalArgumentException if the backup contradicts an existing range.
+   */
+  public void add(final BackupIdentifier id, final BackupDescriptor descriptor) {
+    final var addedRange =
+        new Range(
+            descriptor.previousBackup() != null ? descriptor.previousBackup() : id,
+            descriptor.nextBackup() != null ? descriptor.nextBackup() : id);
+
+    final var existingRange = lookup(id);
+    if (existingRange != null) {
+      if (existingRange.equals(addedRange)) {
+        // already contained, nothing to do
+        return;
+      }
+      if ((existingRange.firstBackup().checkpointId() < addedRange.firstBackup().checkpointId()
+          || existingRange.lastBackup().checkpointId() > addedRange.firstBackup().checkpointId())) {
+        throw new IllegalArgumentException(
+            "Cannot add backup "
+                + id
+                + " with descriptor "
+                + descriptor
+                + " because it is smaller than the existing range "
+                + existingRange);
+      }
+    }
+
+    // by construction, there can only be one adjacent range on each side
+    final var left = leftAdjacent(addedRange);
+    final var right = rightAdjacent(addedRange);
+    if (left != null && right != null) {
+      connectRanges(left, right);
+    } else if (left != null) {
+      addToEnd(left, addedRange);
+    } else if (right != null) {
+      addToStart(addedRange, right);
+    } else {
+      addSingle(addedRange);
+    }
+  }
+
+  private void addSingle(final Range addedRange) {
+    rangesByLastBackup.add(addedRange);
+    rangesByFirstBackup.add(addedRange);
+  }
+
+  private void addToStart(final Range addedRange, final Range right) {
+    final var mergedRange = new Range(addedRange.firstBackup(), right.lastBackup());
+    rangesByLastBackup.remove(right);
+    rangesByFirstBackup.remove(right);
+    rangesByLastBackup.add(mergedRange);
+    rangesByFirstBackup.add(mergedRange);
+  }
+
+  private void addToEnd(final Range left, final Range addedRange) {
+    final var mergedRange = new Range(left.firstBackup(), addedRange.lastBackup());
+    rangesByLastBackup.remove(left);
+    rangesByFirstBackup.remove(left);
+    rangesByLastBackup.add(mergedRange);
+    rangesByFirstBackup.add(mergedRange);
+  }
+
+  private void connectRanges(final Range left, final Range right) {
+    final var mergedRange = new Range(left.firstBackup(), right.lastBackup());
+    rangesByLastBackup.remove(left);
+    rangesByFirstBackup.remove(left);
+    rangesByLastBackup.remove(right);
+    rangesByFirstBackup.remove(right);
+    rangesByLastBackup.add(mergedRange);
+    rangesByFirstBackup.add(mergedRange);
+  }
+
+  private Range rightAdjacent(final Range addedRange) {
+    final var closestRight = rangesByFirstBackup.higher(addedRange);
+    return Range.adjacent(addedRange, closestRight) ? closestRight : null;
+  }
+
+  private Range leftAdjacent(final Range addedRange) {
+    final var closestLeft = rangesByLastBackup.lower(addedRange);
+    return Range.adjacent(closestLeft, addedRange) ? closestLeft : null;
+  }
+
+  /**
+   * Removes a backup from the range index, potentially splitting existing ranges.
+   *
+   * @apiNote The descriptor is trusted and used to construct the new ranges last and first backups.
+   *     Usage of this method must ensure that the descriptor is consistent with the existing range
+   *     containing the backup to be removed. For example, you cannot have an existing range [1, 3]
+   *     and remove backup 2 with nextBackup=null. In practice, this should be guaranteed because
+   *     this information is looked up from the backup store.
+   */
+  public void remove(final BackupIdentifier id, final BackupDescriptor descriptor) {
+    if (lookup(id) instanceof final Range existingRange) {
+      if (existingRange.firstBackup.equals(id) && existingRange.lastBackup.equals(id)) {
+        removeSingle(existingRange, id, descriptor);
+      } else if (descriptor.previousBackup() == null) {
+        removeFromStart(existingRange, id, descriptor);
+      } else if (descriptor.nextBackup() == null) {
+        removeFromEnd(existingRange, id, descriptor);
+      } else {
+        removeFromMiddle(existingRange, id, descriptor);
+      }
+    }
+  }
+
+  private void removeSingle(
+      final Range existingRange, final BackupIdentifier id, final BackupDescriptor descriptor) {
+    if (descriptor.previousBackup() != null || descriptor.nextBackup() != null) {
+      throw new IllegalArgumentException(
+          "Cannot remove backup "
+              + id
+              + " with descriptor "
+              + descriptor
+              + " because it is larger than the existing range "
+              + existingRange);
+    }
+    rangesByLastBackup.remove(existingRange);
+    rangesByFirstBackup.remove(existingRange);
+  }
+
+  private void removeFromEnd(
+      final Range existingRange, final BackupIdentifier id, final BackupDescriptor descriptor) {
+    if (descriptor.previousBackup().checkpointId() < existingRange.firstBackup().checkpointId()) {
+      throw new IllegalArgumentException(
+          "Cannot remove backup "
+              + id
+              + " with descriptor "
+              + descriptor
+              + " because the previous backup is smaller than the existing range "
+              + existingRange);
+    }
+    final var updatedRange = new Range(existingRange.firstBackup(), descriptor.previousBackup());
+    rangesByLastBackup.remove(existingRange);
+    rangesByFirstBackup.remove(existingRange);
+    rangesByLastBackup.add(updatedRange);
+    rangesByFirstBackup.add(updatedRange);
+  }
+
+  private void removeFromStart(
+      final Range existingRange, final BackupIdentifier id, final BackupDescriptor descriptor) {
+    if (descriptor.nextBackup().checkpointId() > existingRange.lastBackup().checkpointId()) {
+      throw new IllegalArgumentException(
+          "Cannot remove backup "
+              + id
+              + " with descriptor "
+              + descriptor
+              + " because the next backup is larger than the existing range "
+              + existingRange);
+    }
+    final var updatedRange = new Range(descriptor.nextBackup(), existingRange.lastBackup());
+    rangesByLastBackup.remove(existingRange);
+    rangesByFirstBackup.remove(existingRange);
+    rangesByLastBackup.add(updatedRange);
+    rangesByFirstBackup.add(updatedRange);
+  }
+
+  private void removeFromMiddle(
+      final Range existingRange, final BackupIdentifier id, final BackupDescriptor descriptor) {
+    if (descriptor.previousBackup().checkpointId() > existingRange.lastBackup().checkpointId()
+        || descriptor.nextBackup().checkpointId() < existingRange.firstBackup().checkpointId()) {
+      throw new IllegalArgumentException(
+          "Cannot remove backup "
+              + id
+              + " with descriptor "
+              + descriptor
+              + " because it is larger than the existing range "
+              + existingRange);
+    }
+    final Range left = new Range(existingRange.firstBackup, descriptor.previousBackup());
+    final Range right = new Range(descriptor.nextBackup(), existingRange.lastBackup);
+    rangesByLastBackup.remove(existingRange);
+    rangesByFirstBackup.remove(existingRange);
+    rangesByLastBackup.add(left);
+    rangesByFirstBackup.add(left);
+    rangesByLastBackup.add(right);
+    rangesByFirstBackup.add(right);
+  }
+
+  public Range lookup(final BackupIdentifier id) {
+    final var singletonRange = new Range(id, id);
+    final var candidateRange = rangesByFirstBackup.floor(singletonRange);
+    if (candidateRange != null && candidateRange.contains(id)) {
+      return candidateRange;
+    } else {
+      return null;
+    }
+  }
+
+  /** A range of backups, defined by a first and last backup identifier. */
+  public record Range(BackupIdentifier firstBackup, BackupIdentifier lastBackup) {
+    public Range {
+      Objects.requireNonNull(firstBackup);
+      lastBackup = Objects.requireNonNullElse(lastBackup, firstBackup);
+      if (firstBackup.checkpointId() > lastBackup.checkpointId()) {
+        throw new IllegalArgumentException(
+            "First backup's checkpointId must be less than or equal to the last backup's checkpointId");
+      }
+    }
+
+    /**
+     * Checks whether the given id is contained in the range, either as the first or last backup, or
+     * in between.
+     */
+    public boolean contains(final BackupIdentifier id) {
+      return id.checkpointId() >= firstBackup.checkpointId()
+          && id.checkpointId() <= lastBackup.checkpointId();
+    }
+
+    public boolean contains(final Range range) {
+      return contains(range.firstBackup()) && contains(range.lastBackup());
+    }
+
+    /**
+     * Checks whether two ranges are adjacent, i.e., the last backup of the left range is the first
+     * backup of the right range.
+     *
+     * <p>This is a static method to allow null ranges to be passed in.
+     */
+    public static boolean adjacent(final Range left, final Range right) {
+      return left != null && right != null && left.lastBackup().equals(right.firstBackup());
+    }
+
+    /**
+     * Expends the range to include the given id. If the id is already included, it'll return the
+     * same range, otherwise it'll return a range with either the first or last backup updated.
+     */
+    public Range add(final BackupIdentifier id) {
+      if (id.checkpointId() < firstBackup.checkpointId()) {
+        return new Range(id, lastBackup);
+      } else if (id.checkpointId() > lastBackup.checkpointId()) {
+        return new Range(firstBackup, id);
+      } else {
+        return this;
+      }
+    }
+
+    /**
+     * Splits the range by removing the given id. If the id is at the boundary of the range, it'll
+     * return a single range (with the boundary removed). If the id is in the middle of the range,
+     * it'll return two ranges.
+     *
+     * <p>The descriptor is trusted and used to construct the new ranges last and first backups.
+     */
+    public SplitRanges remove(final BackupIdentifier id, final BackupDescriptor descriptor) {
+      final Range left;
+      final Range right;
+      if (firstBackup.equals(id)) {
+        left = null;
+      } else {
+        left = new Range(firstBackup, descriptor.previousBackup());
+      }
+      if (lastBackup.equals(id)) {
+        right = null;
+      } else {
+        right = new Range(descriptor.nextBackup(), lastBackup);
+      }
+      return new SplitRanges(left, right);
+    }
+
+    /**
+     * @param left may be null if there's no left range
+     * @param right may be null if there's no right range
+     */
+    public record SplitRanges(Range left, Range right) {}
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.time.Instant;
@@ -23,8 +24,28 @@ public record BackupDescriptorImpl(
     int numberOfPartitions,
     String brokerVersion,
     Instant checkpointTimestamp,
-    @JsonDeserialize(using = CheckpointTypeDeserializer.class) CheckpointType checkpointType)
+    @JsonDeserialize(using = CheckpointTypeDeserializer.class) CheckpointType checkpointType,
+    BackupIdentifier previousBackup,
+    BackupIdentifier nextBackup)
     implements BackupDescriptor {
+
+  public BackupDescriptorImpl(
+      final Optional<String> snapshotId,
+      final long checkpointPosition,
+      final int numberOfPartitions,
+      final String brokerVersion,
+      final Instant checkpointTimestamp,
+      final CheckpointType checkpointType) {
+    this(
+        snapshotId,
+        checkpointPosition,
+        numberOfPartitions,
+        brokerVersion,
+        checkpointTimestamp,
+        checkpointType,
+        null,
+        null);
+  }
 
   public static BackupDescriptorImpl from(final BackupDescriptor descriptor) {
     return new BackupDescriptorImpl(
@@ -33,7 +54,9 @@ public record BackupDescriptorImpl(
         descriptor.numberOfPartitions(),
         descriptor.brokerVersion(),
         descriptor.checkpointTimestamp(),
-        descriptor.checkpointType());
+        descriptor.checkpointType(),
+        descriptor.previousBackup(),
+        descriptor.nextBackup());
   }
 
   /**

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/RangeIndexPropertyTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/RangeIndexPropertyTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import static io.camunda.zeebe.backup.api.Util.descriptor;
+import static io.camunda.zeebe.backup.api.Util.id;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.zeebe.backup.api.RangeIndex.Range;
+import io.camunda.zeebe.backup.api.RangeIndexPropertyTest.Operation.AddOperation;
+import io.camunda.zeebe.backup.api.RangeIndexPropertyTest.Operation.RemoveOperation;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.Tuple;
+import net.jqwik.api.Tuple.Tuple3;
+import net.jqwik.api.state.Action;
+import net.jqwik.api.state.ActionChain;
+import net.jqwik.api.state.Transformer;
+
+public class RangeIndexPropertyTest {
+
+  /**
+   * Verifies that after a series of add and remove operations, the ascending and descending indexes
+   * are consistent with each other. This does not only catch simple mistakes where we forget to add
+   * or remove from one of the indexes, but also subtle behavior bugs because the sets drop entries
+   * where the comparator returns 0 and both indexes use different comparators.
+   */
+  @Property(tries = 2000, shrinking = ShrinkingMode.FULL)
+  void shouldMaintainIdenticalIndexes(@ForAll("rangeActions") final ActionChain<RangeIndex> chain) {
+    chain
+        .withInvariant(
+            rangeIndex ->
+                assertThat(rangeIndex.ascendingRanges())
+                    .containsExactlyElementsOf(rangeIndex.descendingRanges().reversed()))
+        .withInvariant(index -> {})
+        .run();
+  }
+
+  @Provide
+  Arbitrary<ActionChain<RangeIndex>> rangeActions() {
+    return ActionChain.startWith(RangeIndex::new)
+        .withMaxTransformations(100)
+        // Generate more add actions than remove actions to avoid empty indexes
+        .withAction(2, new AddAction())
+        .withAction(1, new RemoveAction());
+  }
+
+  @Provide
+  Arbitrary<Operation> addOperations() {
+    return Arbitraries.longs()
+        .greaterOrEqual(1)
+        .withoutEdgeCases()
+        .flatMap(
+            backupId ->
+                Arbitraries.longs()
+                    .between(backupId - 1, 1000)
+                    .lessOrEqual(backupId - 1)
+                    .injectNull(0.3)
+                    .withoutEdgeCases()
+                    .flatMap(
+                        previousBackupId ->
+                            Arbitraries.longs()
+                                .between(backupId + 1, 1000)
+                                .injectNull(0.3)
+                                .withoutEdgeCases()
+                                .map(
+                                    nextBackupId ->
+                                        new AddOperation(
+                                            backupId, previousBackupId, nextBackupId))));
+  }
+
+  @Provide
+  Arbitrary<Operation> removeOperations() {
+    return Arbitraries.longs()
+        .greaterOrEqual(1)
+        .withoutEdgeCases()
+        .flatMap(
+            backupId ->
+                Arbitraries.longs()
+                    .between(backupId - 1, 1000)
+                    .withoutEdgeCases()
+                    .flatMap(
+                        previousBackupId ->
+                            Arbitraries.longs()
+                                .between(backupId + 1, 1000)
+                                .withoutEdgeCases()
+                                .map(
+                                    nextBackupId ->
+                                        new RemoveOperation(
+                                            backupId, previousBackupId, nextBackupId))));
+  }
+
+  static Arbitrary<Tuple3<Long, Long, Long>> arbitraryBackup() {
+    return Arbitraries.longs()
+        .greaterOrEqual(1)
+        .withoutEdgeCases()
+        .flatMap(
+            backupId ->
+                Arbitraries.longs()
+                    .lessOrEqual(backupId - 1)
+                    .withoutEdgeCases()
+                    .flatMap(
+                        previousBackupId ->
+                            Arbitraries.longs()
+                                .greaterOrEqual(backupId + 1)
+                                .withoutEdgeCases()
+                                .map(
+                                    nextBackupId ->
+                                        Tuple.of(backupId, previousBackupId, nextBackupId))));
+  }
+
+  static final class RemoveAction implements Action.Dependent<RangeIndex> {
+
+    @Override
+    public Arbitrary<Transformer<RangeIndex>> transformer(final RangeIndex state) {
+      return arbitraryBackup()
+          .map(
+              backup -> {
+                final var backupId = backup.get1();
+                final var previousBackupId = backup.get2();
+                final var nextBackupId = backup.get3();
+                final var existingRange = state.lookup(id(nextBackupId));
+                // Only generate a range that is consistent with the current state.
+                // This upholds the API contract of `RangeIndex#remove`.
+                final var minPreviousId =
+                    existingRange != null
+                            && existingRange.firstBackup().checkpointId() > previousBackupId
+                        ? existingRange.firstBackup()
+                        : id(previousBackupId);
+                final var maxNextId =
+                    existingRange != null
+                            && existingRange.lastBackup().checkpointId() < nextBackupId
+                        ? existingRange.lastBackup()
+                        : id(nextBackupId);
+                return Transformer.transform(
+                    "Remove %s[%s,%s]".formatted(backupId, minPreviousId, maxNextId),
+                    mutableState -> {
+                      state.remove(id(backupId), descriptor(minPreviousId, maxNextId));
+                      return state;
+                    });
+              });
+    }
+  }
+
+  static final class AddAction implements Action.Dependent<RangeIndex> {
+    @Override
+    public Arbitrary<Transformer<RangeIndex>> transformer(final RangeIndex state) {
+      return arbitraryBackup()
+          .map(
+              backup -> {
+                final var backupId = backup.get1();
+                final var previousBackupId = backup.get2();
+                final var nextBackupId = backup.get3();
+                final var existingRange = state.lookup(id(nextBackupId));
+                if (Range.adjacent(existingRange, new Range(id(previousBackupId), id(nextBackupId)))
+                    || Range.adjacent(
+                        new Range(id(previousBackupId), id(nextBackupId)), existingRange)) {
+                  return Transformer.transform(
+                      "Add %s[%s,%s]".formatted(backupId, previousBackupId, nextBackupId),
+                      mutableState -> {
+                        state.remove(
+                            id(backupId), descriptor(id(previousBackupId), id(nextBackupId)));
+                        return state;
+                      });
+                } else {
+                  // Skip this addition because it is inconsistent with the current state.
+                  // This upholds the API contract of `RangeIndex#add`.
+                  return Transformer.noop();
+                }
+              });
+    }
+  }
+
+  sealed interface Operation {
+    record AddOperation(long backupId, Long previousId, Long nextId) implements Operation {}
+
+    record RemoveOperation(long backupId, Long previousId, Long nextId) implements Operation {}
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/RangeIndexTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/RangeIndexTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import static io.camunda.zeebe.backup.api.Util.descriptor;
+import static io.camunda.zeebe.backup.api.Util.id;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.RangeIndex.Range;
+import org.junit.jupiter.api.Test;
+
+final class RangeIndexTest {
+
+  @Test
+  void shouldAddNewRange() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup3 = id(3);
+
+    // when
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup3, descriptor(null, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .containsExactly(new Range(backup3, backup3), new Range(backup1, backup1));
+  }
+
+  @Test
+  void shouldAddToRange() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+
+    // when
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .singleElement()
+        .isEqualTo(new Range(backup1, backup2));
+  }
+
+  @Test
+  void shouldAddDuplicates() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+
+    // when
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup1, descriptor(null, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .singleElement()
+        .isEqualTo(new Range(backup1, backup1));
+  }
+
+  @Test
+  void shouldAddContainedBackups() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup3 = id(3);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, null));
+    rangeIndex.add(backup3, descriptor(backup2, null));
+
+    // when
+    rangeIndex.add(backup2, descriptor(backup1, backup3));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .singleElement()
+        .isEqualTo(new Range(backup1, backup3));
+  }
+
+  @Test
+  void shouldMergeAdjacentRanges() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup3 = id(3);
+
+    // when
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup3, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, backup3));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .singleElement()
+        .isEqualTo(new Range(backup1, backup3));
+  }
+
+  @Test
+  void shouldMergeGaps() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup5 = id(5);
+    final var backup10 = id(10);
+
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup10, descriptor(null, null));
+
+    // when - adding a backup that fills the gap
+    rangeIndex.add(backup5, descriptor(backup1, backup10));
+
+    // then - all ranges are merged
+    assertThat(rangeIndex.descendingRanges())
+        .singleElement()
+        .isEqualTo(new Range(backup1, backup10));
+  }
+
+  @Test
+  void shouldRemoveSingleBackupRange() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup3 = id(3);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup3, descriptor(null, null));
+
+    // when
+    rangeIndex.remove(backup3, descriptor(null, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .singleElement()
+        .isEqualTo(new Range(backup1, backup1));
+  }
+
+  @Test
+  void shouldRemoveFromContainingRange() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup3 = id(3);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, null));
+    rangeIndex.add(backup3, descriptor(backup2, null));
+
+    // when
+    rangeIndex.remove(backup2, descriptor(backup1, backup3));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .containsExactly(new Range(backup3, backup3), new Range(backup1, backup1));
+  }
+
+  @Test
+  void shouldRemoveFromRangeLeftBoundary() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup3 = id(3);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, null));
+    rangeIndex.add(backup3, descriptor(backup2, null));
+
+    // when
+    rangeIndex.remove(backup1, descriptor(null, backup2));
+
+    // then
+    assertThat(rangeIndex.descendingRanges()).containsExactly(new Range(backup2, backup3));
+  }
+
+  @Test
+  void shouldRemoveFromRangeRightBoundary() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup3 = id(3);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, null));
+    rangeIndex.add(backup3, descriptor(backup2, null));
+
+    // when
+    rangeIndex.remove(backup3, descriptor(backup2, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges()).containsExactly(new Range(backup1, backup2));
+  }
+
+  @Test
+  void shouldRemoveFromMiddleRangeAtBoundary() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup4 = id(4);
+    final var backup5 = id(5);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup2, descriptor(backup1, null));
+
+    rangeIndex.add(backup4, descriptor(null, null));
+    rangeIndex.add(backup5, descriptor(backup4, null));
+
+    // when
+    rangeIndex.remove(backup2, descriptor(backup1, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .containsExactly(new Range(backup4, backup5), new Range(backup1, backup1));
+  }
+
+  @Test
+  void shouldRemoveNonExistingBackup() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup3 = id(3);
+    rangeIndex.add(backup1, descriptor(null, null));
+    rangeIndex.add(backup3, descriptor(null, null));
+
+    // when
+    rangeIndex.remove(backup2, descriptor(null, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .containsExactly(new Range(backup3, backup3), new Range(backup1, backup1));
+  }
+
+  @Test
+  void shouldHandleMultipleNonAdjacentRanges() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup5 = id(5);
+    final var backup6 = id(6);
+    final var backup10 = id(10);
+
+    // when - add multiple non-adjacent ranges
+    rangeIndex.add(backup1, descriptor(null, backup2));
+    rangeIndex.add(backup5, descriptor(null, backup6));
+    rangeIndex.add(backup10, descriptor(null, null));
+
+    // then
+    assertThat(rangeIndex.descendingRanges())
+        .containsExactly(
+            new Range(backup10, backup10),
+            new Range(backup5, backup6),
+            new Range(backup1, backup2));
+  }
+
+  @Test
+  void shouldLookupWithGaps() {
+    // given
+    final var rangeIndex = new RangeIndex();
+    final var backup1 = id(1);
+    final var backup2 = id(2);
+    final var backup5 = id(5);
+    final var backup6 = id(6);
+
+    rangeIndex.add(backup1, descriptor(null, backup2));
+    rangeIndex.add(backup5, descriptor(null, backup6));
+
+    // when/then - lookups in the gap should return null
+    assertThat(rangeIndex.lookup(id(3))).isNull();
+    assertThat(rangeIndex.lookup(id(4))).isNull();
+    // lookups at range boundaries should succeed
+    assertThat(rangeIndex.lookup(backup1)).isNotNull();
+    assertThat(rangeIndex.lookup(backup2)).isNotNull();
+    assertThat(rangeIndex.lookup(backup5)).isNotNull();
+    assertThat(rangeIndex.lookup(backup6)).isNotNull();
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/Util.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/Util.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+import java.util.Optional;
+import org.jspecify.annotations.NonNull;
+
+final class Util {
+  static BackupIdentifier id(final long checkpointId) {
+    return new TestBackupIdentifier(checkpointId);
+  }
+
+  static BackupIdentifier id(final Integer checkpointId) {
+    if (checkpointId == null) {
+      return null;
+    }
+    return new TestBackupIdentifier(checkpointId);
+  }
+
+  static BackupDescriptor descriptor(final BackupIdentifier left, final BackupIdentifier right) {
+    return new TestBackupDescriptor(left, right);
+  }
+
+  record TestBackupIdentifier(long checkpointId) implements BackupIdentifier {
+    @Override
+    public int nodeId() {
+      return 1;
+    }
+
+    @Override
+    public int partitionId() {
+      return 1;
+    }
+
+    @Override
+    public long checkpointId() {
+      return checkpointId;
+    }
+
+    @Override
+    public @NonNull String toString() {
+      return Long.toString(checkpointId);
+    }
+  }
+
+  record TestBackupDescriptor(BackupIdentifier previousBackup, BackupIdentifier nextBackup)
+      implements BackupDescriptor {
+    @Override
+    public Optional<String> snapshotId() {
+      return Optional.empty();
+    }
+
+    @Override
+    public long checkpointPosition() {
+      return 1;
+    }
+
+    @Override
+    public int numberOfPartitions() {
+      return 1;
+    }
+
+    @Override
+    public String brokerVersion() {
+      return "";
+    }
+
+    @Override
+    public Instant checkpointTimestamp() {
+      return Instant.MIN;
+    }
+
+    @Override
+    public CheckpointType checkpointType() {
+      return CheckpointType.MANUAL_BACKUP;
+    }
+
+    @Override
+    public @NonNull String toString() {
+      return "[%s, %s]".formatted(previousBackup, nextBackup);
+    }
+  }
+}


### PR DESCRIPTION
This adds the data structure and algorithms used to track contiguous backup ranges. This turned out a bit more difficult than expected so I'd be very happy to hear critical feedback and ideas to simply this.