### PR TITLE
Importers Completion rework

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -18,7 +18,7 @@ public class ImportProperties {
   private static final int DEFAULT_SCHEDULER_BACKOFF = 5000;
   private static final int DEFAULT_FLOW_NODE_TREE_CACHE_SIZE = 1000;
   private static final int DEFAULT_MAX_EMPTY_RUNS = 10;
-  private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
+  private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 1;
 
   private int threadsCount = DEFAULT_IMPORT_THREADS_COUNT;
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportConfig.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportConfig.java
@@ -46,14 +46,4 @@ public class ImportConfig {
     executor.initialize();
     return executor;
   }
-
-  @Bean("importerCompletionThreadPoolExecutor")
-  public ThreadPoolTaskExecutor getImporterCompletionTaskExecutor() {
-    final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(11); // 11 import value types
-    executor.setMaxPoolSize(11);
-    executor.setThreadNamePrefix("importer_completion_");
-    executor.initialize();
-    return executor;
-  }
 }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportConfig.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportConfig.java
@@ -46,4 +46,14 @@ public class ImportConfig {
     executor.initialize();
     return executor;
   }
+
+  @Bean("importerCompletionThreadPoolExecutor")
+  public ThreadPoolTaskExecutor getImporterCompletionTaskExecutor() {
+    final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(11); // 11 import value types
+    executor.setMaxPoolSize(11);
+    executor.setThreadNamePrefix("importer_completion_");
+    executor.initialize();
+    return executor;
+  }
 }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
