### PR TITLE
feat: introduce create/update time for jobs

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
@@ -64,4 +64,8 @@ public interface Job {
   Long getElementInstanceKey();
 
   String getTenantId();
+
+  OffsetDateTime getCreationTime();
+
+  OffsetDateTime getLastUpdateTime();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
@@ -48,6 +48,8 @@ public class JobImpl implements Job {
   private final String elementId;
   private final Long elementInstanceKey;
   private final String tenantId;
+  private final OffsetDateTime creationTime;
+  private final OffsetDateTime lastUpdatedTime;
 
   public JobImpl(final JobSearchResult item) {
     jobKey = ParseUtil.parseLongOrNull(item.getJobKey());
@@ -71,6 +73,8 @@ public class JobImpl implements Job {
     elementId = item.getElementId();
     elementInstanceKey = ParseUtil.parseLongOrNull(item.getElementInstanceKey());
     tenantId = item.getTenantId();
+    creationTime = ParseUtil.parseOffsetDateTimeOrNull(item.getCreationTime());
+    lastUpdatedTime = ParseUtil.parseOffsetDateTimeOrNull(item.getLastUpdateTime());
   }
 
   @Override
@@ -176,5 +180,15 @@ public class JobImpl implements Job {
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public OffsetDateTime getCreationTime() {
+    return creationTime;
+  }
+
+  @Override
+  public OffsetDateTime getLastUpdateTime() {
+    return lastUpdatedTime;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -38,6 +38,8 @@ public class JobEntityMapper {
         .elementId(jobDbModel.elementId())
         .elementInstanceKey(jobDbModel.elementInstanceKey())
         .tenantId(jobDbModel.tenantId())
+        .creationTime(jobDbModel.creationTime())
+        .lastUpdateTime(jobDbModel.lastUpdateTime())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -46,6 +46,8 @@ public class JobDbModel implements Copyable<JobDbModel> {
   private String tenantId;
   private int partitionId;
   private OffsetDateTime historyCleanupDate;
+  private OffsetDateTime creationTime;
+  private OffsetDateTime lastUpdateTime;
 
   public JobDbModel(final Long jobKey) {
     this.jobKey = jobKey;
@@ -74,7 +76,9 @@ public class JobDbModel implements Copyable<JobDbModel> {
       final Long elementInstanceKey,
       final String tenantId,
       final int partitionId,
-      final OffsetDateTime historyCleanupDate) {
+      final OffsetDateTime historyCleanupDate,
+      final OffsetDateTime creationTime,
+      final OffsetDateTime lastUpdateTime) {
     this.jobKey = jobKey;
     this.type = type;
     this.worker = worker;
@@ -99,6 +103,8 @@ public class JobDbModel implements Copyable<JobDbModel> {
     this.tenantId = tenantId;
     this.partitionId = partitionId;
     this.historyCleanupDate = historyCleanupDate;
+    this.creationTime = creationTime;
+    this.lastUpdateTime = lastUpdateTime;
   }
 
   @Override
@@ -142,7 +148,9 @@ public class JobDbModel implements Copyable<JobDbModel> {
         elementInstanceKey,
         tenantId,
         partitionId,
-        historyCleanupDate);
+        historyCleanupDate,
+        creationTime,
+        lastUpdateTime);
   }
 
   public Long jobKey() {
@@ -334,6 +342,22 @@ public class JobDbModel implements Copyable<JobDbModel> {
     this.historyCleanupDate = historyCleanupDate;
   }
 
+  public OffsetDateTime creationTime() {
+    return creationTime;
+  }
+
+  public void creationTime(final OffsetDateTime creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  public OffsetDateTime lastUpdateTime() {
+    return lastUpdateTime;
+  }
+
+  public void lastUpdateTime(final OffsetDateTime lastUpdateTime) {
+    this.lastUpdateTime = lastUpdateTime;
+  }
+
   public ObjectBuilder<JobDbModel> toBuilder() {
     return new Builder()
         .jobKey(jobKey)
@@ -358,7 +382,9 @@ public class JobDbModel implements Copyable<JobDbModel> {
         .elementInstanceKey(elementInstanceKey)
         .tenantId(tenantId)
         .partitionId(partitionId)
-        .historyCleanupDate(historyCleanupDate);
+        .historyCleanupDate(historyCleanupDate)
+        .creationTime(creationTime)
+        .lastUpdateTime(lastUpdateTime);
   }
 
   public static class Builder implements ObjectBuilder<JobDbModel> {
@@ -386,6 +412,8 @@ public class JobDbModel implements Copyable<JobDbModel> {
     private String tenantId;
     private int partitionId;
     private OffsetDateTime historyCleanupDate;
+    private OffsetDateTime creationTime;
+    private OffsetDateTime lastUpdateTime;
 
     public Builder jobKey(final Long jobKey) {
       this.jobKey = jobKey;
@@ -502,6 +530,16 @@ public class JobDbModel implements Copyable<JobDbModel> {
       return this;
     }
 
+    public Builder creationTime(final OffsetDateTime value) {
+      creationTime = value;
+      return this;
+    }
+
+    public Builder lastUpdateTime(final OffsetDateTime value) {
+      lastUpdateTime = value;
+      return this;
+    }
+
     @Override
     public JobDbModel build() {
       return new JobDbModel(
@@ -527,7 +565,9 @@ public class JobDbModel implements Copyable<JobDbModel> {
           elementInstanceKey,
           tenantId,
           partitionId,
-          historyCleanupDate);
+          historyCleanupDate,
+          creationTime,
+          lastUpdateTime);
     }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
@@ -93,6 +93,8 @@ public class JobEntityMapperTest {
             .elementId(null)
             .elementInstanceKey(1L)
             .tenantId(null)
+            .creationTime(OffsetDateTime.now())
+            .lastUpdateTime(OffsetDateTime.now())
             .build();
 
     // When
@@ -117,5 +119,7 @@ public class JobEntityMapperTest {
     assertThat(entity.processDefinitionId()).isNull();
     assertThat(entity.elementId()).isNull();
     assertThat(entity.tenantId()).isNull();
+    assertThat(entity.creationTime()).isNotNull();
+    assertThat(entity.lastUpdateTime()).isNotNull();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/cache/rest-api.yaml
@@ -10219,6 +10219,14 @@ components:
         worker:
           description: The name of the worker of this job.
           type: string
+        creationTime:
+          description: When the job was created. Field is present for jobs created after 8.9.
+          type: string
+          format: date-time
+        lastUpdateTime:
+          description: When the job was last updated. Field is present for jobs created after 8.9.
+          type: string
+          format: date-time
     JobStateEnum:
       description: The state of the job.
       type: string

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -40,6 +40,8 @@ public class JobEntityTransformer
         .elementId(value.getFlowNodeId())
         .elementInstanceKey(value.getFlowNodeInstanceId())
         .tenantId(value.getTenantId())
+        .creationTime(value.getCreationTime())
+        .lastUpdateTime(value.getLastUpdateTime())
         .build();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
@@ -16,6 +16,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.CREATION_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_CODE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_MESSAGE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.FLOW_NODE_ID;
@@ -29,6 +30,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_KIN
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LISTENER_EVENT_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
@@ -66,6 +68,10 @@ public class JobFilterTransformer extends IndexFilterTransformer<JobFilter> {
     of(stringOperations(LISTENER_EVENT_TYPE, filter.listenerEventTypeOperations()))
         .ifPresent(queries::addAll);
     of(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()))
+        .ifPresent(queries::addAll);
+    of(dateTimeOperations(CREATION_TIME, filter.creationTimeOperations()))
+        .ifPresent(queries::addAll);
+    of(dateTimeOperations(LAST_UPDATE_TIME, filter.lastUpdateTimeOperations()))
         .ifPresent(queries::addAll);
     of(longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()))
         .ifPresent(queries::addAll);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/JobFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/JobFieldSortingTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.CREATION_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_CODE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_MESSAGE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.FLOW_NODE_ID;
@@ -21,6 +22,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_KIN
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LISTENER_EVENT_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_INSTANCE_KEY;
@@ -53,6 +55,8 @@ public class JobFieldSortingTransformer implements FieldSortingTransformer {
       case "errorMessage" -> ERROR_MESSAGE;
       case "deadline" -> JOB_DEADLINE;
       case "processDefinitionId" -> BPMN_PROCESS_ID;
+      case "creationTime" -> CREATION_TIME;
+      case "lastUpdateTime" -> LAST_UPDATE_TIME;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -36,7 +36,9 @@ public record JobEntity(
     Long processInstanceKey,
     String elementId,
     Long elementInstanceKey,
-    String tenantId)
+    String tenantId,
+    OffsetDateTime creationTime,
+    OffsetDateTime lastUpdateTime)
     implements TenantOwnedEntity {
 
   public static class Builder implements ObjectBuilder<JobEntity> {
@@ -61,6 +63,8 @@ public record JobEntity(
     private String elementId;
     private Long elementInstanceKey;
     private String tenantId;
+    private OffsetDateTime creationTime;
+    private OffsetDateTime lastUpdateTime;
 
     public Builder jobKey(final Long jobKey) {
       this.jobKey = jobKey;
@@ -167,6 +171,16 @@ public record JobEntity(
       return this;
     }
 
+    public Builder creationTime(final OffsetDateTime creationTime) {
+      this.creationTime = creationTime;
+      return this;
+    }
+
+    public Builder lastUpdateTime(final OffsetDateTime lastUpdateTime) {
+      this.lastUpdateTime = lastUpdateTime;
+      return this;
+    }
+
     @Override
     public JobEntity build() {
       return new JobEntity(
@@ -190,7 +204,9 @@ public record JobEntity(
           processInstanceKey,
           elementId,
           elementInstanceKey,
-          tenantId);
+          tenantId,
+          creationTime,
+          lastUpdateTime);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/JobFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/JobFilter.java
@@ -37,7 +37,9 @@ public record JobFilter(
     List<Operation<String>> stateOperations,
     List<Operation<String>> tenantIdOperations,
     List<Operation<String>> typeOperations,
-    List<Operation<String>> workerOperations)
+    List<Operation<String>> workerOperations,
+    List<Operation<OffsetDateTime>> creationTimeOperations,
+    List<Operation<OffsetDateTime>> lastUpdateTimeOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<JobFilter> {
@@ -61,6 +63,8 @@ public record JobFilter(
     private List<Operation<Long>> processInstanceKeyOperations;
     private List<Operation<String>> elementIdOperation;
     private List<Operation<Long>> elementInstanceKeyOperations;
+    private List<Operation<OffsetDateTime>> creationTimeOperations;
+    private List<Operation<OffsetDateTime>> lastUpdateTimeOperations;
 
     public Builder deadlineOperations(final List<Operation<OffsetDateTime>> operations) {
       deadlineOperations = addValuesToList(deadlineOperations, operations);
@@ -342,6 +346,36 @@ public record JobFilter(
       return elementIdOperations(collectValues(operation, operations));
     }
 
+    public Builder creationTimeOperations(final List<Operation<OffsetDateTime>> operations) {
+      creationTimeOperations = addValuesToList(creationTimeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder creationTimeOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return creationTimeOperations(collectValues(operation, operations));
+    }
+
+    public Builder creationTimes(final OffsetDateTime value, final OffsetDateTime... values) {
+      return creationTimeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder lastUpdateTimeOperations(final List<Operation<OffsetDateTime>> operations) {
+      lastUpdateTimeOperations = addValuesToList(lastUpdateTimeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder lastUpdateTimeOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return lastUpdateTimeOperations(collectValues(operation, operations));
+    }
+
+    public Builder lastUpdateTimes(final OffsetDateTime value, final OffsetDateTime... values) {
+      return lastUpdateTimeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
     @Override
     public JobFilter build() {
       return new JobFilter(
@@ -364,7 +398,9 @@ public record JobFilter(
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(typeOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(workerOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(workerOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(creationTimeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(lastUpdateTimeOperations, Collections.emptyList()));
     }
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobTemplate.java
@@ -26,6 +26,8 @@ public class JobTemplate extends AbstractTemplateDescriptor
   public static final String TENANT_ID = "tenantId";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
+  public static final String CREATION_TIME = "creationTime";
+  public static final String LAST_UPDATE_TIME = "lastUpdateTime";
   public static final String JOB_TYPE = "type";
   public static final String JOB_WORKER = "worker";
   public static final String RETRIES = "retries";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
@@ -28,6 +28,12 @@ public class JobEntity
   /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
   private String bpmnProcessId;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  private OffsetDateTime creationTime;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  private OffsetDateTime lastUpdateTime;
+
   private String tenantId;
   private String type;
   private String worker;
@@ -251,6 +257,24 @@ public class JobEntity
     return this;
   }
 
+  public OffsetDateTime getCreationTime() {
+    return creationTime;
+  }
+
+  public JobEntity setCreationTime(final OffsetDateTime creationTime) {
+    this.creationTime = creationTime;
+    return this;
+  }
+
+  public OffsetDateTime getLastUpdateTime() {
+    return lastUpdateTime;
+  }
+
+  public JobEntity setLastUpdateTime(final OffsetDateTime lastUpdateTime) {
+    this.lastUpdateTime = lastUpdateTime;
+    return this;
+  }
+
   public Boolean isDenied() {
     return denied;
   }
@@ -295,7 +319,9 @@ public class JobEntity
         listenerEventType,
         position,
         denied,
-        deniedReason);
+        deniedReason,
+        creationTime,
+        lastUpdateTime);
   }
 
   @Override
@@ -330,7 +356,9 @@ public class JobEntity
         && Objects.equals(listenerEventType, jobEntity.listenerEventType)
         && Objects.equals(position, jobEntity.position)
         && Objects.equals(denied, jobEntity.denied)
-        && Objects.equals(deniedReason, jobEntity.deniedReason);
+        && Objects.equals(deniedReason, jobEntity.deniedReason)
+        && Objects.equals(creationTime, jobEntity.creationTime)
+        && Objects.equals(lastUpdateTime, jobEntity.lastUpdateTime);
   }
 
   @Override
@@ -388,6 +416,10 @@ public class JobEntity
         + denied
         + ", jobDeniedReason="
         + deniedReason
+        + ", creationTime="
+        + creationTime
+        + ", lastUpdateTime="
+        + lastUpdateTime
         + "} "
         + super.toString();
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -17,6 +17,14 @@
       "bpmnProcessId": {
         "type": "keyword"
       },
+      "creationTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "lastUpdateTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
       "processDefinitionKey": {
         "type": "long"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -17,6 +17,14 @@
       "bpmnProcessId": {
         "type": "keyword"
       },
+      "creationTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "lastUpdateTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
       "processDefinitionKey": {
         "type": "long"
       },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -18,6 +18,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DEN
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
@@ -85,6 +86,8 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
   public void updateEntity(final Record<JobRecordValue> record, final JobEntity entity) {
 
     final JobRecordValue recordValue = record.getValue();
+    final var recordTimestampAsOffsetDateTime =
+        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
     entity.setKey(record.getKey());
     entity
         .setPartitionId(record.getPartitionId())
@@ -103,9 +106,14 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
         .setJobKind(recordValue.getJobKind().name())
         .setFlowNodeId(recordValue.getElementId());
 
+    if (record.getIntent().equals(JobIntent.CREATED)) {
+      entity.setCreationTime(recordTimestampAsOffsetDateTime);
+    }
+    entity.setLastUpdateTime(recordTimestampAsOffsetDateTime);
+
     if (record.getIntent().equals(JobIntent.COMPLETED)
         || record.getIntent().equals(JobIntent.CANCELED)) {
-      entity.setEndTime(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+      entity.setEndTime(recordTimestampAsOffsetDateTime);
     }
 
     if (record.getIntent().equals(JobIntent.COMPLETED)) {
@@ -155,6 +163,7 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     updateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
     updateFields.put(PROCESS_DEFINITION_KEY, jobEntity.getProcessDefinitionKey());
     updateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
+    updateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
     if (FAILED_JOB_EVENTS.stream().anyMatch(i -> jobEntity.getState().equals(i.name()))) {
       updateFields.put(JOB_FAILED_WITH_RETRIES_LEFT, jobEntity.isJobFailedWithRetriesLeft());
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -18,6 +18,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DEN
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
@@ -208,6 +209,10 @@ final class JobHandlerTest {
     assertThat(entity.getEndTime()).isNull();
     assertThat(entity.getDeadline())
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(deadline)));
+    assertThat(entity.getCreationTime())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+    assertThat(entity.getLastUpdateTime())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
     // these values are only updated on JobIntent.COMPLETED
     assertThat(entity.isDenied()).isEqualTo(null);
     assertThat(entity.getDeniedReason()).isEqualTo(null);
@@ -412,6 +417,7 @@ final class JobHandlerTest {
     expectedUpdateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
     expectedUpdateFields.put(JOB_DENIED, denied);
     expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
+    expectedUpdateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 
@@ -475,6 +481,7 @@ final class JobHandlerTest {
     expectedUpdateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
     expectedUpdateFields.put(JOB_DENIED, denied);
     expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
+    expectedUpdateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -700,6 +700,14 @@ components:
         worker:
           description: The name of the worker of this job.
           type: string
+        creationTime:
+          description: When the job was created. Field is present for jobs created after 8.9.
+          type: string
+          format: date-time
+        lastUpdateTime:
+          description: When the job was last updated. Field is present for jobs created after 8.9.
+          type: string
+          format: date-time
 
     JobFailRequest:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -642,7 +642,9 @@ public final class SearchQueryResponseMapper {
         .processInstanceKey(KeyUtil.keyToString(job.processInstanceKey()))
         .elementId(job.elementId())
         .elementInstanceKey(KeyUtil.keyToString(job.elementInstanceKey()))
-        .tenantId(job.tenantId());
+        .tenantId(job.tenantId())
+        .creationTime(formatDate(job.creationTime()))
+        .lastUpdateTime(formatDate(job.lastUpdateTime()));
   }
 
   public static ProcessInstanceResult toProcessInstance(final ProcessInstanceEntity p) {


### PR DESCRIPTION
## Description

feat: introduce create/update time for jobs

This PR introduces createdAt and updatedAt timestamp fields for job entities to track when jobs are created and last updated. The implementation spans across the data layer (Elasticsearch/OpenSearch schemas), entity models, export handlers, and search/filter capabilities.

⚠️ Note to reviewer. During implementation, it was discovered that 3 indexes store jobs: `job`, `zeebe-record_job`, and `zeebe-record_job-batch`. The API fetches data from the `job` index, thus only that index is modified. Also, the `zeebe-record*` indexes tightly coupled with Zeebe core engine entities which I personally think is not a great idea to modify since those are very low level.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Testing done

Manual + unit

https://github.com/user-attachments/assets/cde710a2-68c6-410e-b25a-2976b4c00772

### Testing aggregation

Regarding aggregation request per https://github.com/camunda/camunda/issues/39912#issuecomment-3486536852.

```
POST /operate-job-8.6.0_/_search?size=0

{
  "aggs": {
    "creations_over_time": {
      "date_histogram": {
        "field": "createdAt",
        "calendar_interval": "minute"
      }
    }
  }
}

```

Returns

```
{
  "took": 45,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 7,
      "relation": "eq"
    },
    "max_score": null,
    "hits": []
  },
  "aggregations": {
    "creations_over_time": {
      "buckets": [
        {
          "key_as_string": "2025-11-19T15:10:00.000Z",
          "key": 1763565000000,
          "doc_count": 1
        },
        {
          "key_as_string": "2025-11-19T15:11:00.000Z",
          "key": 1763565060000,
          "doc_count": 0
        },
        {
          "key_as_string": "2025-11-19T15:12:00.000Z",
          "key": 1763565120000,
          "doc_count": 1
        },
        {
          "key_as_string": "2025-11-19T15:13:00.000Z",
          "key": 1763565180000,
          "doc_count": 1
        },
        {
          "key_as_string": "2025-11-19T15:14:00.000Z",
          "key": 1763565240000,
          "doc_count": 0
        },
        {
          "key_as_string": "2025-11-19T15:15:00.000Z",
          "key": 1763565300000,
          "doc_count": 0
        },
        {
          "key_as_string": "2025-11-19T15:16:00.000Z",
          "key": 1763565360000,
          "doc_count": 1
        },
        {
          "key_as_string": "2025-11-19T15:17:00.000Z",
          "key": 1763565420000,
          "doc_count": 0
        },
        {
          "key_as_string": "2025-11-19T15:18:00.000Z",
          "key": 1763565480000,
          "doc_count": 0
        },
        {
          "key_as_string": "2025-11-19T15:19:00.000Z",
          "key": 1763565540000,
          "doc_count": 0
        },
        {
          "key_as_string": "2025-11-19T15:20:00.000Z",
          "key": 1763565600000,
          "doc_count": 3
        }
      ]
    }
  }
}
```

## Related issues

closes #39912, #39917
