### PR TITLE
perf: when reading object do not start matching from first property

### DIFF
--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -103,8 +103,10 @@ public class ObjectValue extends BaseValue {
       BaseProperty<? extends BaseValue> prop = null;
 
       for (int k = 0; k < declaredProperties.size(); ++k) {
-        // optimistically start from the same index as the map
-        // we serialize the keys in order, it's our best guess
+        // Cycle on all declared properties, but start iterating through them
+        // by starting on i:
+        // keys are serialized in the same order, so in most cases we can find the right
+        // key without having to iterate on declaredProperties at all.
         final var index = (i + k) % declaredProperties.size();
         final BaseProperty<?> declaredProperty = declaredProperties.get(index);
         final StringValue declaredKey = declaredProperty.getKey();

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -128,14 +128,7 @@ public class ObjectValue extends BaseValue {
       }
     }
 
-    // verify that all required properties are set
-    for (int p = 0; p < declaredProperties.size(); p++) {
-      final BaseProperty<?> prop = declaredProperties.get(p);
-      if (!prop.hasValue()) {
-        throw new RuntimeException(
-            String.format("Property '%s' has no valid value", prop.getKey()));
-      }
-    }
+    verifyAllDeclaredPropertiesAreSet();
   }
 
   @Override
@@ -159,6 +152,15 @@ public class ObjectValue extends BaseValue {
 
     builder.append("}");
     return builder.toString();
+  }
+
+  private void verifyAllDeclaredPropertiesAreSet() {
+    for (final BaseProperty<?> prop : declaredProperties) {
+      if (!prop.hasValue()) {
+        throw new RuntimeException(
+            String.format("Property '%s' has no valid value", prop.getKey()));
+      }
+    }
   }
 
   private <T extends BaseProperty<?>> void writeJson(

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -103,7 +103,10 @@ public class ObjectValue extends BaseValue {
       BaseProperty<? extends BaseValue> prop = null;
 
       for (int k = 0; k < declaredProperties.size(); ++k) {
-        final BaseProperty<?> declaredProperty = declaredProperties.get(k);
+        // optimistically start from the same index as the map
+        // we serialize the keys in order, it's our best guess
+        final var index = (i + k) % declaredProperties.size();
+        final BaseProperty<?> declaredProperty = declaredProperties.get(index);
         final StringValue declaredKey = declaredProperty.getKey();
 
         if (declaredKey.equals(decodedKey)) {
@@ -142,6 +145,18 @@ public class ObjectValue extends BaseValue {
     length += getEncodedLength(undeclaredProperties);
 
     return length;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("{");
+
+    writeJson(builder, declaredProperties, true);
+    writeJson(builder, undeclaredProperties, true);
+
+    builder.append("}");
+    return builder.toString();
   }
 
   private <T extends BaseProperty<?>> void writeJson(
@@ -207,17 +222,5 @@ public class ObjectValue extends BaseValue {
 
   public boolean isEmpty() {
     return declaredProperties.isEmpty() && undeclaredProperties.isEmpty();
-  }
-
-  @Override
-  public String toString() {
-    final StringBuilder builder = new StringBuilder();
-    builder.append("{");
-
-    writeJson(builder, declaredProperties, true);
-    writeJson(builder, undeclaredProperties, true);
-
-    builder.append("}");
-    return builder.toString();
   }
 }


### PR DESCRIPTION
## Description
The double loop in the `read()` method of `ObjectValue` is potential O(N^2) as it iterates over every property defined for every property in the map.

Because it starts from the first property every time it's asymptotic is 
$$\sum_{i=0}^{n-1} i = 0 + 1 + 2 + \ldots + (n-1) = \frac{(n-1)n}{2}$$

With this change, we assume that the object was serialized in the same order defined, so our best guess is to start from the same index in the map. This reduces the iterations to O(n) in the best case. 

There's no microbenchmark created, by I checked that when the fields are serialized in the correct order, then the inner loop just execute the first iteration.
In `ObjectMappingTest` when the fields are reordered it was taking 28 iteration for 7 fields, while with this "fix" it takes just 7.

Some results from a benchmark deployed:

- CPU Usage
<img width="3019" height="715" alt="image" src="https://github.com/user-attachments/assets/629623ee-ac17-492f-b557-497f3f3334b8" />

- Latency > Record processing duration: p99 JOB_COMPLETE/JOB_ACTIVATE:
<img width="3375" height="469" alt="image" src="https://github.com/user-attachments/assets/f3d10fc9-8aba-4b36-b631-784d3b325178" />
Lower percentiles show less difference, probably because p99 is influenced mostly by CPU throttling, which is higher for the `main` version. For lower percentiles the difference is in the order of 4%. 

<img width="3375" height="490" alt="image" src="https://github.com/user-attachments/assets/42ba7181-b831-4a3c-a42c-4ae5303d7e20" />

I think the small difference in the p50 does not explain fully the difference in CPU usage, but there are other places where the deserialization happens. However, the weekly benchmark has been running for a while and the environment is not that controlled. 



## Checklist
- [x] Microbenchmarks module defined in #41014
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
