### PR TITLE
ci: no automatic `backport main` labeling of client changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,14 +7,6 @@ component/build-pipeline:
           - '.github/actionlint*'
           - '.mvn/**'
           - 'maven-settings.xml'
-# to Forward-port PRs fixes to the deprecated java client classes in 8.8 (from 8.7)
-backport main: # TODO replace with 'backport stable/8.8' once the stable branch is created https://github.com/camunda/camunda/issues/26820
-  - all:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'clients/java/src/main/java/io/camunda/zeebe/**'
-              - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch: 'stable/8.7'
 component/c8run:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Description

See https://github.com/camunda/camunda/issues/26820#issuecomment-3531600513

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #26820
