### PR TITLE
[Backport stable/8.8] fix: Add support for sorting Authorization records by `resourceId`

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
@@ -12,7 +12,8 @@ import io.camunda.search.entities.AuthorizationEntity;
 public enum AuthorizationSearchColumn implements SearchColumn<AuthorizationEntity> {
   OWNER_ID("ownerId"),
   OWNER_TYPE("ownerType"),
-  RESOURCE_TYPE("resourceType");
+  RESOURCE_TYPE("resourceType"),
+  RESOURCE_ID("resourceId");
 
   private final String property;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
@@ -29,6 +29,7 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -322,7 +323,6 @@ public class AuthorizationIntegrationTest {
         .join();
 
     // when
-
     camundaClient
         .newCreateAuthorizationCommand()
         .ownerId(USER_ID_2)
@@ -346,6 +346,66 @@ public class AuthorizationIntegrationTest {
               assertThat(authorizationsSearchResponse.items())
                   .map(Authorization::getOwnerId)
                   .contains(USER_ID_1, USER_ID_2);
+            });
+  }
+
+  @Test
+  void searchShouldReturnAuthorizationsSortedByResourceId() {
+    // given: execute all authorization creation commands in parallel
+    final var future1 =
+        camundaClient
+            .newCreateAuthorizationCommand()
+            .ownerId(USER_ID_1)
+            .ownerType(OwnerType.USER)
+            .resourceId("resource-zebra")
+            .resourceType(ResourceType.RESOURCE)
+            .permissionTypes(PermissionType.CREATE)
+            .send();
+
+    final var future2 =
+        camundaClient
+            .newCreateAuthorizationCommand()
+            .ownerId(USER_ID_1)
+            .ownerType(OwnerType.USER)
+            .resourceId("resource-alpha")
+            .resourceType(ResourceType.RESOURCE)
+            .permissionTypes(PermissionType.CREATE)
+            .send();
+
+    final var future3 =
+        camundaClient
+            .newCreateAuthorizationCommand()
+            .ownerId(USER_ID_2)
+            .ownerType(OwnerType.USER)
+            .resourceId("resource-beta")
+            .resourceType(ResourceType.RESOURCE)
+            .permissionTypes(PermissionType.CREATE)
+            .send();
+
+    CompletableFuture.allOf(
+            future1.toCompletableFuture(),
+            future2.toCompletableFuture(),
+            future3.toCompletableFuture())
+        .join();
+
+    Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              // when
+              final var authorizationsSearchResponse =
+                  camundaClient
+                      .newAuthorizationSearchRequest()
+                      .filter(
+                          f -> f.resourceIds("resource-zebra", "resource-alpha", "resource-beta"))
+                      .sort(s -> s.resourceId().asc())
+                      .send()
+                      .join();
+
+              // then
+              assertThat(authorizationsSearchResponse.items())
+                  .map(Authorization::getResourceId)
+                  .containsExactly("resource-alpha", "resource-beta", "resource-zebra");
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
@@ -83,6 +83,22 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceType).reversed());
   }
 
+  @TestTemplate
+  public void shouldSortByResourceIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().asc(),
+        Comparator.comparing(AuthorizationEntity::resourceId));
+  }
+
+  @TestTemplate
+  public void shouldSortByResourceIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourceId().desc(),
+        Comparator.comparing(AuthorizationEntity::resourceId).reversed());
+  }
+
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<AuthorizationSort>> sortBuilder,

--- a/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
@@ -28,7 +28,7 @@ public record AuthorizationQuery(
 
   @Override
   public List<SearchSortOptions> retainValidSortings(final List<SearchSortOptions> sorting) {
-    final var fieldNames = List.of("ownerId", "ownerType", "resourceIds", "resourceType");
+    final var fieldNames = List.of("ownerId", "ownerType", "resourceId", "resourceType");
     return sorting.stream().filter(s -> fieldNames.contains(s.field().field())).toList();
   }
 


### PR DESCRIPTION
# Description
Backport of #40805 to `stable/8.8`.

relates to #40799