### PR TITLE
fix: remove proactive permission check for delete resource

### DIFF
--- a/operate/client/src/App/Decisions/Decision/index.tsx
+++ b/operate/client/src/App/Decisions/Decision/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {observer} from 'mobx-react';
-import {Restricted} from 'modules/components/Restricted';
 import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
 import {useEffect, useState} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
@@ -142,21 +141,11 @@ const Decision: React.FC = observer(() => {
             />
           )}
           {isVersionSelected && decisionDefinitionId !== null && (
-            <Restricted
-              resourceBasedRestrictions={{
-                scopes: ['DELETE'],
-                permissions: groupedDecisionsStore.getPermissions(
-                  decisionId ?? undefined,
-                  tenant,
-                ),
-              }}
-            >
-              <DecisionOperations
-                decisionDefinitionId={decisionDefinitionId}
-                decisionName={decisionName}
-                decisionVersion={version}
-              />
-            </Restricted>
+            <DecisionOperations
+              decisionDefinitionId={decisionDefinitionId}
+              decisionName={decisionName}
+              decisionVersion={version}
+            />
           )}
         </>
       </PanelHeader>

--- a/operate/client/src/App/Decisions/Decision/tests/decisionOperations.test.tsx
+++ b/operate/client/src/App/Decisions/Decision/tests/decisionOperations.test.tsx
@@ -13,8 +13,6 @@ import {mockFetchGroupedDecisions} from 'modules/mocks/api/decisions/fetchGroupe
 import {mockFetchDecisionDefinitionXML} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinitionXML';
 import {Decision} from '..';
 import {createWrapper} from './mocks';
-import {mockMe} from 'modules/mocks/api/v2/me';
-import {createUser} from 'modules/testUtils';
 
 vi.mock('modules/feature-flags', () => ({
   IS_DECISION_DEFINITION_DELETION_ENABLED: true,
@@ -55,25 +53,6 @@ describe('<Decision /> - operations', () => {
   it('should not show delete button when no version is selected', () => {
     render(<Decision />, {
       wrapper: createWrapper('/decisions?name=invoiceClassification'),
-    });
-
-    expect(
-      screen.queryByRole('button', {
-        name: /delete decision definition/i,
-      }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('should not show delete button when user has no resource based permissions', async () => {
-    vi.stubGlobal('clientConfig', {
-      resourcePermissionsEnabled: true,
-    });
-    mockMe().withSuccess(createUser());
-
-    render(<Decision />, {
-      wrapper: createWrapper(
-        '/decisions?name=invoice-assign-approver&version=1',
-      ),
     });
 
     expect(

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
@@ -21,7 +21,6 @@ describe('DiagramHeader', () => {
   it('should render header with full data', async () => {
     render(
       <DiagramHeader
-        isVersionSelected
         processDetails={{
           processName: 'My Process',
           bpmnProcessId: 'MyProcess',
@@ -50,7 +49,6 @@ describe('DiagramHeader', () => {
   it('should render header without version tag', async () => {
     render(
       <DiagramHeader
-        isVersionSelected
         processDetails={{
           processName: 'My Process',
           bpmnProcessId: 'MyProcess',
@@ -77,7 +75,6 @@ describe('DiagramHeader', () => {
   it('should render header without data', async () => {
     render(
       <DiagramHeader
-        isVersionSelected
         processDetails={{
           processName: 'My Process',
         }}

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
@@ -28,7 +28,6 @@ describe('DiagramHeader', () => {
           versionTag: 'MyVersionTag',
         }}
         processDefinitionId=""
-        tenant=""
       />,
     );
 
@@ -55,7 +54,6 @@ describe('DiagramHeader', () => {
           version: '1',
         }}
         processDefinitionId=""
-        tenant=""
       />,
     );
 
@@ -79,7 +77,6 @@ describe('DiagramHeader', () => {
           processName: 'My Process',
         }}
         processDefinitionId=""
-        tenant=""
       />,
     );
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
@@ -28,7 +28,6 @@ type ProcessDetails = {
 type DiagramHeaderProps = {
   processDetails: ProcessDetails;
   processDefinitionId?: string;
-  tenant?: string;
   panelHeaderRef?: React.RefObject<HTMLDivElement | null>;
 };
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
@@ -10,8 +10,6 @@ import {observer} from 'mobx-react';
 import isNil from 'lodash/isNil';
 import {CopiableProcessID} from 'App/Processes/CopiableProcessID';
 import {ProcessOperations} from '../../ProcessOperations';
-import {Restricted} from 'modules/components/Restricted';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {
   PanelHeader,
   Description,
@@ -31,21 +29,15 @@ type DiagramHeaderProps = {
   processDetails: ProcessDetails;
   processDefinitionId?: string;
   tenant?: string;
-  isVersionSelected: boolean;
   panelHeaderRef?: React.RefObject<HTMLDivElement | null>;
 };
 
 const DiagramHeader: React.FC<DiagramHeaderProps> = observer(
-  ({
-    processDetails,
-    processDefinitionId,
-    tenant,
-    isVersionSelected,
-    panelHeaderRef,
-  }) => {
+  ({processDetails, processDefinitionId, panelHeaderRef}) => {
     const {processName, bpmnProcessId, version, versionTag} = processDetails;
     const hasVersionTag = !isNil(versionTag);
     const hasSelectedProcess = bpmnProcessId !== undefined;
+    const hasSelectedVersion = version !== undefined && version !== 'all';
 
     return (
       <PanelHeader
@@ -84,21 +76,12 @@ const DiagramHeader: React.FC<DiagramHeaderProps> = observer(
           </>
         )}
 
-        {isVersionSelected && processDefinitionId !== undefined && (
-          <Restricted
-            resourceBasedRestrictions={{
-              scopes: ['DELETE'],
-              permissions: processesStore.getPermissions(bpmnProcessId, tenant),
-            }}
-          >
-            {version !== undefined && (
-              <ProcessOperations
-                processDefinitionId={processDefinitionId}
-                processName={processName}
-                processVersion={version}
-              />
-            )}
-          </Restricted>
+        {hasSelectedVersion && processDefinitionId !== undefined && (
+          <ProcessOperations
+            processDefinitionId={processDefinitionId}
+            processName={processName}
+            processVersion={version}
+          />
         )}
       </PanelHeader>
     );

--- a/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.tsx
@@ -142,7 +142,6 @@ const DiagramPanel: React.FC = observer(() => {
       <DiagramHeader
         processDetails={processDetails}
         processDefinitionId={processId}
-        isVersionSelected={isVersionSelected}
         tenant={tenant}
       />
       <DiagramShell

--- a/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.tsx
@@ -56,9 +56,7 @@ function setSearchParam(
 const DiagramPanel: React.FC = observer(() => {
   const navigate = useNavigate();
   const location = useLocation();
-  const {version, flowNodeId, tenant} = getProcessInstanceFilters(
-    location.search,
-  );
+  const {version, flowNodeId} = getProcessInstanceFilters(location.search);
 
   const isVersionSelected = version !== undefined && version !== 'all';
 
@@ -142,7 +140,6 @@ const DiagramPanel: React.FC = observer(() => {
       <DiagramHeader
         processDetails={processDetails}
         processDefinitionId={processId}
-        tenant={tenant}
       />
       <DiagramShell
         status={getStatus()}


### PR DESCRIPTION
## Description

Remove proactive permission checks for delete process/definition definition (see Option 1 in the [issue](https://github.com/camunda/camunda/issues/38711)). The button is now always visible if a version is selected.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38711 
