### PR TITLE
Rename retention properties after breaking configuration changes for 8.9

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -142,11 +142,11 @@ orchestration:
       camunda.operate.importerEnabled: "false"
       camunda.operate.elasticsearch.numberOfShards: 3
       # Schema management has been moved out of exporter - to be bootstrap at start; once
-      camunda.data.secondaryStorage.retention.enabled: "true"
+      camunda.data.secondary-storage.retention.enabled: "true"
       # 0s causes ILM to move data asap - it is normally the default
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-      camunda.data.secondaryStorage.retention.minimumAge: "70m"
-      camunda.data.secondaryStorage.elasticsearch.history.policyName: "camunda-retention-policy"
+      camunda.data.secondary-storage.retention.minimum-age: "70m"
+      camunda.data.secondary-storage.elasticsearch.history.policy-name: "camunda-retention-policy"
       #Metrics:
       camunda.flags.jfr.metrics: "true"
       # RocksDB memory limit setting, limits the overall RocksDB memory usage

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -126,13 +126,6 @@ orchestration:
       zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
       zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
       zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
-      # We moved the archiver configuration under retention at some point, but still need to support the previous
-      # versions for now, so the configurations for retention are duplicated
-      zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
-      # 0s causes ILM to move data asap - it is normally the default
-      # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-      zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "70m"
-      zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
       # Configure a rate limit for all writes, so that we can visualize flow control metrics.
       zeebe.broker.flowControl.write.enabled: "true"
       zeebe.broker.flowControl.write.limit: 4000
@@ -147,6 +140,8 @@ orchestration:
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
       camunda.data.secondary-storage.retention.minimum-age: "70m"
       camunda.data.secondary-storage.elasticsearch.history.policy-name: "camunda-retention-policy"
+      camunda.database.retention.policyName: "camunda-retention-policy"
+      zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
       #Metrics:
       camunda.flags.jfr.metrics: "true"
       # RocksDB memory limit setting, limits the overall RocksDB memory usage

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -142,11 +142,11 @@ orchestration:
       camunda.operate.importerEnabled: "false"
       camunda.operate.elasticsearch.numberOfShards: 3
       # Schema management has been moved out of exporter - to be bootstrap at start; once
-      camunda.database.retention.enabled: "true"
+      camunda.data.secondaryStorage.retention.enabled: "true"
       # 0s causes ILM to move data asap - it is normally the default
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-      camunda.database.retention.minimumAge: "70m"
-      camunda.database.retention.policyName: "camunda-retention-policy"
+      camunda.data.secondaryStorage.retention.minimumAge: "70m"
+      camunda.data.secondaryStorage.elasticsearch.history.policyName: "camunda-retention-policy"
       #Metrics:
       camunda.flags.jfr.metrics: "true"
       # RocksDB memory limit setting, limits the overall RocksDB memory usage


### PR DESCRIPTION
Some breaking changes were made in the configuration of secondary storage's retention policy.

> Error starting Tomcat context. Exception: org.springframework.beans.factory.UnsatisfiedDependencyException. Message: Error creating bean with name 'brokerBasedConfiguration' defined in URL [jar:file:/usr/local/camunda/lib/camunda-zeebe-8.9.0-SNAPSHOT.jar!/io/camunda/application/commons/configuration/BrokerBasedConfiguration.class]: Unsatisfied dependency expressed through constructor parameter 2: Error creating bean with name 'brokerBasedProperties' defined in io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride: Failed to instantiate [io.camunda.configuration.beans.BrokerBasedProperties]: Factory method 'brokerBasedProperties' threw exception with message: Ambiguous configuration. The value camunda.data.secondary-storage.retention.enabled=false conflicts with the values 'true' from the legacy properties camunda.database.retention.enabled, zeebe.broker.exporters.camundaexporter.args.history.retention.enabled


See https://github.com/camunda/camunda-operator/pull/4694/files#diff-3afac6842228c7b15b5a0095bf473211963afbb8a2d48184261ad4075d9c61ad

