### PR TITLE
[Backport stable/8.7] fix: fail fast if a partition generates a key outside of its keyspace

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
-import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import java.time.InstantSource;
 
 public class MigrationTransitionStep implements PartitionTransitionStep {
@@ -44,7 +43,9 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             context.getPartitionId(),
             zeebeDb,
             zeebeDbContext,
-            new DbKeyGenerator(context.getPartitionId(), zeebeDb, zeebeDbContext),
+            () -> {
+              throw new IllegalCallerException("New keys cannot be generated during migration");
+            },
             transientMessageSubscriptionState,
             transientProcessMessageSubscriptionState,
             context.getBrokerCfg().getExperimental().getEngine().createEngineConfiguration(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
@@ -74,5 +75,25 @@ public final class KeyGeneratorTest {
     assertThat(Protocol.decodePartitionId(keyOfSecondPartition)).isEqualTo(secondPartitionId);
 
     newDb.close();
+  }
+
+  @Test
+  public void shouldFailIfKeyOfAnotherPartitionIsSet() {
+    // given
+    final ZeebeDb<ZbColumnFamilies> newDb = stateRule.createNewDb();
+    final DbKeyGenerator keyGenerator2 =
+        new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, newDb, newDb.createContext());
+
+    final long keyOfAnotherPartition =
+        Protocol.encodePartitionId(Protocol.DEPLOYMENT_PARTITION + 1, 100);
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> keyGenerator2.setKeyIfHigher(keyOfAnotherPartition))
+        .havingCause()
+        .withMessageContaining(
+            String.format(
+                "Provided key %d does not belong to partition %d",
+                keyOfAnotherPartition, Protocol.DEPLOYMENT_PARTITION));
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorKeyGeneratorErrorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorKeyGeneratorErrorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.camunda.zeebe.stream.util.RecordToWrite;
+import io.camunda.zeebe.stream.util.Records;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class StreamProcessorKeyGeneratorErrorTest {
+
+  @RegisterExtension
+  private final StreamPlatformExtension streamPlatformExtension = new StreamPlatformExtension();
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  private StreamProcessor streamProcessor;
+
+  @Test
+  void shouldShutdownIfKeyGenerationFailed() {
+    // given
+    streamProcessor = streamPlatform.startStreamProcessorNotAwaitOpening();
+    final var mockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+
+    final var zeebeDb = streamPlatform.getZeebeDb();
+    final DbKeyGenerator dbKeyGenerator = new DbKeyGenerator(1, zeebeDb, zeebeDb.createContext());
+    // set the key generator to a value that will cause an overflow on next key generation
+    dbKeyGenerator.setKeyIfHigher(Protocol.encodePartitionId(1, (long) Math.pow(2, 51) - 1));
+    when(mockedRecordProcessor.process(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              dbKeyGenerator.nextKey();
+              return null;
+            });
+
+    // when - processing fails due to key generation error
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    Awaitility.await("wait to become unhealthy")
+        .until(() -> streamProcessor.getHealthReport().isUnhealthy());
+
+    Assertions.assertThat(streamProcessor.isFailed()).isTrue();
+  }
+}


### PR DESCRIPTION
# Description
Backport of #40992 to `stable/8.7`.

relates to #40981