### PR TITLE
feat: Add property-based authorization to OC REST API and CamundaClient

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -86,6 +86,12 @@
           "code": "java.field.removed",
           "old": "field io.camunda.client.protocol.rest.DecisionInstanceStateEnum.UNSPECIFIED",
           "justification": "Removed impossible state from REST protocol enum - aligned with API response enum cleanup"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.client.api.search.filter.AuthorizationFilter io.camunda.client.api.search.filter.AuthorizationFilter::resourceIds(java.util.List<java.lang.String>)",
+          "justification": "Updated the parameter type from List to Collection to make API more flexible. This remains backward-compatible for users, as any List already implements Collection and callers can continue passing the same arguments."
         }
       ]
     }

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2475,7 +2475,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *   .newCreateAuthorizationCommand()
    *   .ownerId(ownerId)
    *   .ownerType(ownerType)
-   *   .resourceId(resourceId)
+   *   .resourceId(resourceId) // or .resourcePropertyName(resourcePropertyName)
    *   .resourceType(resourceType)
    *   .permission(PermissionType.READ)
    *   .send();
@@ -2543,7 +2543,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *   .newUpdateAuthorizationCommand(authorizationKey)
    *   .ownerId(ownerId)
    *   .ownerType(ownerType)
-   *   .resourceId(resourceId)
+   *   .resourceId(resourceId) // or .resourcePropertyName(resourcePropertyName)
    *   .resourceType(resourceType)
    *   .permissionTypes(Set.of(PermissionType.READ))
    *   .send();

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAuthorizationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAuthorizationCommandStep1.java
@@ -50,6 +50,14 @@ public interface CreateAuthorizationCommandStep1 {
      * @return the builder for this command
      */
     CreateAuthorizationCommandStep4 resourceId(String resourceId);
+
+    /**
+     * Sets the resource property name for the authorization.
+     *
+     * @param resourcePropertyName the property name of the resource
+     * @return the builder for this command
+     */
+    CreateAuthorizationCommandStep4 resourcePropertyName(String resourcePropertyName);
   }
 
   interface CreateAuthorizationCommandStep4 {

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAuthorizationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAuthorizationCommandStep1.java
@@ -50,6 +50,14 @@ public interface UpdateAuthorizationCommandStep1 {
      * @return the builder for this command
      */
     UpdateAuthorizationCommandStep4 resourceId(String resourceId);
+
+    /**
+     * Sets the resource property name for the authorization.
+     *
+     * @param resourcePropertyName the property name of the resource
+     * @return the builder for this command
+     */
+    UpdateAuthorizationCommandStep4 resourcePropertyName(String resourcePropertyName);
   }
 
   interface UpdateAuthorizationCommandStep4 {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AuthorizationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AuthorizationFilter.java
@@ -18,7 +18,7 @@ package io.camunda.client.api.search.filter;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
-import java.util.List;
+import java.util.Collection;
 
 public interface AuthorizationFilter extends SearchRequestFilter {
 
@@ -52,7 +52,7 @@ public interface AuthorizationFilter extends SearchRequestFilter {
    * @param resourceIds the IDs of the resource
    * @return the updated filter
    */
-  AuthorizationFilter resourceIds(final List<String> resourceIds);
+  AuthorizationFilter resourceIds(final Collection<String> resourceIds);
 
   /**
    * Filter authorizations by the specified resource property names.
@@ -68,7 +68,7 @@ public interface AuthorizationFilter extends SearchRequestFilter {
    * @param resourcePropertyNames the names of the resource properties
    * @return the updated filter
    */
-  AuthorizationFilter resourcePropertyNames(final List<String> resourcePropertyNames);
+  AuthorizationFilter resourcePropertyNames(final Collection<String> resourcePropertyNames);
 
   /**
    * Filter authorizations by the specified resource type.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AuthorizationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AuthorizationFilter.java
@@ -55,6 +55,22 @@ public interface AuthorizationFilter extends SearchRequestFilter {
   AuthorizationFilter resourceIds(final List<String> resourceIds);
 
   /**
+   * Filter authorizations by the specified resource property names.
+   *
+   * @param resourcePropertyNames the names of the resource properties
+   * @return the updated filter
+   */
+  AuthorizationFilter resourcePropertyNames(final String... resourcePropertyNames);
+
+  /**
+   * Filter authorizations by the specified resource property names.
+   *
+   * @param resourcePropertyNames the names of the resource properties
+   * @return the updated filter
+   */
+  AuthorizationFilter resourcePropertyNames(final List<String> resourcePropertyNames);
+
+  /**
    * Filter authorizations by the specified resource type.
    *
    * @param resourceType the type of the resource

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Authorization.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Authorization.java
@@ -32,5 +32,7 @@ public interface Authorization {
 
   String getResourceId();
 
+  String getResourcePropertyName();
+
   List<PermissionType> getPermissionTypes();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AuthorizationSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AuthorizationSort.java
@@ -26,4 +26,6 @@ public interface AuthorizationSort extends SearchRequestSort<AuthorizationSort> 
   AuthorizationSort resourceId();
 
   AuthorizationSort resourceType();
+
+  AuthorizationSort resourcePropertyName();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAuthorizationCommandImpl.java
@@ -32,7 +32,11 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateAuthorizationResponseImpl;
 import io.camunda.client.impl.util.EnumUtil;
-import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.AuthorizationCreateResult;
+import io.camunda.client.protocol.rest.AuthorizationRequest;
+import io.camunda.client.protocol.rest.OwnerTypeEnum;
+import io.camunda.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -79,6 +83,13 @@ public class CreateAuthorizationCommandImpl
     ArgumentUtil.ensureNotNull("resourceId", resourceId);
     ArgumentUtil.ensureNotEmpty("resourceId", resourceId);
     request.setResourceId(resourceId);
+    return this;
+  }
+
+  @Override
+  public CreateAuthorizationCommandStep4 resourcePropertyName(final String resourcePropertyName) {
+    ArgumentUtil.ensureNotNullNorEmpty("resourcePropertyName", resourcePropertyName);
+    request.setResourcePropertyName(resourcePropertyName);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAuthorizationCommandImpl.java
@@ -87,6 +87,13 @@ public class UpdateAuthorizationCommandImpl
   }
 
   @Override
+  public UpdateAuthorizationCommandStep4 resourcePropertyName(final String resourcePropertyName) {
+    ArgumentUtil.ensureNotNullNorEmpty("resourcePropertyName", resourcePropertyName);
+    request.setResourcePropertyName(resourcePropertyName);
+    return this;
+  }
+
+  @Override
   public UpdateAuthorizationCommandStep5 resourceType(final ResourceType resourceType) {
     ArgumentUtil.ensureNotNull("resourceType", resourceType);
     request.setResourceType(EnumUtil.convert(resourceType, ResourceTypeEnum.class));

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AuthorizationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AuthorizationFilterImpl.java
@@ -49,13 +49,23 @@ public class AuthorizationFilterImpl
 
   @Override
   public AuthorizationFilter resourceIds(final String... resourceIds) {
-    filter.setResourceIds(Arrays.asList(resourceIds));
-    return this;
+    return resourceIds(Arrays.asList(resourceIds));
   }
 
   @Override
   public AuthorizationFilter resourceIds(final List<String> resourceIds) {
     filter.setResourceIds(resourceIds);
+    return this;
+  }
+
+  @Override
+  public AuthorizationFilter resourcePropertyNames(final String... resourcePropertyNames) {
+    return resourcePropertyNames(Arrays.asList(resourcePropertyNames));
+  }
+
+  @Override
+  public AuthorizationFilter resourcePropertyNames(final List<String> resourcePropertyNames) {
+    filter.setResourcePropertyNames(resourcePropertyNames);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AuthorizationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AuthorizationFilterImpl.java
@@ -22,8 +22,9 @@ import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 
 public class AuthorizationFilterImpl
     extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.AuthorizationFilter>
@@ -53,8 +54,8 @@ public class AuthorizationFilterImpl
   }
 
   @Override
-  public AuthorizationFilter resourceIds(final List<String> resourceIds) {
-    filter.setResourceIds(resourceIds);
+  public AuthorizationFilter resourceIds(final Collection<String> resourceIds) {
+    filter.setResourceIds(new ArrayList<>(resourceIds));
     return this;
   }
 
@@ -64,8 +65,8 @@ public class AuthorizationFilterImpl
   }
 
   @Override
-  public AuthorizationFilter resourcePropertyNames(final List<String> resourcePropertyNames) {
-    filter.setResourcePropertyNames(resourcePropertyNames);
+  public AuthorizationFilter resourcePropertyNames(final Collection<String> resourcePropertyNames) {
+    filter.setResourcePropertyNames(new ArrayList<>(resourcePropertyNames));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AuthorizationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AuthorizationImpl.java
@@ -26,6 +26,7 @@ public class AuthorizationImpl implements Authorization {
   private final String authorizationKey;
   private final String ownerId;
   private final String resourceId;
+  private final String resourcePropertyName;
   private final OwnerType ownerType;
   private final ResourceType resourceType;
   private final List<PermissionType> permissionTypes;
@@ -34,12 +35,14 @@ public class AuthorizationImpl implements Authorization {
       final String authorizationKey,
       final String ownerId,
       final String resourceId,
+      final String resourcePropertyName,
       final OwnerType ownerType,
       final ResourceType resourceType,
       final List<PermissionType> permissionTypes) {
     this.authorizationKey = authorizationKey;
     this.ownerId = ownerId;
     this.resourceId = resourceId;
+    this.resourcePropertyName = resourcePropertyName;
     this.ownerType = ownerType;
     this.resourceType = resourceType;
     this.permissionTypes = permissionTypes;
@@ -68,6 +71,11 @@ public class AuthorizationImpl implements Authorization {
   @Override
   public String getResourceId() {
     return resourceId;
+  }
+
+  @Override
+  public String getResourcePropertyName() {
+    return resourcePropertyName;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -284,6 +284,7 @@ public final class SearchResponseMapper {
         response.getAuthorizationKey(),
         response.getOwnerId(),
         response.getResourceId(),
+        response.getResourcePropertyName(),
         EnumUtil.convert(response.getOwnerType(), OwnerType.class),
         EnumUtil.convert(response.getResourceType(), ResourceType.class),
         convertedPermissionTypes);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AuthorizationSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AuthorizationSortImpl.java
@@ -42,6 +42,11 @@ public class AuthorizationSortImpl extends SearchRequestSortBase<AuthorizationSo
   }
 
   @Override
+  public AuthorizationSort resourcePropertyName() {
+    return field("resourcePropertyName");
+  }
+
+  @Override
   protected AuthorizationSort self() {
     return this;
   }

--- a/clients/java/src/test/java/io/camunda/client/authorization/UpdateAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/UpdateAuthorizationTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class UpdateAuthorizationTest extends ClientRestTest {
 
   @Test
-  void shouldSendCommand() {
+  void shouldSendCommandForIdBasedAuthorization() {
     // when
     client
         .newUpdateAuthorizationCommand(1L)
@@ -46,6 +46,35 @@ public class UpdateAuthorizationTest extends ClientRestTest {
     assertThat(request.getOwnerType())
         .isEqualTo(io.camunda.client.protocol.rest.OwnerTypeEnum.USER);
     assertThat(request.getResourceId()).isEqualTo("resourceId");
+    assertThat(request.getResourcePropertyName()).isNull();
+    assertThat(request.getResourceType())
+        .isEqualTo(io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE);
+    assertThat(request.getPermissionTypes())
+        .containsExactly(
+            io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE,
+            io.camunda.client.protocol.rest.PermissionTypeEnum.READ);
+  }
+
+  @Test
+  void shouldSendCommandForPropertyBasedAuthorization() {
+    // when
+    client
+        .newUpdateAuthorizationCommand(1L)
+        .ownerId("ownerId")
+        .ownerType(OwnerType.USER)
+        .resourcePropertyName("resourcePropertyName")
+        .resourceType(ResourceType.RESOURCE)
+        .permissionTypes(PermissionType.CREATE, PermissionType.READ)
+        .send()
+        .join();
+
+    // then
+    final AuthorizationRequest request = gatewayService.getLastRequest(AuthorizationRequest.class);
+    assertThat(request.getOwnerId()).isEqualTo("ownerId");
+    assertThat(request.getOwnerType())
+        .isEqualTo(io.camunda.client.protocol.rest.OwnerTypeEnum.USER);
+    assertThat(request.getResourceId()).isNull();
+    assertThat(request.getResourcePropertyName()).isEqualTo("resourcePropertyName");
     assertThat(request.getResourceType())
         .isEqualTo(io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE);
     assertThat(request.getPermissionTypes())
@@ -142,6 +171,42 @@ public class UpdateAuthorizationTest extends ClientRestTest {
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("resourceId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullResourcePropertyName() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAuthorizationCommand(1L)
+                    .ownerId("ownerId")
+                    .ownerType(OwnerType.USER)
+                    .resourcePropertyName(null)
+                    .resourceType(ResourceType.RESOURCE)
+                    .permissionTypes(PermissionType.CREATE, PermissionType.READ)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourcePropertyName must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyResourcePropertyName() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateAuthorizationCommand(1L)
+                    .ownerId("ownerId")
+                    .ownerType(OwnerType.USER)
+                    .resourcePropertyName("")
+                    .resourceType(ResourceType.RESOURCE)
+                    .permissionTypes(PermissionType.CREATE, PermissionType.READ)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourcePropertyName must not be empty");
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -83,6 +83,7 @@ public class AuthorizationServices
             .setResourceType(request.resourceType())
             .setResourceMatcher(getResourceMatcher(request.resourceId()))
             .setResourceId(request.resourceId())
+            .setResourcePropertyName(request.resourcePropertyName())
             .setPermissionTypes(request.permissionTypes());
     return sendBrokerRequest(brokerRequest);
   }
@@ -113,12 +114,17 @@ public class AuthorizationServices
             .setOwnerType(request.ownerType())
             .setResourceMatcher(getResourceMatcher(request.resourceId()))
             .setResourceId(request.resourceId())
+            .setResourcePropertyName(request.resourcePropertyName())
             .setResourceType(request.resourceType())
             .setPermissionTypes(request.permissionTypes());
     return sendBrokerRequest(brokerRequest);
   }
 
   private AuthorizationResourceMatcher getResourceMatcher(final String resourceId) {
+    if (resourceId.isEmpty()) {
+      return AuthorizationResourceMatcher.PROPERTY;
+    }
+
     return AuthorizationScope.WILDCARD.getResourceId().equals(resourceId)
         ? AuthorizationResourceMatcher.ANY
         : AuthorizationResourceMatcher.ID;
@@ -128,6 +134,7 @@ public class AuthorizationServices
       String ownerId,
       AuthorizationOwnerType ownerType,
       String resourceId,
+      String resourcePropertyName,
       AuthorizationResourceType resourceType,
       Set<PermissionType> permissionTypes) {}
 
@@ -136,6 +143,7 @@ public class AuthorizationServices
       String ownerId,
       AuthorizationOwnerType ownerType,
       String resourceId,
+      String resourcePropertyName,
       AuthorizationResourceType resourceType,
       Set<PermissionType> permissionTypes) {}
 }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -81,7 +80,7 @@ public class AuthorizationServices
             .setOwnerId(request.ownerId())
             .setOwnerType(request.ownerType())
             .setResourceType(request.resourceType())
-            .setResourceMatcher(getResourceMatcher(request.resourceId()))
+            .setResourceMatcher(request.resourceMatcher())
             .setResourceId(request.resourceId())
             .setResourcePropertyName(request.resourcePropertyName())
             .setPermissionTypes(request.permissionTypes());
@@ -112,7 +111,7 @@ public class AuthorizationServices
             .setAuthorizationKey(request.authorizationKey())
             .setOwnerId(request.ownerId())
             .setOwnerType(request.ownerType())
-            .setResourceMatcher(getResourceMatcher(request.resourceId()))
+            .setResourceMatcher(request.resourceMatcher())
             .setResourceId(request.resourceId())
             .setResourcePropertyName(request.resourcePropertyName())
             .setResourceType(request.resourceType())
@@ -120,19 +119,10 @@ public class AuthorizationServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  private AuthorizationResourceMatcher getResourceMatcher(final String resourceId) {
-    if (resourceId.isEmpty()) {
-      return AuthorizationResourceMatcher.PROPERTY;
-    }
-
-    return AuthorizationScope.WILDCARD.getResourceId().equals(resourceId)
-        ? AuthorizationResourceMatcher.ANY
-        : AuthorizationResourceMatcher.ID;
-  }
-
   public record CreateAuthorizationRequest(
       String ownerId,
       AuthorizationOwnerType ownerType,
+      AuthorizationResourceMatcher resourceMatcher,
       String resourceId,
       String resourcePropertyName,
       AuthorizationResourceType resourceType,
@@ -142,6 +132,7 @@ public class AuthorizationServices
       long authorizationKey,
       String ownerId,
       AuthorizationOwnerType ownerType,
+      AuthorizationResourceMatcher resourceMatcher,
       String resourceId,
       String resourcePropertyName,
       AuthorizationResourceType resourceType,

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -172,7 +172,7 @@ paths:
 
 components:
   schemas:
-    AuthorizationRequest:
+    AuthorizationIdBasedRequest:
       type: object
       additionalProperties: false
       properties:
@@ -201,6 +201,46 @@ components:
         - resourceId
         - resourceType
         - permissionTypes
+
+    AuthorizationPropertyBasedRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        ownerId:
+          description: The ID of the owner of the permissions.
+          type: string
+        ownerType:
+          $ref: '#/components/schemas/OwnerTypeEnum'
+        resourcePropertyName:
+          description: The name of the resource property on which this authorization is based.
+          type: string
+        resourceType:
+          description: The type of resource to add permissions to.
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/ResourceTypeEnum'
+        permissionTypes:
+          type: array
+          description: The permission types to add.
+          items:
+            allOf:
+              - $ref: '#/components/schemas/PermissionTypeEnum'
+      required:
+        - ownerId
+        - ownerType
+        - resourcePropertyName
+        - resourceType
+        - permissionTypes
+
+    AuthorizationRequest:
+      x-polymorphic-schema: true
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/AuthorizationIdBasedRequest'
+        - $ref: '#/components/schemas/AuthorizationPropertyBasedRequest'
+      description: |
+        Defines an authorization request.
+        Either an id-based or a property-based authorization can be provided.
 
     AuthorizationSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -310,6 +310,9 @@ components:
         resourceId:
           description: ID of the resource the permission relates to.
           type: string
+        resourcePropertyName:
+          description: The name of the resource property the permission relates to.
+          type: string
         permissionTypes:
           description: Specifies the types of the permissions.
           type: array

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -252,6 +252,7 @@ components:
             - ownerId
             - ownerType
             - resourceId
+            - resourcePropertyName
             - resourceType
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
@@ -285,6 +286,11 @@ components:
           $ref: '#/components/schemas/OwnerTypeEnum'
         resourceIds:
           description: The IDs of the resource to search permissions for.
+          type: array
+          items:
+            type: string
+        resourcePropertyNames:
+          description: The names of the resource properties to search permissions for.
           type: array
           items:
             type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -308,10 +308,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
         resourceId:
-          description: ID of the resource the permission relates to.
+          description: ID of the resource the permission relates to (mutually exclusive with `resourcePropertyName`).
           type: string
         resourcePropertyName:
-          description: The name of the resource property the permission relates to.
+          description: The name of the resource property the permission relates to (mutually exclusive with `resourceId`).
           type: string
         permissionTypes:
           description: Specifies the types of the permissions.

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -12,7 +12,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorizationCreateResult'
+              $ref: '#/components/schemas/AuthorizationRequest'
         required: true
       responses:
         "201":
@@ -20,7 +20,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthorizationResult'
+                $ref: '#/components/schemas/AuthorizationCreateResult'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.BasicStringFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateFilterProperty;
@@ -37,6 +38,7 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateFilterProperty
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageRequest;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskStateFilterProperty;
+import io.camunda.zeebe.gateway.rest.deserializer.AuthorizationRequestDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperatioItemStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationStateFilterPropertyDeserializer;
@@ -114,6 +116,7 @@ public class JacksonConfig {
         IncidentErrorTypeFilterProperty.class, new IncidentErrorTypePropertyDeserializer());
     module.addDeserializer(
         IncidentStateFilterProperty.class, new IncidentStatePropertyDeserializer());
+    module.addDeserializer(AuthorizationRequest.class, new AuthorizationRequestDeserializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AuthorizationRequestDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AuthorizationRequestDeserializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ONLY_ONE_FIELD;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationIdBasedRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPropertyBasedRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
+import io.camunda.zeebe.gateway.rest.exception.DeserializationException;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AuthorizationRequestDeserializer extends JsonDeserializer<AuthorizationRequest> {
+
+  private static final String RESOURCE_ID_FIELD = "resourceId";
+  private static final String RESOURCE_PROPERTY_NAME_FIELD = "resourcePropertyName";
+  private static final Set<String> SUPPORTED_FIELDS =
+      Set.of(RESOURCE_ID_FIELD, RESOURCE_PROPERTY_NAME_FIELD);
+
+  @Override
+  public AuthorizationRequest deserialize(
+      final JsonParser jsonParser, final DeserializationContext deserializationContext)
+      throws IOException {
+    final var codec = jsonParser.getCodec();
+    final var treeNode = codec.readTree(jsonParser);
+
+    final Set<String> presentFields = new HashSet<>();
+    final var fields = treeNode.fieldNames();
+
+    while (fields.hasNext()) {
+      final String field = fields.next();
+      if (SUPPORTED_FIELDS.contains(field) && !(treeNode.get(field) instanceof NullNode)) {
+        presentFields.add(field);
+      }
+    }
+
+    validateFields(presentFields);
+
+    // Remove null fields from the tree to prevent parsing errors
+    if (treeNode.get(RESOURCE_ID_FIELD) instanceof NullNode) {
+      ((ObjectNode) treeNode).remove(RESOURCE_ID_FIELD);
+    }
+    if (treeNode.get(RESOURCE_PROPERTY_NAME_FIELD) instanceof NullNode) {
+      ((ObjectNode) treeNode).remove(RESOURCE_PROPERTY_NAME_FIELD);
+    }
+
+    if (presentFields.contains(RESOURCE_PROPERTY_NAME_FIELD)) {
+      return codec.treeToValue(treeNode, AuthorizationPropertyBasedRequest.class);
+    }
+    return codec.treeToValue(treeNode, AuthorizationIdBasedRequest.class);
+  }
+
+  private static void validateFields(final Set<String> presentFields) {
+    if (presentFields.size() > 1) {
+      throw new DeserializationException(
+          ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(getErrorMessageParam()));
+    }
+    if (presentFields.isEmpty()) {
+      throw new DeserializationException(
+          ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(getErrorMessageParam()));
+    }
+  }
+
+  private static String getErrorMessageParam() {
+    return "[%s, %s]".formatted(RESOURCE_ID_FIELD, RESOURCE_PROPERTY_NAME_FIELD);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/RequestMapper.java
@@ -134,7 +134,9 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -401,6 +403,7 @@ public class RequestMapper {
             new CreateAuthorizationRequest(
                 request.getOwnerId(),
                 AuthorizationOwnerType.valueOf(request.getOwnerType().name()),
+                resolveIdBasedResourceMatcher(request.getResourceId()),
                 request.getResourceId(),
                 "",
                 AuthorizationResourceType.valueOf(request.getResourceType().name()),
@@ -416,6 +419,7 @@ public class RequestMapper {
             new CreateAuthorizationRequest(
                 request.getOwnerId(),
                 AuthorizationOwnerType.valueOf(request.getOwnerType().name()),
+                AuthorizationResourceMatcher.PROPERTY,
                 "",
                 request.getResourcePropertyName(),
                 AuthorizationResourceType.valueOf(request.getResourceType().name()),
@@ -444,6 +448,7 @@ public class RequestMapper {
                 authorizationKey,
                 request.getOwnerId(),
                 AuthorizationOwnerType.valueOf(request.getOwnerType().name()),
+                resolveIdBasedResourceMatcher(request.getResourceId()),
                 request.getResourceId(),
                 "",
                 AuthorizationResourceType.valueOf(request.getResourceType().name()),
@@ -461,10 +466,18 @@ public class RequestMapper {
                 authorizationKey,
                 request.getOwnerId(),
                 AuthorizationOwnerType.valueOf(request.getOwnerType().name()),
+                AuthorizationResourceMatcher.PROPERTY,
                 "",
                 request.getResourcePropertyName(),
                 AuthorizationResourceType.valueOf(request.getResourceType().name()),
                 transformPermissionTypes(request.getPermissionTypes())));
+  }
+
+  private static AuthorizationResourceMatcher resolveIdBasedResourceMatcher(
+      final String resourceId) {
+    return AuthorizationScope.WILDCARD.getResourceId().equals(resourceId)
+        ? AuthorizationResourceMatcher.ANY
+        : AuthorizationResourceMatcher.ID;
   }
 
   private static ProblemDetail createUnsupportedAuthorizationProblemDetail(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -918,6 +918,7 @@ public class SearchQueryFilterMapper {
                     .ownerIds(f.getOwnerId())
                     .ownerType(f.getOwnerType() == null ? null : f.getOwnerType().getValue())
                     .resourceIds(f.getResourceIds())
+                    .resourcePropertyNames(f.getResourcePropertyNames())
                     .resourceType(
                         f.getResourceType() == null ? null : f.getResourceType().getValue())
                     .build())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.mapper.search;
 import static io.camunda.zeebe.gateway.rest.mapper.ResponseMapper.formatDate;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.search.entities.AuthorizationEntity;
@@ -1249,17 +1250,13 @@ public final class SearchQueryResponseMapper {
         .ownerId(authorization.ownerId())
         .ownerType(OwnerTypeEnum.fromValue(authorization.ownerType()))
         .resourceType(ResourceTypeEnum.valueOf(authorization.resourceType()))
-        .resourceId(nullIfEmpty(authorization.resourceId()))
-        .resourcePropertyName(nullIfEmpty(authorization.resourcePropertyName()))
+        .resourceId(defaultIfEmpty(authorization.resourceId(), null))
+        .resourcePropertyName(defaultIfEmpty(authorization.resourcePropertyName(), null))
         .permissionTypes(
             authorization.permissionTypes().stream()
                 .map(PermissionType::name)
                 .map(PermissionTypeEnum::fromValue)
                 .toList());
-  }
-
-  private static String nullIfEmpty(final String value) {
-    return StringUtils.defaultIfEmpty(value, null);
   }
 
   private static ProcessInstanceStateEnum toProtocolState(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -1255,6 +1255,7 @@ public final class SearchQueryResponseMapper {
         .ownerType(OwnerTypeEnum.fromValue(authorization.ownerType()))
         .resourceType(ResourceTypeEnum.valueOf(authorization.resourceType()))
         .resourceId(resourceId)
+        .resourcePropertyName(authorization.resourcePropertyName())
         .permissionTypes(
             authorization.permissionTypes().stream()
                 .map(PermissionType::name)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.rest.mapper.search;
 
 import static io.camunda.zeebe.gateway.rest.mapper.ResponseMapper.formatDate;
-import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
 
@@ -1245,22 +1244,22 @@ public final class SearchQueryResponseMapper {
   }
 
   public static AuthorizationResult toAuthorization(final AuthorizationEntity authorization) {
-    final var resourceId =
-        (WILDCARD.getMatcher().value() == authorization.resourceMatcher())
-            ? "*"
-            : authorization.resourceId();
     return new AuthorizationResult()
         .authorizationKey(KeyUtil.keyToString(authorization.authorizationKey()))
         .ownerId(authorization.ownerId())
         .ownerType(OwnerTypeEnum.fromValue(authorization.ownerType()))
         .resourceType(ResourceTypeEnum.valueOf(authorization.resourceType()))
-        .resourceId(resourceId)
-        .resourcePropertyName(authorization.resourcePropertyName())
+        .resourceId(nullIfEmpty(authorization.resourceId()))
+        .resourcePropertyName(nullIfEmpty(authorization.resourcePropertyName()))
         .permissionTypes(
             authorization.permissionTypes().stream()
                 .map(PermissionType::name)
                 .map(PermissionTypeEnum::fromValue)
                 .toList());
+  }
+
+  private static String nullIfEmpty(final String value) {
+    return StringUtils.defaultIfEmpty(value, null);
   }
 
   private static ProcessInstanceStateEnum toProtocolState(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -757,6 +757,7 @@ public class SearchQuerySortRequestMapper {
         case OWNER_ID -> builder.ownerId();
         case OWNER_TYPE -> builder.ownerType();
         case RESOURCE_ID -> builder.resourceId();
+        case RESOURCE_PROPERTY_NAME -> builder.resourcePropertyName();
         case RESOURCE_TYPE -> builder.resourceType();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationIdBasedRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPropertyBasedRequest;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
@@ -45,6 +46,24 @@ public final class AuthorizationRequestValidator {
               violations,
               idPattern,
               AuthorizationScope.WILDCARD_CHAR::equals);
+        });
+  }
+
+  public static Optional<ProblemDetail> validatePropertyBasedRequest(
+      final AuthorizationPropertyBasedRequest request, final Pattern idPattern) {
+    return validate(
+        violations -> {
+          validateCommonRequestProperties(
+              request.getOwnerId(),
+              request.getOwnerType(),
+              request.getResourceType(),
+              request.getPermissionTypes(),
+              idPattern,
+              violations);
+
+          // resourcePropertyName validation
+          IdentifierValidator.validateId(
+              request.getResourcePropertyName(), "resourcePropertyName", violations, idPattern);
         });
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
@@ -10,39 +10,68 @@ package io.camunda.zeebe.gateway.rest.validator;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
-import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationIdBasedRequest;
+import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.springframework.http.ProblemDetail;
 
 public final class AuthorizationRequestValidator {
 
-  public static Optional<ProblemDetail> validateAuthorizationRequest(
-      final AuthorizationRequest request, final Pattern idPattern) {
+  private AuthorizationRequestValidator() {
+    // utility class
+  }
+
+  public static Optional<ProblemDetail> validateIdBasedRequest(
+      final AuthorizationIdBasedRequest request, final Pattern idPattern) {
     return validate(
         violations -> {
-          // owner validation
-          IdentifierValidator.validateId(request.getOwnerId(), "ownerId", violations, idPattern);
-          if (request.getOwnerType() == null) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("ownerType"));
-          }
+          validateCommonRequestProperties(
+              request.getOwnerId(),
+              request.getOwnerType(),
+              request.getResourceType(),
+              request.getPermissionTypes(),
+              idPattern,
+              violations);
 
-          // resource validation
+          // resourceId validation
           IdentifierValidator.validateId(
               request.getResourceId(),
               "resourceId",
               violations,
               idPattern,
               AuthorizationScope.WILDCARD_CHAR::equals);
-          if (request.getResourceType() == null) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("resourceType"));
-          }
-
-          // permissions validation
-          if (request.getPermissionTypes() == null || request.getPermissionTypes().isEmpty()) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("permissionTypes"));
-          }
         });
+  }
+
+  private static void validateCommonRequestProperties(
+      final String ownerId,
+      final OwnerTypeEnum ownerType,
+      final ResourceTypeEnum resourceType,
+      final List<PermissionTypeEnum> permissionTypes,
+      final Pattern idPattern,
+      final List<String> violations) {
+
+    // owner validation
+    IdentifierValidator.validateId(ownerId, "ownerId", violations, idPattern);
+
+    // ownerType validation
+    if (ownerType == null) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("ownerType"));
+    }
+
+    // resourceType validation
+    if (resourceType == null) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("resourceType"));
+    }
+
+    // permissions validation
+    if (permissionTypes == null || permissionTypes.isEmpty()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("permissionTypes"));
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -144,6 +144,68 @@ public class AuthorizationControllerTest extends RestControllerTest {
   }
 
   @Test
+  void createAuthorizationShouldReturnBadRequestWhenBothResourceIdAndPropertyNameProvided() {
+    // given
+    final var request =
+        """
+            {
+              "ownerType": "USER",
+              "resourceType": "RESOURCE",
+              "resourceId": "resourceId",
+              "resourcePropertyName": "propertyName",
+              "permissionTypes":["CREATE"]
+            }""";
+
+    final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    expectedBody.setTitle("Bad Request");
+    expectedBody.setInstance(URI.create("/v2/authorizations"));
+    expectedBody.setDetail("Only one of [resourceId, resourcePropertyName] is allowed");
+
+    // when - then
+    webClient
+        .post()
+        .uri("/v2/authorizations")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody(ProblemDetail.class)
+        .isEqualTo(expectedBody);
+  }
+
+  @Test
+  void createAuthorizationShouldReturnBadRequestWhenNoResourceIdNorPropertyNameProvided() {
+    // given
+    final var request =
+        """
+            {
+              "ownerType": "USER",
+              "resourceType": "RESOURCE",
+              "permissionTypes":["CREATE"]
+            }""";
+
+    final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    expectedBody.setTitle("Bad Request");
+    expectedBody.setInstance(URI.create("/v2/authorizations"));
+    expectedBody.setDetail("At least one of [resourceId, resourcePropertyName] is required");
+
+    // when - then
+    webClient
+        .post()
+        .uri("/v2/authorizations")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody(ProblemDetail.class)
+        .isEqualTo(expectedBody);
+  }
+
+  @Test
   void deleteAuthorizationShouldReturnNoContent() {
     // given
     final long authorizationKey = 100L;
@@ -231,6 +293,68 @@ public class AuthorizationControllerTest extends RestControllerTest {
     webClient
         .put()
         .uri("/v2/authorizations/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody(ProblemDetail.class)
+        .isEqualTo(expectedBody);
+  }
+
+  @Test
+  void updateAuthorizationShouldReturnBadRequestWhenBothResourceIdAndPropertyNameProvided() {
+    // given
+    final var request =
+        """
+            {
+              "ownerType": "USER",
+              "resourceType": "USER_TASK",
+              "resourceId": "123",
+              "resourcePropertyName": "assignee",
+              "permissionTypes":["UPDATE"]
+            }""";
+
+    final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    expectedBody.setTitle("Bad Request");
+    expectedBody.setInstance(URI.create("/v2/authorizations/2"));
+    expectedBody.setDetail("Only one of [resourceId, resourcePropertyName] is allowed");
+
+    // when - then
+    webClient
+        .put()
+        .uri("/v2/authorizations/2")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody(ProblemDetail.class)
+        .isEqualTo(expectedBody);
+  }
+
+  @Test
+  void updateAuthorizationShouldReturnBadRequestWhenNoResourceIdNorPropertyNameProvided() {
+    // given
+    final var request =
+        """
+            {
+              "ownerType": "USER",
+              "resourceType": "USER_TASK",
+              "permissionTypes":["UPDATE"]
+            }""";
+
+    final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    expectedBody.setTitle("Bad Request");
+    expectedBody.setInstance(URI.create("/v2/authorizations/3"));
+    expectedBody.setDetail("At least one of [resourceId, resourcePropertyName] is required");
+
+    // when - then
+    webClient
+        .put()
+        .uri("/v2/authorizations/3")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.net.URI;
@@ -331,6 +332,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             new CreateAuthorizationRequest(
                 "ownerId",
                 AuthorizationOwnerType.USER,
+                AuthorizationResourceMatcher.ID,
                 "resourceId",
                 "",
                 AuthorizationResourceType.RESOURCE,
@@ -346,6 +348,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             new CreateAuthorizationRequest(
                 "ownerId",
                 AuthorizationOwnerType.USER,
+                AuthorizationResourceMatcher.ANY,
                 "*",
                 "",
                 AuthorizationResourceType.RESOURCE,
@@ -361,6 +364,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             new CreateAuthorizationRequest(
                 "ownerId",
                 AuthorizationOwnerType.USER,
+                AuthorizationResourceMatcher.PROPERTY,
                 "",
                 "assignee",
                 AuthorizationResourceType.USER_TASK,
@@ -384,6 +388,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 100,
                 "ownerId",
                 AuthorizationOwnerType.USER,
+                AuthorizationResourceMatcher.ID,
                 "resourceId",
                 "",
                 AuthorizationResourceType.RESOURCE,
@@ -400,6 +405,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 200,
                 "ownerId",
                 AuthorizationOwnerType.USER,
+                AuthorizationResourceMatcher.ANY,
                 "*",
                 "",
                 AuthorizationResourceType.RESOURCE,
@@ -416,6 +422,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 300,
                 "ownerId",
                 AuthorizationOwnerType.USER,
+                AuthorizationResourceMatcher.PROPERTY,
                 "",
                 "assignee",
                 AuthorizationResourceType.USER_TASK,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationIdBasedRequest;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
@@ -71,7 +72,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var resourceId = "resourceId";
 
     final var request =
-        new AuthorizationRequest()
+        new AuthorizationIdBasedRequest()
             .ownerId(ownerId)
             .ownerType(OwnerTypeEnum.USER)
             .resourceId(resourceId)
@@ -236,7 +237,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var resourceId = "resourceId";
 
     final var request =
-        new AuthorizationRequest()
+        new AuthorizationIdBasedRequest()
             .ownerId(ownerId)
             .ownerType(OwnerTypeEnum.USER)
             .resourceId(resourceId)
@@ -370,14 +371,14 @@ public class AuthorizationControllerTest extends RestControllerTest {
 
     return Stream.of(
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissionTypes(permissions),
             "No ownerId provided."),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
@@ -385,21 +386,14 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .permissionTypes(permissions),
             "No ownerId provided."),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissionTypes(permissions),
             "No ownerType provided."),
         Arguments.of(
-            new AuthorizationRequest()
-                .ownerId("ownerId")
-                .ownerType(OwnerTypeEnum.USER)
-                .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissionTypes(permissions),
-            "No resourceId provided."),
-        Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("")
@@ -407,21 +401,21 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .permissionTypes(permissions),
             "No resourceId provided."),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .permissionTypes(permissions),
             "No resourceType provided."),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE),
             "No permissionTypes provided."),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
@@ -429,7 +423,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .permissionTypes(List.of()),
             "No permissionTypes provided."),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("foo!!")
@@ -438,7 +432,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             "The provided resourceId contains illegal characters. It must match the pattern '%s'."
                 .formatted(SecurityConfiguration.DEFAULT_ID_REGEX)),
         Arguments.of(
-            new AuthorizationRequest()
+            new AuthorizationIdBasedRequest()
                 .ownerId("ownerId!!")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("foo")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationIdBasedRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPropertyBasedRequest;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
@@ -370,6 +371,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var permissions = List.of(PermissionTypeEnum.CREATE);
 
     return Stream.of(
+        // AuthorizationIdBasedRequest tests
         Arguments.of(
             new AuthorizationIdBasedRequest()
                 .ownerType(OwnerTypeEnum.USER)
@@ -439,6 +441,77 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissionTypes(permissions),
             "The provided ownerId contains illegal characters. It must match the pattern '%s'."
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX)),
+        // AuthorizationPropertyBasedRequest tests
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("resourcePropertyName")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(permissions),
+            "No ownerId provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("resourcePropertyName")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(permissions),
+            "No ownerId provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId")
+                .resourcePropertyName("resourcePropertyName")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(permissions),
+            "No ownerType provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("resourcePropertyName")
+                .permissionTypes(permissions),
+            "No resourceType provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("resourcePropertyName")
+                .resourceType(ResourceTypeEnum.RESOURCE),
+            "No permissionTypes provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("resourcePropertyName")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(List.of()),
+            "No permissionTypes provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId!!")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("resourcePropertyName")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(permissions),
+            "The provided ownerId contains illegal characters. It must match the pattern '%s'."
+                .formatted(SecurityConfiguration.DEFAULT_ID_REGEX)),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(permissions),
+            "No resourcePropertyName provided."),
+        Arguments.of(
+            new AuthorizationPropertyBasedRequest()
+                .ownerId("ownerId")
+                .ownerType(OwnerTypeEnum.USER)
+                .resourcePropertyName("property!!")
+                .resourceType(ResourceTypeEnum.RESOURCE)
+                .permissionTypes(permissions),
+            "The provided resourcePropertyName contains illegal characters. It must match the pattern '%s'."
                 .formatted(SecurityConfiguration.DEFAULT_ID_REGEX)));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -56,6 +56,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                  "ownerId": "foo",
                  "ownerType": "USER",
                  "resourceType": "PROCESS_DEFINITION",
+                 "resourcePropertyName": "",
                  "resourceId": "2",
                  "permissionTypes": ["CREATE"]
                }
@@ -131,6 +132,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                   "ownerId": "ownerId",
                   "ownerType": "USER",
                   "resourceId": "resourceId",
+                  "resourcePropertyName": "",
                   "resourceType": "PROCESS_DEFINITION",
                   "permissionTypes": ["CREATE"]
                 }""",

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -56,13 +56,28 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                  "ownerId": "foo",
                  "ownerType": "USER",
                  "resourceType": "PROCESS_DEFINITION",
-                 "resourcePropertyName": "",
                  "resourceId": "2",
                  "permissionTypes": ["CREATE"]
+               },
+               {
+                 "authorizationKey": "2",
+                 "ownerId": "foo",
+                 "ownerType": "USER",
+                 "resourceType": "RESOURCE",
+                 "resourceId": "*",
+                 "permissionTypes": ["CREATE"]
+               },
+               {
+                 "authorizationKey": "3",
+                 "ownerId": "foo",
+                 "ownerType": "USER",
+                 "resourceType": "USER_TASK",
+                 "resourcePropertyName": "assignee",
+                 "permissionTypes": ["CLAIM"]
                }
              ],
              "page": {
-               "totalItems": 1,
+               "totalItems": 3,
                "startCursor": "f",
                "endCursor": "v",
                "hasMoreTotalItems": false
@@ -72,7 +87,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
 
   private static final SearchQueryResult<AuthorizationEntity> SEARCH_QUERY_RESULT =
       new Builder<AuthorizationEntity>()
-          .total(1L)
+          .total(3L)
           .items(
               List.of(
                   new AuthorizationEntity(
@@ -83,7 +98,25 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                       AuthorizationResourceMatcher.ID.value(),
                       "2",
                       "",
-                      Set.of(PermissionType.CREATE))))
+                      Set.of(PermissionType.CREATE)),
+                  new AuthorizationEntity(
+                      2L,
+                      "foo",
+                      OwnerTypeEnum.USER.getValue(),
+                      ResourceTypeEnum.RESOURCE.getValue(),
+                      AuthorizationResourceMatcher.ANY.value(),
+                      "*",
+                      null,
+                      Set.of(PermissionType.CREATE)),
+                  new AuthorizationEntity(
+                      3L,
+                      "foo",
+                      OwnerTypeEnum.USER.getValue(),
+                      ResourceTypeEnum.USER_TASK.getValue(),
+                      AuthorizationResourceMatcher.PROPERTY.value(),
+                      "",
+                      "assignee",
+                      Set.of(PermissionType.CLAIM))))
           .startCursor("f")
           .endCursor("v")
           .build();
@@ -132,7 +165,6 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                   "ownerId": "ownerId",
                   "ownerType": "USER",
                   "resourceId": "resourceId",
-                  "resourcePropertyName": "",
                   "resourceType": "PROCESS_DEFINITION",
                   "permissionTypes": ["CREATE"]
                 }""",

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationRequest.java
@@ -54,6 +54,11 @@ public class BrokerAuthorizationRequest extends BrokerExecuteCommand<Authorizati
     return this;
   }
 
+  public BrokerAuthorizationRequest setResourcePropertyName(final String resourcePropertyName) {
+    requestDto.setResourcePropertyName(resourcePropertyName);
+    return this;
+  }
+
   public BrokerAuthorizationRequest setResourceType(final AuthorizationResourceType resourceType) {
     requestDto.setResourceType(resourceType);
     return this;


### PR DESCRIPTION
## Description

This PR provides support for property-based authorizations to the Orchestration Cluster Authorization REST API and the CamundaClient.

In addition to ID-based authorizations (`resourceId`), the API and client now support authorizations that are defined against a resource property via a new `resourcePropertyName` field. This enables more flexible, attribute-style access control while keeping the REST API structure explicit and easy to understand.

### What this PR changes

#### 1. REST API: Authorization models and validation

- Adds support for `resourcePropertyName` to the OC Authorization REST API models:
  - Create/Update authorization
  - Get/Search authorization
- Updates the OpenAPI spec (`authorization.yaml`) so that:
  - `AuthorizationRequest` is now defined as a `oneOf`:
    - `AuthorizationIdBasedRequest`
    - `AuthorizationPropertyBasedRequest` (new)
  - The two variants are mutually exclusive:
    - ID-based authorization requires `resourceId`.
    - Property-based authorization requires `resourcePropertyName`.
- Enforces validation for Create/Update endpoints:
  - Exactly one of `resourceId` or `resourcePropertyName` must be provided.
  - It is invalid to:
    - Provide both fields, or
    - Provide neither field / leave both empty.

For ID-based auth (keep the same JSON structure as before):
```json
{
  "ownerId": "string",
  "ownerType": "USER",
  "resourceId": "string",
  "resourceType": "AUTHORIZATION",
  "permissionTypes": ["ACCESS"]
}
```

For property-based auth (new):

```json
{
  "ownerId": "string",
  "ownerType": "USER",
  "resourcePropertyName": "string", // new property
  "resourceType": "USER_TASK",
  "permissionTypes": ["CLAIM"]
}
```
- Extends the Get/Search Authorizations response to include `resourcePropertyName` and to `sort`/`filter` by `resourcePropertyName/s`.

> [!NOTE]
> The [Get](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/get-authorization/) and [Search](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-authorizations/) Authorizations endpoints will omit `resourceId` and `resourcePropertyName` from the JSON response when those values are not relevant for the given authorization. Specifically, for resource-id–based authorizations, `resourcePropertyName` is not included in the response, even though it may be stored as an empty string (`""`) in secondary storage; similarly, for property-based authorizations, `resourceId` is omitted.
>
> This behavior is implemented by setting the corresponding fields to `null` in [SearchQueryResponseMapper#toAuthorization](https://github.com/camunda/camunda/pull/41079/files#diff-7e539eb0200aa8a710f73c73bfacbf8953f170ed44625db7a194bdc51fad7bff) when they are empty, so that responses are not overloaded with properties that do not apply to the current authorization.
> <details><summary>Examples</summary>
>
> <p><code>ID/ANY</code> authorization will look like:</p>
> <pre><code>
> {
>   "authorizationKey": "2",
>   "ownerId": "foo",
>   "ownerType": "USER",
>   "resourceType": "RESOURCE",
>   "resourceId": "*",
>   "permissionTypes": ["CREATE"]
> }
> </code></pre>
>
> <p>and a <code>PROPERTY</code> authorization will look like:</p>
> <pre><code>
> {
>   "authorizationKey": "3",
>   "ownerId": "foo",
>   "ownerType": "USER",
>   "resourceType": "USER_TASK",
>   "resourcePropertyName": "assignee",
>   "permissionTypes": ["CLAIM"]
> }
> </code></pre></details>

#### 2. CamundaClient support

- Extends the CamundaClient so that:
  - `newCreateAuthorizationCommand` supports specifying `resourcePropertyName` as an alternative to `resourceId` (mutually exclusive).
  - `newUpdateAuthorizationCommand` supports `resourcePropertyName` for updating existing authorizations (mutually exclusive with `resourceId`).
  - `newAuthorizationGetRequest` and `newAuthorizationSearchRequest` include `resourcePropertyName` in their response types.
- allows `newAuthorizationSearchRequest` to sort and filter by `resourcePropertyName`.

### Why this is needed
Property-based authorization will be used for the `USER_TASK` resource type. This allows defining authorization rules that grant permissions based on specific task properties (such as `assignee`, `candidateUsers`, or `candidateGroups`), rather than only by resource ID or wildcard (`*`).

### Commit structure
The commits in this PR are structured logically by concern to make the review process easier and to clearly show how each part of the stack is adapted for property-based authorization.

## Related issues

closes #40079
