### PR TITLE
[Backport stable/8.7] feat: when a job cannot be sent to the client it should be logged at INFO

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -281,7 +281,7 @@ public final class RoundRobinActivateJobsHandler<T> implements ActivateJobsHandl
 
   private void logResponseNotSent(
       final String jobType, final List<Long> jobKeys, final String reason) {
-    Loggers.GATEWAY_LOGGER.debug(
+    Loggers.GATEWAY_LOGGER.info(
         "Failed to send {} activated jobs for type {} (with job keys: {}) to client, because: {}",
         jobKeys.size(),
         jobType,


### PR DESCRIPTION
# Description
Backport of #41090 to `stable/8.7`.

relates to 