### PR TITLE
feat: improve UX for "no permission for operation"

### DIFF
--- a/operate/client/src/App/Decisions/Decision/DecisionOperations/index.test.tsx
+++ b/operate/client/src/App/Decisions/Decision/DecisionOperations/index.test.tsx
@@ -188,13 +188,11 @@ describe('<DecisionOperations />', () => {
 
     await user.click(screen.getByRole('button', {name: /danger Delete/}));
 
-    await waitFor(() => {
-      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: 'You do not have permission',
-        isDismissable: true,
-      });
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'warning',
+      title: "You don't have permission to perform this operation",
+      subtitle: 'Please contact the administrator if you need access.',
+      isDismissable: true,
     });
     expect(panelStatesStore.state.isOperationsCollapsed).toBe(true);
   });

--- a/operate/client/src/App/Decisions/Decision/DecisionOperations/index.tsx
+++ b/operate/client/src/App/Decisions/Decision/DecisionOperations/index.tsx
@@ -132,7 +132,7 @@ const DecisionOperations: React.FC<Props> = ({
             },
             onError: (statusCode: number) => {
               setIsOperationRunning(false);
-              handleOperationError(statusCode === 403);
+              handleOperationError(statusCode);
             },
           });
         }}

--- a/operate/client/src/App/Decisions/Decision/DecisionOperations/index.tsx
+++ b/operate/client/src/App/Decisions/Decision/DecisionOperations/index.tsx
@@ -19,6 +19,7 @@ import {UnorderedList} from 'modules/components/DeleteDefinitionModal/Warning/st
 import {decisionDefinitionStore} from 'modules/stores/decisionDefinition';
 import {notificationsStore} from 'modules/stores/notifications';
 import {tracking} from 'modules/tracking';
+import {handleOperationError} from 'modules/utils/notifications';
 
 type Props = {
   decisionDefinitionId: string;
@@ -131,14 +132,7 @@ const DecisionOperations: React.FC<Props> = ({
             },
             onError: (statusCode: number) => {
               setIsOperationRunning(false);
-
-              notificationsStore.displayNotification({
-                kind: 'error',
-                title: 'Operation could not be created',
-                subtitle:
-                  statusCode === 403 ? 'You do not have permission' : undefined,
-                isDismissable: true,
-              });
+              handleOperationError(statusCode === 403);
             },
           });
         }}

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.tsx
@@ -13,6 +13,7 @@ import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {Operations} from 'modules/components/Operations';
 import {modificationsStore} from 'modules/stores/modifications';
 import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError as handleOperationErrorUtil} from 'modules/utils/notifications';
 import {tracking} from 'modules/tracking';
 import {Locations} from 'modules/Routes';
 import {PROCESS_INSTANCE_DEPRECATED_QUERY_KEY} from 'modules/queries/processInstance/deprecated/useProcessInstanceDeprecated';
@@ -82,13 +83,7 @@ const ProcessInstanceOperations: React.FC<Props> = ({processInstance}) => {
 
   const handleOperationError: ErrorHandler = ({statusCode}) => {
     invalidateQueries();
-
-    notificationsStore.displayNotification({
-      kind: 'error',
-      title: 'Operation could not be created',
-      subtitle: statusCode === 403 ? 'You do not have permission' : undefined,
-      isDismissable: true,
-    });
+    handleOperationErrorUtil(statusCode === 403);
   };
 
   const handleOperationSuccess = (operationType: OperationEntityType) => {

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.tsx
@@ -83,7 +83,7 @@ const ProcessInstanceOperations: React.FC<Props> = ({processInstance}) => {
 
   const handleOperationError: ErrorHandler = ({statusCode}) => {
     invalidateQueries();
-    handleOperationErrorUtil(statusCode === 403);
+    handleOperationErrorUtil(statusCode);
   };
 
   const handleOperationSuccess = (operationType: OperationEntityType) => {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -53,9 +53,9 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
       });
       processInstancesSelectionStore.reset();
     },
-    onError: ({message}) => {
+    onError: (error) => {
       panelStatesStore.expandOperationsPanel();
-      handleOperationError(message.includes('403'));
+      handleOperationError(error.response?.status);
     },
   });
 
@@ -68,9 +68,9 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
       });
       processInstancesSelectionStore.reset();
     },
-    onError: ({message}) => {
+    onError: (error) => {
       panelStatesStore.expandOperationsPanel();
-      handleOperationError(message.includes('403'));
+      handleOperationError(error.response?.status);
     },
   });
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -22,8 +22,8 @@ import {useResolveProcessInstancesIncidentsBatchOperation} from 'modules/mutatio
 import {tracking} from 'modules/tracking';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
 import {processInstancesStore} from 'modules/stores/processInstances';
