### PR TITLE
fix: run isValid() method in NodeIdProvider executor

### DIFF
--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -83,7 +83,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     return CompletableFuture.supplyAsync(
             () -> currentLease != null && currentLease.lease().isStillValid(now, leaseDuration),
             executor)
-        .orTimeout(leaseDuration.dividedBy(3).toMillis(), TimeUnit.MILLISECONDS)
+        .orTimeout(leaseDuration.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS)
         .exceptionally(
             t -> {
               LOG.warn("Failed to check the status of the lease. Marking it as failed", t);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -81,8 +81,9 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   public CompletableFuture<Boolean> isValid() {
     final var now = clock.millis();
     return CompletableFuture.supplyAsync(
-            () -> currentLease != null && currentLease.lease().isStillValid(now, leaseDuration))
-        .orTimeout(leaseDuration.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS)
+            () -> currentLease != null && currentLease.lease().isStillValid(now, leaseDuration),
+            executor)
+        .orTimeout(leaseDuration.dividedBy(3).toMillis(), TimeUnit.MILLISECONDS)
         .exceptionally(
             t -> {
               LOG.warn("Failed to check the status of the lease. Marking it as failed", t);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -165,7 +165,9 @@ public class RepositoryNodeIdProviderIT {
 
     // then
     // verify that the lease status is not ready continuously
-    Awaitility.await().during(EXPIRY_DURATION).untilAsserted(this::assertLeaseIsNotReady);
+    Awaitility.await()
+        .during(EXPIRY_DURATION)
+        .untilAsserted(() -> assertThat(nodeIdProvider.getCurrentLease()).isNull());
     // all leases are unchanged
     final var currentLeases =
         IntStream.range(0, clusterSize).mapToObj(repository::getLease).toList();
@@ -219,8 +221,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldReleaseGracefullyWhenClosed()
-      throws ExecutionException, InterruptedException, TimeoutException {
+  public void shouldReleaseGracefullyWhenClosed() {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -229,7 +230,7 @@ public class RepositoryNodeIdProviderIT {
     final var lease = nodeIdProvider.getCurrentLease();
 
     // when
-    assertThatNoException().isThrownBy(() -> nodeIdProvider.close());
+    assertThatNoException().isThrownBy(nodeIdProvider::close);
 
     // then
     // clock is not moved, so the lease can only be acquired if released


### PR DESCRIPTION
## Description
Method to be used in health check was not run in `RepositoryNodeIdProvider` executor, which would not signal if the thread is blocked or not.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
