### PR TITLE
Support all sort options for batch operation search 

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -10,7 +10,11 @@ package io.camunda.db.rdbms.sql.columns;
 import io.camunda.search.entities.BatchOperationEntity;
 
 public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEntity> {
-  BATCH_OPERATION_KEY("batchOperationKey");
+  BATCH_OPERATION_KEY("batchOperationKey"),
+  STATE("state"),
+  OPERATION_TYPE("operationType"),
+  START_DATE("startDate"),
+  END_DATE("endDate");
 
   private final String property;
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
@@ -50,6 +52,19 @@ public class SearchColumnTest {
               List.of(
                   Tuple.of(BatchOperationItemState.ACTIVE, BatchOperationItemState.ACTIVE),
                   Tuple.of(BatchOperationItemState.ACTIVE, "ACTIVE"))),
+          Map.entry(
+              BatchOperationState.class,
+              List.of(
+                  Tuple.of(BatchOperationState.ACTIVE, BatchOperationState.ACTIVE),
+                  Tuple.of(BatchOperationState.ACTIVE, "ACTIVE"))),
+          Map.entry(
+              BatchOperationType.class,
+              List.of(
+                  Tuple.of(
+                      BatchOperationType.MIGRATE_PROCESS_INSTANCE,
+                      BatchOperationType.MIGRATE_PROCESS_INSTANCE),
+                  Tuple.of(
+                      BatchOperationType.MIGRATE_PROCESS_INSTANCE, "MIGRATE_PROCESS_INSTANCE"))),
           Map.entry(
               ProcessInstanceState.class,
               List.of(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -265,6 +265,7 @@ public class SearchQuerySortRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
+        case BATCH_OPERATION_KEY -> builder.batchOperationKey();
         case STATE -> builder.state();
         case OPERATION_TYPE -> builder.operationType();
         case START_DATE -> builder.startDate();


### PR DESCRIPTION
## Description

Adds support for all defined API sort options for batch operation search on all data layers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40873 
