### PR TITLE
feat: add process instance incident resolution to zod schema

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.17
+
+### 🚀 Enhancements
+
+- add process instance incident resolution to zod schema ([#41107](https://github.com/camunda/camunda/pull/41107))
+
+### ❤️ Contributors
+
+- Patrick Dehn ([@pedesen](https://github.com/pedesen))
+
 ## v0.0.16
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/index.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/index.ts
@@ -82,6 +82,7 @@ import {
 	createMigrationBatchOperation,
 	createModificationBatchOperation,
 	modifyProcessInstance,
+	resolveProcessInstanceIncidents,
 } from './process-instance';
 import {
 	getUserTask,
@@ -296,6 +297,7 @@ const endpoints = {
 	createMigrationBatchOperation,
 	createModificationBatchOperation,
 	modifyProcessInstance,
+	resolveProcessInstanceIncidents,
 } as const;
 
 export {currentUserSchema, getCurrentUser, type CurrentUser} from './authentication';
@@ -610,6 +612,7 @@ export {
 	type CreateModificationBatchOperationRequestBody,
 	type CreateModificationBatchOperationResponseBody,
 	type ModifyProcessInstanceRequestBody,
+	type ResolveProcessInstanceIncidentsResponseBody,
 } from './process-instance';
 export {
 	userTaskSchema,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
@@ -335,6 +335,20 @@ const modifyProcessInstance: Endpoint<Pick<ProcessInstance, 'processInstanceKey'
 	getUrl: ({processInstanceKey}) => `/${API_VERSION}/process-instances/${processInstanceKey}/modification`,
 };
 
+const resolveProcessInstanceIncidentsResponseBodySchema = z.object({
+	batchOperationKey: z.string(),
+	batchOperationType: batchOperationTypeSchema,
+});
+
+type ResolveProcessInstanceIncidentsResponseBody = z.infer<
+	typeof resolveProcessInstanceIncidentsResponseBodySchema
+>;
+
+const resolveProcessInstanceIncidents: Endpoint<Pick<ProcessInstance, 'processInstanceKey'>> = {
+	method: 'POST',
+	getUrl: ({processInstanceKey}) => `/${API_VERSION}/process-instances/${processInstanceKey}/incident-resolution`,
+};
+
 export {
 	createProcessInstance,
 	getProcessInstance,
@@ -349,6 +363,7 @@ export {
 	createMigrationBatchOperation,
 	createModificationBatchOperation,
 	modifyProcessInstance,
+	resolveProcessInstanceIncidents,
 	createProcessInstanceRequestBodySchema,
 	createProcessInstanceResponseBodySchema,
 	modifyProcessInstanceRequestBodySchema,
@@ -360,6 +375,7 @@ export {
 	getProcessInstanceCallHierarchyResponseBodySchema,
 	getProcessInstanceStatisticsResponseBodySchema,
 	getProcessInstanceSequenceFlowsResponseBodySchema,
+	resolveProcessInstanceIncidentsResponseBodySchema,
 	processInstanceStateSchema,
 	processInstanceSchema,
 	sequenceFlowSchema,
@@ -390,4 +406,5 @@ export type {
 	CreateModificationBatchOperationRequestBody,
 	CreateModificationBatchOperationResponseBody,
 	ModifyProcessInstanceRequestBody,
+	ResolveProcessInstanceIncidentsResponseBody,
 };

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.16",
+        "@camunda/camunda-api-zod-schemas": "0.0.17",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.16.tgz",
-      "integrity": "sha512-Z3E8jhSHp+nFXFekdxJPntpPWYMxYZb6msbqLVTIJSu+2uo9WsEeeewR9H+Rua8RecueW9q8PO/RAx7hSX8ldQ==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.17.tgz",
+      "integrity": "sha512-xzmByE2zf6xdaUKO2kKRrVaY7F5X2P0FqyrN/c78HD5iGYG2BcpgZdHhp1DA2JK9gtcw0S8mBpMXD05HEn4b/A==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.16",
+    "@camunda/camunda-api-zod-schemas": "0.0.17",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.16",
+        "@camunda/camunda-api-zod-schemas": "0.0.17",
         "@camunda/camunda-composite-components": "0.21.1",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.16.tgz",
-      "integrity": "sha512-Z3E8jhSHp+nFXFekdxJPntpPWYMxYZb6msbqLVTIJSu+2uo9WsEeeewR9H+Rua8RecueW9q8PO/RAx7hSX8ldQ==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.17.tgz",
+      "integrity": "sha512-xzmByE2zf6xdaUKO2kKRrVaY7F5X2P0FqyrN/c78HD5iGYG2BcpgZdHhp1DA2JK9gtcw0S8mBpMXD05HEn4b/A==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.16",
+    "@camunda/camunda-api-zod-schemas": "0.0.17",
     "@camunda/camunda-composite-components": "0.21.1",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",


### PR DESCRIPTION
## Description

This PR adds the [resolve process instance incidents endpoint](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/resolve-process-instance-incidents/) to zod schema

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
