### PR TITLE
Test whether SecureMessagingIT fails

### DIFF
--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -60,7 +60,7 @@ LABEL io.k8s.description="Tool for process observability and troubleshooting pro
 EXPOSE 8080
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
+RUN apk add --no-cache bash openjdk21-jre tzdata
 
 ENV OPE_HOME=/usr/local/operate
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -226,7 +226,7 @@ final class SecuredClusteredMessagingIT {
 
   private void assertAddressIsSecured(final Object nodeId, final SocketAddress address) {
     SslAssert.assertThat(address)
-        .as("node %s is not secured correctly at address %s", nodeId, address)
+        .as("node %s is not secured correctly REMOVEME at address %s", nodeId, address)
         .isSecuredBy(CERTIFICATE);
   }
 


### PR DESCRIPTION
## Description

Removed 'gcompat' and 'libgcc' from the operate.Dockerfile to test https://github.com/camunda/camunda/pull/31499

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
