### PR TITLE
40668 stabilize update tests

### DIFF
--- a/zeebe/qa/update-tests/README.md
+++ b/zeebe/qa/update-tests/README.md
@@ -1,3 +1,5 @@
+see [Testing Guide](https://github.com/camunda/camunda/blob/main/docs/testing/acceptance.md#rolling-update-tests) for more information
+
 ## Pre-requisites
 
 To run the upgradability tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the camunda/zeebe dir):

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -38,12 +38,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.ContainerState;
@@ -57,6 +59,8 @@ import org.testcontainers.utility.DockerImageName;
  * versions.
  */
 final class RollingUpdateTest {
+
+  private static List<Arguments> cachedVersionMatrix;
 
   private static final BpmnModelInstance PROCESS =
       Bpmn.createExecutableProcess("process")
@@ -93,6 +97,13 @@ final class RollingUpdateTest {
 
   private final Collection<ZeebeVolume> volumes = new LinkedList<>();
 
+  static Stream<Arguments> versionMatrix() {
+    if (cachedVersionMatrix == null) {
+      cachedVersionMatrix = VersionCompatibilityMatrix.auto().toList();
+    }
+    return cachedVersionMatrix.stream();
+  }
+
   @BeforeEach
   public void setup() {
     cluster.getBrokers().values().forEach(this::configureBroker);
@@ -106,7 +117,7 @@ final class RollingUpdateTest {
   }
 
   @ParameterizedTest(name = "from {0} to {1}")
-  @MethodSource("io.camunda.zeebe.test.VersionCompatibilityMatrix#auto")
+  @MethodSource("versionMatrix")
   void shouldBeAbleToRestartContainerWithNewVersion(final String from, final String to) {
     // given
     updateAllBrokers(from);
@@ -137,7 +148,7 @@ final class RollingUpdateTest {
   }
 
   @ParameterizedTest(name = "from {0} to {1}")
-  @MethodSource("io.camunda.zeebe.test.VersionCompatibilityMatrix#auto")
+  @MethodSource("versionMatrix")
   void shouldReplicateSnapshotAcrossVersions(final String from, final String to) {
     // given
     updateAllBrokers(from);
@@ -204,7 +215,7 @@ final class RollingUpdateTest {
   }
 
   @ParameterizedTest(name = "from {0} to {1}")
-  @MethodSource("io.camunda.zeebe.test.VersionCompatibilityMatrix#auto")
+  @MethodSource("versionMatrix")
   void shouldPerformRollingUpdate(final String from, final String to) {
     // given
     updateAllBrokers(from);

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -65,7 +65,7 @@ final class VersionCompatibilityMatrix {
    *       upgrade paths.
    * </ul>
    */
-  private static Stream<Arguments> auto() {
+  static Stream<Arguments> auto() {
     final var matrix = new VersionCompatibilityMatrix();
 
     if (System.getenv("ZEEBE_CI_CHECK_VERSION_COMPATIBILITY") != null) {

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -10,14 +10,49 @@ package io.camunda.zeebe.test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionProvider;
+import io.camunda.zeebe.util.SemanticVersion;
 import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class VersionCompatibilityMatrixTest {
+
+  @Test
+  void filterPreReleaseVersion() {
+    final VersionCompatibilityMatrix matrix =
+        new VersionCompatibilityMatrix(
+            new StaticVersionProvider(
+                Set.of("8.7.11", "8.8.2", "8.8.2-optimize"),
+                Set.of("8.7.11", "8.8.2", "8.8.2-optimize")));
+
+    final var versions =
+        matrix.discoverVersions().map(SemanticVersion::toString).collect(Collectors.toSet());
+
+    assertThat(versions).isEqualTo(Set.of("8.7.11", "8.8.2"));
+  }
+
+  @Test
+  void filterUnreleasedLatestVersion() {
+    final VersionCompatibilityMatrix matrix =
+        new VersionCompatibilityMatrix(
+            new StaticVersionProvider(
+                Set.of("8.7.11", "8.8.0", "8.8.1", "8.8.2", "8.8.2-optimize"),
+                Set.of("8.7.11", "8.8.0", "8.8.1")));
+
+    final var versions =
+        matrix.discoverVersions().map(SemanticVersion::toString).collect(Collectors.toSet());
+
+    assertThat(versions).isEqualTo(Set.of("8.7.11", "8.8.0", "8.8.1"));
+  }
+
   @ParameterizedTest(name = "Sharding {0} elements into {1} shards")
   @MethodSource("sizeAndShards")
   void shouldShardCompletely(final int size, final int totalShards) {
@@ -40,5 +75,34 @@ class VersionCompatibilityMatrixTest {
                     .boxed()
                     .filter(shards -> shards < size)
                     .map(shards -> arguments(size, shards)));
+  }
+
+  static class StaticVersionProvider implements VersionProvider {
+
+    private final Set<SemanticVersion> versions;
+    private final Set<SemanticVersion> releasedVersions;
+
+    public StaticVersionProvider(final Set<String> versions, final Set<String> releasedVersions) {
+      this.versions =
+          versions.stream()
+              .map(SemanticVersion::parse)
+              .flatMap(Optional::stream)
+              .collect(Collectors.toSet());
+      this.releasedVersions =
+          releasedVersions.stream()
+              .map(SemanticVersion::parse)
+              .flatMap(Optional::stream)
+              .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Stream<SemanticVersion> discoverVersions() {
+      return versions.stream();
+    }
+
+    @Override
+    public boolean isReleased(final SemanticVersion version) {
+      return releasedVersions.contains(version);
+    }
   }
 }


### PR DESCRIPTION
## Description

During our release process it could happen in the past, that we tried to test releases that haven't been fully published leading to failing tests in CI blocking engineers.

Thus we adjusted the release process to only create a github release entry/entity, when the release artifacts have been fully published to maven/docker.

Therefore, this PR adds a check to the latest patch version of every minor to check the existence of the actual release (GH api is not super supportive, thus we only check the latest patches 😓 )


> Dear Reviewer,
> 
> the second commit contains the actual fix, and might be enough to get this done.
> the third commit is about refactoring it a bit nicer and testable, but isn't crucially necessary
> 
> Feel free to leave your thoughts 😄 

## Related issues

closes #40668