-import {notificationsStore} from 'modules/stores/notifications';
 import {buildMutationRequestBody} from './buildMutationRequestBody';
+import {handleOperationError} from 'modules/utils/notifications';
 
 type Props = {
   selectedInstancesCount: number;
@@ -55,14 +55,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
     },
     onError: ({message}) => {
       panelStatesStore.expandOperationsPanel();
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: message.includes('403')
-          ? 'You do not have permission'
-          : undefined,
-        isDismissable: true,
-      });
+      handleOperationError(message.includes('403'));
     },
   });
 
@@ -77,14 +70,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
     },
     onError: ({message}) => {
       panelStatesStore.expandOperationsPanel();
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: message.includes('403')
-          ? 'You do not have permission'
-          : undefined,
-        isDismissable: true,
-      });
+      handleOperationError(message.includes('403'));
     },
   });
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
@@ -85,7 +85,7 @@ function useOperationApply() {
             operationType,
             shouldPollAllVisibleIds: selectedProcessInstanceIds.length === 0,
           });
-          handleOperationError(statusCode === 403);
+          handleOperationError(statusCode);
         },
       });
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/useOperationApply/index.ts
@@ -11,7 +11,7 @@ import {operationsStore} from 'modules/stores/operations';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {tracking} from 'modules/tracking';
-import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
 import {type Modifications} from 'modules/api/processInstances/operations';
 import type {OperationEntityType} from 'modules/types/operate';
 
@@ -85,13 +85,7 @@ function useOperationApply() {
             operationType,
             shouldPollAllVisibleIds: selectedProcessInstanceIds.length === 0,
           });
-          notificationsStore.displayNotification({
-            kind: 'error',
-            title: 'Operation could not be created',
-            subtitle:
-              statusCode === 403 ? 'You do not have permission' : undefined,
-            isDismissable: true,
-          });
+          handleOperationError(statusCode === 403);
         },
       });
 

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
@@ -224,13 +224,11 @@ describe('<ProcessOperations />', () => {
 
     await user.click(screen.getByRole('button', {name: /danger Delete/}));
 
-    await waitFor(() => {
-      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: 'You do not have permission',
-        isDismissable: true,
-      });
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'warning',
+      title: "You don't have permission to perform this operation",
+      subtitle: 'Please contact the administrator if you need access.',
+      isDismissable: true,
     });
     expect(panelStatesStore.state.isOperationsCollapsed).toBe(true);
   });

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
@@ -17,6 +17,7 @@ import {panelStatesStore} from 'modules/stores/panelStates';
 import {StructuredList} from 'modules/components/StructuredList';
 import {UnorderedList} from 'modules/components/DeleteDefinitionModal/Warning/styled';
 import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
 import {tracking} from 'modules/tracking';
 import {observer} from 'mobx-react';
 import {processInstancesStore} from 'modules/stores/processInstances';
@@ -146,16 +147,7 @@ const ProcessOperations: React.FC<Props> = observer(
               },
               onError: (statusCode: number) => {
                 setIsOperationRunning(false);
-
-                notificationsStore.displayNotification({
-                  kind: 'error',
-                  title: 'Operation could not be created',
-                  subtitle:
-                    statusCode === 403
-                      ? 'You do not have permission'
-                      : undefined,
-                  isDismissable: true,
-                });
+                handleOperationError(statusCode === 403);
               },
             });
           }}

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
@@ -147,7 +147,7 @@ const ProcessOperations: React.FC<Props> = observer(
               },
               onError: (statusCode: number) => {
                 setIsOperationRunning(false);
-                handleOperationError(statusCode === 403);
+                handleOperationError(statusCode);
               },
             });
           }}

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -85,13 +85,13 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
             operationType: 'MODIFY_PROCESS_INSTANCE',
           });
         },
-        onError: ({message}) => {
+        onError: (error) => {
           processInstancesStore.unmarkProcessInstancesWithActiveOperations({
             instanceIds: ids,
             operationType: 'MODIFY_PROCESS_INSTANCE',
             shouldPollAllVisibleIds: selectedProcessInstanceIds.length === 0,
           });
-          handleOperationError(message.includes('403'));
+          handleOperationError(error.response?.status);
         },
       });
 

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -24,7 +24,7 @@ import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useI
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
 import {getFlowNodeName} from 'modules/utils/flowNodes';
