### PR TITLE
fix: add document permissions when migrating to 8.8

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ResourceBasedAuthorizationConstants.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ResourceBasedAuthorizationConstants.java
@@ -15,6 +15,7 @@ public final class ResourceBasedAuthorizationConstants {
       Set.of(
           AuthorizationResourceType.AUTHORIZATION,
           AuthorizationResourceType.COMPONENT,
+          AuthorizationResourceType.DOCUMENT,
           AuthorizationResourceType.GROUP,
           AuthorizationResourceType.ROLE,
           AuthorizationResourceType.USER,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -73,6 +73,12 @@ public class StaticEntities {
               DEVELOPER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
+              AuthorizationResourceType.DOCUMENT,
+              Set.of(PermissionType.CREATE, PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              DEVELOPER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
               AuthorizationResourceType.MESSAGE,
               Set.of(PermissionType.READ)),
           new CreateAuthorizationRequest(
@@ -149,6 +155,12 @@ public class StaticEntities {
               TASK_USER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
+              AuthorizationResourceType.DOCUMENT,
+              Set.of(PermissionType.CREATE, PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              TASK_USER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
               AuthorizationResourceType.PROCESS_DEFINITION,
               Set.of(
                   PermissionType.READ_PROCESS_DEFINITION,
@@ -186,6 +198,12 @@ public class StaticEntities {
               AuthorizationOwnerType.ROLE,
               "*",
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.DOCUMENT,
               Set.of(PermissionType.READ)),
           new CreateAuthorizationRequest(
               VISITOR_ROLE_ID,
@@ -306,6 +324,12 @@ public class StaticEntities {
             "*",
             AuthorizationResourceType.RESOURCE,
             Set.of(PermissionType.READ)),
+        new CreateAuthorizationRequest(
+            ownerId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.DOCUMENT,
+            AuthorizationResourceType.DOCUMENT.getSupportedPermissionTypes()),
         new CreateAuthorizationRequest(
             ownerId,
             AuthorizationOwnerType.CLIENT,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -260,6 +260,12 @@ public class StaticEntities {
                         ownerId,
                         ownerType,
                         "*",
+                        AuthorizationResourceType.DOCUMENT,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
                         AuthorizationResourceType.PROCESS_DEFINITION,
                         Set.of(
                             PermissionType.READ_PROCESS_DEFINITION,
@@ -273,6 +279,12 @@ public class StaticEntities {
                         TASKLIST_RESOURCE_ID,
                         AuthorizationResourceType.COMPONENT,
                         Set.of(PermissionType.ACCESS)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.DOCUMENT,
+                        AuthorizationResourceType.DOCUMENT.getSupportedPermissionTypes()),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/ClientMigrationHandlerTest.java
@@ -85,7 +85,7 @@ public class ClientMigrationHandlerTest {
     // then
     final ArgumentCaptor<CreateAuthorizationRequest> request =
         ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(9)).createAuthorization(request.capture());
+    verify(authorizationServices, times(10)).createAuthorization(request.capture());
     final var requests = request.getAllValues();
     assertThat(requests)
         .extracting(
@@ -153,6 +153,11 @@ public class ClientMigrationHandlerTest {
             tuple(
                 "tasklist-client-id",
                 AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
+            tuple(
+                "tasklist-client-id",
+                AuthorizationOwnerType.CLIENT,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
@@ -185,7 +190,7 @@ public class ClientMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(9)).createAuthorization(any());
+    verify(authorizationServices, times(10)).createAuthorization(any());
   }
 
   @Test
@@ -210,6 +215,6 @@ public class ClientMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(10)).createAuthorization(any());
+    verify(authorizationServices, times(11)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -61,7 +61,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(25)).createAuthorization(results.capture());
+    verify(authorizationServices, times(28)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
     assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
   }
@@ -82,7 +82,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
 
     // then
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(7)).createAuthorization(results.capture());
+    verify(authorizationServices, times(10)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
     final List<CreateAuthorizationRequest> expectedAuthorizations =
         ROLE_PERMISSIONS.stream()
@@ -90,11 +90,32 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
             .collect(Collectors.toList());
     expectedAuthorizations.add(
         new CreateAuthorizationRequest(
+            "developer",
+            AuthorizationOwnerType.ROLE,
+            "*",
+            AuthorizationResourceType.DOCUMENT,
+            Set.of(PermissionType.CREATE, PermissionType.READ)));
+    expectedAuthorizations.add(
+        new CreateAuthorizationRequest(
             "taskuser",
             AuthorizationOwnerType.ROLE,
             "*",
             AuthorizationResourceType.PROCESS_DEFINITION,
             Set.of(PermissionType.READ_USER_TASK, PermissionType.UPDATE_USER_TASK)));
+    expectedAuthorizations.add(
+        new CreateAuthorizationRequest(
+            "taskuser",
+            AuthorizationOwnerType.ROLE,
+            "*",
+            AuthorizationResourceType.DOCUMENT,
+            Set.of(PermissionType.CREATE, PermissionType.READ)));
+    expectedAuthorizations.add(
+        new CreateAuthorizationRequest(
+            "visitor",
+            AuthorizationOwnerType.ROLE,
+            "*",
+            AuthorizationResourceType.DOCUMENT,
+            Set.of(PermissionType.READ)));
     assertThat(requests).containsExactlyInAnyOrderElementsOf(expectedAuthorizations);
   }
 
@@ -113,6 +134,6 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(26)).createAuthorization(any());
+    verify(authorizationServices, times(29)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -95,7 +95,7 @@ public class ClientMigrationHandlerTest {
     // then
     final ArgumentCaptor<CreateAuthorizationRequest> request =
         ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(16)).createAuthorization(request.capture());
+    verify(authorizationServices, times(17)).createAuthorization(request.capture());
     final var requests = request.getAllValues();
     assertThat(requests)
         .extracting(
@@ -224,7 +224,13 @@ public class ClientMigrationHandlerTest {
                 AuthorizationOwnerType.CLIENT,
                 "tasklist",
                 AuthorizationResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)));
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                "ClientTwo",
+                AuthorizationOwnerType.CLIENT,
+                "*",
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)));
   }
 
   @Test
@@ -282,7 +288,7 @@ public class ClientMigrationHandlerTest {
     migrationHandler.migrate();
 
     //
-    verify(authorizationServices, times(16))
+    verify(authorizationServices, times(17))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 
@@ -314,7 +320,7 @@ public class ClientMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(17))
+    verify(authorizationServices, times(18))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -118,10 +118,10 @@ public class KeycloakRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(21))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(20);
+    assertThat(authorizationRequests).hasSize(21);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -248,6 +248,11 @@ public class KeycloakRoleMigrationHandlerTest {
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.DECISION_DEFINITION,
                 Set.of(
                     PermissionType.CREATE_DECISION_INSTANCE,
@@ -323,7 +328,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(13)).createAuthorization(results.capture());
+    verify(authorizationServices, times(15)).createAuthorization(results.capture());
     final var authorizationRequests = results.getAllValues();
     assertThat(authorizationRequests)
         .extracting(
@@ -403,6 +408,11 @@ public class KeycloakRoleMigrationHandlerTest {
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.READ)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(PermissionType.READ_USER_TASK)),
             // zeebe write
@@ -417,6 +427,11 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
@@ -472,7 +487,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
-    verify(authorizationServices, times(20)).createAuthorization(any());
+    verify(authorizationServices, times(21)).createAuthorization(any());
   }
 
   @Test
@@ -535,7 +550,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
-    verify(authorizationServices, Mockito.times(21))
+    verify(authorizationServices, Mockito.times(22))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -122,10 +122,10 @@ public class OidcRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(21))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(20);
+    assertThat(authorizationRequests).hasSize(21);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -249,6 +249,11 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
@@ -332,7 +337,7 @@ public class OidcRoleMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
-    verify(authorizationServices, times(20)).createAuthorization(any());
+    verify(authorizationServices, times(21)).createAuthorization(any());
   }
 
   @Test
@@ -395,7 +400,7 @@ public class OidcRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
-    verify(authorizationServices, Mockito.times(21))
+    verify(authorizationServices, Mockito.times(22))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 
@@ -455,10 +460,10 @@ public class OidcRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(21))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(20);
+    assertThat(authorizationRequests).hasSize(21);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -582,6 +587,11 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -140,6 +140,10 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
                     PermissionType.READ_USER_TASK,
                     PermissionType.UPDATE_USER_TASK,
                     PermissionType.READ_PROCESS_DEFINITION)),
