### PR TITLE
34042 e2e operate verify filter functionality process view

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -16,6 +16,8 @@ import {OperateProcessInstancePage} from '@pages/OperateProcessInstancePage';
 import {OperateFiltersPanelPage} from '@pages/OperateFiltersPanelPage';
 import {OperateDashboardPage} from '@pages/OperateDashboardPage';
 import {OperateDiagramPage} from '@pages/OperateDiagramPage';
+import {OperateProcessMigrationModePage} from '@pages/OperateProcessMigrationModePage';
+import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
@@ -40,6 +42,8 @@ type PlaywrightFixtures = {
   operateProcessesPage: OperateProcessesPage;
   operateProcessInstancePage: OperateProcessInstancePage;
   operateFiltersPanelPage: OperateFiltersPanelPage;
+  operateProcessMigrationModePage: OperateProcessMigrationModePage;
+  operateOperationPanelPage: OperateOperationPanelPage;
   operateDashboardPage: OperateDashboardPage;
   operateDiagramPage: OperateDiagramPage;
   taskDetailsPage: TaskDetailsPage;
@@ -94,6 +98,12 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateFiltersPanelPage: async ({page}, use) => {
     await use(new OperateFiltersPanelPage(page));
+  },
+  operateProcessMigrationModePage: async ({page}, use) => {
+    await use(new OperateProcessMigrationModePage(page));
+  },
+  operateOperationPanelPage: async ({page}, use) => {
+    await use(new OperateOperationPanelPage(page));
   },
   taskDetailsPage: async ({page}, use) => {
     await use(new TaskDetailsPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -189,7 +189,7 @@ export class IdentityUsersPage {
   }
 
   async editUser(
-    currentUser: {username: string, email: string},
+    currentUser: {username: string; email: string},
     updatedUser: {name: string; email: string},
   ) {
     await waitForItemInList(this.page, this.userCell(currentUser.username), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator, expect} from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 type OptionalFilter =
   | 'Variable'
@@ -26,7 +26,6 @@ export class OperateFiltersPanelPage {
   readonly completedInstancesCheckbox: Locator;
   readonly canceledInstancesCheckbox: Locator;
   readonly finishedInstancesCheckbox: Locator;
-
   readonly processNameFilter: Locator;
   readonly processVersionFilter: Locator;
   readonly processInstanceKeysFilter: Locator;
@@ -57,22 +56,22 @@ export class OperateFiltersPanelPage {
     this.page = page;
     this.runningInstancesCheckbox = this.page
       .locator('label')
-      .filter({hasText: 'Running'});
+      .filter({ hasText: 'Running' });
     this.activeInstancesCheckbox = this.page
       .locator('label')
-      .filter({hasText: 'Active'});
+      .filter({ hasText: 'Active' });
     this.incidentsInstancesCheckbox = this.page
       .locator('label')
-      .filter({hasText: 'Incidents'});
+      .filter({ hasText: 'Incidents' });
     this.completedInstancesCheckbox = this.page
       .locator('label')
-      .filter({hasText: 'Completed'});
+      .filter({ hasText: 'Completed' });
     this.canceledInstancesCheckbox = this.page
       .locator('label')
-      .filter({hasText: 'Canceled'});
+      .filter({ hasText: 'Canceled' });
     this.finishedInstancesCheckbox = this.page
       .locator('label')
-      .filter({hasText: 'Finished'});
+      .filter({ hasText: 'Finished' });
     this.processNameFilter = this.page.getByRole('combobox', {
       name: 'Name',
     });
@@ -158,23 +157,23 @@ export class OperateFiltersPanelPage {
   }
 
   async removeOptionalFilter(filterName: OptionalFilter) {
-    await this.page.getByLabel(filterName, {exact: true}).hover();
+    await this.page.getByLabel(filterName, { exact: true }).hover();
     await this.page.getByLabel(`Remove ${filterName} Filter`).click();
   }
 
   async selectProcess(option: string) {
     await this.processNameFilter.click();
-    await this.page.getByRole('option', {name: option, exact: true}).click();
+    await this.page.getByRole('option', { name: option, exact: true }).click();
   }
 
   async selectVersion(option: string) {
     await this.processVersionFilter.click();
-    await this.page.getByRole('option', {name: option, exact: true}).click();
+    await this.page.getByRole('option', { name: option, exact: true }).click();
   }
 
   async selectFlowNode(option: string) {
     await this.flowNodeFilter.click();
-    await this.page.getByRole('option', {name: option}).click();
+    await this.page.getByRole('option', { name: option }).click();
   }
 
   async fillVariableNameFilter(name: string) {
@@ -217,7 +216,7 @@ export class OperateFiltersPanelPage {
     await expect(this.dateFilterDialog).toBeVisible();
 
     const date = new Date();
-    const monthName = date.toLocaleString('default', {month: 'long'});
+    const monthName = date.toLocaleString('default', { month: 'long' });
     const year = date.getFullYear();
 
     await this.fromDateInput.click();
@@ -258,11 +257,11 @@ export class OperateFiltersPanelPage {
   }
 
   async clickMultipleVariablesSwitch() {
-    await this.multipleVariablesSwitch.click({force: true});
+    await this.multipleVariablesSwitch.click({ force: true });
   }
 
   async clickRunningInstancesCheckbox(): Promise<void> {
-    await this.runningInstancesCheckbox.click({timeout: 60000});
+    await this.runningInstancesCheckbox.click({ timeout: 60000 });
   }
 
   async clickActiveInstancesCheckbox(): Promise<void> {
@@ -270,17 +269,17 @@ export class OperateFiltersPanelPage {
   }
 
   async clickIncidentsInstancesCheckbox(): Promise<void> {
-    await this.incidentsInstancesCheckbox.click({timeout: 60000});
+    await this.incidentsInstancesCheckbox.click({ timeout: 60000 });
   }
 
   async clickFinishedInstancesCheckbox(): Promise<void> {
-    await this.finishedInstancesCheckbox.click({timeout: 60000});
+    await this.finishedInstancesCheckbox.click({ timeout: 60000 });
   }
 
   async clickCompletedInstancesCheckbox(): Promise<void> {
-    await this.completedInstancesCheckbox.click({timeout: 60000});
+    await this.completedInstancesCheckbox.click({ timeout: 60000 });
   }
   async clickCanceledInstancesCheckbox(): Promise<void> {
-    await this.canceledInstancesCheckbox.click({timeout: 60000});
+    await this.canceledInstancesCheckbox.click({ timeout: 60000 });
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -20,17 +20,19 @@ type OptionalFilter =
 
 export class OperateFiltersPanelPage {
   private page: Page;
-  readonly activeCheckbox: Locator;
-  readonly incidentsCheckbox: Locator;
+  readonly activeInstancesCheckbox: Locator;
+  readonly incidentsInstancesCheckbox: Locator;
   readonly runningInstancesCheckbox: Locator;
-  readonly completedCheckbox: Locator;
-  readonly canceledCheckbox: Locator;
+  readonly completedInstancesCheckbox: Locator;
+  readonly canceledInstancesCheckbox: Locator;
   readonly finishedInstancesCheckbox: Locator;
+
   readonly processNameFilter: Locator;
   readonly processVersionFilter: Locator;
   readonly processInstanceKeysFilter: Locator;
   readonly processInstanceKeysFilterOption: Locator;
   readonly parentProcessInstanceKey: Locator;
+  readonly processInstanceKey: Locator;
   readonly flowNodeFilter: Locator;
   readonly operationIdFilter: Locator;
   readonly resetFiltersButton: Locator;
@@ -53,22 +55,24 @@ export class OperateFiltersPanelPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.activeCheckbox = this.page.getByRole('checkbox', {name: 'Active'});
-    this.incidentsCheckbox = this.page.getByRole('checkbox', {
-      name: 'Incidents',
-    });
-    this.runningInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Running Instances',
-    });
-    this.completedCheckbox = this.page.getByRole('checkbox', {
-      name: 'Completed',
-    });
-    this.canceledCheckbox = this.page.getByRole('checkbox', {
-      name: 'Canceled',
-    });
-    this.finishedInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Finished Instances',
-    });
+    this.runningInstancesCheckbox = this.page
+      .locator('label')
+      .filter({hasText: 'Running'});
+    this.activeInstancesCheckbox = this.page
+      .locator('label')
+      .filter({hasText: 'Active'});
+    this.incidentsInstancesCheckbox = this.page
+      .locator('label')
+      .filter({hasText: 'Incidents'});
+    this.completedInstancesCheckbox = this.page
+      .locator('label')
+      .filter({hasText: 'Completed'});
+    this.canceledInstancesCheckbox = this.page
+      .locator('label')
+      .filter({hasText: 'Canceled'});
+    this.finishedInstancesCheckbox = this.page
+      .locator('label')
+      .filter({hasText: 'Finished'});
     this.processNameFilter = this.page.getByRole('combobox', {
       name: 'Name',
     });
@@ -83,6 +87,9 @@ export class OperateFiltersPanelPage {
     });
     this.parentProcessInstanceKey = page.getByRole('textbox', {
       name: 'parent process instance key',
+    });
+    this.processInstanceKey = page.getByRole('textbox', {
+      name: 'process instance key',
     });
     this.flowNodeFilter = this.page.getByRole('combobox', {
       name: 'flow node',
@@ -238,6 +245,10 @@ export class OperateFiltersPanelPage {
     await this.errorMessageFilter.fill(errorMessage);
   }
 
+  async fillOperationIdFilter(operationId: string) {
+    await this.operationIdFilter.fill(operationId);
+  }
+
   async clickJsonEditorModal() {
     await this.jsonEditorModalButton.click();
   }
@@ -248,5 +259,28 @@ export class OperateFiltersPanelPage {
 
   async clickMultipleVariablesSwitch() {
     await this.multipleVariablesSwitch.click({force: true});
+  }
+
+  async clickRunningInstancesCheckbox(): Promise<void> {
+    await this.runningInstancesCheckbox.click({timeout: 60000});
+  }
+
+  async clickActiveInstancesCheckbox(): Promise<void> {
+    await this.activeInstancesCheckbox.click();
+  }
+
+  async clickIncidentsInstancesCheckbox(): Promise<void> {
+    await this.incidentsInstancesCheckbox.click({timeout: 60000});
+  }
+
+  async clickFinishedInstancesCheckbox(): Promise<void> {
+    await this.finishedInstancesCheckbox.click({timeout: 60000});
+  }
+
+  async clickCompletedInstancesCheckbox(): Promise<void> {
+    await this.completedInstancesCheckbox.click({timeout: 60000});
+  }
+  async clickCanceledInstancesCheckbox(): Promise<void> {
+    await this.canceledInstancesCheckbox.click({timeout: 60000});
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+export class OperateOperationPanelPage {
+  private page: Page;
+  readonly expandButton: Locator;
+  readonly collapseButton: Locator;
+  readonly operationList: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.expandButton = page.getByRole('button', {name: 'Expand Operations'});
+    this.collapseButton = page.getByRole('button', {
+      name: 'Collapse Operations',
+    });
+    this.operationList = page.getByTestId('operations-list');
+  }
+
+  getAllOperationEntries(): Locator {
+    return this.operationList.getByTestId('operations-entry');
+  }
+
+  static getOperationEntrySuccess(operationEntry: Locator): Locator {
+    return operationEntry.getByText('1 operation succeeded');
+  }
+
+  static getOperationID(operationEntry: Locator): Locator {
+    return operationEntry.getByTestId('operation-id');
+  }
+
+  static getOperationType(operationEntry: Locator): Locator {
+    return operationEntry.getByRole('heading');
+  }
+
+  async expandOperationIdField(): Promise<void> {
+    await this.expandButton.click({timeout: 30000});
+  }
+
+  async collapseOperationIdField(): Promise<void> {
+    await this.collapseButton.click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+export class OperateProcessMigrationModePage {
+  private page: Page;
+  readonly targetVersionCombo: Locator;
+  readonly nextButton: Locator;
+  readonly confirmButton: Locator;
+  readonly migrationConfirmationInput: Locator;
+  readonly migrationConfirmationButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.targetVersionCombo = page.getByRole('combobox', {
+      name: 'Target Version',
+    });
+    this.nextButton = this.page.getByRole('button', {name: 'Next'});
+    this.confirmButton = this.page.getByRole('button', {name: 'Confirm'});
+    this.migrationConfirmationInput = this.page
+      .getByRole('dialog')
+      .locator('input');
+    this.migrationConfirmationButton = page
+      .getByLabel('Migration confirmation')
+      .getByRole('button', {name: 'Confirm'});
+  }
+
+  async clickTargetVersionCombo(): Promise<void> {
+    await this.targetVersionCombo.click();
+  }
+
+  async selectTargetVersion(version: string): Promise<void> {
+    await this.page.getByRole('option', {name: version, exact: true}).click();
+  }
+
+  async clickNextButton(): Promise<void> {
+    await this.nextButton.click();
+  }
+
+  async clickConfirmButton(): Promise<void> {
+    await this.confirmButton.click();
+  }
+
+  async fillMigrationConfirmation(text: string): Promise<void> {
+    await this.migrationConfirmationInput.fill(text);
+  }
+
+  async clickMigrationConfirmationButton(): Promise<void> {
+    await this.migrationConfirmationButton.click();
+  }
+
+  async migrateProcessToVersion(version: string): Promise<void> {
+    await this.clickTargetVersionCombo();
+    await this.selectTargetVersion(version);
+    await this.clickNextButton();
+    await this.clickConfirmButton();
+    await this.fillMigrationConfirmation('MIGRATE');
+    await this.clickMigrationConfirmationButton();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -9,17 +9,13 @@
 import {Page, Locator, expect} from '@playwright/test';
 import {OperateDiagramPage} from './OperateDiagramPage';
 import {sleep} from '../utils/sleep';
+import {checkUpdateOnVersion} from 'utils/zeebeClient';
 
 class OperateProcessesPage {
   private page: Page;
   readonly processResultCount: Locator;
-  readonly processActiveCheckbox: Locator;
-  readonly processCompletedCheckbox: Locator;
-  readonly processRunningInstancesCheckbox: Locator;
-  readonly processIncidentsCheckbox: Locator;
   readonly processPageHeading: Locator;
   readonly noMatchingInstancesMessage: Locator;
-  readonly processFinishedInstancesCheckbox: Locator;
   readonly processNameFilter: Locator;
   readonly processInstanceLink: Locator;
   readonly startDateSortButton: Locator;
@@ -30,33 +26,27 @@ class OperateProcessesPage {
   readonly parentInstanceIdCell: Locator;
   readonly endDateCell: Locator;
   readonly versionCell: Locator;
+  readonly processInstanceKeyCell: Locator;
+  readonly migrateBatchOperationButton: Locator;
+  readonly cancelBatchOperationButton: Locator;
+  readonly applyCancelBatchOperationDialogButton: Locator;
+  readonly continueMigrationDialogButton: Locator;
+  readonly cancelProcessInstanceButton: Locator;
+  readonly cancelProcessInstanceDialogButton: Locator;
+  readonly singleCancellationSpinner: Locator;
+  readonly tableLoadingSpinner: Locator;
   readonly diagram: InstanceType<typeof OperateDiagramPage>;
 
   constructor(page: Page) {
     this.page = page;
     this.diagram = new OperateDiagramPage(page);
     this.processResultCount = page.getByTestId('result-count');
-    this.processActiveCheckbox = page
-      .locator('label')
-      .filter({hasText: 'Active'});
-    this.processCompletedCheckbox = page
-      .locator('label')
-      .filter({hasText: 'Completed'});
-    this.processRunningInstancesCheckbox = page
-      .locator('label')
-      .filter({hasText: 'Running Instances'});
-    this.processIncidentsCheckbox = page
-      .locator('label')
-      .filter({hasText: 'Incidents'});
     this.processPageHeading = page
       .getByTestId('expanded-panel')
       .getByRole('heading', {name: 'Process'});
     this.noMatchingInstancesMessage = page.getByText(
       'There are no Instances matching this filter set',
     );
-    this.processFinishedInstancesCheckbox = page
-      .getByTestId('filter-finished-instances')
-      .getByRole('checkbox');
     this.processNameFilter = page.getByRole('combobox', {name: 'name'});
     this.processInstanceLink = page
       .getByRole('link', {
@@ -76,6 +66,10 @@ class OperateProcessesPage {
       name: 'sort by name',
     });
     this.processInstancesTable = page.getByTestId('data-list').getByRole('row');
+    this.processInstanceKeyCell = page
+      .getByTestId('data-list')
+      .getByTestId('cell-processInstanceKey')
+      .first();
     this.parentInstanceIdCell = page
       .getByTestId('data-list')
       .getByTestId('cell-parentInstanceId')
@@ -84,27 +78,27 @@ class OperateProcessesPage {
       .getByTestId('data-list')
       .getByTestId('cell-endDate')
       .first();
-    this.versionCell = page.getByTestId('process-version-select');
-  }
-
-  async clickProcessActiveCheckbox(): Promise<void> {
-    await this.processActiveCheckbox.click();
-  }
-
-  async clickProcessCompletedCheckbox(): Promise<void> {
-    await this.processCompletedCheckbox.click({timeout: 120000});
-  }
-
-  async clickProcessIncidentsCheckbox(): Promise<void> {
-    await this.processIncidentsCheckbox.click({timeout: 90000});
-  }
-
-  async clickRunningProcessInstancesCheckbox(): Promise<void> {
-    await this.processRunningInstancesCheckbox.click({timeout: 90000});
-  }
-
-  async clickFinishedProcessInstancesCheckbox(): Promise<void> {
-    await this.processFinishedInstancesCheckbox.click({timeout: 90000});
+    this.versionCell = page.getByTestId('cell-processVersion');
+    this.migrateBatchOperationButton = page.getByRole('button', {
+      name: 'Migrate',
+    });
+    this.cancelBatchOperationButton = page.getByTestId(
+      'cancel-batch-operation',
+    );
+    this.applyCancelBatchOperationDialogButton = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Apply'});
+    this.continueMigrationDialogButton = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Continue'});
+    this.cancelProcessInstanceButton = page
+      .getByRole('button', {name: 'Cancel Instance'})
+      .first();
+    this.cancelProcessInstanceDialogButton = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Apply'});
+    this.singleCancellationSpinner = page.getByTestId('operation-spinner');
+    this.tableLoadingSpinner = page.getByTestId('data-table-loader');
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -133,6 +127,22 @@ class OperateProcessesPage {
     );
   }
 
+  async checkVersion(processInstanceKey: string): Promise<void> {
+    const maxRetries = 10;
+    let retryCount = 0;
+    while (retryCount < maxRetries) {
+      try {
+        await checkUpdateOnVersion('2', processInstanceKey);
+        return;
+      } catch {
+        retryCount++;
+        console.log(`Attempt ${retryCount} failed. Retrying...`);
+        await this.page.reload();
+      }
+    }
+    throw new Error(`Failed to check version after ${maxRetries} attempts.`);
+  }
+
   async assertProcessInstanceLink(processInstanceKey: string): Promise<void> {
     await expect(
       this.page.getByRole('link', {
@@ -155,6 +165,68 @@ class OperateProcessesPage {
 
   async clickProcessNameSortButton(): Promise<void> {
     await this.processNameSortButton.click();
+  }
+
+  async selectProcessCheckboxByPIK(...PIK: string[]): Promise<void> {
+    for (const key of PIK) {
+      await this.page.locator(`label[for$="${key}"]`).click();
+    }
+  }
+
+  async clickCancelBatchOperationButton(): Promise<void> {
+    await this.cancelBatchOperationButton.click();
+  }
+
+  async clickApplyCancelBatchOperationDialogButton(): Promise<void> {
+    await this.applyCancelBatchOperationDialogButton.click();
+  }
+
+  async clickMigrateBatchOperationButton(): Promise<void> {
+    await this.migrateBatchOperationButton.click();
+  }
+
+  async clickContinueMigrationDialogButton(): Promise<void> {
+    await this.continueMigrationDialogButton.click();
+  }
+
+  async clickCancelProcessInstanceButton(): Promise<void> {
+    await this.cancelProcessInstanceButton.click();
+  }
+
+  async clickCancelProcessInstanceDialogButton(): Promise<void> {
+    await this.cancelProcessInstanceDialogButton.click();
+  }
+
+  async tableHasInstanceKey(keyStr: string): Promise<boolean> {
+    const meow = this.processInstancesTable
+      .getByTestId('cell-processInstanceKey')
+      .getByText(keyStr);
+    if (await meow.count()) {
+      return true;
+    }
+    return false;
+  }
+
+  async visibleKeys(): Promise<string[]> {
+    const texts = await this.page
+      .getByTestId('cell-processInstanceKey')
+      .allInnerTexts();
+    return texts.map((t) => t.trim());
+  }
+
+  static getProcessVersion(row: Locator): Locator {
+    return row.getByTestId('cell-processVersion');
+  }
+
+  static getRowByProcessInstanceKey(page: Page, keyStr: string): Locator {
+    return page
+      .getByTestId('data-list')
+      .getByRole('row')
+      .filter({
+        has: page
+          .getByTestId('cell-processInstanceKey')
+          .filter({hasText: keyStr}),
+      });
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/FlakyWorker.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/FlakyWorker.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="ba05bc3" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="ProcessFlakyWorker" name="FailedWorker" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_04uvmbi</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_04uvmbi" sourceRef="StartEvent_1" targetRef="Activity_12dtms2" />
+    <bpmn:serviceTask id="Activity_12dtms2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="flaky-worker" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_04uvmbi</bpmn:incoming>
+      <bpmn:outgoing>Flow_028ufmk</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0imbakd">
+      <bpmn:incoming>Flow_028ufmk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_028ufmk" sourceRef="Activity_12dtms2" targetRef="Event_0imbakd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ProcessFlakyWorker">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m4zema_di" bpmnElement="Activity_12dtms2">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0imbakd_di" bpmnElement="Event_0imbakd">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_04uvmbi_di" bpmnElement="Flow_04uvmbi">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_028ufmk_di" bpmnElement="Flow_028ufmk">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/ProcessToCancel.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/ProcessToCancel.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="d4cbe29" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="ProcessToCancel" name="ProcessToCancel" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_10hbqcc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_10hbqcc" sourceRef="StartEvent_1" targetRef="Activity_07qbjge" />
+    <bpmn:userTask id="Activity_07qbjge">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10hbqcc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dt7hcd</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1h5a8dc">
+      <bpmn:incoming>Flow_0dt7hcd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0dt7hcd" sourceRef="Activity_07qbjge" targetRef="Event_1h5a8dc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1im3r0c">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0efuhuw_di" bpmnElement="Activity_07qbjge">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h5a8dc_di" bpmnElement="Event_1h5a8dc">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10hbqcc_di" bpmnElement="Flow_10hbqcc">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dt7hcd_di" bpmnElement="Flow_0dt7hcd">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/Versioned Process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/Versioned Process.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="7f5c191" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="versionedProcess" name="Versioned Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1gh09ar</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1gh09ar" sourceRef="StartEvent_1" targetRef="Activity_1w6c4zk" />
+    <bpmn:manualTask id="Activity_1w6c4zk">
+      <bpmn:incoming>Flow_1gh09ar</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vy472r</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_0vy472r" sourceRef="Activity_1w6c4zk" targetRef="Activity_1b1zqkp" />
+    <bpmn:userTask id="Activity_1b1zqkp">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0vy472r</bpmn:incoming>
+      <bpmn:outgoing>Flow_0q9zv7q</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0q9zv7q" sourceRef="Activity_1b1zqkp" targetRef="Activity_0177exb" />
+    <bpmn:userTask id="Activity_0177exb">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0q9zv7q</bpmn:incoming>
+      <bpmn:outgoing>Flow_1lnscrb</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1j1p0tz">
+      <bpmn:incoming>Flow_1lnscrb</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1lnscrb" sourceRef="Activity_0177exb" targetRef="Event_1j1p0tz" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_11rcfjo">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00e5laa_di" bpmnElement="Activity_1w6c4zk">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dc51tp_di" bpmnElement="Activity_1b1zqkp">
+        <dc:Bounds x="400" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1snd9oo_di" bpmnElement="Activity_0177exb">
+        <dc:Bounds x="560" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1j1p0tz_di" bpmnElement="Event_1j1p0tz">
+        <dc:Bounds x="722" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1gh09ar_di" bpmnElement="Flow_1gh09ar">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vy472r_di" bpmnElement="Flow_0vy472r">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="400" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q9zv7q_di" bpmnElement="Flow_0q9zv7q">
+        <di:waypoint x="500" y="118" />
+        <di:waypoint x="560" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lnscrb_di" bpmnElement="Flow_1lnscrb">
+        <di:waypoint x="660" y="118" />
+        <di:waypoint x="722" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/Versioned Process_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/Versioned Process_2.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="7f5c191" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="versionedProcess" name="Versioned Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1gh09ar</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1gh09ar" sourceRef="StartEvent_1" targetRef="Activity_1w6c4zk" />
+    <bpmn:manualTask id="Activity_1w6c4zk">
+      <bpmn:incoming>Flow_1gh09ar</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vy472r</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_0vy472r" sourceRef="Activity_1w6c4zk" targetRef="Activity_1b1zqkp" />
+    <bpmn:userTask id="Activity_1b1zqkp">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0vy472r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rc1usw</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1gjqite">
+      <bpmn:incoming>Flow_1rc1usw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1rc1usw" sourceRef="Activity_1b1zqkp" targetRef="Event_1gjqite" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_11rcfjo">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00e5laa_di" bpmnElement="Activity_1w6c4zk">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dc51tp_di" bpmnElement="Activity_1b1zqkp">
+        <dc:Bounds x="400" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1gjqite_di" bpmnElement="Event_1gjqite">
+        <dc:Bounds x="562" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1gh09ar_di" bpmnElement="Flow_1gh09ar">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vy472r_di" bpmnElement="Flow_0vy472r">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="400" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rc1usw_di" bpmnElement="Flow_1rc1usw">
+        <di:waypoint x="500" y="118" />
+        <di:waypoint x="562" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityProcess.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="d4cbe29" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="CallActivityProcess" name="Call Activity Process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1a3emhl</bpmn:outgoing>
@@ -10,32 +10,48 @@
         <zeebe:calledElement processId="CalledProcess" propagateAllChildVariables="false" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1a3emhl</bpmn:incoming>
-      <bpmn:outgoing>Flow_1j9hrgw</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1fgve6m</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:endEvent id="Event_1p0nsc7">
-      <bpmn:incoming>Flow_1j9hrgw</bpmn:incoming>
+    <bpmn:sequenceFlow id="Flow_1fgve6m" sourceRef="Activity_13otele" targetRef="Activity_1uxd8yb" />
+    <bpmn:endEvent id="Event_0gfc9mn">
+      <bpmn:incoming>Flow_1l13cvl</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1j9hrgw" sourceRef="Activity_13otele" targetRef="Event_1p0nsc7" />
+    <bpmn:sequenceFlow id="Flow_1l13cvl" sourceRef="Activity_1uxd8yb" targetRef="Event_0gfc9mn" />
+    <bpmn:callActivity id="Activity_1uxd8yb" name="Call Activiry with error">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="processWithAnError" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1fgve6m</bpmn:incoming>
+      <bpmn:outgoing>Flow_1l13cvl</bpmn:outgoing>
+    </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CallActivityProcess">
-      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1j9hrgw_di" bpmnElement="Flow_1j9hrgw">
-        <di:waypoint x="370" y="117" />
-        <di:waypoint x="432" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1jff16t_di" bpmnElement="Activity_13otele">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1p0nsc7_di" bpmnElement="Event_1p0nsc7">
-        <dc:Bounds x="432" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0gfc9mn_di" bpmnElement="Event_0gfc9mn">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hersz0_di" bpmnElement="Activity_1uxd8yb">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fgve6m_di" bpmnElement="Flow_1fgve6m">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1l13cvl_di" bpmnElement="Flow_1l13cvl">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -59,6 +59,7 @@ test.describe('HTO User Flow Tests', () => {
     taskDetailsPage,
     taskPanelPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     page,
     loginPage,
   }) => {
@@ -87,7 +88,7 @@ test.describe('HTO User Flow Tests', () => {
       await expect(operateHomePage.processesTab).toBeVisible({timeout: 120000});
       await operateHomePage.clickProcessesTab();
       await operateProcessesPage.filterByProcessName('Job_Worker_Process');
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(10000);
       await operateProcessesPage.clickProcessInstanceLink();
       await operateProcessInstancePage.completedIconAssertion();
@@ -106,7 +107,7 @@ test.describe('HTO User Flow Tests', () => {
     await test.step('View Process Instance in Operate, Edit the Variable & Assert the Variable is Updated in Tasklist', async () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
-      await expect(operateHomePage.processesTab).toBeVisible({timeout: 180000});
+      await expect(operateHomePage.processesTab).toBeVisible({timeout: 60000});
       await operateHomePage.clickProcessesTab();
       await operateProcessesPage.filterByProcessName('Variable_Process');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -159,13 +160,14 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     page,
     loginPage,
   }) => {
     await test.step('View Process Instance in Operate and complete User Task in Tasklist', async () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
-      await expect(operateHomePage.processesTab).toBeVisible({timeout: 180000});
+      await expect(operateHomePage.processesTab).toBeVisible({timeout: 60000});
       await operateHomePage.clickProcessesTab();
       await operateProcessesPage.filterByProcessName('Form_User_Task');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -183,8 +185,8 @@ test.describe('HTO User Flow Tests', () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
-      await operateProcessesPage.clickProcessActiveCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.clickActiveInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Form_User_Task');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -196,15 +198,16 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     loginPage,
     page,
   }) => {
     await test.step('View Process Instance in Operate and check if process is complete', async () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
-      await expect(operateHomePage.processesTab).toBeVisible({timeout: 180000});
+      await expect(operateHomePage.processesTab).toBeVisible({timeout: 60000});
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Start_Form_Process');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -217,6 +220,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskDetailsPage,
     taskPanelPage,
     loginPage,
@@ -262,7 +266,7 @@ test.describe('HTO User Flow Tests', () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName(
         'Zeebe_Priority_User_Task_Process',
@@ -278,6 +282,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskDetailsPage,
     taskPanelPage,
   }) => {
@@ -301,9 +306,9 @@ test.describe('HTO User Flow Tests', () => {
 
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
-      await expect(operateHomePage.processesTab).toBeVisible({timeout: 120000});
+      await expect(operateHomePage.processesTab).toBeVisible({timeout: 60000});
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Zeebe_User_Task_Process');
       await operateProcessesPage.clickProcessInstanceLink();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -6,16 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
-import {expect} from '@playwright/test';
-import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
-import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
-import {waitForAssertion} from 'utils/waitForAssertion';
-import {sleep} from 'utils/sleep';
-import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
+import { test } from 'fixtures';
+import { expect } from '@playwright/test';
+import { deploy, createInstances, createSingleInstance } from 'utils/zeebeClient';
+import { captureScreenshot, captureFailureVideo } from '@setup';
+import { navigateToApp } from '@pages/UtilitiesPage';
+import { waitForAssertion } from 'utils/waitForAssertion';
+import { sleep } from 'utils/sleep';
+import { OperateOperationPanelPage } from '@pages/OperateOperationPanelPage';
 
-type ProcessInstance = {processInstanceKey: number};
+type ProcessInstance = { processInstanceKey: number };
 
 let callActivityProcessInstance: ProcessInstance;
 let orderProcessInstance: ProcessInstance;
@@ -51,7 +51,7 @@ test.beforeAll(async () => {
 
   callActivityProcessInstance = {
     processInstanceKey: Number(
-      (await createSingleInstance('CallActivityProcess', 1, {filtersTest: 456}))
+      (await createSingleInstance('CallActivityProcess', 1, { filtersTest: 456 }))
         .processInstanceKey,
     ),
   };
@@ -59,7 +59,7 @@ test.beforeAll(async () => {
   await deploy(['./resources/Variable_Process.bpmn']);
   variableProcessInstance = {
     processInstanceKey: Number(
-      (await createSingleInstance('Variable_Process', 1, {filtersTest: 604}))
+      (await createSingleInstance('Variable_Process', 1, { filtersTest: 604 }))
         .processInstanceKey,
     ),
   };
@@ -70,14 +70,14 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instances Filters', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+  test.beforeEach(async ({ page, loginPage, operateHomePage }) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });
 
-  test.afterEach(async ({page}, testInfo) => {
+  test.afterEach(async ({ page }, testInfo) => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
@@ -130,8 +130,6 @@ test.describe('Process Instances Filters', () => {
         .toBeGreaterThan(1);
     });
 
-    // TODO: think about DRY here (first part repeat first test.step())
-    // But on the other side we don't want tests to be interdependent
     await test.step('Filter by Parent Instance Key and by Error Message and assert results', async () => {
       const callActivityProcessInstanceKey =
         callActivityProcessInstance.processInstanceKey.toString();
@@ -229,7 +227,7 @@ test.describe('Process Instances Filters', () => {
       await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
     });
 
-    await test.step('Filter by variable and assert results', async ({}) => {
+    await test.step('Filter by variable and assert results', async ({ }) => {
       await operateFiltersPanelPage.displayOptionalFilter('Variable');
       await operateFiltersPanelPage.fillVariableNameFilter('filtersTest');
       await operateFiltersPanelPage.fillVariableValueFilter('604');
@@ -257,7 +255,7 @@ test.describe('Process Instances Filters', () => {
       });
     });
 
-    await test.step('Filter by process instance key with one key and assert results', async ({}) => {
+    await test.step('Filter by process instance key with one key and assert results', async ({ }) => {
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
 
@@ -281,7 +279,7 @@ test.describe('Process Instances Filters', () => {
       });
     });
 
-    await test.step('Filter by process instance key with multiple keys and assert results', async ({}) => {
+    await test.step('Filter by process instance key with multiple keys and assert results', async ({ }) => {
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
       const callActivityProcessInstanceKey =
@@ -326,14 +324,14 @@ test.describe('Process Instances Filters', () => {
     await test.step('Filter by variable and operation id and assert results', async () => {
       const processToCancelMeowInstance = {
         processInstanceKey: Number(
-          (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))
+          (await createSingleInstance('ProcessToCancel', 1, { sound: 'meow' }))
             .processInstanceKey,
         ),
       };
 
       const processToCancelGawInstance = {
         processInstanceKey: Number(
-          (await createSingleInstance('ProcessToCancel', 1, {sound: 'gaw'}))
+          (await createSingleInstance('ProcessToCancel', 1, { sound: 'gaw' }))
             .processInstanceKey,
         ),
       };
@@ -372,7 +370,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 30000});
+          ).toBeVisible({ timeout: 30000 });
         },
         onFailure: async () => {
           await page.reload();
@@ -449,7 +447,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 30000});
+          ).toBeVisible({ timeout: 30000 });
         },
         onFailure: async () => {
           await page.reload();
@@ -473,7 +471,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 30000});
+          ).toBeVisible({ timeout: 30000 });
         },
         onFailure: async () => {
           await page.reload();
@@ -499,7 +497,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 30000});
+          ).toBeVisible({ timeout: 30000 });
         },
         onFailure: async () => {
           await page.reload();
@@ -546,7 +544,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 60000});
+          ).toBeVisible({ timeout: 60000 });
         },
         onFailure: async () => {
           await page.reload();
@@ -632,11 +630,11 @@ test.describe('Process Instances Filters', () => {
             exact: true,
           },
         ),
-      ).toBeVisible({timeout: 60000});
+      ).toBeVisible({ timeout: 60000 });
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           callActivityProcessInstanceKey.toString(),
-          {exact: true},
+          { exact: true },
         ),
       ).toBeHidden();
     });
@@ -663,7 +661,7 @@ test.describe('Process Instances Filters', () => {
     });
 
     await test.step('Check that process instances table is filtered correctly', async () => {
-      await expect(page.getByText('2 results')).toBeVisible({timeout: 60000});
+      await expect(page.getByText('2 results')).toBeVisible({ timeout: 60000 });
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           orderProcessInstanceKey.toString(),
@@ -675,7 +673,7 @@ test.describe('Process Instances Filters', () => {
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           callActivityProcessInstanceKey.toString(),
-          {exact: true},
+          { exact: true },
         ),
       ).toBeVisible();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -12,11 +12,14 @@ import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
+import {sleep} from 'utils/sleep';
+import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 
 type ProcessInstance = {processInstanceKey: number};
 
 let callActivityProcessInstance: ProcessInstance;
 let orderProcessInstance: ProcessInstance;
+let variableProcessInstance: ProcessInstance;
 
 test.beforeAll(async () => {
   await deploy([
@@ -52,6 +55,18 @@ test.beforeAll(async () => {
         .processInstanceKey,
     ),
   };
+
+  await deploy(['./resources/Variable_Process.bpmn']);
+  variableProcessInstance = {
+    processInstanceKey: Number(
+      (await createSingleInstance('Variable_Process', 1, {filtersTest: 604}))
+        .processInstanceKey,
+    ),
+  };
+
+  await deploy(['./resources/Versioned Process.bpmn']);
+  await deploy(['./resources/Versioned Process_2.bpmn']);
+  await deploy(['./resources/ProcessToCancel.bpmn']);
 });
 
 test.describe('Process Instances Filters', () => {
@@ -66,10 +81,11 @@ test.describe('Process Instances Filters', () => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
-  test('Filter process instances by parent key, date range, and error message', async ({
+  test('Filter process instances by parent key, date range, variable, instance key and error message', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
+    operateOperationPanelPage,
   }) => {
     await test.step('Filter by Parent Process Instance Key and assert results', async () => {
       const callActivityProcessInstanceKey =
@@ -81,10 +97,6 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
         callActivityProcessInstanceKey,
       );
-      await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible(
-        {timeout: 60000},
-      );
-      await operateProcessesPage.clickProcessCompletedCheckbox();
       await waitForAssertion({
         assertion: async () => {
           await expect(page.getByText('1 result')).toBeVisible();
@@ -93,10 +105,19 @@ test.describe('Process Instances Filters', () => {
           await page.reload();
         },
       });
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
       await expect(operateProcessesPage.parentInstanceIdCell).toHaveText(
         callActivityProcessInstanceKey,
       );
-      expect(await operateProcessesPage.processInstancesTable.count()).toBe(1);
+      expect(await operateProcessesPage.processInstancesTable.count()).toBe(2);
     });
 
     await test.step('Reset filter', async () => {
@@ -109,8 +130,46 @@ test.describe('Process Instances Filters', () => {
         .toBeGreaterThan(1);
     });
 
+    // TODO: think about DRY here (first part repeat first test.step())
+    // But on the other side we don't want tests to be interdependent
+    await test.step('Filter by Parent Instance Key and by Error Message and assert results', async () => {
+      const callActivityProcessInstanceKey =
+        callActivityProcessInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Parent Process Instance Key',
+      );
+      await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
+        callActivityProcessInstanceKey,
+      );
+      await expect(page.getByText('1 result')).toBeVisible();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      const errorMessage =
+        "Failed to extract the correlation key for 'nonExistingClientId'";
+      await operateFiltersPanelPage.displayOptionalFilter('Error Message');
+      await operateFiltersPanelPage.fillErrorMessageFilter(errorMessage);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
     await test.step('Filter by End Date Range and assert results', async () => {
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
 
       let currentRowCount =
         await operateProcessesPage.processInstancesTable.count();
@@ -169,6 +228,289 @@ test.describe('Process Instances Filters', () => {
       await expect(operateFiltersPanelPage.errorMessageFilter).toBeHidden();
       await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
     });
+
+    await test.step('Filter by variable and assert results', async ({}) => {
+      await operateFiltersPanelPage.displayOptionalFilter('Variable');
+      await operateFiltersPanelPage.fillVariableNameFilter('filtersTest');
+      await operateFiltersPanelPage.fillVariableValueFilter('604');
+
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+
+      await sleep(1_000);
+
+      await waitForAssertion({
+        assertion: async () => {
+          const variableProcessInstanceKeys = new Set<string>();
+          for (const element of await operateProcessesPage.processInstancesTable
+            .getByTestId('cell-processInstanceKey')
+            .elementHandles()) {
+            variableProcessInstanceKeys.add(await element.innerText());
+          }
+          expect(
+            variableProcessInstanceKeys.has(variableProcessInstanceKey),
+          ).toBeTruthy();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Filter by process instance key with one key and assert results', async ({}) => {
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        variableProcessInstanceKey,
+      );
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.processInstanceKeyCell).toHaveText(
+            variableProcessInstanceKey,
+          );
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Filter by process instance key with multiple keys and assert results', async ({}) => {
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+      const callActivityProcessInstanceKey =
+        callActivityProcessInstance.processInstanceKey.toString();
+      await operateFiltersPanelPage.resetFiltersButton.click();
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+
+      await expect(
+        operateFiltersPanelPage.finishedInstancesCheckbox,
+      ).toBeVisible();
+      await expect(
+        operateFiltersPanelPage.finishedInstancesCheckbox,
+      ).toBeEnabled();
+      await operateFiltersPanelPage.finishedInstancesCheckbox.click();
+
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        `${variableProcessInstanceKey}, ${callActivityProcessInstanceKey}`,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Reset filter', async () => {
+      await operateFiltersPanelPage.clickResetFilters();
+      await expect(
+        operateFiltersPanelPage.processInstanceKeysFilter,
+      ).toBeHidden();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThan(1);
+    });
+
+    await test.step('Filter by variable and operation id and assert results', async () => {
+      const processToCancelMeowInstance = {
+        processInstanceKey: Number(
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))
+            .processInstanceKey,
+        ),
+      };
+
+      const processToCancelGawInstance = {
+        processInstanceKey: Number(
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'gaw'}))
+            .processInstanceKey,
+        ),
+      };
+
+      const processToCancelInstanceMeowIK =
+        processToCancelMeowInstance.processInstanceKey.toString();
+      const processToCancelInstanceGawIK =
+        processToCancelGawInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        `${processToCancelInstanceMeowIK}, ${processToCancelInstanceGawIK}`,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateProcessesPage.selectProcessCheckboxByPIK(
+        processToCancelInstanceMeowIK,
+        processToCancelInstanceGawIK,
+      );
+
+      await operateProcessesPage.clickCancelBatchOperationButton();
+
+      await operateProcessesPage.clickCancelProcessInstanceDialogButton();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      var lastOperation = operateOperationPanelPage
+        .getAllOperationEntries()
+        .last();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            OperateOperationPanelPage.getOperationType(lastOperation),
+          ).toHaveText('Cancel');
+        },
+        onFailure: async () => {
+          lastOperation = operateOperationPanelPage
+            .getAllOperationEntries()
+            .last();
+          await page.reload();
+        },
+      });
+
+      const operationId =
+        await OperateOperationPanelPage.getOperationID(
+          lastOperation,
+        ).innerText();
+
+      await operateOperationPanelPage.collapseOperationIdField();
+
+      await operateFiltersPanelPage.clickResetFilters();
+      await operateFiltersPanelPage.runningInstancesCheckbox.click();
+      await operateFiltersPanelPage.finishedInstancesCheckbox.click();
+      await operateFiltersPanelPage.displayOptionalFilter('Operation Id');
+      await operateFiltersPanelPage.fillOperationIdFilter(operationId);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.displayOptionalFilter('Variable');
+      await operateFiltersPanelPage.fillVariableNameFilter('sound');
+      await operateFiltersPanelPage.fillVariableValueFilter('"meow"');
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Filter by end and start date range', async () => {
+      await operateFiltersPanelPage.resetFiltersButton.click();
+
+      await operateFiltersPanelPage.displayOptionalFilter('Start Date Range');
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: '1',
+        toDay: '1',
+        fromTime: '00:00:00',
+        toTime: '00:00:00',
+      });
+      await operateFiltersPanelPage.clickApply();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.displayOptionalFilter('End Date Range');
+
+      const todayDate = new Date();
+      console.log('Today date:', todayDate.getDate());
+
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: todayDate.getDate().toString(),
+        toDay: todayDate.getDate().toString(),
+        fromTime: '00:00:00',
+        toTime: '23:59:59',
+      });
+      await operateFiltersPanelPage.clickApply();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.removeOptionalFilter('Start Date Range');
+
+      await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
+      await operateFiltersPanelPage.displayOptionalFilter('Start Date Range');
+      await expect(operateFiltersPanelPage.startDateFilter).toBeVisible();
+
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: todayDate.getDate().toString(),
+        toDay: todayDate.getDate().toString(),
+        fromTime: '00:00:00',
+        toTime: '23:59:59',
+      });
+
+      await operateFiltersPanelPage.clickApply();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.finishedInstancesCheckbox.click();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThanOrEqual(2);
+    });
   });
 
   test('Interaction between diagram and filters', async ({
@@ -180,6 +522,7 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.selectProcess(
         'Process With Multiple Versions',
       );
+      await operateFiltersPanelPage.selectVersion('2');
       await waitForAssertion({
         assertion: async () => {
           await expect
@@ -247,7 +590,7 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.processInstanceKeysFilter.fill(
         `${orderProcessInstanceKey}, ${callActivityProcessInstanceKey}`,
       );
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
     });
     await test.step('Add Variable Filter', async () => {
       await operateFiltersPanelPage.displayOptionalFilter('Variable');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -118,7 +118,7 @@ test.describe('process page', () => {
     await waitForAssertion({
       assertion: async () => {
         await expect(
-          taskPanelPage.availableTasks.getByText('User_Task'),
+          taskPanelPage.availableTasks.getByText('User_Task').first(),
         ).toBeVisible();
       },
       onFailure: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/expectInViewport.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/expectInViewport.ts
@@ -6,15 +6,18 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { expect, Locator } from '@playwright/test';
+import {expect, Locator} from '@playwright/test';
 
 /**
  * Asserts whether a Locator is in the viewport.
- * 
+ *
  * @param locator - The Playwright Locator to check
  * @param shouldBeVisible - true if expected to be in the viewport, false if expected to be out
  */
-export async function expectInViewport(locator: Locator, shouldBeVisible: boolean) {
+export async function expectInViewport(
+  locator: Locator,
+  shouldBeVisible: boolean,
+) {
   const isInViewport = await locator.evaluate((el) => {
     const rect = el.getBoundingClientRect();
     return (

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForAssertion.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForAssertion.ts
@@ -14,7 +14,7 @@ async function waitForAssertion(options: {
   const {assertion, onFailure: fallback, maxRetries = 3} = options;
   let retries = 1;
 
-  while (retries < maxRetries) {
+  while (retries <= maxRetries) {
     try {
       await assertion();
       break;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -78,10 +78,30 @@ const cancelProcessInstance = async (processInstanceKey: string) => {
   return zeebe.cancelProcessInstance({processInstanceKey});
 };
 
+async function searchByProcessInstanceKey(processInstanceKey: string) {
+  return zeebe.searchProcessInstances({filter: {processInstanceKey}});
+}
+async function checkUpdateOnVersion(
+  targetVersion: string,
+  processInstanceKey: string,
+) {
+  const res = await zeebe.searchProcessInstances({
+    filter: {processInstanceKey},
+  });
+  const item = res?.items?.[0];
+  console.log(
+    `Target Version ${targetVersion}, Current Version ${item?.processDefinitionVersion}`,
+  );
+  console.log(!!item, item?.processDefinitionVersion == targetVersion);
+  return !!item && item.processDefinitionVersion == targetVersion;
+}
+
 export {
   deploy,
   createInstances,
   generateManyVariables,
   createSingleInstance,
   cancelProcessInstance,
+  searchByProcessInstanceKey,
+  checkUpdateOnVersion,
 };


### PR DESCRIPTION
## Description
Added Operate filters tests, refactored checkboxes locators in `OperateProcessesPage` and `OperateFiltersPanelPage`

## Related issues
Related to #34042, #33949

## Related on demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/19464266141)