### PR TITLE
[Backport stable/8.8] fix: insert UsageMetricsTUEntity might already exist

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.elasticsearch.action.DocWriteResponse.Result;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -34,7 +35,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -131,7 +131,9 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
               .source(objectMapper.writeValueAsString(entity), XContentType.JSON);
 
       final IndexResponse response = esClient.index(request, RequestOptions.DEFAULT);
-      return response.status() == RestStatus.CREATED;
+      final Result result = response.getResult();
+
+      return Result.CREATED.equals(result) || Result.UPDATED.equals(result);
     } catch (final IOException e) {
       LOGGER.error(e.getMessage(), e);
       throw new TasklistRuntimeException("Error while trying to upsert entity: " + entity);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -149,7 +149,9 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
                       .document(entity));
 
       final IndexResponse response = openSearchClient.index(request);
-      return Result.Created.equals(response.result());
+      final Result result = response.result();
+
+      return Result.Created.equals(result) || Result.Updated.equals(result);
     } catch (final IOException | OpenSearchException e) {
       LOGGER.error(e.getMessage(), e);
       throw new TasklistRuntimeException("Error while trying to upsert entity: " + entity);

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import org.elasticsearch.action.DocWriteResponse.Result;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -42,7 +43,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
@@ -88,12 +88,12 @@ public class TaskMetricsStoreElasticSearchTest {
             .setTenantId("<default>")
             .setPartitionId(0);
     final var indexResponse = mock(IndexResponse.class);
-    when(indexResponse.status()).thenReturn(RestStatus.CREATED);
     final IndexRequest expectedIndexRequest =
         new IndexRequest(METRIC_INDEX_NAME)
             .id(expectedEntry.getId())
             .source(objectMapper.writeValueAsString(expectedEntry), XContentType.JSON);
     when(esClient.index(any(), eq(RequestOptions.DEFAULT))).thenReturn(indexResponse);
+    when(indexResponse.getResult()).thenReturn(Result.CREATED);
 
     // When
     instance.registerTaskAssigned(task);


### PR DESCRIPTION
# Description
Backport of #41044 to `stable/8.8`.

relates to #40985