### PR TITLE
feat: send a payload w/ heartbeats if both parties agree on it

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/SbeUtil.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/SbeUtil.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging;
+
+public class SbeUtil {
+  public static BooleanType toSBE(final boolean value) {
+    return value ? BooleanType.TRUE : BooleanType.FALSE;
+  }
+
+  public static boolean toBoolean(final BooleanType booleanType) {
+    // safe to use == as it's an enum
+    return BooleanType.TRUE == booleanType;
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
@@ -3,6 +3,11 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import io.atomix.cluster.messaging.HeartbeatRequestEncoder;
+import io.atomix.cluster.messaging.HeartbeatResponseDecoder;
+import io.atomix.cluster.messaging.HeartbeatResponseEncoder;
+import io.atomix.cluster.messaging.MessageHeaderDecoder;
+import io.atomix.cluster.messaging.MessageHeaderEncoder;
 import io.atomix.cluster.messaging.impl.ProtocolReply.Status;
 import io.atomix.utils.net.Address;
 import io.netty.channel.ChannelDuplexHandler;
@@ -16,6 +21,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.agrona.collections.LongHashSet;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
 /**
@@ -48,7 +54,7 @@ import org.slf4j.Logger;
 abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
   // DO NOT CHANGE: changing the subject is a backward INCOMPATIBLE change.
   static final String HEARTBEAT_SUBJECT = "internal-heartbeat";
-  static final byte[] HEARTBEAT_PAYLOAD = new byte[0];
+  static final byte[] EMPTY_HEARTBEAT_PAYLOAD = new byte[0];
   static final String IDLE_STATE_HANDLER_NAME = "idle";
   static final String HEARTBEAT_HANDLER_NAME = "heartbeat";
 
@@ -61,11 +67,22 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
   }
 
   static final class Server extends HeartbeatHandler {
+    private static final int HEARTBEAT_RESPONSE_SIZE =
+        MessageHeaderEncoder.ENCODED_LENGTH + HeartbeatResponseEncoder.BLOCK_LENGTH;
     private final Duration heartbeatTimeout;
+    private final boolean sendHeartbeatPayload;
+    private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
+    private final HeartbeatResponseEncoder heartbeatResponseEncoder =
+        new HeartbeatResponseEncoder();
 
-    Server(final Logger log, final Duration heartbeatTimeout, final boolean fireHeartbeats) {
+    Server(
+        final Logger log,
+        final Duration heartbeatTimeout,
+        final boolean fireHeartbeats,
+        final boolean sendHeartbeatPayload) {
       super(log, fireHeartbeats);
       this.heartbeatTimeout = heartbeatTimeout;
+      this.sendHeartbeatPayload = sendHeartbeatPayload;
     }
 
     @Override
@@ -86,7 +103,7 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
           && request.subject().equals(HEARTBEAT_SUBJECT)) {
         heartbeatReceived = true;
         ctx.writeAndFlush(createHeartbeat(request.id()));
-        if (!Arrays.equals(request.payload(), HEARTBEAT_PAYLOAD)) {
+        if (!Arrays.equals(request.payload(), EMPTY_HEARTBEAT_PAYLOAD)) {
           log.warn(
               "Received unexpected heartbeat payload from {}, perhaps the message subject {} is accidentally reused",
               request.sender(),
@@ -118,16 +135,31 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
     }
 
     private ProtocolMessage createHeartbeat(final long id) {
-      return new ProtocolReply(id, HEARTBEAT_PAYLOAD, Status.OK);
+      final byte[] payload =
+          sendHeartbeatPayload ? writeHeartbeatResponse() : EMPTY_HEARTBEAT_PAYLOAD;
+      return new ProtocolReply(id, payload, Status.OK);
+    }
+
+    private byte[] writeHeartbeatResponse() {
+      final var heartbeatResponseBuffer = new UnsafeBuffer(new byte[HEARTBEAT_RESPONSE_SIZE]);
+      heartbeatResponseEncoder.wrapAndApplyHeader(heartbeatResponseBuffer, 0, messageHeaderEncoder);
+      heartbeatResponseEncoder.receivedAt(System.currentTimeMillis());
+      return heartbeatResponseBuffer.byteArray();
     }
   }
 
   static final class Client extends HeartbeatHandler {
+    private static final int HEARTBEAT_REQUEST_SIZE =
+        MessageHeaderEncoder.ENCODED_LENGTH + HeartbeatRequestEncoder.BLOCK_LENGTH;
     private final LongHashSet outstandingHeartbeats = new LongHashSet();
     private final AtomicLong messageIdGenerator;
     private final Address advertisedAddress;
     private final Duration heartbeatTimeout;
     private final Duration heartbeatInterval;
+    private final boolean sendHeartbeatPayload;
+    private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
+    private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+    private final HeartbeatRequestEncoder heartbeatRequestEncoder = new HeartbeatRequestEncoder();
 
     Client(
         final Logger log,
@@ -135,12 +167,14 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
         final Address advertisedAddress,
         final Duration heartbeatTimeout,
         final Duration heartbeatInterval,
-        final boolean fireHeartbeats) {
+        final boolean fireHeartbeats,
+        final boolean sendHeartbeatPayload) {
       super(log, fireHeartbeats);
       this.messageIdGenerator = messageIdGenerator;
       this.advertisedAddress = advertisedAddress;
       this.heartbeatTimeout = heartbeatTimeout;
       this.heartbeatInterval = heartbeatInterval;
+      this.sendHeartbeatPayload = sendHeartbeatPayload;
     }
 
     @Override
@@ -161,7 +195,13 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
       boolean heartbeatReceived = forwardHeartbeats;
       if (msg instanceof final ProtocolReply reply) {
-        final var isHeartbeat = outstandingHeartbeats.contains(reply.id());
+        var isHeartbeat = false;
+        if (sendHeartbeatPayload) {
+          messageHeaderDecoder.wrap(new UnsafeBuffer(reply.payload()), 0);
+          isHeartbeat = messageHeaderDecoder.schemaId() == HeartbeatResponseDecoder.SCHEMA_ID;
+        } else {
+          isHeartbeat = reply.payload().length == 0 && outstandingHeartbeats.contains(reply.id());
+        }
         // remove all heartbeats sent before (and equal) to the last ProtocolReply received.
         // Note that all ProtocolReply messages (not just heartbeat messages) can indicate that
         // the channel is still open and transmitting.
@@ -176,11 +216,6 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
 
           if (reply.status() != Status.OK) {
             log.warn("Received a Heartbeat response with status {}", reply.status());
-          } else if (!Arrays.equals(reply.payload(), HEARTBEAT_PAYLOAD)) {
-            log.warn(
-                "Received unexpected heartbeat payload, perhaps the message subject {} is accidentally reused: {}",
-                HEARTBEAT_SUBJECT,
-                reply);
           }
         }
       }
@@ -224,14 +259,21 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
      * @return a heartbeat
      */
     private ProtocolRequest createOutstandingHeartbeat() {
+      final byte[] payload =
+          sendHeartbeatPayload ? writeHeartbeatRequest() : EMPTY_HEARTBEAT_PAYLOAD;
       final var heartbeat =
           new ProtocolRequest(
-              messageIdGenerator.incrementAndGet(),
-              advertisedAddress,
-              HEARTBEAT_SUBJECT,
-              HEARTBEAT_PAYLOAD);
+              messageIdGenerator.incrementAndGet(), advertisedAddress, HEARTBEAT_SUBJECT, payload);
       outstandingHeartbeats.add(heartbeat.id());
       return heartbeat;
+    }
+
+    private byte[] writeHeartbeatRequest() {
+      final UnsafeBuffer heartbeatRequestBuffer =
+          new UnsafeBuffer(new byte[HEARTBEAT_REQUEST_SIZE]);
+      heartbeatRequestEncoder.wrapAndApplyHeader(heartbeatRequestBuffer, 0, messageHeaderEncoder);
+      heartbeatRequestEncoder.sentAt(System.currentTimeMillis());
+      return heartbeatRequestBuffer.byteArray();
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
@@ -132,7 +132,7 @@ abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
     private ProtocolMessage createHeartbeat(final long id) {
       final byte[] payload =
           sendHeartbeatPayload ? writeHeartbeatResponse() : EMPTY_HEARTBEAT_PAYLOAD;
-      log.debug("Heartbeat response payload for req id={} is {}", id, payload);
+      log.trace("Heartbeat response payload for req id={} is {}", id, payload);
       return new ProtocolReply(id, payload, Status.OK);
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatSetupHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatSetupHandler.java
@@ -7,6 +7,8 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import static io.atomix.cluster.messaging.SbeUtil.*;
+
 import io.atomix.cluster.messaging.BooleanType;
 import io.atomix.cluster.messaging.HeartbeatSetupRequestDecoder;
 import io.atomix.cluster.messaging.HeartbeatSetupRequestEncoder;
@@ -30,14 +32,19 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
   protected final String afterHandler;
   protected final Logger log;
   protected final boolean forwardHeartbeats;
+  protected final boolean sendHeartbeatPayload;
   protected final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   protected final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
 
   protected HeartbeatSetupHandler(
-      final String afterHandler, final Logger log, final boolean forwardHeartbeats) {
+      final String afterHandler,
+      final Logger log,
+      final boolean forwardHeartbeats,
+      final boolean sendHeartbeatPayload) {
     this.afterHandler = afterHandler;
     this.log = log;
     this.forwardHeartbeats = forwardHeartbeats;
+    this.sendHeartbeatPayload = sendHeartbeatPayload;
   }
 
   /**
@@ -63,18 +70,23 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
         final Address advertisedAddress,
         final Duration heartbeatTimeout,
         final Duration heartbeatInterval,
-        final boolean forwardHeartbeats) {
-      super(afterHandler, log, forwardHeartbeats);
+        final boolean forwardHeartbeats,
+        final boolean sendHeartbeatPayload) {
+      super(afterHandler, log, forwardHeartbeats, sendHeartbeatPayload);
       this.messageIdGenerator = messageIdGenerator;
       this.advertisedAddress = advertisedAddress;
       this.heartbeatTimeout = heartbeatTimeout;
       this.heartbeatInterval = heartbeatInterval;
+      log.debug(
+          "Creating HeartbeatSetupHandler.Client from {} with sendHeartbeatPayload={}",
+          advertisedAddress,
+          sendHeartbeatPayload);
     }
 
     @Override
     public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
       if (ctx.channel().isActive()) {
-        ctx.writeAndFlush(createHeartbeatRequest());
+        ctx.writeAndFlush(createHeartbeatRequest(sendHeartbeatPayload));
       }
     }
 
@@ -86,8 +98,8 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
         boolean isHeartbeatEnabled = false;
         boolean isPayloadEnabled = false;
         if (decoder != null) {
-          isHeartbeatEnabled = decoder.heartbeatEnabled() == BooleanType.TRUE;
-          isPayloadEnabled = decoder.sendPayload() == BooleanType.TRUE;
+          isHeartbeatEnabled = toBoolean(decoder.heartbeatEnabled());
+          isPayloadEnabled = toBoolean(decoder.sendPayload());
         }
         log.trace(
             "Received HeartbeatResponse: id={}, heartbeatEnabled={}, isPayloadEnabled={}",
@@ -122,11 +134,11 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
           [MessageHeaderEncoder.ENCODED_LENGTH + HeartbeatSetupRequestEncoder.BLOCK_LENGTH];
     }
 
-    private ProtocolRequest createHeartbeatRequest() {
+    private ProtocolRequest createHeartbeatRequest(final boolean sendPayload) {
       final var bytes = allocateRequestBuffer();
       final var buffer = new UnsafeBuffer(bytes);
       requestEncoder.wrapAndApplyHeader(buffer, 0, headerEncoder);
-      requestEncoder.heartbeatTimeout(heartbeatTimeout.toMillis()).sendPayload(BooleanType.TRUE);
+      requestEncoder.heartbeatTimeout(heartbeatTimeout.toMillis()).sendPayload(toSBE(sendPayload));
       heartbeatRequestId = messageIdGenerator.incrementAndGet();
       return new ProtocolRequest(
           heartbeatRequestId, advertisedAddress, HEARTBEAT_SETUP_SUBJECT, bytes);
@@ -154,8 +166,15 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
     private final HeartbeatSetupResponseEncoder responseEncoder =
         new HeartbeatSetupResponseEncoder();
 
-    public Server(final String afterHandler, final Logger log, final boolean forwardHeartbeats) {
-      super(afterHandler, log, forwardHeartbeats);
+    public Server(
+        final String afterHandler,
+        final Logger log,
+        final boolean forwardHeartbeats,
+        final boolean sendHeartbeatPayload) {
+      super(afterHandler, log, forwardHeartbeats, sendHeartbeatPayload);
+      log.debug(
+          "Creating HeartbeatSetupHandler.Server with sendHeartbeatPayload={}",
+          sendHeartbeatPayload);
     }
 
     @Override
@@ -165,16 +184,19 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
           && request.subject().equals(HEARTBEAT_SETUP_SUBJECT)) {
         final var decoder = heartbeatTimeout(request.payload());
         long timeout = 0;
-        boolean sendPayload = false;
+        boolean sendPayloadInRequest = false;
         if (decoder != null) {
           timeout = decoder.heartbeatTimeout();
-          sendPayload = decoder.sendPayload() == BooleanType.TRUE;
+          sendPayloadInRequest = toBoolean(decoder.sendPayload());
         }
+        final var sendPayload = sendHeartbeatPayload && sendPayloadInRequest;
         if (timeout > 0) {
           log.trace(
-              "Received heartbeat request: id:{}, heartbeatTimeout={} millis",
+              "Received heartbeat request: id:{}, heartbeatTimeout={} millis, sendPayload={}: server will send payload? {}",
               request.id(),
-              timeout);
+              timeout,
+              sendPayloadInRequest,
+              sendPayload);
           ctx.pipeline()
               .addAfter(
                   afterHandler,
@@ -184,7 +206,7 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
         }
         // the heartbeat setup is done, no need to stay in the pipeline
         ctx.pipeline().remove(this);
-        ctx.writeAndFlush(heartbeatResponse(request.id()));
+        ctx.writeAndFlush(heartbeatResponse(request.id(), sendPayload));
 
         ReferenceCountUtil.release(msg);
       } else {
@@ -204,11 +226,17 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
       }
     }
 
-    private ProtocolReply heartbeatResponse(final long id) {
+    /**
+     * @param id of the request
+     * @param sendPayload if we should reply with sendPayload or not. Note that if the client did
+     *     send sendPayload=false, we should send false even the server supports them.
+     */
+    private ProtocolReply heartbeatResponse(final long id, final boolean sendPayload) {
       final var bytes = allocateResponseBuffer();
       final var buffer = new UnsafeBuffer(bytes);
       responseEncoder.wrapAndApplyHeader(buffer, 0, headerEncoder);
       responseEncoder.heartbeatEnabled(BooleanType.TRUE);
+      responseEncoder.sendPayload(toSBE(sendPayload));
       return new ProtocolReply(id, bytes, Status.OK);
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatSetupHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatSetupHandler.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler {
 
@@ -54,6 +55,7 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
    */
   public static final class Client extends HeartbeatSetupHandler {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Client.class);
     final AtomicLong messageIdGenerator;
     private final Address advertisedAddress;
     private final Duration heartbeatTimeout;
@@ -65,14 +67,13 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
 
     public Client(
         final String afterHandler,
-        final Logger log,
         final AtomicLong messageIdGenerator,
         final Address advertisedAddress,
         final Duration heartbeatTimeout,
         final Duration heartbeatInterval,
         final boolean forwardHeartbeats,
         final boolean sendHeartbeatPayload) {
-      super(afterHandler, log, forwardHeartbeats, sendHeartbeatPayload);
+      super(afterHandler, LOG, forwardHeartbeats, sendHeartbeatPayload);
       this.messageIdGenerator = messageIdGenerator;
       this.advertisedAddress = advertisedAddress;
       this.heartbeatTimeout = heartbeatTimeout;
@@ -162,16 +163,16 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
    * a {@link HeartbeatHandler.Server}
    */
   public static final class Server extends HeartbeatSetupHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(Server.class);
     private final HeartbeatSetupRequestDecoder requestDecoder = new HeartbeatSetupRequestDecoder();
     private final HeartbeatSetupResponseEncoder responseEncoder =
         new HeartbeatSetupResponseEncoder();
 
     public Server(
         final String afterHandler,
-        final Logger log,
         final boolean forwardHeartbeats,
         final boolean sendHeartbeatPayload) {
-      super(afterHandler, log, forwardHeartbeats, sendHeartbeatPayload);
+      super(afterHandler, LOG, forwardHeartbeats, sendHeartbeatPayload);
       log.debug(
           "Creating HeartbeatSetupHandler.Server with sendHeartbeatPayload={}",
           sendHeartbeatPayload);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatSetupHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatSetupHandler.java
@@ -151,7 +151,7 @@ public abstract sealed class HeartbeatSetupHandler extends ChannelDuplexHandler 
         responseDecoder.wrapAndApplyHeader(buffer, 0, headerDecoder);
         return responseDecoder;
       } catch (final IllegalStateException e) {
-        log.warn("Unable to decode heartbeat response, heartbeats are disabled.", e);
+        log.info("Unable to decode heartbeat response, heartbeats are disabled.", e);
         return null;
       }
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -147,6 +147,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
 
   // flag for passing heartbeats down the pipeline
   private boolean forwardHeartbeats = false;
+  private boolean sendHeartbeatPayload = true;
   private boolean heartbeatsEnabled = true;
 
   public NettyMessagingService(
@@ -955,6 +956,11 @@ public final class NettyMessagingService implements ManagedMessagingService {
     heartbeatsEnabled = false;
   }
 
+  @VisibleForTesting
+  void noHeartbeatPayload() {
+    sendHeartbeatPayload = false;
+  }
+
   /** Channel initializer for basic connections. */
   private class BasicClientChannelInitializer extends ChannelInitializer<SocketChannel> {
 
@@ -1157,7 +1163,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
                     advertisedAddress,
                     config.getHeartbeatTimeout(),
                     config.getHeartbeatInterval(),
-                    forwardHeartbeats));
+                    forwardHeartbeats,
+                    sendHeartbeatPayload));
       }
       future.complete(context.channel());
     }
@@ -1206,7 +1213,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
             .addBefore(
                 MESSAGE_DISPATCHER_NAME,
                 "heartbeat-setup",
-                new HeartbeatSetupHandler.Server("decoder", log, forwardHeartbeats));
+                new HeartbeatSetupHandler.Server(
+                    "decoder", log, forwardHeartbeats, sendHeartbeatPayload));
       }
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -1158,7 +1158,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
                 "heartbeat-setup",
                 new HeartbeatSetupHandler.Client(
                     "decoder",
-                    log,
                     messageIdGenerator,
                     advertisedAddress,
                     config.getHeartbeatTimeout(),
@@ -1214,7 +1213,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
                 MESSAGE_DISPATCHER_NAME,
                 "heartbeat-setup",
                 new HeartbeatSetupHandler.Server(
-                    "decoder", log, forwardHeartbeats, sendHeartbeatPayload));
+                    "decoder", forwardHeartbeats, sendHeartbeatPayload));
       }
     }
   }

