### PR TITLE
fix: extend element details data with message subscription fields

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
@@ -360,4 +360,25 @@ describe('MetadataPopover <Details />', () => {
     expect(screen.getByText(/"jobType"/)).toBeInTheDocument();
     expect(screen.getByText(/"jobWorker"/)).toBeInTheDocument();
   });
+
+  it('should display message subscription data fields', async () => {
+    const incidentMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        messageName: 'message',
+        correlationKey: '1',
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={incidentMetaData} elementId="Activity_11ptrz9" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(screen.getByText(/"messageName"/)).toBeInTheDocument();
+    expect(screen.getByText(/"correlationKey"/)).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -43,6 +43,8 @@ type V2InstanceMetadata = {
   jobDeadline?: string | null;
   jobCustomHeaders: Record<string, unknown> | null;
   jobKey?: string | null;
+  messageName?: string | null;
+  correlationKey?: string | null;
 } & Partial<UserTask>;
 
 type V2MetaDataDto = Omit<MetaDataDto, 'instanceMetadata' | 'incident'> & {
@@ -123,6 +125,8 @@ function createV2InstanceMetadata(
     flowNodeInstanceId: elementInstance.elementInstanceKey,
     flowNodeId: elementInstance.elementId,
     flowNodeType: oldMetadata?.flowNodeType,
+    messageName: oldMetadata?.messageName,
+    correlationKey: oldMetadata?.correlationKey,
 
     creationDate,
     completionDate,

--- a/operate/client/src/modules/api/processInstances/fetchFlowNodeMetaData.ts
+++ b/operate/client/src/modules/api/processInstances/fetchFlowNodeMetaData.ts
@@ -26,6 +26,8 @@ type InstanceMetaDataDto = {
   jobDeadline: string | null;
   jobCustomHeaders: {[key: string]: string} | null;
   jobId: string | null;
+  correlationKey?: string | null;
+  messageName?: string | null;
 };
 
 type MetaDataDto = {


### PR DESCRIPTION
## Description

Retrieves message subscription data from `flow-node-metadata` endpoint 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41019 
