### PR TITLE
[Backport stable/8.8] Support all sort options for batch operation search 

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -10,7 +10,11 @@ package io.camunda.db.rdbms.sql.columns;
 import io.camunda.search.entities.BatchOperationEntity;
 
 public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEntity> {
-  BATCH_OPERATION_KEY("batchOperationKey");
+  BATCH_OPERATION_KEY("batchOperationKey"),
+  STATE("state"),
+  OPERATION_TYPE("operationType"),
+  START_DATE("startDate"),
+  END_DATE("endDate");
 
   private final String property;
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
@@ -49,6 +51,19 @@ public class SearchColumnTest {
               List.of(
                   Tuple.of(BatchOperationItemState.ACTIVE, BatchOperationItemState.ACTIVE),
                   Tuple.of(BatchOperationItemState.ACTIVE, "ACTIVE"))),
+          Map.entry(
+              BatchOperationState.class,
+              List.of(
+                  Tuple.of(BatchOperationState.ACTIVE, BatchOperationState.ACTIVE),
+                  Tuple.of(BatchOperationState.ACTIVE, "ACTIVE"))),
+          Map.entry(
+              BatchOperationType.class,
+              List.of(
+                  Tuple.of(
+                      BatchOperationType.MIGRATE_PROCESS_INSTANCE,
+                      BatchOperationType.MIGRATE_PROCESS_INSTANCE),
+                  Tuple.of(
+                      BatchOperationType.MIGRATE_PROCESS_INSTANCE, "MIGRATE_PROCESS_INSTANCE"))),
           Map.entry(
               ProcessInstanceState.class,
               List.of(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -244,6 +244,7 @@ public class SearchQuerySortRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
+        case BATCH_OPERATION_KEY -> builder.batchOperationKey();
         case STATE -> builder.state();
         case OPERATION_TYPE -> builder.operationType();
         case START_DATE -> builder.startDate();


### PR DESCRIPTION
# Description
Backport of #40896 to `stable/8.8`.

relates to #40873