### PR TITLE
[Backport stable/8.7] ci: move leader balancing step from old to new benchmark workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -367,6 +367,14 @@ jobs:
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.load-test-load }}
+      - name: Setup leader balancing
+        run: |
+          kubectl create cronjob leader-balancer \
+          --namespace ${{ inputs.name }} \
+          --image=curlimages/curl:7.87.0 \
+          --schedule="*/10 * * * *" \
+          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance \
+          || echo "Leader balancer cronjob already exists"
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -369,12 +369,15 @@ jobs:
           ${{ inputs.load-test-load }}
       - name: Setup leader balancing
         run: |
-          kubectl create cronjob leader-balancer \
-          --namespace ${{ inputs.name }} \
-          --image=curlimages/curl:7.87.0 \
-          --schedule="*/10 * * * *" \
-          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance \
-          || echo "Leader balancer cronjob already exists"
+          if ! kubectl get cronjob leader-balancer --namespace ${{ inputs.name }} &>/dev/null; then
+            kubectl create cronjob leader-balancer \
+              --namespace ${{ inputs.name }} \
+              --image=curlimages/curl:7.87.0 \
+              --schedule="*/10 * * * *" \
+              -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
+          else
+            echo "Leader balancer cronjob already exists"
+          fi
       - name: Summarize deployment
         if: success()
         run: |


### PR DESCRIPTION
# Description
Backport of #40735 to `stable/8.7`.

relates to 