### PR TITLE
fix: variable value ignored

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -106,6 +106,9 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
     if (variableAnnotation != null && !Variable.DEFAULT_NAME.equals(variableAnnotation.name())) {
       return variableAnnotation.name();
     }
+    if (variableAnnotation != null && !Variable.DEFAULT_NAME.equals(variableAnnotation.value())) {
+      return variableAnnotation.value();
+    }
     return parameterInfo.getParameterName();
   }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -60,6 +60,15 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
       @Variable final String var1, @VariablesAsType final ComplexProcessVariable var2) {}
 
   @JobWorker
+  void variableOnlyWorker(@Variable final String foo) {}
+
+  @JobWorker
+  void variableWithValueOnlyWorker(@Variable("foo") final String bar) {}
+
+  @JobWorker
+  void variableWithNameOnlyWorker(@Variable(name = "foo") final String bar) {}
+
+  @JobWorker
   void activatedJobWorker(@Variable final String var1, final ActivatedJob activatedJob) {}
 
   @JobWorker
@@ -68,6 +77,45 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   @JobWorker
   void sampleWorkerWithEmptyJsonProperty(
       @VariablesAsType final PropertyAnnotatedClassEmptyValue annotatedClass) {}
+
+  @Test
+  void shouldExtractVariableNameFromParameterName() {
+    // given
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties());
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "variableOnlyWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).containsExactly("foo");
+  }
+
+  @Test
+  void shouldExtractVariableNameFromValue() {
+    // given
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties());
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "variableWithValueOnlyWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).containsExactly("foo");
+  }
+
+  @Test
+  void shouldExtractVariableNameFromName() {
+    // given
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties());
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "variableWithNameOnlyWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).containsExactly("foo");
+  }
 
   @Test
   void shouldNotAdjustVariableFilterVariablesAsActivatedJobIsInjectedLegacy() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR fixes an issue where the variable "value" property has been ignored while collecting the "fetchVariables".

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