-import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
 import {useModifyProcessInstancesBatchOperation} from 'modules/mutations/processes/useModifyProcessInstancesBatchOperation';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
@@ -91,14 +91,7 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
             operationType: 'MODIFY_PROCESS_INSTANCE',
             shouldPollAllVisibleIds: selectedProcessInstanceIds.length === 0,
           });
-          notificationsStore.displayNotification({
-            kind: 'error',
-            title: 'Operation could not be created',
-            subtitle: message.includes('403')
-              ? 'You do not have permission'
-              : undefined,
-            isDismissable: true,
-          });
+          handleOperationError(message.includes('403'));
         },
       });
 

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
@@ -50,7 +50,7 @@ const InstanceOperations: React.FC<Props> = ({
   });
 
   const handleOperationError: ErrorHandler = ({statusCode}) => {
-    handleOperationErrorUtil(statusCode === 403);
+    handleOperationErrorUtil(statusCode);
   };
 
   const handleOperationSuccess = (operationType: OperationEntityType) => {

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
@@ -8,6 +8,7 @@
 
 import {Operations} from 'modules/components/Operations';
 import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError as handleOperationErrorUtil} from 'modules/utils/notifications';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {tracking} from 'modules/tracking';
 import {operationsStore, type ErrorHandler} from 'modules/stores/operations';
@@ -49,12 +50,7 @@ const InstanceOperations: React.FC<Props> = ({
   });
 
   const handleOperationError: ErrorHandler = ({statusCode}) => {
-    notificationsStore.displayNotification({
-      kind: 'error',
-      title: 'Operation could not be created',
-      subtitle: statusCode === 403 ? 'You do not have permission' : undefined,
-      isDismissable: true,
-    });
+    handleOperationErrorUtil(statusCode === 403);
   };
 
   const handleOperationSuccess = (operationType: OperationEntityType) => {

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
@@ -17,7 +17,7 @@ import {Locations} from 'modules/Routes';
 import {tracking} from 'modules/tracking';
 import {MigrationConfirmationModal} from '../MigrationConfirmationModal/index.tsx';
 import {useMigrateProcessInstancesBatchOperation} from 'modules/mutations/processes/useMigrateProcessInstancesBatchOperation';
-import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
 import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
 import {buildMigrationBatchOperationFilter} from './buildMigrationBatchOperationFilter.ts';
 import {panelStatesStore} from 'modules/stores/panelStates';
@@ -34,15 +34,7 @@ const Footer: React.FC = observer(() => {
         operationType: 'MIGRATE_PROCESS_INSTANCE',
       });
     },
-    onError: ({message}) =>
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: message.includes('403')
-          ? 'You do not have permission'
-          : undefined,
-        isDismissable: true,
-      }),
+    onError: ({message}) => handleOperationError(message.includes('403')),
   });
 
   return (

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
@@ -34,7 +34,9 @@ const Footer: React.FC = observer(() => {
         operationType: 'MIGRATE_PROCESS_INSTANCE',
       });
     },