--- a/zeebe/atomix/cluster/src/main/resources/cluster-messaging.xml
+++ b/zeebe/atomix/cluster/src/main/resources/cluster-messaging.xml
@@ -8,7 +8,7 @@
   -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.atomix.cluster.messaging" id="10" version="1"
+  package="io.atomix.cluster.messaging" id="10" version="2"
   semanticVersion="0.1.0" description="Broker messages" byteOrder="littleEndian"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://fixprotocol.io/2016/sbe http://fixprotocol.io/2016/sbe/sbe.xsd">
@@ -17,10 +17,20 @@
 
   <sbe:message name="HeartbeatSetupRequest" id="1">
     <field name="heartbeatTimeout" id="0" type="uint32"/>
+    <field name="sendPayload" id="1" type="BooleanType" defaultValue="false" optional="true" sinceVersion="2"/>
   </sbe:message>
 
   <sbe:message name="HeartbeatSetupResponse" id="2">
     <field name="heartbeatEnabled" id="0" type="BooleanType" />
+    <field name="sendPayload" id="1" type="BooleanType" defaultValue="false" optional="true" sinceVersion="2"/>
+  </sbe:message>
+
+  <sbe:message name="HeartbeatRequest" id="3" sinceVersion="2">
+    <field name="sentAt" id="0" type="uint64" />
+  </sbe:message>
+
+  <sbe:message name="HeartbeatResponse" id="4" sinceVersion="2">
+    <field name="receivedAt" id="0" type="uint64" />
   </sbe:message>
 
 </sbe:messageSchema>

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -226,32 +226,16 @@ final class NettyMessagingServiceTest {
                         .isNotNull()
                         .satisfies(heartbeat -> assertThat(heartbeat.receivedAt()).isPositive());
                   } else {
-                    // At least one party doesn't support payloads: verify empty heartbeats
-                    assertThat(
-                            emptyHeartbeatFromClientReceived.get()
-                                || heartbeatFromClient.get() != null)
-                        .as("Heartbeat from client should be received (empty or with payload)")
-                        .isTrue();
-                    assertThat(
-                            emptyHeartbeatResponseFromServerReceived.get()
-                                || heartbeatResponseFromServer.get() != null)
+                    // At least one party doesn't support payloads: negotiation requires both to
+                    // agree, so empty heartbeats are exchanged
+                    assertThat(emptyHeartbeatFromClientReceived.get())
                         .as(
-                            "Heartbeat response from server should be received (empty or with payload)")
+                            "Client should send empty heartbeats when negotiation results in no payload support")
                         .isTrue();
