### PR TITLE
ci: adapt deprecated-client labeler to new module path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,14 +12,10 @@ component/c8-api:
       - any-glob-to-any-file:
           - 'zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml'
           - 'zeebe/gateway-rest/**'
-# hint on changes done to the deprecated java client, and that might need to applied to the supported client
 deprecated-client:
-  - all:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'clients/java/src/main/java/io/camunda/zeebe/**'
-              - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch: 'main' # TODO replace with 'backport stable/8.8' in https://github.com/camunda/camunda/issues/26820
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'clients/java-deprecated/**'
 component/c8run:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Description

This just updates the labeler to actually check the deprecated client path.
This was missed previously when the zeebe client was extracted to a dedicated module.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #40982
