### PR TITLE
[Backport stable/8.8] ci: adapt deprecated-client labeler to new module path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,14 +13,10 @@ component/c8-api:
           - 'zeebe/gateway-protocol/src/main/proto/rest-api.yaml'
           - 'zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml'
           - 'zeebe/gateway-rest/**'
-# hint on changes done to the deprecated java client, and that might need to applied to the supported client
 deprecated-client:
-  - all:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'clients/java/src/main/java/io/camunda/zeebe/**'
-              - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch: 'main' # TODO replace with 'backport stable/8.8' in https://github.com/camunda/camunda/issues/26820
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'clients/java-deprecated/**'
 component/c8run:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
# Description
Backport of #40990 to `stable/8.8`.

relates to #40982