@@ -154,7 +154,6 @@ public class ImportJob implements Callable<Boolean> {
       final var batchVersion = SemanticVersion.fromVersion(version);
 
       if (batchVersion.getMajor() == 8 && batchVersion.getMinor() >= 8) {
-        recordsReaderHolder.addPartitionCompletedImporting(subBatch.getPartitionId());
         return true;
       }
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
@@ -584,7 +584,7 @@ public class ElasticsearchRecordsReader implements RecordsReader {
   }
 
   private void markRecordReaderCompletedIfMinimumEmptyBatchesReceived() {
-    if (recordsReaderHolder.hasPartitionCompletedImporting(partitionId)) {
+    if (isPartitionCompletedImporting(partitionId)) {
       recordsReaderHolder.incrementEmptyBatches(partitionId, importValueType);
     }
 
@@ -600,6 +600,23 @@ public class ElasticsearchRecordsReader implements RecordsReader {
             e);
       }
     }
+  }
+
+  private boolean isPartitionCompletedImporting(final int partitionId) {
+    try {
+      final var tenantImportPosition =
+          importPositionHolder.getLatestLoadedPosition(
+              ImportValueType.TENANT.getAliasTemplate(), partitionId);
+
+      return tenantImportPosition.getIndexName() != null
+          && tenantImportPosition.getIndexName().contains("8.8");
+    } catch (final IOException e) {
+      LOGGER.error(
+          "Failed to check import position of tenant alias in partition [{}], this may block importers from being marked as completed",
+          partitionId,
+          e);
+    }
+    return false;
   }
 
   private void executeNext() {

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
@@ -109,6 +110,10 @@ public class ElasticsearchRecordsReader implements RecordsReader {
   @Autowired
   @Qualifier("recordsReaderThreadPoolExecutor")
   private ThreadPoolTaskScheduler readersExecutor;
+
+  @Autowired
+  @Qualifier("importerCompletionThreadPoolExecutor")
+  private ThreadPoolTaskExecutor importerCompletionExecutor;
 
   @Autowired private ImportPositionHolder importPositionHolder;
 
@@ -603,20 +608,38 @@ public class ElasticsearchRecordsReader implements RecordsReader {
   }
 
   private boolean isPartitionCompletedImporting(final int partitionId) {
-    try {
-      final var tenantImportPosition =
-          importPositionHolder.getLatestLoadedPosition(
-              ImportValueType.TENANT.getAliasTemplate(), partitionId);
+    final var importPositionFutures =
+        Arrays.stream(ImportValueType.IMPORT_VALUE_TYPES)
+            .map(
+                valueType ->
+                    CompletableFuture.supplyAsync(
+                        () -> getLatestLoadedPosition(valueType, partitionId),
+                        importerCompletionExecutor))
+            .toList();
 
-      return tenantImportPosition.getIndexName() != null
-          && tenantImportPosition.getIndexName().contains("8.8");
+    CompletableFuture.allOf(importPositionFutures.toArray(new CompletableFuture[0])).join();
+
+    final List<ImportPositionEntity> importPositions =
+        importPositionFutures.stream().map(CompletableFuture::join).toList();
+
+    return importPositions.stream()
+        .anyMatch(
+            position -> position.getIndexName() != null && position.getIndexName().contains("8.8"));
+  }
+
+  private ImportPositionEntity getLatestLoadedPosition(
+      final ImportValueType valueType, final int partitionId) {
+    try {
+      return importPositionHolder.getLatestLoadedPosition(
+          valueType.getAliasTemplate(), partitionId);
     } catch (final IOException e) {
       LOGGER.error(
-          "Failed to check import position of tenant alias in partition [{}], this may block importers from being marked as completed",
+          "Failed to check import position of [{}] alias in partition [{}], this may block importers from being marked as completed",
+          valueType.getAliasTemplate(),
           partitionId,
           e);
+      throw new OperateRuntimeException(e);
     }
-    return false;
   }
 
   private void executeNext() {

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/opensearch/OpensearchRecordsReader.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/opensearch/OpensearchRecordsReader.java
@@ -547,7 +547,7 @@ public class OpensearchRecordsReader implements RecordsReader {
   }
 
   private void markRecordReaderCompletedIfMinimumEmptyBatchesReceived() {
-    if (recordsReaderHolder.hasPartitionCompletedImporting(partitionId)) {
+    if (isPartitionCompletedImporting(partitionId)) {
       recordsReaderHolder.incrementEmptyBatches(partitionId, importValueType);
     }
 
@@ -563,6 +563,22 @@ public class OpensearchRecordsReader implements RecordsReader {
             e);
       }
     }
+  }
+
+  private boolean isPartitionCompletedImporting(final int partitionId) {
+    try {
+      final var tenantImportPosition =
+          importPositionHolder.getLatestLoadedPosition("tenant", partitionId);
+
+      return tenantImportPosition.getIndexName() != null
+          && tenantImportPosition.getIndexName().contains("8.8");
+    } catch (final IOException e) {
+      LOGGER.error(
+          "Failed to check import position of tenant alias in partition [{}], this may block importers from being marked as completed",
+          partitionId,
+          e);
+    }
+    return false;
   }
 
   private void executeNext() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -88,7 +88,6 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.open(new ExporterTestController());
 
     recordsReaderHolder.resetCountEmptyBatches();
-    recordsReaderHolder.resetPartitionsCompletedImporting();
     registry.clear();
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -219,7 +219,6 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     waitForTenantImportPositionToNotNull(1);
-    ;
 
     // then
     // require multiple checks to avoid race condition. If records are written to zeebe indices and

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -99,7 +99,6 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.open(new ExporterTestController());
 
     recordsReaderHolder.resetCountEmptyBatches();
-    recordsReaderHolder.resetPartitionsCompletedImporting();
   }
 
   @Test


### PR DESCRIPTION
## Description

There is a scenario where the importers never complete this is due to 

Upgrade from 8.7 to 8.8 (I created an 8.8 SaaS generation with the environment override CAMUNDA_OPERATE_IMPORTER_COMPLETEDREADERMINEMPTYBATCHES=1000. I will explain why below)
Wait for the importer to import the tenant.
Wait for the importer to flush the tenant's import position to Elasticsearch.
At this point, the position is flushed with completed=false since completedReaderMinEmptyBatches has not yet been reached (set too 1000).
Remove the CAMUNDA_OPERATE_IMPORTER_COMPLETEDREADERMINEMPTYBATCHES override (it will reset to the default value of 5).
Restart the Operate importer.
The import position stays stuck with completed=false.

Root Cause

The transition to completed=true in the import-position is conditional on two factors:
New 8.8 records being detected, and
The completedReaderMinEmptyBatches threshold being reached.

-----------------

This should fix as now completion logic relies on the fact that an 8.8 tenant record has been imported and then the same empty batch logic which as also been reduced to 1.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40267 
