### PR TITLE
build: remove identity-auth profile tag

### DIFF
--- a/dist/src/main/java/io/camunda/application/Profile.java
+++ b/dist/src/main/java/io/camunda/application/Profile.java
@@ -31,7 +31,6 @@ public enum Profile {
 
   // authentication profiles
   CONSOLIDATED_AUTH("consolidated-auth"),
-  IDENTITY_AUTH("identity-auth"),
 
   // indicating legacy standalone application
   STANDALONE("standalone");

--- a/dist/src/main/resources/application-operate.properties
+++ b/dist/src/main/resources/application-operate.properties
@@ -7,7 +7,6 @@ spring.thymeleaf.check-template-location=true
 spring.thymeleaf.prefix=classpath:/META-INF/resources/
 
 #---
-spring.config.activate.on-profile=identity-auth
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${camunda.identity.issuer:${camunda.operate.identity.issuerUrl:}}
 # Fallback Identity configuration for deprecated env variable naming
 camunda.identity.issuer=${camunda.operate.identity.issuerUrl:${CAMUNDA_OPERATE_IDENTITY_ISSUER_URL:}}

--- a/dist/src/main/resources/application-operate.properties
+++ b/dist/src/main/resources/application-operate.properties
@@ -7,16 +7,6 @@ spring.thymeleaf.check-template-location=true
 spring.thymeleaf.prefix=classpath:/META-INF/resources/
 
 #---
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${camunda.identity.issuer:${camunda.operate.identity.issuerUrl:}}
-# Fallback Identity configuration for deprecated env variable naming
-camunda.identity.issuer=${camunda.operate.identity.issuerUrl:${CAMUNDA_OPERATE_IDENTITY_ISSUER_URL:}}
-camunda.identity.issuerBackendUrl=${camunda.operate.identity.issuerBackendUrl:${CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL:}}
-camunda.identity.clientId=${camunda.operate.identity.clientId:${CAMUNDA_OPERATE_IDENTITY_CLIENT_ID:}}
-camunda.identity.clientSecret=${camunda.operate.identity.clientSecret:${CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET:}}
-camunda.identity.audience=${camunda.operate.identity.audience:}
-camunda.identity.baseUrl=${camunda.operate.identity.baseUrl:}
-
-#---
 spring.config.activate.on-profile=standalone
 # Fallback authorizations configuration for deprecated env variable naming
 camunda.security.authorizations.enabled=${camunda.operate.identity.resourcePermissionsEnabled:false}

--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -113,7 +113,7 @@ services:
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
-      - SPRING_PROFILES_ACTIVE=dev-data,identity-auth
+      - SPRING_PROFILES_ACTIVE=dev-data
       - CAMUNDA_IDENTITY_ISSUER=http://localhost:18080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_CLIENT_ID=operate
@@ -142,7 +142,6 @@ services:
       - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_TASKLIST_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
-      - SPRING_PROFILES_ACTIVE=identity-auth
       - CAMUNDA_TASKLIST_IDENTITY_ISSUERURL=http://localhost:18080/auth/realms/camunda-platform
       - CAMUNDA_TASKLIST_IDENTITY_ISSUERBACKENDURL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_TASKLIST_IDENTITY_CLIENT_ID=tasklist

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -130,7 +130,7 @@ services:
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL=http://elasticsearch:9200
-      - SPRING_PROFILES_ACTIVE=identity-auth,dev-data
+      - SPRING_PROFILES_ACTIVE=dev-data
       - CAMUNDA_IDENTITY_ISSUER=http://localhost:18080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_CLIENT_ID=operate

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -145,7 +145,7 @@ services:
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_OPENSEARCH_URL=http://opensearch:9200
       - CAMUNDA_OPERATE_ZEEBEOPENSEARCH_URL=http://opensearch:9200
-      - SPRING_PROFILES_ACTIVE=identity-auth,dev-data
+      - SPRING_PROFILES_ACTIVE=dev-data
       - CAMUNDA_IDENTITY_ISSUER=http://localhost:18080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_CLIENT_ID=operate

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -129,7 +129,7 @@ services:
     environment:
       - SERVER_PORT=8081
       - SERVER_SERVLET_CONTEXT_PATH=/operate
-      - SPRING_PROFILES_ACTIVE=identity-auth,dev-data
+      - SPRING_PROFILES_ACTIVE=dev-data
       - CAMUNDA_OPERATE_TASKLIST_URL=http://localhost:8082/tasklist
       - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
       - CAMUNDA_OPERATE_OPENSEARCH_URL=http://opensearch:9200

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -45,5 +45,5 @@ spring:
   thymeleaf:
     prefix: classpath:/static/
 ---
-spring.config.activate.on-profile: identity-auth, sso-auth
+spring.config.activate.on-profile: sso-auth
 camunda.webapps.login-delegated: true

--- a/tasklist/Makefile
+++ b/tasklist/Makefile
@@ -69,7 +69,7 @@ env-sso-up: $(DATABASE) setup-maven-context
 .PHONY: env-identity-up
 env-identity-up: $(DATABASE) identity setup-maven-context
 	$(eval SERVICES := zeebe_identity)
-	$(eval SPRING_PROFILES_ACTIVE = dev,dev-data,identity-auth)
+	$(eval SPRING_PROFILES_ACTIVE = dev,dev-data)
 	@set -o allexport && source $(MAVEN_CONTEXT) set +o allexport && \
 		$(WRITE_OR_REPLACE_SCRIPT) CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL $${EXT_CAMUNDA_IDENTITY_ISSUER_BACKEND_URL} $(MAVEN_CONTEXT) && \
 		$(WRITE_OR_REPLACE_SCRIPT) CAMUNDA_TASKLIST_IDENTITY_BASEURL $${EXT_CAMUNDA_IDENTITY_URL} $(MAVEN_CONTEXT) && \
@@ -84,7 +84,7 @@ env-identity-up: $(DATABASE) identity setup-maven-context
 .PHONY: env-identity-oauth-up
 env-identity-oauth-up: $(DATABASE) identity-oauth setup-maven-context
 	$(eval SERVICES := zeebe_oauth)
-	$(eval SPRING_PROFILES_ACTIVE = dev,dev-data,identity-auth)
+	$(eval SPRING_PROFILES_ACTIVE = dev,dev-data)
 	@set -o allexport && source $(MAVEN_CONTEXT) set +o allexport && \
 		$(WRITE_OR_REPLACE_SCRIPT) CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL $${EXT_CAMUNDA_IDENTITY_ISSUER_BACKEND_URL} $(MAVEN_CONTEXT) && \
 		$(WRITE_OR_REPLACE_SCRIPT) CAMUNDA_TASKLIST_IDENTITY_BASEURL $${EXT_CAMUNDA_IDENTITY_URL} $(MAVEN_CONTEXT) && \
@@ -97,7 +97,7 @@ env-identity-oauth-up: $(DATABASE) identity-oauth setup-maven-context
 .PHONY: env-identity-mt-up
 env-identity-mt-up: $(DATABASE) identity-oauth multi-tenancy setup-maven-context
 	$(eval SERVICES := zeebe_mt)
-	$(eval SPRING_PROFILES_ACTIVE = dev,dev-data,identity-auth)
+	$(eval SPRING_PROFILES_ACTIVE = dev,dev-data)
 	@set -o allexport && source $(MAVEN_CONTEXT) set +o allexport && \
 		$(WRITE_OR_REPLACE_SCRIPT) CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL $${EXT_CAMUNDA_IDENTITY_ISSUER_BACKEND_URL} $(MAVEN_CONTEXT) && \
 		$(WRITE_OR_REPLACE_SCRIPT) CAMUNDA_TASKLIST_IDENTITY_BASEURL $${EXT_CAMUNDA_IDENTITY_URL} $(MAVEN_CONTEXT) && \

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -158,7 +158,6 @@ services:
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_BROKER_CLUSTER_PARTITIONS_COUNT=4
-      - SPRING_PROFILES_ACTIVE=identity-auth
       - CAMUNDA_IDENTITY_ISSUERURL=http://localhost:18080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_ISSUERBACKENDURL=http://keycloak:8080/auth/realms/camunda-platform
       - CAMUNDA_IDENTITY_BASEURL=http://identity:8084
@@ -229,7 +228,7 @@ services:
     <<: *tasklist
     environment:
       - SERVER_PORT=8082
-      - SPRING_PROFILES_ACTIVE=dev,dev-data,identity-auth
+      - SPRING_PROFILES_ACTIVE=dev,dev-data
     ports:
       - 8082:8082
     depends_on:
@@ -312,7 +311,7 @@ services:
       - 8081:8081
     environment:
       - SERVER_PORT=8081
-      - SPRING_PROFILES_ACTIVE=dev,dev-data,identity-auth
+      - SPRING_PROFILES_ACTIVE=dev,dev-data
     depends_on:
       - ${DATABASE}
       - zeebe_identity

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -39,5 +39,5 @@ management.endpoint.health.probes.enabled: true
 management.endpoints.web.exposure.include: health,prometheus,loggers,usage-metrics,backups
 management.endpoint.health.group.readiness.include: readinessState,searchEngineCheck
 ---
-spring.config.activate.on-profile: identity-auth, sso-auth
+spring.config.activate.on-profile: sso-auth
 camunda.webapps.login-delegated: true

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthProbeIntegrationTest.java
@@ -210,8 +210,7 @@ public class GatewayHealthProbeIntegrationTest {
   @Nested
   final class WithAuthenticationIdentityTest {
     @TestZeebe(awaitReady = false, awaitCompleteTopology = false) // since there's no broker
-    private final TestStandaloneGateway gateway =
-        new TestStandaloneGateway().withAdditionalProfile("identity-auth");
+    private final TestStandaloneGateway gateway = new TestStandaloneGateway();
 
     @Test
     void shouldReportReadinessUpWithoutAuthentication() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes the rest of the references to the legacy auth profile `identity-tag` from the code.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

* #41035
