### PR TITLE
feat: update decision-instances search with more advanced filters

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.16
+
+### 🚀 Enhancements
+
+- update decision-instances search with more advanced filters ([#40895](https://github.com/camunda/camunda/pull/40895))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.15
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
@@ -14,6 +14,7 @@ import {
 	advancedDateTimeFilterSchema,
 	basicStringFilterSchema,
 	type Endpoint,
+  getEnumFilterSchema,
 } from './common';
 import {evaluatedDecisionInputItemSchema, matchedDecisionRuleItemSchema} from './decision-definition';
 
@@ -52,7 +53,6 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 		'evaluationFailure',
 		'processDefinitionKey',
 		'processInstanceKey',
-		'processInstanceId',
 		'decisionDefinitionKey',
 		'decisionDefinitionId',
 		'decisionDefinitionName',
@@ -64,11 +64,12 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 	] as const,
 	filter: z
 		.object({
+			decisionEvaluationInstanceKey: basicStringFilterSchema,
+			state: getEnumFilterSchema(decisionInstanceStateSchema),
 			evaluationDate: advancedDateTimeFilterSchema,
 			decisionDefinitionKey: basicStringFilterSchema,
+			elementInstanceKey: basicStringFilterSchema,
 			...decisionInstanceSchema.pick({
-				decisionEvaluationInstanceKey: true,
-				state: true,
 				evaluationFailure: true,
 				decisionDefinitionId: true,
 				decisionDefinitionName: true,
@@ -78,7 +79,6 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 				decisionEvaluationKey: true,
 				processDefinitionKey: true,
 				processInstanceKey: true,
-				elementInstanceKey: true,
 				rootDecisionDefinitionKey: true,
 			}).shape,
 		})

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.15",
+	"version": "0.0.16",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.15",
+        "@camunda/camunda-api-zod-schemas": "0.0.16",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.15.tgz",
-      "integrity": "sha512-26dPp6T3q+82I3Q/HHbnq7rcts/0UoHc4XMT1OXknpZ/XM//nC6jfv4ojOqaQR/iYzYLoqY/fIHZuTZIPcy8iQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.16.tgz",
+      "integrity": "sha512-Z3E8jhSHp+nFXFekdxJPntpPWYMxYZb6msbqLVTIJSu+2uo9WsEeeewR9H+Rua8RecueW9q8PO/RAx7hSX8ldQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.15",
+    "@camunda/camunda-api-zod-schemas": "0.0.16",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.15",
+        "@camunda/camunda-api-zod-schemas": "0.0.16",
         "@camunda/camunda-composite-components": "0.21.1",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.15.tgz",
-      "integrity": "sha512-26dPp6T3q+82I3Q/HHbnq7rcts/0UoHc4XMT1OXknpZ/XM//nC6jfv4ojOqaQR/iYzYLoqY/fIHZuTZIPcy8iQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.16.tgz",
+      "integrity": "sha512-Z3E8jhSHp+nFXFekdxJPntpPWYMxYZb6msbqLVTIJSu+2uo9WsEeeewR9H+Rua8RecueW9q8PO/RAx7hSX8ldQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.15",
+    "@camunda/camunda-api-zod-schemas": "0.0.16",
     "@camunda/camunda-composite-components": "0.21.1",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",


### PR DESCRIPTION
## Description

Adjusts the API Zod schemas for decision-instances search to allow advanced filters for `decisionEvaluationInstanceKey` and `state`. Please refer to the [related slack discussion](https://camunda.slack.com/archives/C088A1LL5CZ/p1763029528202849?thread_ts=1762960822.715199&cid=C088A1LL5CZ).

Furthermore, I removed a sort field that was never supported by the API, and changed the schema for `elementInstanceKey`, which already supports an advanced filter according to the API spec.

The API will be adjusted in the coming days to support advanced filters for these fields.

## Checklist

- [x] Changes to the package have to be released.

## Related issues

relates #27347
