### PR TITLE
ci: use correct type for ttl

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -53,7 +53,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
-      ttl: '28'
+      ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
@@ -67,7 +67,7 @@ jobs:
       - benchmark-data
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}-mixed
-      ttl: '28'
+      ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
@@ -81,7 +81,7 @@ jobs:
       - benchmark-data
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}-latency
-      ttl: '28'
+      ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}


### PR DESCRIPTION
## Description

 * Medic benchmark creation failed because of wrong type usage

## Related

see https://github.com/camunda/camunda/actions/runs/19415646690 
