### PR TITLE
Add delete form permission for operate in SaaS

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -291,7 +291,11 @@ public class StaticEntities {
             AuthorizationOwnerType.CLIENT,
             "*",
             AuthorizationResourceType.RESOURCE,
-            Set.of(PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+            Set.of(
+                PermissionType.READ,
+                PermissionType.DELETE_PROCESS,
+                PermissionType.DELETE_DRD,
+                PermissionType.DELETE_FORM)),
         new CreateAuthorizationRequest(
             clientId,
             AuthorizationOwnerType.CLIENT,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractSaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractSaaSIdentityMigrationIT.java
@@ -373,6 +373,11 @@ public abstract class AbstractSaaSIdentityMigrationIT {
               "permissions": ["Operate", "Zeebe"]
             },
             {
+              "name": "Operate",
+              "clientId": "operate-client",
+              "permissions": ["Operate"]
+             },
+            {
               "name": "Tasklist",
               "clientId": "tasklist-client",
               "permissions": ["Tasklist"]

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -437,7 +437,7 @@ public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
                       .map(Authorization::getOwnerType)
                       .filter(OwnerType.CLIENT::equals)
                       .toList();
-              assertThat(authorizations.size()).isEqualTo(10);
+              assertThat(authorizations.size()).isEqualTo(16);
             });
 
     // then
@@ -503,6 +503,45 @@ public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
                 OwnerType.CLIENT,
                 ResourceType.BATCH,
                 Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+            tuple(
+                "operate-client",
+                OwnerType.CLIENT,
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
+            tuple(
+                "operate-client",
+                OwnerType.CLIENT,
+                ResourceType.PROCESS_DEFINITION,
+                Set.of(
+                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_DEFINITION,
+                    PermissionType.READ_PROCESS_INSTANCE)),
+            tuple(
+                "operate-client",
+                OwnerType.CLIENT,
+                ResourceType.BATCH,
+                Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+            tuple(
+                "operate-client",
+                OwnerType.CLIENT,
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM)),
+            tuple(
+                "operate-client",
+                OwnerType.CLIENT,
+                ResourceType.DECISION_DEFINITION,
+                Set.of(
+                    PermissionType.READ_DECISION_INSTANCE,
+                    PermissionType.READ_DECISION_DEFINITION)),
+            tuple(
+                "operate-client",
+                OwnerType.CLIENT,
+                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                Set.of(PermissionType.READ)),
             tuple(
                 "tasklist-client",
                 OwnerType.CLIENT,


### PR DESCRIPTION
## Description
The identity migration lacked `DELETE_FORM` permission for the resource for operate (as mention here in the [doc](https://docs.google.com/document/d/1XqG9Y9SXvakwcJ7ZheE8lgd6X0PMWSuyH4IbYTzLYeE/edit?tab=t.0#:~:text=Operate%20client%20which-,can,-already%20delete%20processes)) in `operate` section.
Please see more in commit messages.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38364
