### PR TITLE
feat: add sorting to v2 process instances table

### DIFF
--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
@@ -175,15 +175,17 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
             {
               header: 'Name',
               key: 'processName',
+              sortKey: 'processDefinitionName',
             },
             {
               header: 'Process Instance Key',
               key: 'processInstanceKey',
-              sortKey: 'id',
+              sortKey: 'processInstanceKey',
             },
             {
               header: 'Version',
               key: 'processVersion',
+              sortKey: 'processDefinitionVersion',
             },
             ...(hasVersionTags
               ? [
@@ -199,12 +201,14 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
                   {
                     header: 'Tenant',
                     key: 'tenant',
+                    sortKey: 'tenantId',
                   },
                 ]
               : []),
             {
               header: 'Start Date',
               key: 'startDate',
+              sortKey: 'startDate',
               isDefault: true,
             },
             {
@@ -215,6 +219,7 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
             {
               header: 'Parent Process Instance Key',
               key: 'parentInstanceId',
+              sortKey: 'parentProcessInstanceKey',
             },
           ]}
           batchOperationId={batchOperationId}

--- a/operate/client/src/App/Processes/ListView/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/index.tsx
@@ -34,6 +34,7 @@ const ListView: React.FC = observer(() => {
   const {getFilters} = useFilters();
 
   const filters = getFilters();
+
   const {process, tenant, version} = filters;
   const {
     state: {status: processesStatus},

--- a/operate/client/src/App/Processes/ListView/v2/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/tests/index.test.tsx
@@ -196,9 +196,12 @@ describe('Instances', () => {
       expect(screen.queryByTestId('data-table-loader')).not.toBeInTheDocument();
     });
 
-    expect(
-      withinRow.getByRole('checkbox', {name: /select row/i}),
-    ).toBeChecked();
+    const updatedRow = await screen.findByRole('row', {
+      name: /2251799813685594/i,
+    });
+    const updatedCheckbox = within(updatedRow).getByRole('checkbox');
+
+    expect(updatedCheckbox).toBeChecked();
   });
 
   it('should refetch data when navigated from header', async () => {

--- a/operate/client/src/modules/queries/processInstance/useProcessInstancesPaginated.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessInstancesPaginated.ts
@@ -48,6 +48,7 @@ const useProcessInstancesPaginated = <
     staleTime: 5000,
     enabled: options?.enabled ?? true,
     select: options?.select,
+    placeholderData: (previousData) => previousData,
     queryFn: async ({pageParam}) => {
       const {response, error} = await searchProcessInstances({
         ...payload,

--- a/operate/client/src/modules/utils/filter/v2/getSortFromUrl.test.ts
+++ b/operate/client/src/modules/utils/filter/v2/getSortFromUrl.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getSortFromUrl} from './getSortFromUrl';
+
+function createSortUrl(field: string, order: string): string {
+  const params = new URLSearchParams();
+  params.set('sort', `${field}+${order}`);
+  return `?${params.toString()}`;
+}
+
+describe('getSortFromUrl', () => {
+  it('should return default sort when no sort parameter present', () => {
+    const result = getSortFromUrl('?active=true');
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should return default sort when sort parameter is empty', () => {
+    const result = getSortFromUrl('?sort=');
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should handle "processInstanceKey" field name', () => {
+    const result = getSortFromUrl(createSortUrl('processInstanceKey', 'asc'));
+    expect(result).toEqual([{field: 'processInstanceKey', order: 'asc'}]);
+  });
+
+  it('should handle "processDefinitionName"  field name', () => {
+    const result = getSortFromUrl(
+      createSortUrl('processDefinitionName', 'desc'),
+    );
+    expect(result).toEqual([{field: 'processDefinitionName', order: 'desc'}]);
+  });
+
+  it('should handle "processDefinitionVersion" field name', () => {
+    const result = getSortFromUrl(
+      createSortUrl('processDefinitionVersion', 'asc'),
+    );
+    expect(result).toEqual([{field: 'processDefinitionVersion', order: 'asc'}]);
+  });
+
+  it('should handle "startDate" field name', () => {
+    const result = getSortFromUrl(createSortUrl('startDate', 'desc'));
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should handle "tenantId"  field name', () => {
+    const result = getSortFromUrl(createSortUrl('tenantId', 'desc'));
+    expect(result).toEqual([{field: 'tenantId', order: 'desc'}]);
+  });
+
+  it('should handle  "parentProcessInstanceKey" ield name', () => {
+    const result = getSortFromUrl(
+      createSortUrl('parentProcessInstanceKey', 'asc'),
+    );
+    expect(result).toEqual([{field: 'parentProcessInstanceKey', order: 'asc'}]);
+  });
+
+  it('should fallback to default sort when field is invalid', () => {
+    const result = getSortFromUrl(createSortUrl('invalidField', 'asc'));
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should fallback to default order when order is invalid', () => {
+    const params = new URLSearchParams();
+    params.set('sort', 'startDate+invalid');
+    const result = getSortFromUrl(`?${params.toString()}`);
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should fallback to default when URL format is invalid', () => {
+    const result = getSortFromUrl('?sort=invalid');
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should handle empty URL search string', () => {
+    const result = getSortFromUrl('');
+    expect(result).toEqual([{field: 'startDate', order: 'desc'}]);
+  });
+
+  it('should handle URL with multiple parameters', () => {
+    const params = new URLSearchParams();
+    params.set('active', 'true');
+    params.set('incidents', 'true');
+    params.set('sort', 'processInstanceKey+asc');
+    const result = getSortFromUrl(`?${params.toString()}`);
+    expect(result).toEqual([{field: 'processInstanceKey', order: 'asc'}]);
+  });
+});

--- a/operate/client/src/modules/utils/filter/v2/getSortFromUrl.ts
+++ b/operate/client/src/modules/utils/filter/v2/getSortFromUrl.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {getSortParams} from 'modules/utils/filter';
+
+const VALID_SORTABLE_FIELDS = new Set([
+  'processInstanceKey',
+  'processDefinitionName',
+  'processDefinitionVersion',
+  'startDate',
+  'tenantId',
+  'parentProcessInstanceKey',
+]);
+
+type SortItem = NonNullable<QueryProcessInstancesRequestBody['sort']>[number];
+type SortField = SortItem['field'];
+type SortOrder = SortItem['order'];
+
+const DEFAULT_SORT: SortItem = {
+  field: 'startDate',
+  order: 'desc',
+};
+
+const isValidSortField = (field: string): field is SortField => {
+  return VALID_SORTABLE_FIELDS.has(field);
+};
+
+const normalizeSortOrder = (
+  order: string | undefined,
+): SortOrder | undefined => {
+  if (order === 'asc' || order === 'desc') {
+    return order;
+  }
+  return undefined;
+};
+
+const getSortFromUrl = (
+  urlSearch?: string,
+): QueryProcessInstancesRequestBody['sort'] => {
+  const sortParams = getSortParams(urlSearch);
+
+  if (!sortParams || !isValidSortField(sortParams.sortBy)) {
+    return [DEFAULT_SORT];
+  }
+
+  const order = normalizeSortOrder(sortParams.sortOrder);
+
+  if (!order) {
+    return [DEFAULT_SORT];
+  }
+
+  return [{field: sortParams.sortBy, order}];
+};
+
+export {getSortFromUrl, VALID_SORTABLE_FIELDS, DEFAULT_SORT};


### PR DESCRIPTION
## Description

- Extend v2 PI table with sorting by `startDate`, parentProcessInstanceKey, `version`, `processInstanceKey`, `processDefinitionName`
- Add utility function for sort param retrieving
- Extend query with placeholder data to keep table behavior during sorting

## Related issues

closes #40510 