-
-                    // Additionally verify that at least one side has empty payload as expected
-                    if (!clientSupportsPayload) {
-                      assertThat(emptyHeartbeatFromClientReceived.get())
-                          .as(
-                              "Client should send empty heartbeats when it doesn't support payloads")
-                          .isTrue();
-                    }
-                    if (!serverSupportsPayload) {
-                      assertThat(emptyHeartbeatResponseFromServerReceived.get())
-                          .as(
-                              "Server should send empty heartbeat responses when it doesn't support payloads")
-                          .isTrue();
-                    }
+                    assertThat(emptyHeartbeatResponseFromServerReceived.get())
+                        .as(
+                            "Server should send empty heartbeat responses when negotiation results in no payload support")
+                        .isTrue();
                   }
                 });
       }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -21,7 +21,10 @@ import static org.assertj.core.api.Assertions.*;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.sun.security.auth.module.UnixSystem;
+import io.atomix.cluster.messaging.HeartbeatRequestDecoder;
+import io.atomix.cluster.messaging.HeartbeatResponseDecoder;
 import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.atomix.cluster.messaging.MessageHeaderDecoder;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.utils.net.Address;
@@ -52,8 +55,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.agrona.collections.MutableReference;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +69,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /** Netty messaging service test. */
 final class NettyMessagingServiceTest {
@@ -120,6 +130,97 @@ final class NettyMessagingServiceTest {
               return Long.parseLong(columns[UID_COLUMN]) == uid;
             })
         .count();
