### PR TITLE
feat: when a job cannot be sent to the client it should be logged at INFO

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -281,7 +281,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
 
   private void logResponseNotSent(
       final String jobType, final List<Long> jobKeys, final String reason) {
-    Loggers.GATEWAY_LOGGER.debug(
+    Loggers.GATEWAY_LOGGER.info(
         "Failed to send {} activated jobs for type {} (with job keys: {}) to client, because: {}",
         jobKeys.size(),
         jobType,


### PR DESCRIPTION
## Description
When a job cannot be sent to the client, it is marked as failed and reactivated in the broker.
This means that the job will have one less retry available. If it's the last retry, this will result in an incident.
If the gateway log level is not set to DEBUG, then it's almost impossible to understand for the operator what was the cause of the incident.

This situation arised in a support case, where an incident was created and the customer was able to reproduce the issue in a test environment with DEBUG logs enabled.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
SUPPORT-30088
