### PR TITLE
feat: allow api user use `#innerInstance` suffix

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAdHocSubProcessTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.processinstance.migration;
 
 import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
 import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.AD_HOC_SUB_PROCESS_ELEMENTS;
+import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +17,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -39,143 +41,7 @@ public class MigrateAdHocSubProcessTest {
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
-  // ==================== Basic Ad-Hoc Sub-Process Migration Tests ====================
-
-  @Test
-  public void shouldMigrateAdHocSubProcessAndUpdateVariables() {
-    // given
-    final String sourceProcessId = helper.getBpmnProcessId();
-    final String targetProcessId = helper.getBpmnProcessId() + "2";
-
-    final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                createProcessWithAdHocSubProcess(sourceProcessId, "adHocSubProcess", "taskA"))
-            .withXmlResource(
-                createProcessWithAdHocSubProcess(targetProcessId, "adHocSubProcess", "taskB"))
-            .deploy();
-
-    final long targetProcessDefinitionKey =
-        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
-
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
-
-    // Activate the ad-hoc subprocess
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .activateElement("adHocSubProcess")
-        .modify();
-
-    final long adHocSubProcessInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementId("adHocSubProcess")
-            .getFirst()
-            .getKey();
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("adHocSubProcess", "adHocSubProcess")
-        .migrate();
-
-    // then - verify element migrated and variables were updated for ad-hoc subprocess
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("adHocSubProcess")
-                .getFirst()
-                .getValue())
-        .hasProcessDefinitionKey(targetProcessDefinitionKey)
-        .hasBpmnProcessId(targetProcessId)
-        .hasElementId("adHocSubProcess")
-        .hasBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS);
-
-    assertThat(
-            RecordingExporter.variableRecords(VariableIntent.UPDATED)
-                .withScopeKey(adHocSubProcessInstanceKey)
-                .withName(AD_HOC_SUB_PROCESS_ELEMENTS)
-                .exists())
-        .isTrue();
-
-    final var updatedVariable =
-        RecordingExporter.variableRecords(VariableIntent.UPDATED)
-            .withScopeKey(adHocSubProcessInstanceKey)
-            .withName(AD_HOC_SUB_PROCESS_ELEMENTS)
-            .getFirst()
-            .getValue();
-
-    assertThat(updatedVariable)
-        .hasProcessDefinitionKey(targetProcessDefinitionKey)
-        .hasBpmnProcessId(targetProcessId);
-  }
-
-  // ==================== mapElementIds Method Tests ====================
-
-  @Test
-  public void shouldAutomaticallyAddInnerInstanceMappingForAdHocSubProcess() {
-    // given
-    final String sourceProcessId = helper.getBpmnProcessId();
-    final String targetProcessId = helper.getBpmnProcessId() + "2";
-
-    final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                createProcessWithAdHocSubProcess(sourceProcessId, "adHocSubProcess", "taskA"))
-            .withXmlResource(
-                createProcessWithAdHocSubProcess(targetProcessId, "adHocSubProcess", "taskB"))
-            .deploy();
-
-    final long targetProcessDefinitionKey =
-        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
-
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
-
-    // Activate the ad-hoc subprocess
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .activateElement("adHocSubProcess")
-        .modify();
-
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("adHocSubProcess")
-        .await();
-
-    // when - only providing the base ad-hoc subprocess mapping (no explicit #innerInstance)
-    final var migrationResult =
-        ENGINE
-            .processInstance()
-            .withInstanceKey(processInstanceKey)
-            .migration()
-            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-            .addMappingInstruction("adHocSubProcess", "adHocSubProcess")
-            .migrate();
-
-    // then - migration should succeed and automatically handle #innerInstance mapping
-    assertThat(migrationResult)
-        .hasRecordType(RecordType.EVENT)
-        .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
-
-    // The #innerInstance mapping should be automatically added by mapElementIds method
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("adHocSubProcess")
-                .exists())
-        .isTrue();
-  }
+  // ==================== NON Ad-Hoc Sub-Process Migration Test ====================
 
   @Test
   public void shouldNotAddInnerInstanceMappingForNonAdHocElements() {
@@ -222,7 +88,82 @@ public class MigrateAdHocSubProcessTest {
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
   }
 
-  // ==================== Edge Cases and Complex Scenarios ====================
+  // ==================== Basic Ad-Hoc Sub-Process Migration Tests ====================
+
+  @Test
+  public void shouldMigrateAdHocSubProcessAndUpdateVariables() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(createProcessWithAdHocSubProcess(sourceProcessId, "ahsp-1", "taskA"))
+            .withXmlResource(createProcessWithAdHocSubProcess(targetProcessId, "ahsp-2", "taskB"))
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    // Activate the ad-hoc subprocess
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("ahsp-1")
+        .modify();
+
+    final long adHocSubProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("ahsp-1")
+            .getFirst()
+            .getKey();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("ahsp-1", "ahsp-2")
+        .addMappingInstruction("taskA", "taskB")
+        .migrate();
+
+    // then - verify element migrated and variables were updated for ad-hoc subprocess
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("ahsp-2")
+                .getFirst()
+                .getValue())
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("ahsp-2")
+        .hasBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS);
+
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.UPDATED)
+                .withScopeKey(adHocSubProcessInstanceKey)
+                .withName(AD_HOC_SUB_PROCESS_ELEMENTS)
+                .exists())
+        .isTrue();
+
+    final var updatedVariable =
+        RecordingExporter.variableRecords(VariableIntent.UPDATED)
+            .withScopeKey(adHocSubProcessInstanceKey)
+            .withName(AD_HOC_SUB_PROCESS_ELEMENTS)
+            .getFirst()
+            .getValue();
+
+    assertThat(updatedVariable)
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId);
+  }
 
   @Test
   public void shouldMigrateMultipleAdHocSubProcesses() {
@@ -237,18 +178,18 @@ public class MigrateAdHocSubProcessTest {
                 Bpmn.createExecutableProcess(sourceProcessId)
                     .startEvent()
                     .adHocSubProcess(
-                        "adHoc1", ahsp -> ahsp.serviceTask("taskA1", t -> t.zeebeJobType("taskA1")))
+                        "ahsp-1", ahsp -> ahsp.serviceTask("taskA1", t -> t.zeebeJobType("taskA1")))
                     .adHocSubProcess(
-                        "adHoc2", ahsp -> ahsp.serviceTask("taskA2", t -> t.zeebeJobType("taskA2")))
+                        "ahsp-2", ahsp -> ahsp.serviceTask("taskA2", t -> t.zeebeJobType("taskA2")))
                     .endEvent()
                     .done())
             .withXmlResource(
                 Bpmn.createExecutableProcess(targetProcessId)
                     .startEvent()
                     .adHocSubProcess(
-                        "adHoc1", ahsp -> ahsp.serviceTask("taskB1", t -> t.zeebeJobType("taskB1")))
+                        "ahsp-3", ahsp -> ahsp.serviceTask("taskB1", t -> t.zeebeJobType("taskB1")))
                     .adHocSubProcess(
-                        "adHoc2", ahsp -> ahsp.serviceTask("taskB2", t -> t.zeebeJobType("taskB2")))
+                        "ahsp-4", ahsp -> ahsp.serviceTask("taskB2", t -> t.zeebeJobType("taskB2")))
                     .endEvent()
                     .done())
             .deploy();
