### PR TITLE
feat: Flush the rdbms execution queue only after a record has been pr…

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -278,6 +278,20 @@ public class RdbmsWriter {
   }
 
   public void flush() {
-    executionQueue.flush();
+    flush(true);
+  }
+
+  /**
+   * Flushes the execution queue based on the force parameter.
+   *
+   * @param force if true, forces an immediate flush; if false, only flushes if queue limits are
+   *     reached
+   */
+  public void flush(final boolean force) {
+    if (force) {
+      executionQueue.flush();
+    } else {
+      executionQueue.checkQueueForFlush();
+    }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
@@ -9,13 +9,54 @@ package io.camunda.db.rdbms.write.queue;
 
 public interface ExecutionQueue {
 
+  /**
+   * Enqueues the given entry to be executed later in a batch.
+   *
+   * @param entry the queue item to enqueue
+   */
   void executeInQueue(QueueItem entry);
 
+  /**
+   * Registers a listener to be called before flushing the queue.<br>
+   * <br>
+   * Note: When multiple listeners are registered, they are called in the order of their
+   * registration.
+   *
+   * @param listener the pre-flush listener to register
+   */
   void registerPreFlushListener(PreFlushListener listener);
 
+  /**
+   * Registers a listener to be called right after flushing the queue.<br>
+   * <br>
+   * Note: When multiple listeners are registered, they are called in the order of their
+   * registration.
+   *
+   * @param listener the post-flush listener to register
+   */
   void registerPostFlushListener(PostFlushListener listener);
 
+  /**
+   * Flushes the queue, executing all enqueued items in a batch.
+   *
+   * @return the number of flushed items
+   */
   int flush();
 
-  boolean tryMergeWithExistingQueueItem(QueueItemMerger... combiners);
+  /**
+   * Takes the given queueItemMerger and processes all queue items with it. The queueItemMerger will
+   * try to find a matching queue item and eventually then modify this queue item.
+   *
+   * @param merger the queue item merger to apply
+   * @return if a merge has been performed
+   */
+  boolean tryMergeWithExistingQueueItem(QueueItemMerger merger);
+
+  /**
+   * Checks if the queue has reached its flush limit and flushes if necessary. Does nothing if no
+   * flush limit is configured (queueFlushLimit <= 0).
+   *
+   * @return true if the queue was flushed, false otherwise
+   */
+  boolean checkQueueForFlush();
 }


### PR DESCRIPTION
## Description

This PR makes sure, that the RDBMS writer queue does not flush while a record is still being processed. This ensures, that the SQL write statements caused by the processing of one record are always executed in the same one transaction.

## Related issues

closes #38626 