### PR TITLE
deps: bump commons-lang3 version

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -300,6 +300,14 @@
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
       </dependency>
+
+      <!-- Override Spring Boot's commons-lang3 version to address CVEs -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -63,6 +63,7 @@
     <logback.version>1.5.19</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
     <commons.io.version>2.17.0</commons.io.version>
+    <commons.lang3.version>3.18.0</commons.lang3.version>
 
     <version.node>v20.9.0</version.node>
     <version.yarn>v1.22.19</version.yarn>
@@ -305,7 +306,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
+        <version>${commons.lang3.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds an explicit commons-lang3 version override to Optimize’s dependencyManagement to ensure the patched version for CVE-2025-48924 is consistently applied across all modules.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40902
