### PR TITLE
feat: add  flag based on dockerhub support suggestion

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Path to the dockerfile, that should be used; defaults to Dockerfile'
     required: false
     default: 'Dockerfile'
+  debug:
+    description: 'Enable debug logging for BuildKit daemon'
+    required: false
+    default: 'false'
 
 outputs:
   image:
@@ -79,6 +83,7 @@ runs:
       with:
         # to be able to push to local registry, which we use in our tests, we need to use host network
         driver-opts: network=host
+        buildkitd-flags: ${{ inputs.debug == 'true' && '--debug' || '' }}
         endpoint: zeebe-context
         install: true
 

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -325,6 +325,8 @@ jobs:
           push: true
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
           platforms: ${{ env.PLATFORMS }}
+          # turns on BuildKit debug logging
+          debug: 'true'
       - name: Verify Zeebe Docker image
         uses: ./.github/actions/verify-platform-docker
         with:
@@ -422,6 +424,8 @@ jobs:
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
           platforms: ${{ env.PLATFORMS }}
           dockerfile: operate.Dockerfile
+          # turns on BuildKit debug logging
+          debug: 'true'
       - name: Verify Operate Docker image
         uses: ./.github/actions/verify-platform-docker
         with:
@@ -521,6 +525,8 @@ jobs:
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
           platforms: ${{ env.PLATFORMS }}
           dockerfile: tasklist.Dockerfile
+          # turns on BuildKit debug logging
+          debug: 'true'
       - name: Verify Tasklist Docker image
         uses: ./.github/actions/verify-platform-docker
         with:
@@ -627,6 +633,8 @@ jobs:
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
           platforms: ${{ env.PLATFORMS }}
           dockerfile: camunda.Dockerfile
+          # turns on BuildKit debug logging
+          debug: 'true'
       - name: Verify Camunda Docker image
         uses: ./.github/actions/verify-platform-docker
         with:


### PR DESCRIPTION
# 🎯  Target

Based on the recent release issue, and the support ticket opened for DockerHub they suggest to apply the following flag for the `build-platform-docker1` github action:

```
- name: Set up Docker Buildx
      uses: docker/setup-buildx-action@v3
      with:
        # to be able to push to local registry, which we use in our tests, we need to use host network
        driver-opts: network=host
        buildkitd-flags: --debug
        endpoint: zeebe-context
        install: true
```

# 🔧  Improvements:
sample test workflow [here](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19423442863/job/55565382190)
- Set up Docker Buildx step is [updated with](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19423528923/job/55565643420#step:4:4) `buildkitd-flags: --debug`
- Logs are visible at the end of the workflow under the [Post Setup Docker Buildx](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19423947567/job/55566990654#step:24:2)

- Tested workflow [file](https://github.com/camunda/update-docker-buildx-logic-test/actions/runs/19423947567/workflow)