### PR TITLE
[Backport stable/8.7] fix: reject modifications that terminate flow scopes required by activation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -123,6 +123,23 @@ public final class ProcessInstanceModificationModifyProcessor
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
       with an ancestor scope key that is not an ancestor of the element to activate:%s""";
 
+<<<<<<< HEAD
+=======
+  private static final String ERROR_MESSAGE_PROCESS_INSTANCE_SUSPENDED =
+      """
+      Expected to modify instance of process '%s' but it is currently suspended. \
+      Suspended process instances cannot be modified.""";
+
+  private static final String ERROR_MESSAGE_ACTIVATION_FLOW_SCOPE_TERMINATED =
+      """
+      Expected to modify instance of process '%s' but it contains one or more activate instructions \
+      for elements whose required flow scope instance is also being terminated: %s. \
+      Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.""";
+
+  private static final String ERROR_MESSAGE_ACTIVATION_FLOW_SCOPE_CONFLICT =
+      "element '%s' requires flow scope instance '%d' which is being terminated";
+
+>>>>>>> a179c426 (fix: activation without flow scope is rejected)
   private static final EnumSet<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.of(
           BpmnElementType.UNSPECIFIED,
@@ -319,6 +336,10 @@ public final class ProcessInstanceModificationModifyProcessor
         .flatMap(valid -> validateVariableScopeExists(process, activateInstructions))
         .flatMap(valid -> validateVariableScopeIsFlowScope(process, activateInstructions))
         .flatMap(valid -> validateAncestorKeys(process, value))
+        .flatMap(
+            valid ->
+                validateElementIsNotActivatedForTerminatedFlowScope(
+                    process, activateInstructions, terminateInstructions))
         .map(valid -> VALID);
   }
 
@@ -644,6 +665,71 @@ public final class ProcessInstanceModificationModifyProcessor
     }
 
     return false;
+  }
+
+  private Either<Rejection, ?> validateElementIsNotActivatedForTerminatedFlowScope(
+      final DeployedProcess process,
+      final List<ProcessInstanceModificationActivateInstructionValue> activateInstructions,
+      final List<ProcessInstanceModificationTerminateInstructionValue> terminateInstructions) {
+    // Collect all terminate instance keys
+    final Set<Long> terminatedInstanceKeys =
+        terminateInstructions.stream()
+            .map(ProcessInstanceModificationTerminateInstructionValue::getElementInstanceKey)
+            .collect(Collectors.toSet());
+
+    final List<String> conflictingActivations = new ArrayList<>();
+    for (final var terminatedInstanceKey : terminatedInstanceKeys) {
+      final var terminatedInstance = elementInstanceState.getInstance(terminatedInstanceKey);
+      if (terminatedInstance == null) {
+        // this should be already validated in validateElementInstanceExists
+        continue;
+      }
+
+      final var terminatedElement =
+          process.getProcess().getElementById(terminatedInstance.getValue().getElementId());
+      // Find all elements that have the terminated element as flow scope
+      // consider nested flow scopes as well as activate instructions that has ancestor scope key
+      // set
+      final var conflictingElements =
+          activateInstructions.stream()
+              .filter(
+                  activationInstruction -> {
+                    final var elementToActivate =
+                        process.getProcess().getElementById(activationInstruction.getElementId());
+
+                    if (activationInstruction.getAncestorScopeKey() > 0) {
+                      // if ancestor scope key is set, check if it matches the terminated instance
+                      // key
+                      return activationInstruction.getAncestorScopeKey() == terminatedInstanceKey;
+                    }
+
+                    final String terminatedElementId =
+                        BufferUtil.bufferAsString(terminatedElement.getId());
+
+                    return isFlowScopeOfElement(elementToActivate, terminatedElementId);
+                  })
+              .toList();
+
+      for (final var conflictingElement : conflictingElements) {
+        conflictingActivations.add(
+            String.format(
+                ERROR_MESSAGE_ACTIVATION_FLOW_SCOPE_CONFLICT,
+                conflictingElement.getElementId(),
+                terminatedInstanceKey));
+      }
+    }
+
+    if (conflictingActivations.isEmpty()) {
+      return VALID;
+    }
+
+    final String reason =
+        String.format(
+            ERROR_MESSAGE_ACTIVATION_FLOW_SCOPE_TERMINATED,
+            BufferUtil.bufferAsString(process.getBpmnProcessId()),
+            String.join(", ", conflictingActivations));
+
+    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
   }
 
   public void executeVariableInstruction(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -123,13 +123,6 @@ public final class ProcessInstanceModificationModifyProcessor
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
       with an ancestor scope key that is not an ancestor of the element to activate:%s""";
 
