### PR TITLE
test: fail tests if RecordingExported is not short-circuited

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -125,6 +125,7 @@ public final class RecordingExporter implements Exporter {
 
   private static long maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
   private static volatile boolean autoAcknowledge = true;
+  private static boolean failOnTimeout = true;
 
   private Controller controller;
 
@@ -142,6 +143,14 @@ public final class RecordingExporter implements Exporter {
    */
   public static void disableAwaitingIncomingRecords() {
     setMaximumWaitTime(0);
+  }
+
+  public static void failOnTimeout() {
+    failOnTimeout = true;
+  }
+
+  public static void doNotFailOnTimeout() {
+    failOnTimeout = false;
   }
 
   @Override
@@ -651,6 +660,12 @@ public final class RecordingExporter implements Exporter {
     autoAcknowledge = shouldAcknowledgeRecords;
   }
 
+  public static class AwaitRecordIteratorTimeoutException extends RuntimeException {
+    public AwaitRecordIteratorTimeoutException(final String message) {
+      super(message);
+    }
+  }
+
   public static class AwaitingRecordIterator implements Iterator<Record<?>> {
 
     private int nextIndex = 0;
@@ -667,12 +682,18 @@ public final class RecordingExporter implements Exporter {
         final long endTime = now + maximumWaitTime;
         while (isEmpty() && endTime > now) {
           final long waitTime = endTime - now;
+          boolean timedOut = false;
           try {
-            IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
+            timedOut = !IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
           } catch (final InterruptedException ignored) {
             // ignored
           }
           now = System.currentTimeMillis();
+
+          if (failOnTimeout && timedOut) {
+            throw new AwaitRecordIteratorTimeoutException(
+                "RecordingExporter timed out after " + waitTime + "ms");
+          }
         }
         return !isEmpty();
       } finally {


### PR DESCRIPTION
## Description

Given the asynchronous nature of the engine, the `RecordingExporter` used in tests to keep track of which records have been generated is implemented in such a way that it will wait up to a configurable amount of time (5 seconds by default) for new records when retrieving them.
In order to avoid waiting for more than the necessary time, the calls to the `RecordingExporter` should always be short-circuited (e.g. by using `.limit()`).
If the configured waiting time elapses without new records being retrieved, it means that either:
- the record was expected but it was not generated, which means that the test should fail
- the `RecordingExporter` was used without short-circuiting or with an incorrect limit, in this case the test should still fail due to misuse

This PR achieves this by throwing an exception in the `AwaitingRecordIterator` if the timeout is reached.

Since there could be rare cases when it is actually desirable to wait for the timeout before returning the collected records, this feature is configurable through the `RecordingExporter.failOnTimeout()` and `RecordingExporter.doNotFailOnTimeout()` methods.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39897
