### PR TITLE
fix: sync resource permissions in ui and backend

### DIFF
--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -66,13 +66,10 @@ const resourcePermissions: ResourcePermissionsType = {
     PermissionType.READ_DECISION_DEFINITION,
     PermissionType.READ_DECISION_INSTANCE,
   ],
-  DECISION_REQUIREMENTS_DEFINITION: [
-    PermissionType.DELETE,
-    PermissionType.READ,
-    PermissionType.UPDATE,
-  ],
+  DECISION_REQUIREMENTS_DEFINITION: [PermissionType.READ],
   RESOURCE: [
     PermissionType.CREATE,
+    PermissionType.READ,
     PermissionType.DELETE_DRD,
     PermissionType.DELETE_FORM,
     PermissionType.DELETE_PROCESS,


### PR DESCRIPTION
## Description

Add a RESOURCE authorization in Identity. The READ permission is missing in the dialog box.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39946 
