### PR TITLE
fix: allow 0 as valid value for numJobWorkerExecutorThreads

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -85,8 +85,7 @@ public interface CamundaClientBuilder {
   CamundaClientBuilder defaultJobWorkerMaxJobsActive(int maxJobsActive);
 
   /**
-   * @param numThreads The number of threads for invocation of job workers. Setting this value to 0
-   *     effectively disables subscriptions and workers. Default value is 1.
+   * @param numThreads The number of threads for invocation of job workers. Default value is 1.
    */
   CamundaClientBuilder numJobWorkerExecutionThreads(int numThreads);
 

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -86,6 +86,8 @@ public interface CamundaClientBuilder {
 
   /**
    * @param numThreads The number of threads for invocation of job workers. Default value is 1.
+   *     Setting this value to 0 causes the client to reuse the scheduled executor for job handling
+   *     (backward compatibility behavior).
    */
   CamundaClientBuilder numJobWorkerExecutionThreads(int numThreads);
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -516,7 +516,8 @@ public final class CamundaClientImpl implements CamundaClient {
       scheduledExecutor = configuration.jobWorkerSchedulingExecutor();
       ownsScheduledExecutor = configuration.ownsJobWorkerSchedulingExecutor();
     } else {
-      scheduledExecutor = Executors.newScheduledThreadPool(1);
+      // default to using a scheduled executor with 0 core pool, which creates threads as needed
+      scheduledExecutor = Executors.newScheduledThreadPool(0);
       ownsScheduledExecutor = true;
     }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -532,7 +532,7 @@ public final class CamundaClientImpl implements CamundaClient {
       if (threadCount == 0) {
         // fallback to using the scheduled executor for both purposes
         // this ensures backward compatibility with the old behavior when 0 was accepted
-        // as a valid value for "use default number of threads"
+        // as a valid value; this reuses the single-threaded scheduled executor for job handling
         jobHandlingExecutor = scheduledExecutor;
         ownsJobHandlingExecutor = false; // since both executors are the same
       } else {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -528,8 +528,17 @@ public final class CamundaClientImpl implements CamundaClient {
       ownsJobHandlingExecutor = configuration.ownsJobHandlingExecutor();
     } else {
       final int threadCount = configuration.getNumJobWorkerExecutionThreads();
-      jobHandlingExecutor = Executors.newFixedThreadPool(threadCount);
-      ownsJobHandlingExecutor = true;
+
+      if (threadCount == 0) {
+        // fallback to using the scheduled executor for both purposes
+        // this ensures backward compatibility with the old behavior when 0 was accepted
+        // as a valid value for "use default number of threads"
+        jobHandlingExecutor = scheduledExecutor;
+        ownsJobHandlingExecutor = false; // since both executors are the same
+      } else {
+        jobHandlingExecutor = Executors.newFixedThreadPool(threadCount);
+        ownsJobHandlingExecutor = true;
+      }
     }
 
     return new JobWorkerExecutors(

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -46,6 +46,7 @@ import static io.camunda.client.impl.LegacyZeebeClientEnvironmentVariables.ZEEBE
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -639,6 +640,21 @@ public final class CamundaClientTest {
       verify(executor)
           .schedule(any(Runnable.class), eq(pollInterval.toMillis()), eq(TimeUnit.MILLISECONDS));
     }
+  }
+
+  @Test
+  public void shouldNotThrowWhenNumExecutionThreadsIsZero() {
+    assertThatNoException()
+        .isThrownBy(() -> CamundaClient.newClientBuilder().numJobWorkerExecutionThreads(0).build());
+  }
+
+  @Test
+  public void shouldThrowWhenNumExecutionThreadsIsNegative() {
+    // when/then
+    assertThatThrownBy(
+            () -> CamundaClient.newClientBuilder().numJobWorkerExecutionThreads(-1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("corePoolSize must be non-negative");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -653,8 +653,7 @@ public final class CamundaClientTest {
     // when/then
     assertThatThrownBy(
             () -> CamundaClient.newClientBuilder().numJobWorkerExecutionThreads(-1).build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("corePoolSize must be non-negative");
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

0 used to be a valid input in the previous implementation where we reused the scheduled thread pool for everything. The new approach uses a fixedThreadPool instead, which throws an exception if maxThreads is <=0. This was changed in #40058.

In this PR, we now use 0 as a trigger to reuse the scheduled executor for both scheduling and job handling.

Additionally, this PR changes the incorrect JavaDoc statement about 0 leading to disabling job workers. This was never a documented behavior of a scheduled thread pool, see https://bugs.openjdk.org/browse/JDK-7091003

More context: [🔒 Slack](https://camunda.slack.com/archives/C0807665N8G/p1763041726348249?thread_ts=1762966793.300119&cid=C0807665N8G)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
