### PR TITLE
build: override zeebe-build-tools for optimize plugins

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -221,6 +221,39 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${zeebe.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${zeebe.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${zeebe.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
@@ -512,6 +545,17 @@
             <phase>clean</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>io.camunda</groupId>
+            <artifactId>zeebe-build-tools</artifactId>
+            <version>${zeebe.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

### Problem

Optimize is released separately from the main Camunda monorepo and is currently on version `8.8.2-SNAPSHOT`, while the rest of the monorepo has moved ahead to `8.8.3-SNAPSHOT`. 

Optimize inherits from `zeebe-parent:8.8.3-SNAPSHOT`, which manages all Zeebe/Camunda dependency versions through its dependency management. However, the parent POM was configuring these dependencies to resolve to `8.8.2-SNAPSHOT` versions, which are no longer available in Nexus since the monorepo has progressed to `8.8.3-SNAPSHOT`.

This caused CI build failures with errors like:
```
Could not find artifact io.camunda:zeebe-build-tools:jar:8.8.2-SNAPSHOT
```

The issue is that build plugins (Checkstyle, Surefire, Failsafe, SpotBugs) were also trying to resolve `zeebe-build-tools:8.8.2-SNAPSHOT` as a plugin dependency

### Solution

To maintain Optimize's independent release cycle while depending on available Zeebe artifacts:

3. **Overrode Maven plugin configurations** in both `<pluginManagement>` and `<plugins>` sections to ensure all build plugins use the correct `zeebe-build-tools` version:
   - `maven-checkstyle-plugin`
   - `maven-surefire-plugin`
   - `maven-failsafe-plugin`
   - `spotbugs-maven-plugin`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
