### PR TITLE
Fix load test clean up workflow

### DIFF
--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
         run: |
-          currentDate=$(date -d ${{ inputs.date }} +%Y-%m-%d)
+          currentDate=$(date -d "${{ inputs.date }}" +'%Y-%m-%d')
           echo "Date used for deletion: $currentDate"
           namespacesDeleted=""
           for ns in $(kubectl get namespace --selector=deadline-date="$currentDate" -o json | jq -r '.items[].metadata.name');

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -11,7 +11,6 @@ on:
         description: 'Date in YYYY-MM-DD format to delete load tests for (defaults to current date)'
         type: string
         required: false
-        default: ''
 
 defaults:
   run:


### PR DESCRIPTION
## Description

* The date command fails when the input is empty and has no quotes, as it is taking the formating option as input then.
 * Adding quotes to fallback to empty, which means now


See successful run https://github.com/camunda/camunda/actions/runs/19357466740/job/55381466942