### PR TITLE
feat: Expose dbType via API

### DIFF
--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-utils</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
@@ -265,6 +270,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operate/common/src/main/java/io/camunda/operate/EnvironmentService.java
+++ b/operate/common/src/main/java/io/camunda/operate/EnvironmentService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate;
+
+import io.camunda.spring.utils.DatabaseTypeUtils;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnvironmentService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentService.class);
+
+  private final Environment environment;
+  private final Map<String, String> databaseTypes =
+      Map.of(
+          "elasticsearch", "document-store",
+          "opensearch", "document-store",
+          "rdbms", "rdbms",
+          "none", "none");
+
+  public EnvironmentService(final Environment environment) {
+    this.environment = environment;
+  }
+
+  public String getDatabaseType() {
+    final var dbType = DatabaseTypeUtils.getDatabaseTypeOrDefault(environment);
+    if (!databaseTypes.containsKey(dbType)) {
+      LOGGER.warn("Could not identify database type: {}", dbType);
+      return "unknown";
+    }
+    return databaseTypes.get(dbType);
+  }
+}

--- a/operate/common/src/test/java/io/camunda/operate/EnvironmentServiceTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/EnvironmentServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate;
+
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.core.env.Environment;
+
+public class EnvironmentServiceTest {
+
+  private EnvironmentService environmentService;
+  private Environment mockEnvironment;
+
+  @BeforeEach
+  public void setup() {
+    mockEnvironment = mock(Environment.class);
+    environmentService = new EnvironmentService(mockEnvironment);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "elasticsearch, document-store",
+    "opensearch, document-store",
+    "rdbms, rdbms",
+    "none, none",
+    "invalid, unknown"
+  })
+  void testGetDatabaseType(final String environmentValue, final String expectedOutput) {
+    // given
+    when(mockEnvironment.getProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE))
+        .thenReturn(environmentValue);
+
+    // when
+    final String result = environmentService.getDatabaseType();
+
+    // then
+    assertThat(result).isEqualTo(expectedOutput);
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceEnterpriseIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceEnterpriseIT.java
@@ -16,6 +16,7 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.operate.EnvironmentService;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -34,6 +35,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
     classes = {
       TestApplicationWithNoBeans.class,
       OperateProfileService.class,
+      EnvironmentService.class,
       ClientConfig.class,
       ClientConfigRestService.class,
       JacksonConfig.class,
@@ -81,7 +83,8 @@ public class ClientConfigRestServiceEnterpriseIT extends OperateAbstractIT {
                 + "\"isLoginDelegated\":false,"
                 + "\"tasklistUrl\":null,"
                 + "\"resourcePermissionsEnabled\":false,"
-                + "\"multiTenancyEnabled\":true"
+                + "\"multiTenancyEnabled\":true,"
+                + "\"databaseType\":\"document-store\""
                 + "};");
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ClientConfigRestServiceIT.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.operate.EnvironmentService;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -61,6 +62,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 public class ClientConfigRestServiceIT extends OperateAbstractIT {
 
   @MockitoBean private OperateProfileService operateProfileService;
+  @MockitoBean private EnvironmentService environmentService;
   @MockitoBean private SecurityConfiguration securityConfiguration;
   @MockitoBean private AuthorizationsConfiguration authorizationsConfiguration;
   @MockitoBean private AuthenticationConfiguration authenticationConfiguration;
@@ -77,6 +79,7 @@ public class ClientConfigRestServiceIT extends OperateAbstractIT {
     given(securityConfiguration.getMultiTenancy()).willReturn(multiTenancyConfiguration);
     given(authenticationConfiguration.getOidc()).willReturn(oidcAuthenticationConfiguration);
     given(operateProfileService.isLoginDelegated()).willReturn(true);
+    given(environmentService.getDatabaseType()).willReturn("document-store");
   }
 
   @Test
@@ -109,7 +112,8 @@ public class ClientConfigRestServiceIT extends OperateAbstractIT {
                 + "\"isLoginDelegated\":true,"
                 + "\"tasklistUrl\":\"https://tasklist.camunda.io/tl\","
                 + "\"resourcePermissionsEnabled\":true,"
-                + "\"multiTenancyEnabled\":false"
+                + "\"multiTenancyEnabled\":false,"
+                + "\"databaseType\":\"document-store\""
                 + "};");
   }
 
@@ -143,7 +147,8 @@ public class ClientConfigRestServiceIT extends OperateAbstractIT {
                 + "\"isLoginDelegated\":true,"
                 + "\"tasklistUrl\":null,"
                 + "\"resourcePermissionsEnabled\":true,"
-                + "\"multiTenancyEnabled\":false"
+                + "\"multiTenancyEnabled\":false,"
+                + "\"databaseType\":\"document-store\""
                 + "};");
   }
 