-<<<<<<< HEAD
-=======
-  private static final String ERROR_MESSAGE_PROCESS_INSTANCE_SUSPENDED =
-      """
-      Expected to modify instance of process '%s' but it is currently suspended. \
-      Suspended process instances cannot be modified.""";
-
   private static final String ERROR_MESSAGE_ACTIVATION_FLOW_SCOPE_TERMINATED =
       """
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
@@ -139,7 +132,6 @@ public final class ProcessInstanceModificationModifyProcessor
   private static final String ERROR_MESSAGE_ACTIVATION_FLOW_SCOPE_CONFLICT =
       "element '%s' requires flow scope instance '%d' which is being terminated";
 
->>>>>>> a179c426 (fix: activation without flow scope is rejected)
   private static final EnumSet<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.of(
           BpmnElementType.UNSPECIFIED,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -879,4 +879,467 @@ public class ModifyProcessInstanceRejectionTest {
                 modified process instance: '%d'"""
                 .formatted(PROCESS_ID, subProcessKeyTwo));
   }
+
+  @Test
+  public void shouldRejectActivationWhenFlowScopeIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .endEvent("sub-end"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("sub-end")
+            .terminateElement(subProcessElementInstance.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect that activation is rejected when flow scope is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+              Expected to modify instance of process '%s' but it contains one or more activate instructions \
+              for elements whose required flow scope instance is also being terminated: element 'sub-end' requires flow scope instance '%s' \
+              which is being terminated. Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope."""
+                .formatted(PROCESS_ID, subProcessElementInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectMultipleActivationsWhenFlowScopeIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .serviceTask("B", b -> b.zeebeJobType("B"))
+                            .endEvent("sub-end"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("A")
+            .activateElement("B")
+            .terminateElement(subProcessElementInstance.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect that multiple activations are rejected when flow scope is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions "
+                    + "for elements whose required flow scope instance is also being terminated: "
+                    + "element 'A' requires flow scope instance '%s' which is being terminated, "
+                    + "element 'B' requires flow scope instance '%s' which is being terminated. "
+                    + "Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.")
+                .formatted(
+                    PROCESS_ID,
+                    subProcessElementInstance.getKey(),
+                    subProcessElementInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectOnlyInvalidActivationsWhenFlowScopeIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .serviceTask("B", b -> b.zeebeJobType("B"))
+                            .endEvent("sub-end"))
+                .serviceTask("C", c -> c.zeebeJobType("C"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("B") // inside terminated scope
+            .activateElement("C") // outside terminated scope
+            .terminateElement(subProcessElementInstance.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs(
+            "Expect that only invalid activation is rejected when flow scope is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions "
+                    + "for elements whose required flow scope instance is also being terminated: "
+                    + "element 'B' requires flow scope instance '%s' which is being terminated. "
+                    + "Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.")
+                .formatted(PROCESS_ID, subProcessElementInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectActivationWithAncestorScopeKeyIfTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .endEvent("sub-end"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("sub-end", subProcessElementInstance.getKey())
+            .terminateElement(subProcessElementInstance.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs(
+            "Expect that activation with ancestor scope key is rejected if ancestor is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions "
+                    + "for elements whose required flow scope instance is also being terminated: "
+                    + "element 'sub-end' requires flow scope instance '%s' which is being terminated. "
+                    + "Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.")
+                .formatted(PROCESS_ID, subProcessElementInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectActivationInsideTerminatedEventSubProcess() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "event-subprocess",
+                    esp ->
+                        esp.startEvent()
+                            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+                            .serviceTask("B", t -> t.zeebeJobType("B"))
+                            .endEvent())
+                .startEvent()
+                .userTask("C")
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "1").create();
+    ENGINE.message().withName("msg").withCorrelationKey("1").publish();
+    final var eventSubProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+            .getFirst();
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("B")
+            .terminateElement(eventSubProcessInstance.getKey())
+            .expectRejection()
+            .modify();
+    // then
+    assertThat(rejection)
+        .describedAs("Expect activation inside terminated event subprocess is rejected")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions "
+                    + "for elements whose required flow scope instance is also being terminated: "
+                    + "element 'B' requires flow scope instance '%s' which is being terminated. "
+                    + "Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.")
+                .formatted(PROCESS_ID, eventSubProcessInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectActivationOfTwoLevelNestedElementWhenFlowScopeIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .subProcess(
+                                "sub-subprocess",
+                                spn ->
+                                    spn.embeddedSubProcess()
+                                        .startEvent()
+                                        .serviceTask("B", a -> a.zeebeJobType("B"))
+                                        .endEvent("sub-sub-end"))
+                            .endEvent("sub-end"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .withElementId("subprocess")
+            .getFirst();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("sub-sub-end")
+            .terminateElement(subProcessElementInstance.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect that activation is rejected when flow scope is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+              Expected to modify instance of process '%s' but it contains one or more activate instructions \
+              for elements whose required flow scope instance is also being terminated: element 'sub-sub-end' requires flow scope instance '%s' \
+              which is being terminated. Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope."""
+                .formatted(PROCESS_ID, subProcessElementInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectActivationOfThreeLevelNestedElementWhenFlowScopeIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .subProcess(
+                                "sub-subprocess",
+                                spn ->
+                                    spn.embeddedSubProcess()
+                                        .startEvent()
+                                        .serviceTask("B", b -> b.zeebeJobType("B"))
+                                        .subProcess(
+                                            "sub-sub-subprocess",
+                                            spnn ->
+                                                spnn.embeddedSubProcess()
+                                                    .startEvent()
+                                                    .serviceTask("C", c -> c.zeebeJobType("C"))
+                                                    .endEvent("sub-sub-sub-end"))
+                                        .endEvent("sub-sub-end"))
+                            .endEvent("sub-end"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .withElementId("subprocess")
+            .getFirst();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("sub-sub-sub-end")
+            .terminateElement(subProcessElementInstance.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect that activation is rejected when flow scope is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions "
+                    + "for elements whose required flow scope instance is also being terminated: "
+                    + "element 'sub-sub-sub-end' requires flow scope instance '%s' which is being terminated. "
+                    + "Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.")
+                .formatted(PROCESS_ID, subProcessElementInstance.getKey()));
+  }
+
+  @Test
+  public void shouldAcceptActivationWithValidAncestorScopeKey() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("A", a -> a.zeebeJobType("A"))
+                            .endEvent("sub-end"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessElementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst();
+
+    // when
+    final var event =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("sub-end", processInstanceKey)
+            .terminateElement(subProcessElementInstance.getKey())
+            .modify();
+
+    // then
+    assertThat(event)
+        .describedAs("Expect that activation with valid ancestor scope key is accepted")
+        .hasRecordType(io.camunda.zeebe.protocol.record.RecordType.EVENT)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFIED);
+  }
+
+  @Test
+  public void shouldAcceptActivationWithValidAncestorScopeKeyInEventSubProcess() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "event-subprocess",
+                    esp ->
+                        esp.startEvent()
+                            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+                            .serviceTask("B", t -> t.zeebeJobType("B"))
+                            .endEvent())
+                .startEvent()
+                .userTask("C")
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "1").create();
+    ENGINE.message().withName("msg").withCorrelationKey("1").publish();
+    final var eventSubProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+            .getFirst();
+    // when
+    final var event =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("B", eventSubProcessInstance.getKey())
+            .modify();
+    // then
+    assertThat(event)
+        .describedAs(
+            "Expect activation with valid ancestor scope key in event subprocess is accepted")
+        .hasRecordType(io.camunda.zeebe.protocol.record.RecordType.EVENT)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFIED);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -375,59 +375,6 @@ public class ModifyProcessInstanceTest {
     verifyThatElementIsCompleted(processInstanceKey, "C");
     verifyThatElementIsCompleted(processInstanceKey, "event-subprocess");
     verifyThatProcessInstanceIsCompleted(processInstanceKey);
-
-    assert false;
-  }
-
-  @Test
-  public void shouldHandleConflictingSubProcessTerminationAndChildActivation() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .subProcess(
-                    "subprocess",
-                    sp ->
-                        sp.embeddedSubProcess()
-                            .startEvent()
-                            .serviceTask("A", a -> a.zeebeJobType("A"))
-                            .endEvent("sub-end"))
-                .endEvent()
-                .done())
-        .deploy();
-
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    final var subProcessElementInstance =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SUB_PROCESS)
-            .getFirst();
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .activateElement("sub-end")
-        .terminateElement(subProcessElementInstance.getKey())
-        .modify();
-
-    // then
-    assert false;
-    // Currently, this leads to an invalid state:
-    // The end event inside the sub-process (`sub-end`) is activated, but its flow scope instance
-    // (the sub-process) has already been terminated.
-    // If you refer to the console output for this failed test you would notice the final event log
-    // is to activate the 'sub-end' element but an error is issued instead:
-    // !INVALID_STATE (`Expected flow scope instance with key '<key>' to be present in state but not
-    // found.)`
-    //
-    // This test reproduces the inconsistency, but the expected behavior is still under discussion.
-    // Possible solutions are being evaluated and will be described in the related GitHub issue.
-
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -1318,6 +1319,9 @@ public class ModifyProcessInstanceTest {
   @Test
   public void shouldTerminateProcessIfProcessInstanceKeyIsPassedAsTerminateInstruction() {
     // regression test for https://github.com/camunda/camunda/issues/11413
+    // This is now handled by https://github.com/camunda/camunda/pull/38179, which enforces
+    // that an element cannot be activated if its flow scope is being terminated.
+    // This follows option 1 of the solution proposal in issue #11413.
     // given
     ENGINE
         .deployment()
@@ -1334,23 +1338,27 @@ public class ModifyProcessInstanceTest {
     getElementInstanceKeyOfElement(processInstanceKey, "A");
 
     // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .activateElement("B")
-        .terminateElement(processInstanceKey)
-        .modify();
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("B")
+            .terminateElement(processInstanceKey)
+            .expectRejection()
+            .modify();
 
     // then
-    assertThatElementIsTerminated(processInstanceKey, PROCESS_ID);
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .onlyCommandRejections()
-                .limit("B", ProcessInstanceIntent.ACTIVATE_ELEMENT))
-        .describedAs("Activation of User Task B should be rejected")
-        .isNotEmpty();
+    io.camunda.zeebe.protocol.record.Assertions.assertThat(rejection)
+        .describedAs(
+            "Expect that activation is rejected when flow scope (e.g process instance) is terminated")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions "
+                    + "for elements whose required flow scope instance is also being terminated: "
+                    + "element 'B' requires flow scope instance '%s' which is being terminated. "
+                    + "Please provide a valid ancestor scope key for the activation or avoid terminating the required flow scope.")
+                .formatted(PROCESS_ID, processInstanceKey));
   }
 
   private static void verifyThatRootElementIsActivated(


### PR DESCRIPTION
# Description
Backport of #38179 to `stable/8.7`.

relates to #37079