### PR TITLE
ci: use Minimus image for Operate to reduce CVEs

### DIFF
--- a/.ci/docker/test/operate-docker-labels.golden.json
+++ b/.ci/docker/test/operate-docker-labels.golden.json
@@ -17,5 +17,7 @@
   "org.opencontainers.image.title": "Camunda Operate",
   "org.opencontainers.image.url": "https://camunda.com/platform/operate/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/openjre",
+  "io.minimus.images.line": "21"
 }

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -403,11 +403,18 @@ jobs:
           secrets: |
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -461,7 +468,7 @@ jobs:
           command: |
             docker -D buildx imagetools create \
               --tag ${{ env.DOCKER_IMAGE }}:latest \
-              ${{ steps.build-operate-docker.outputs.image }} 
+              ${{ steps.build-operate-docker.outputs.image }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -84,6 +84,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - name: Build Maven
         run: |
           ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
@@ -382,6 +383,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -108,6 +108,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
 
       #########################################################################
       # Build Operate frontend

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -69,6 +69,13 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -119,6 +119,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
 
       #########################################################################
       # Build frontend

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,6 +1,11 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="alpine:3.22.2"
-ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
+ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
+ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk:
+#ARG BASE_IMAGE="alpine:3.22.2"
+#ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
 
 # Prepare Operate Distribution
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare
@@ -14,19 +19,12 @@ RUN tar xzvf operate.tar.gz --strip 1 && \
 COPY docker-notice.txt notice.txt
 RUN sed -i '/^exec /i cat /usr/local/operate/notice.txt' bin/operate
 
-### Base image ###
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
-
-# Install Tini
-RUN apk update && apk add --no-cache tini
-
 ### Application Image ###
 # TARGETARCH is provided by buildkit
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS app
 
-FROM base AS app
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -35,7 +33,7 @@ ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="operate@camunda.com"
@@ -59,15 +57,14 @@ LABEL io.k8s.description="Tool for process observability and troubleshooting pro
 
 EXPOSE 8080
 
-RUN apk update && apk upgrade
-RUN apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
-
 ENV OPE_HOME=/usr/local/operate
 
 WORKDIR ${OPE_HOME}
 VOLUME /tmp
 VOLUME ${OPE_HOME}/logs
 
+# Switch to root to allow setting up our own user
+USER root
 RUN addgroup --gid 1001 camunda && \
     adduser -D -h ${OPE_HOME} -G camunda -u 1001 camunda && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
@@ -80,4 +77,4 @@ COPY --from=prepare --chown=1001:0 --chmod=0775 /tmp/operate ${OPE_HOME}
 
 USER 1001:1001
 
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/operate/bin/operate"]
+ENTRYPOINT ["/usr/local/operate/bin/operate"]


### PR DESCRIPTION
## Description

Migrating `operate.Dockerfile` that produces `camunda/operate` on DockerHub to use the hardened Docker base images from Minimus. These changes are similar to https://github.com/camunda/camunda/pull/36539.

In https://github.com/camunda/camunda/pull/31499 several native libraries got introduced to allow secure cluster communications for Operate and Tasklist, together with an integration test to verify the desired behavior -> this test is green after converting to Minimus.
To double-check that the test fails if the Docker image lacks required native libraries I opened https://github.com/camunda/camunda/pull/41091

This PR also adjusts CI jobs that build the Operate Docker image to require Minimus credentials.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - out of scope of https://github.com/camunda/camunda/issues/40739

## Related issues

Related to https://github.com/camunda/camunda/issues/40739