-    onError: ({message}) => handleOperationError(message.includes('403')),
+    onError: (error) => {
+      return handleOperationError(error.response?.status);
+    },
   });
 
   return (

--- a/operate/client/src/modules/components/IncidentOperation/index.tsx
+++ b/operate/client/src/modules/components/IncidentOperation/index.tsx
@@ -17,6 +17,7 @@ import {tracking} from 'modules/tracking';
 import {InlineLoading} from '@carbon/react';
 import {Container} from './styled';
 import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
 import {useResolveIncident} from 'modules/mutations/incidents/useResolveIncident';
 
 type Props = {
@@ -31,12 +32,7 @@ const IncidentOperation: React.FC<Props> = observer(
 
     const handleError: ErrorHandler = ({statusCode}) => {
       setHasActiveOperation(false);
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: statusCode === 403 ? 'You do not have permission' : undefined,
-        isDismissable: true,
-      });
+      handleOperationError(statusCode === 403);
     };
 
     const handleOnClick = async (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/operate/client/src/modules/components/IncidentOperation/index.tsx
+++ b/operate/client/src/modules/components/IncidentOperation/index.tsx
@@ -32,7 +32,7 @@ const IncidentOperation: React.FC<Props> = observer(
 
     const handleError: ErrorHandler = ({statusCode}) => {
       setHasActiveOperation(false);
-      handleOperationError(statusCode === 403);
+      handleOperationError(statusCode);
     };
 
     const handleOnClick = async (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/operate/client/src/modules/mutations/processes/useCancelProcessInstancesBatchOperation.ts
+++ b/operate/client/src/modules/mutations/processes/useCancelProcessInstancesBatchOperation.ts
@@ -17,12 +17,13 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {createCancellationBatchOperation} from 'modules/api/v2/processInstances/createCancellationBatchOperation';
 import {BATCH_OPERATIONS_QUERY_KEY} from 'modules/queries/batch-operations/useBatchOperations';
+import type {RequestError} from 'modules/request';
 
 const useCancelProcessInstancesBatchOperation = (
   options?: Partial<
     UseMutationOptions<
       CreateCancellationBatchOperationResponseBody,
-      Error,
+      RequestError,
       CreateCancellationBatchOperationRequestBody
     >
   >,

--- a/operate/client/src/modules/mutations/processes/useMigrateProcessInstancesBatchOperation.ts
+++ b/operate/client/src/modules/mutations/processes/useMigrateProcessInstancesBatchOperation.ts
@@ -17,12 +17,13 @@ import type {
   CreateMigrationBatchOperationResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {BATCH_OPERATIONS_QUERY_KEY} from 'modules/queries/batch-operations/useBatchOperations.ts';
+import type {RequestError} from 'modules/request';
 
 const useMigrateProcessInstancesBatchOperation = (
   options?: Partial<
     UseMutationOptions<
       CreateMigrationBatchOperationResponseBody,
-      Error,
+      RequestError,
       CreateMigrationBatchOperationRequestBody
     >
   >,

--- a/operate/client/src/modules/mutations/processes/useModifyProcessInstancesBatchOperation.ts
+++ b/operate/client/src/modules/mutations/processes/useModifyProcessInstancesBatchOperation.ts
@@ -17,12 +17,13 @@ import type {
   CreateModificationBatchOperationResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {BATCH_OPERATIONS_QUERY_KEY} from 'modules/queries/batch-operations/useBatchOperations';
+import type {RequestError} from 'modules/request';
 
 const useModifyProcessInstancesBatchOperation = (
   options?: Partial<
     UseMutationOptions<
       CreateModificationBatchOperationResponseBody,
-      Error,
+      RequestError,
       CreateModificationBatchOperationRequestBody
     >
   >,

--- a/operate/client/src/modules/mutations/processes/useResolveProcessInstancesIncidentsBatchOperation.ts
+++ b/operate/client/src/modules/mutations/processes/useResolveProcessInstancesIncidentsBatchOperation.ts
@@ -17,12 +17,13 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {resolveProcessInstancesIncidentsBatchOperation} from 'modules/api/v2/processes/resolveProcessInstancesIncidentsBatchOperation';
 import {BATCH_OPERATIONS_QUERY_KEY} from 'modules/queries/batch-operations/useBatchOperations';
+import type {RequestError} from 'modules/request';
 
 const useResolveProcessInstancesIncidentsBatchOperation = (
   options?: Partial<
     UseMutationOptions<
       CreateIncidentResolutionBatchOperationResponseBody,
-      Error,
+      RequestError,
       CreateIncidentResolutionBatchOperationRequestBody
     >
   >,

--- a/operate/client/src/modules/utils/notifications.ts
+++ b/operate/client/src/modules/utils/notifications.ts
@@ -8,8 +8,8 @@
 
 import {notificationsStore} from 'modules/stores/notifications';
 
-const handleOperationError = (isPermissionError: boolean) => {
-  if (isPermissionError) {
+const handleOperationError = (statusCode?: number) => {
+  if (statusCode === 403) {
     return notificationsStore.displayNotification({
       kind: 'warning',
       title: "You don't have permission to perform this operation",

--- a/operate/client/src/modules/utils/notifications.ts
+++ b/operate/client/src/modules/utils/notifications.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {notificationsStore} from 'modules/stores/notifications';
+
+const handleOperationError = (isPermissionError: boolean) => {
+  if (isPermissionError) {
+    return notificationsStore.displayNotification({
+      kind: 'warning',
+      title: "You don't have permission to perform this operation",
+      subtitle: 'Please contact the administrator if you need access.',
+      isDismissable: true,
+    });
+  }
+  notificationsStore.displayNotification({
+    kind: 'error',
+    title: 'Operation could not be created',
+    isDismissable: true,
+  });
+};
+
+export {handleOperationError};


### PR DESCRIPTION
## Description

- Add handleOperationError util which shows a warning notification as designed if there is a status 403 response. Falls back to a generic error notification otherwise.
- Use that util for all operation errors.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #29895
