### PR TITLE
build: change Operate FE unit tests to self-hosted runner

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -42,12 +42,12 @@ jobs:
   operate-backend-unit-tests:
     name: "Unit"
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions: {} # GITHUB_TOKEN unused in this job
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        suite: [ DataLayer, CoreFeatures ]
+        suite: [DataLayer, CoreFeatures]
         include:
           - suite: DataLayer
             suiteName: Data Layer
@@ -58,14 +58,13 @@ jobs:
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
 
-
   # Checks to see if Operate can properly build itself and a docker image
   build-operate-backend:
     if: inputs.runBeTests
     name: "Build Back End"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions: {} # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       TEST_OWNER: Core Features
@@ -93,7 +92,7 @@ jobs:
         uses: ./.github/actions/build-platform-docker
         with:
           dockerfile: operate.Dockerfile
-          repository: 'registry.camunda.cloud/team-operate/camunda-operate'
+          repository: "registry.camunda.cloud/team-operate/camunda-operate"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -108,9 +107,9 @@ jobs:
   fe-unit-tests:
     if: inputs.runFeTests
     name: "Unit - Front End"
-    runs-on: ubuntu-latest
+    runs-on: gcp-perf-core-8-default
     timeout-minutes: 10
-    permissions: { } # GITHUB_TOKEN unused in this job
+    permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
       TEST_OWNER: Core Features
@@ -361,7 +360,7 @@ jobs:
     name: "Integration / Backup Restore ITs"
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions: {} # GITHUB_TOKEN unused in this job
     env:
       DOCKER_IMAGE_TAG: current-test
       TEST_OWNER: Data Layer


### PR DESCRIPTION
## Description

It was discovered, that Operate FE Unit tests occasionally run out of memory (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`), see https://camunda.slack.com/archives/C09SYSLUQLW

Examples:
https://github.com/camunda/camunda/actions/runs/19370092653/job/55423486259
https://github.com/camunda/camunda/actions/runs/19370862177/job/55426200975
https://github.com/camunda/camunda/actions/runs/19371749167/job/55429204931

To mitigate it, this PR switches to the self-hosted runner `gcp-perf-core-8-default` for the Operate FE unit tests.

The tests were successfully run several times on this PR to ensure stability (see https://github.com/camunda/camunda/actions/runs/19434927335/job/55606349066?pr=41074)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
