### PR TITLE
build: update zeebe-test-containers to 3.6.9 to fix RollingUpdateTest

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,7 +97,7 @@
     <version.testcontainer-mariadb>1.20.0</version.testcontainer-mariadb>
     <version.postgressql-testcontainer>1.20.1</version.postgressql-testcontainer>
     <version.netflix.concurrency>0.5.3</version.netflix.concurrency>
-    <version.zeebe-test-container>3.6.8</version.zeebe-test-container>
+    <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
     <version.feel-scala>1.19.3</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.5</version.rest-assured>


### PR DESCRIPTION
## Description
The fix for this test was done in zeebe-test-containers, in the latest released version

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40683 
