### PR TITLE
test: cleanup HealthCheckIT tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -120,7 +120,7 @@ public class HealthCheckIT {
             "0.0.0.0",
             TOXIPROXY.getMappedPort(proxy.internalPort()),
             s3Endpoint.getPath(),
-            s3Endpoint.getPath(),
+            s3Endpoint.getQuery(),
             s3Endpoint.getFragment());
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -126,7 +126,10 @@ public class HealthCheckIT {
 
   @AfterEach
   public void cleanUp() throws IOException {
-    proxy.proxy().toxics().get(LATENCY_TOXIC).remove();
+    final var toxic = proxy.proxy().toxics().get(LATENCY_TOXIC);
+    if (toxic != null) {
+      toxic.remove();
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description
Unfortunately a couple of fix/cleanups from the latest PR were not included, so I opened a new PR:

- the query path param was incorrectly set to path in toxiproxy
- cleanup toxiproxy `toxics` in `@AfterEach`, does not matter much right now, but it will if we add another test case.

