### PR TITLE
C8Run regression tests workflow adjustment

### DIFF
--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -6,8 +6,8 @@ name: C8Run RDBMS Regression Tests
 
 on:
   pull_request:
-    branches:
-      - main
+    paths:
+      - "c8run/**"
   workflow_dispatch:
     inputs:
       branch:
@@ -39,7 +39,7 @@ jobs:
   build_and_test_c8run:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       fail-fast: false
       matrix:
         env: [ 'local' ]


### PR DESCRIPTION
This pull request updates the workflow configuration for running RDBMS regression tests, focusing on when the workflow is triggered and how jobs are parallelized.

Workflow trigger changes:

* The workflow will now run on pull requests that modify files in the `c8run/**` path, instead of any changes to the `main` branch.

Job parallelization changes:

* The maximum number of parallel jobs for the `build_and_test_c8run` job has been reduced from 2 to 1, limiting concurrency.
