### PR TITLE
ci: use Minimus image for Optimize to reduce CVEs

### DIFF
--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -76,6 +76,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
 
       #########################################################################
       # Build Optimize frontend

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -55,6 +55,7 @@ jobs:
         vault-address: ${{ secrets.VAULT_ADDR }}
         vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
         vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+        minimus: true
     - name: Build Optimize Backend
       uses: ./.github/actions/run-maven
       with:

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -130,6 +130,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
           maven-servers: |
             [{
                 "id": "central",

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,5 +1,11 @@
-ARG BASE_IMAGE="alpine:3.22.2"
-ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
+# hadolint global ignore=DL3006
+ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
+ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk:
+#ARG BASE_IMAGE="alpine:3.22.2"
+#ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
 
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 WORKDIR /
@@ -65,9 +71,10 @@ EXPOSE 8090 8091
 
 VOLUME /tmp
 
-RUN apk add --no-cache bash curl tini openjdk21-jre tzdata && \
-    apk -U upgrade && \
-    curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
+# Switch to root to allow setting up our own user
+USER root
+RUN mkdir -p /usr/local/bin/ && \
+    wget -nv -O /usr/local/bin/wait-for-it.sh "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" && \
     chmod +x /usr/local/bin/wait-for-it.sh && \
     addgroup -S -g 1001 camunda && \
     adduser -S -g 1001 -u 1001 camunda && \
@@ -77,7 +84,6 @@ RUN apk add --no-cache bash curl tini openjdk21-jre tzdata && \
 WORKDIR /optimize
 USER 1001:1001
 
-ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["./optimize.sh"]
 
 COPY --chown=1001:1001 --from=base /tmp/build .


### PR DESCRIPTION
## Description

Instead of Alpine, adjust the `optimize.Dockerfile` which produces the `camunda/optimize` image on DockerHub to use hardened Minimus base images to lower the amount of CVEs due to faster updates.

This PR also adjusts CI jobs that build the Optimize Docker image to require Minimus credentials.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - out of scope of https://github.com/camunda/camunda/issues/40739

## Related issues

Related to https://github.com/camunda/camunda/issues/40739