@@ -179,7 +184,8 @@ public class ClientConfigRestServiceIT extends OperateAbstractIT {
                 + "\"isLoginDelegated\":true,"
                 + "\"tasklistUrl\":null,"
                 + "\"resourcePermissionsEnabled\":true,"
-                + "\"multiTenancyEnabled\":false"
+                + "\"multiTenancyEnabled\":false,"
+                + "\"databaseType\":\"document-store\""
                 + "};");
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.EnvironmentService;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -31,7 +32,9 @@ public class ClientConfig {
   public String tasklistUrl;
   public boolean resourcePermissionsEnabled;
   public boolean multiTenancyEnabled;
+  public String databaseType;
   @Autowired private OperateProfileService profileService;
+  @Autowired private EnvironmentService environmentService;
   @Autowired private OperateProperties operateProperties;
   @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private ServletContext context;
@@ -50,6 +53,7 @@ public class ClientConfig {
     tasklistUrl = operateProperties.getTasklistUrl();
     resourcePermissionsEnabled = securityConfiguration.getAuthorizations().isEnabled();
     multiTenancyEnabled = securityConfiguration.getMultiTenancy().isChecksEnabled();
+    databaseType = environmentService.getDatabaseType();
     try {
       return String.format(
           "window.clientConfig = %s;", new ObjectMapper().writeValueAsString(this));

--- a/spring-utils/src/main/java/io/camunda/spring/utils/DatabaseTypeUtils.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/DatabaseTypeUtils.java
@@ -35,7 +35,7 @@ public final class DatabaseTypeUtils {
    * @param env the Spring environment
    * @return the database type or "elasticsearch" if not set
    */
-  private static String getDatabaseTypeOrDefault(final Environment env) {
+  public static String getDatabaseTypeOrDefault(final Environment env) {
     return Optional.ofNullable(env.getProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE))
         .orElse("elasticsearch");
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR extends the response of `/operate/client-config.js` with the `databaseType` field

1: When Elasticsearch/Opensearch is used

```
GET http://localhost:8080/operate/client-config.js

Response
----------
window.clientConfig = { "isEnterprise": false, "canLogout": true, "contextPath": "", "baseName": "/operate", "organizationId": null, "clusterId": null, "mixpanelAPIHost": null, "mixpanelToken": null, "isLoginDelegated": false, "tasklistUrl": null, "resourcePermissionsEnabled": false, "multiTenancyEnabled": false, "databaseType": "document-store" };
```

2: When RDBMS is used

```
GET http://localhost:8080/operate/client-config.js

Response
----------
window.clientConfig = { "isEnterprise": false, "canLogout": true, "contextPath": "", "baseName": "/operate", "organizationId": null, "clusterId": null, "mixpanelAPIHost": null, "mixpanelToken": null, "isLoginDelegated": false, "tasklistUrl": null, "resourcePermissionsEnabled": false, "multiTenancyEnabled": false, "databaseType": "rdbms" };
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39306