@@ -264,19 +205,19 @@ public class MigrateAdHocSubProcessTest {
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .modification()
-        .activateElement("adHoc1")
+        .activateElement("ahsp-1")
         .modify();
 
     ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .modification()
-        .activateElement("adHoc2")
+        .activateElement("ahsp-2")
         .modify();
 
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withElementId("adHoc2")
+        .withElementId("ahsp-2")
         .await();
 
     // when
@@ -285,28 +226,32 @@ public class MigrateAdHocSubProcessTest {
         .withInstanceKey(processInstanceKey)
         .migration()
         .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("adHoc1", "adHoc1")
-        .addMappingInstruction("adHoc2", "adHoc2")
+        .addMappingInstruction("ahsp-1", "ahsp-3")
+        .addMappingInstruction("taskA1", "taskB1")
+        .addMappingInstruction("ahsp-2", "ahsp-4")
+        .addMappingInstruction("taskA2", "taskB2")
         .migrate();
 
     // then
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementId("adHoc1")
+                .withElementId("ahsp-3")
                 .exists())
         .isTrue();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementId("adHoc2")
+                .withElementId("ahsp-4")
                 .exists())
         .isTrue();
   }
 
+  // ==================== #innerInstance Suffix Validation Tests ====================
+
   @Test
-  public void shouldMigrateAdHocSubProcessWithDifferentActivities() {
+  public void shouldMigrateAdHocSubProcessWithInnerInstanceAndUpdateVariables() {
     // given
     final String sourceProcessId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "2";
@@ -314,11 +259,8 @@ public class MigrateAdHocSubProcessTest {
     final var deployment =
         ENGINE
             .deployment()
-            .withXmlResource(
-                createProcessWithAdHocSubProcess(sourceProcessId, "adHocSubProcess", "taskA"))
-            .withXmlResource(
-                createProcessWithAdHocSubProcess(
-                    targetProcessId, "adHocSubProcess", "taskB", "taskC"))
+            .withXmlResource(createProcessWithAdHocSubProcess(sourceProcessId, "ahsp-1", "taskA"))
+            .withXmlResource(createProcessWithAdHocSubProcess(targetProcessId, "ahsp-2", "taskB"))
             .deploy();
 
     final long targetProcessDefinitionKey =
@@ -332,36 +274,39 @@ public class MigrateAdHocSubProcessTest {
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .modification()
-        .activateElement("adHocSubProcess")
+        .activateElement("ahsp-1")
         .modify();
 
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("adHocSubProcess")
-        .await();
-
-    // when - migrate to ad-hoc subprocess with different set of activities
-    final var migrationResult =
-        ENGINE
-            .processInstance()
-            .withInstanceKey(processInstanceKey)
-            .migration()
-            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-            .addMappingInstruction("adHocSubProcess", "adHocSubProcess")
-            .migrate();
-
-    // then
-    assertThat(migrationResult)
-        .hasRecordType(RecordType.EVENT)
-        .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
-
-    // Verify the ad-hoc subprocess variables were updated with new activities metadata
     final long adHocSubProcessInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("adHocSubProcess")
+            .withElementId("ahsp-1")
             .getFirst()
             .getKey();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("ahsp-1", "ahsp-2")
+        .addMappingInstruction(
+            "ahsp-1" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX,
+            "ahsp-2" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX)
+        .migrate();
+
+    // then - verify element migrated and variables were updated for ad-hoc subprocess
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("ahsp-2")
+                .getFirst()
+                .getValue())
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("ahsp-2")
+        .hasBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS);
 
     assertThat(
             RecordingExporter.variableRecords(VariableIntent.UPDATED)
@@ -369,6 +314,291 @@ public class MigrateAdHocSubProcessTest {
                 .withName(AD_HOC_SUB_PROCESS_ELEMENTS)
                 .exists())
         .isTrue();
+
+    final var updatedVariable =
+        RecordingExporter.variableRecords(VariableIntent.UPDATED)
+            .withScopeKey(adHocSubProcessInstanceKey)
+            .withName(AD_HOC_SUB_PROCESS_ELEMENTS)
+            .getFirst()
+            .getValue();
+
+    assertThat(updatedVariable)
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId);
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenInnerInstanceInSourceButNotInTarget() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(createProcessWithAdHocSubProcess(sourceProcessId, "ahsp-1", "taskA"))
+            .withXmlResource(createProcessWithAdHocSubProcess(targetProcessId, "ahsp-2", "taskB"))
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    // Activate the ad-hoc subprocess
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("ahsp-1")
+        .modify();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("ahsp-1")
+        .await();
+
+    // when - using #innerInstance in source but not in target
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("ahsp-1", "ahsp-2")
+        .addMappingInstruction("ahsp-1" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX, "ahsp-4")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            String.format(
+                "Expected to migrate process instance '%s' but mapping instructions contain a non-existing target element id 'ahsp-4'. Elements provided in mapping instructions must exist in the target process definition.",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenInnerInstanceInTargetButNotInSource() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(createProcessWithAdHocSubProcess(sourceProcessId, "ahsp-1", "taskA"))
+            .withXmlResource(createProcessWithAdHocSubProcess(targetProcessId, "ahsp-2", "taskB"))
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    // Activate the ad-hoc subprocess
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("ahsp-1")
+        .modify();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("ahsp-1")
+        .await();
+
+    // when - using #innerInstance in target but not in source
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("ahsp-1", "ahsp-2")
+        .addMappingInstruction("ahsp-3", "ahsp-2" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX)
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            String.format(
+                "Expected to migrate process instance '%s' but mapping instructions contain a non-existing source element id 'ahsp-3'. Elements provided in mapping instructions must exist in the source process definition.",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenInnerInstanceUsedWithoutBaseElementMapping() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(createProcessWithAdHocSubProcess(sourceProcessId, "ahsp-1", "taskA"))
+            .withXmlResource(createProcessWithAdHocSubProcess(targetProcessId, "ahsp-2", "taskB"))
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    // Activate the ad-hoc subprocess
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("ahsp-1")
+        .modify();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("ahsp-1")
+        .await();
+
+    // when - using #innerInstance without providing mapping for the base element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction(
+            "ahsp-1" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX,
+            "ahsp-2" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX)
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                "Expected to migrate process instance '%s' but no mapping instruction defined for active element with id 'ahsp-1'. Elements cannot be migrated without a mapping.",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenInnerInstanceSuffixUsedWithoutAdHocSubProcess() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .serviceTask("taskA", t -> t.zeebeJobType("taskA"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("taskB", t -> t.zeebeJobType("taskB"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    // when - attempting to use #innerInstance suffix on a non-ad-hoc element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("taskA", "taskB")
+        .addMappingInstruction(
+            "taskA" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX,
+            "taskB" + AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX)
+        .expectRejection()
+        .migrate();
+
+    // then - fails because element id with ad-hoc sub-process reference doesn't exist
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            String.format(
+                "Expected to migrate process instance '%s' but mapping instructions contain a non-existing source element id 'taskA#innerInstance'. Elements provided in mapping instructions must exist in the source process definition.",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectMigrationWhenInnerInstanceSuffixUsedWithBlankBase() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .serviceTask("taskA", t -> t.zeebeJobType("taskA"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("taskB", t -> t.zeebeJobType("taskB"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    // when - attempting to use #innerInstance suffix on a non-ad-hoc element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("taskA", "taskB")
+        .addMappingInstruction(
+            AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX,
+            AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX)
+        .expectRejection()
+        .migrate();
+
+    // then - fails because element id with ad-hoc sub-process reference doesn't exist
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            String.format(
+                "Expected to migrate process instance '%s' but mapping instructions contain a non-existing source element id '#innerInstance'. Elements provided in mapping instructions must exist in the source process definition.",
+                processInstanceKey));
   }
 
   // ==================== Multi-Instance Ad-Hoc Sub-Process Tests ====================


### PR DESCRIPTION
## Description

### Support for `#innerInstance` suffix

Let broker do all necessary validations

Add test cases that validate `#innerInstance` suffix usage.


## Related issues

closes #40738