+  }
+
+  @Nested
+  final class HeartbeatPayloadTest {
+
+    static Stream<Arguments> sendPayloadArguments() {
+      final Supplier<Stream<Boolean>> booleans = () -> Stream.of(true, false);
+      return booleans.get().flatMap(b1 -> booleans.get().map(b2 -> Arguments.of(b1, b2)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("sendPayloadArguments")
+    void shouldSendHeartbeatPayloadIfConfigured(
+        final boolean clientSupportsPayload, final boolean serverSupportsPayload) throws Exception {
+      try (final var clientNetty = newMessagingService();
+          final var serverNetty = newMessagingService()) {
+        clientNetty.enableHeartbeatsForwarding();
+        serverNetty.enableHeartbeatsForwarding();
+        if (!clientSupportsPayload) {
+          clientNetty.noHeartbeatPayload();
+        }
+        if (!serverSupportsPayload) {
+          serverNetty.noHeartbeatPayload();
+        }
+        clientNetty.start().join();
+        serverNetty.start().join();
+        final var heartbeatFromClient = new MutableReference<HeartbeatRequestDecoder>(null);
+        serverNetty.registerHandler(
+            HeartbeatHandler.HEARTBEAT_SUBJECT,
+            (BiConsumer<Address, byte[]>)
+                (addr, payload) -> {
+                  if (payload != null && payload.length > 0) {
+                    heartbeatFromClient.set(
+                        new HeartbeatRequestDecoder()
+                            .wrapAndApplyHeader(
+                                new UnsafeBuffer(payload), 0, new MessageHeaderDecoder()));
+                  }
+                },
+            Runnable::run);
+
+        // when - connect and intercept heartbeat responses from server
+        final var heartbeatResponseFromServer =
+            new MutableReference<HeartbeatResponseDecoder>(null);
+        final var clientChannel =
+            clientNetty.getChannelPool().getChannel(serverNetty.address(), "test").join();
+
+        // Wait for heartbeat handler to be installed (after setup completes)
+        Awaitility.await("Until heartbeat handler is installed")
+            .until(
+                () ->
+                    clientChannel.pipeline().get(HeartbeatHandler.HEARTBEAT_HANDLER_NAME) != null);
+
+        // add interceptor before heartbeat handler to capture ProtocolReply
+        final var interceptingHandler =
+            new ChannelInboundHandlerAdapter() {
+              @Override
+              public void channelRead(final ChannelHandlerContext ctx, final Object msg)
+                  throws Exception {
+                if (msg instanceof final ProtocolReply reply
+                    && reply.payload() != null
+                    && reply.payload().length > 0) {
+                  heartbeatResponseFromServer.set(
+                      new HeartbeatResponseDecoder()
+                          .wrapAndApplyHeader(
+                              new UnsafeBuffer(reply.payload()), 0, new MessageHeaderDecoder()));
+                }
+                ctx.fireChannelRead(msg);
+              }
+            };
+        clientChannel
+            .pipeline()
+            .addBefore(
+                HeartbeatHandler.HEARTBEAT_HANDLER_NAME, "test-interceptor", interceptingHandler);
+
+        // then - payload should have content only when both client and server support
+        // it
+        Awaitility.await("Until heartbeats payloads are received")
+            .atMost(Duration.ofSeconds(2))
+            .untilAsserted(
+                () -> {
+                  if (clientSupportsPayload && serverSupportsPayload) {
+                    assertThat(heartbeatFromClient.get())
+                        .isNotNull()
+                        .satisfies(heartbeat -> assertThat(heartbeat.sentAt()).isPositive());
+                    assertThat(heartbeatResponseFromServer.get())
+                        .isNotNull()
+                        .satisfies(heartbeat -> assertThat(heartbeat.receivedAt()).isPositive());
+                  }
+                });
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Description
- Add new HeartbeatRequest and HeartbeatResponse messages with optional fields for backward compatibility (schema version 2)
- Implement heartbeat payload negotiation during handshake, where each party indicates if they support attaching payloads to heartbeats
- Allow client/server to be configured to send heartbeats with or without payloads
- Add tests covering all 4 combinations of heartbeat enabled/disabled for both client and server

### Details

This PR introduces a configurable heartbeat payload mechanism. During the handshake phase, both client and server communicate whether they can attach payloads to heartbeats. For backward compatibility with older clients, the SBE protocol defaults to BooleanType.NULL (treated as not supporting payloads).
The implementation allows heartbeat messages to be identified by inspecting their schemaId, and includes tests that verify correct message decoding and timestamp setting across all configuration combinations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
closes #27110 