+            tuple(
+                "tasklist",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
             tuple(
                 "identity",
@@ -231,6 +235,10 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
             tuple("operate", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
             tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
+            tuple(
+                "tasklist",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
             tuple(
                 "identity",
                 ResourceType.GROUP,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
@@ -76,6 +76,10 @@ public class KeycloakIdentityMigrationWithRBAIT extends AbstractKeycloakIdentity
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
             tuple(
                 "tasklist",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
+            tuple(
+                "tasklist",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(PermissionType.READ_USER_TASK, PermissionType.UPDATE_USER_TASK)),
             tuple(

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -302,6 +302,10 @@ public class OidcIdentityMigrationIT {
             tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
             tuple(
                 "tasklist",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
+            tuple(
+                "tasklist",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_USER_TASK,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -172,6 +172,12 @@ public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
                 DEVELOPER_ROLE_ID,
                 OwnerType.ROLE,
                 "*",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ)),
+            tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
@@ -313,6 +319,12 @@ public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
                 VISITOR_ROLE_ID,
                 OwnerType.ROLE,
                 "*",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.READ)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
                     PermissionType.READ_PROCESS_DEFINITION,
@@ -425,7 +437,7 @@ public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
                       .map(Authorization::getOwnerType)
                       .filter(OwnerType.CLIENT::equals)
                       .toList();
-              assertThat(authorizations.size()).isEqualTo(9);
+              assertThat(authorizations.size()).isEqualTo(10);
             });
 
     // then
@@ -491,6 +503,11 @@ public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
                 OwnerType.CLIENT,
                 ResourceType.BATCH,
                 Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+            tuple(
+                "tasklist-client",
+                OwnerType.CLIENT,
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE)),
             tuple(
                 "tasklist-client",
                 OwnerType.CLIENT,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationWithRBAIT.java
@@ -57,7 +57,7 @@ public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigratio
                       .map(Authorization::getOwnerId)
                       .filter(ROLE_IDS::contains)
                       .toList();
-              assertThat(migratedAuthorizations.size()).isEqualTo(7);
+              assertThat(migratedAuthorizations.size()).isEqualTo(10);
             });
 
     // then
@@ -87,6 +87,12 @@ public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigratio
                 ResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
             tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ)),
+            tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
                 OwnerType.ROLE,
                 "operate",
@@ -98,6 +104,12 @@ public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigratio
                 "tasklist",
                 ResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
+            tuple(
+                TASK_USER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.CREATE, PermissionType.READ)),
             tuple(
                 TASK_USER_ROLE_ID,
                 OwnerType.ROLE,
@@ -115,6 +127,12 @@ public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigratio
                 OwnerType.ROLE,
                 "tasklist",
                 ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)));
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.DOCUMENT,
+                Set.of(PermissionType.READ)));
   }
 }


### PR DESCRIPTION
## Description

The identity migration lacked to create permissions for the document resource
to tasklist related roles/8.7 permissions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40923
