### PR TITLE
feat: Add support for Opensearch in StandaloneSchemaManagerIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -7,314 +7,145 @@
  */
 package io.camunda.it.schema;
 
-import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
-import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import io.camunda.application.Profile;
-import io.camunda.exporter.CamundaExporter;
-import io.camunda.operate.webapp.api.v1.entities.ProcessInstance;
+import io.camunda.it.schema.strategy.ElasticsearchBackendStrategy;
+import io.camunda.it.schema.strategy.OpenSearchBackendStrategy;
+import io.camunda.it.schema.strategy.SearchBackendStrategy;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
-import io.camunda.search.connect.es.ElasticsearchConnector;
-import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import java.io.IOException;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.images.builder.Transferable;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @ZeebeIntegration
-@Testcontainers
 final class StandaloneSchemaManagerIT {
 
-  public static final String ADMIN_USER = "camunda-admin";
-  public static final String ADMIN_PASSWORD = "admin123";
-  public static final String ADMIN_ROLE = "superuser";
-
-  public static final String APP_USER = "camunda-app";
-  public static final String APP_PASSWORD = "app123";
-  public static final String APP_ROLE = "camunda_app_role";
-  public static final String APP_ROLE_DEFINITION =
-      // language=yaml
-      """
-          camunda_app_role:
-            indices:
-              - names: ['zeebe-*', 'operate-*', 'tasklist-*', 'camunda-*']
-                privileges: ['manage', 'read', 'write']
-          """;
+  @TestZeebe(autoStart = false)
+  final TestStandaloneSchemaManager schemaManager = new TestStandaloneSchemaManager();
 
   @TestZeebe(autoStart = false)
-  final TestStandaloneSchemaManager schemaManager =
-      new TestStandaloneSchemaManager()
-          .withProperty(
-              "zeebe.broker.exporters.elasticsearch.class-name",
-              ElasticsearchExporter.class.getName())
-          .withProperty("zeebe.broker.exporters.elasticsearch.args.index.create-template", "true")
-          .withProperty("zeebe.broker.exporters.elasticsearch.args.retention.enabled", "true")
-          .withProperty(
-              "zeebe.broker.exporters.elasticsearch.args.authentication.username", ADMIN_USER)
-          .withProperty(
-              "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD)
-          .withProperty("camunda.data.secondary-storage.type", "elasticsearch")
-          .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
-          .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
-          .withProperty("camunda.data.secondary-storage.retention.enabled", "true");
+  final TestCamundaApplication camunda = new TestCamundaApplication();
 
-  @TestZeebe(autoStart = false)
-  final TestCamundaApplication camunda =
-      new TestCamundaApplication()
-          .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
-          .withUnauthenticatedAccess()
-          .withProperty(CREATE_SCHEMA_PROPERTY, "false")
-          .withProperty("camunda.operate.elasticsearch.health-check-enabled", "false")
-          .withProperty("camunda.tasklist.elasticsearch.health-check-enabled", "false")
-          .withProperty(
-              "zeebe.broker.exporters.elasticsearch.class-name",
-              ElasticsearchExporter.class.getName())
-          .withProperty("camunda.data.secondary-storage.type", "elasticsearch")
-          .withProperty("camunda.data.secondary-storage.elasticsearch.username", APP_USER)
-          .withProperty("camunda.data.secondary-storage.elasticsearch.password", APP_PASSWORD)
-          .withExporter(
-              CamundaExporter.class.getSimpleName(),
-              cfg -> {
-                cfg.setClassName(CamundaExporter.class.getName());
-                cfg.setArgs(
-                    Map.of(
-                        "connect",
-                        Map.of("username", APP_USER, "password", APP_PASSWORD),
-                        "createSchema",
-                        false,
-                        "history",
-                        Map.of("retention", Map.of("enabled", true))));
-              })
-          .withExporter(
-              ElasticsearchExporter.class.getSimpleName(),
-              cfg -> {
-                cfg.setClassName(ElasticsearchExporter.class.getName());
-                cfg.setArgs(
-                    Map.of(
-                        "index",
-                        Map.of("createTemplate", false),
-                        "retention",
-                        Map.of("enabled", false, "managePolicy", false),
-                        "authentication",
-                        Map.of("username", APP_USER, "password", APP_PASSWORD)));
-              });
-
-  @Container
-  private final ElasticsearchContainer es =
-      new ElasticsearchContainer(
-              DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-                  .withTag(SUPPORTED_ELASTICSEARCH_VERSION))
-          // Enable security features
-          .withEnv("xpack.security.enabled", "true")
-          // Ensure a fast and reliable startup
-          .withStartupTimeout(Duration.ofMinutes(5))
-          .withStartupAttempts(3)
-          .withEnv("xpack.security.enabled", "true")
-          .withEnv("xpack.watcher.enabled", "false")
-          .withEnv("xpack.ml.enabled", "false")
-          .withCopyToContainer(
-              Transferable.of(APP_ROLE_DEFINITION), "/usr/share/elasticsearch/config/roles.yml")
-          .withClasspathResourceMapping(
-              "elasticsearch-fast-startup.options",
-              "/usr/share/elasticsearch/config/jvm.options.d/elasticsearch-fast-startup.options",
-              BindMode.READ_ONLY);
-
-  @AutoClose private ElasticsearchClient esAdminClient;
-
-  @BeforeEach
-  void setup() throws IOException, InterruptedException {
-    // setup ES admin user
-    es.execInContainer("elasticsearch-users", "useradd", ADMIN_USER, "-p", ADMIN_PASSWORD);
-    es.execInContainer("elasticsearch-users", "roles", ADMIN_USER, "-a", ADMIN_ROLE);
-
-    // Create ES client for admin user
-    final var config = new ConnectConfiguration();
-    config.setUrl("http://" + es.getHttpHostAddress());
-    config.setUsername(ADMIN_USER);
-    config.setPassword(ADMIN_PASSWORD);
-    esAdminClient = new ElasticsearchConnector(config).createClient();
-
-    // create app user with APP_ROLE role
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
-        .pollInterval(Duration.ofSeconds(1))
-        .ignoreExceptions()
-        .until(
-            () ->
-                esAdminClient
-                    .security()
-                    .putUser(r -> r.username(APP_USER).password(APP_PASSWORD).roles(APP_ROLE))
-                    .created());
-
-    final String esUrl = "http://" + es.getHttpHostAddress();
-
-    // Connect to ES in Standalone Schema Manager
-    schemaManager
-        .withProperty("camunda.data.secondary-storage.elasticsearch.url", esUrl)
-        .withProperty("zeebe.broker.exporters.elasticsearch.args.url", esUrl);
-
-    // Connect to ES in Camunda
-    camunda
-        .withProperty("camunda.data.secondary-storage.elasticsearch.url", esUrl)
-        .updateExporterArgs(
-            CamundaExporter.class.getSimpleName(),
-            args -> ((Map) args.get("connect")).put("url", esUrl))
-        .updateExporterArgs(
-            ElasticsearchExporter.class.getSimpleName(), args -> args.put("url", esUrl));
+  static Stream<SearchBackendStrategy> strategies() {
+    return Stream.of(new ElasticsearchBackendStrategy(), new OpenSearchBackendStrategy());
   }
 
-  @Test
-  void canUseCamunda() {
-    // given
-    schemaManager.start();
-    camunda.start();
+  @ParameterizedTest
+  @MethodSource("strategies")
+  void canUseCamunda(final SearchBackendStrategy strategy) throws Exception {
+    try (strategy) {
+      strategy.initialize(schemaManager, camunda);
 
-    // when -- creating a process instance with user task
-    final long processInstanceKey;
-    try (final var camundaClient = camunda.newClientBuilder().build()) {
-      // Deploy process with user task
-      camundaClient
-          .newDeployResourceCommand()
-          .addProcessModel(
-              Bpmn.createExecutableProcess("process-with-user-task")
-                  .startEvent()
-                  .userTask("user-task")
-                  .zeebeUserTask()
-                  .endEvent()
-                  .done(),
-              "process-with-user-task.bpmn")
-          .send()
-          .join();
-      processInstanceKey =
-          camundaClient
-              .newCreateInstanceCommand()
-              .bpmnProcessId("process-with-user-task")
-              .latestVersion()
-              .send()
-              .join()
-              .getProcessInstanceKey();
+      final long processInstanceKey;
+      try (final var client = camunda.newClientBuilder().build()) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess("process-with-user-task")
+                    .startEvent()
+                    .userTask("user-task")
+                    .zeebeUserTask()
+                    .endEvent()
+                    .done(),
+                "process-with-user-task.bpmn")
+            .send()
+            .join();
 
-      // then -- user task exists and can be completed
-      final var userTaskKey =
-          Awaitility.await("should create a user task")
-              .atMost(Duration.ofSeconds(60))
-              .ignoreExceptions()
-              .until(
-                  () ->
-                      camundaClient
-                          .newUserTaskSearchRequest()
-                          .send()
-                          .join()
-                          .items()
-                          .getFirst()
-                          .getUserTaskKey(),
-                  Objects::nonNull);
-      camundaClient.newAssignUserTaskCommand(userTaskKey).assignee("demo").send().join();
-      camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join();
+        processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId("process-with-user-task")
+                .latestVersion()
+                .send()
+                .join()
+                .getProcessInstanceKey();
 
-      // then -- process instance is completed
-      Awaitility.await("process instance should be completed")
-          .atMost(Duration.ofSeconds(60))
+        final var userTaskKey =
+            Awaitility.await("user task created")
+                .atMost(Duration.ofSeconds(60))
+                .ignoreExceptions()
+                .until(
+                    () ->
+                        client
+                            .newUserTaskSearchRequest()
+                            .send()
+                            .join()
+                            .items()
+                            .getFirst()
+                            .getUserTaskKey(),
+                    Objects::nonNull);
+
+        client.newAssignUserTaskCommand(userTaskKey).assignee("demo").send().join();
+        client.newCompleteUserTaskCommand(userTaskKey).send().join();
+
+        Awaitility.await("process instance completed")
+            .atMost(Duration.ofSeconds(60))
+            .ignoreExceptions()
+            .untilAsserted(
+                () -> {
+                  final var result =
+                      client.newProcessInstanceGetRequest(processInstanceKey).send().join();
+                  assertThat(result.getEndDate()).isNotNull();
+                });
+      }
+      Awaitility.await("Zeebe records templates exist and records are exported to Elasticsearch")
+          .atMost(Duration.ofSeconds(5))
           .ignoreExceptions()
           .untilAsserted(
               () -> {
-                final var result =
-                    camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
-                assertThat(result.getEndDate()).isNotNull();
+                assertThat(strategy.countTemplates("zeebe-record*")).isGreaterThan(0);
+                assertThat(strategy.countDocuments("zeebe-record*")).isGreaterThan(0);
               });
     }
-
-    Awaitility.await("Zeebe records templates exist and records are exported to Elasticsearch")
-        .atMost(Duration.ofSeconds(5))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              assertThat(
-                      esAdminClient
-                          .indices()
-                          .getIndexTemplate(r -> r.name("zeebe-record*"))
-                          .indexTemplates())
-                  .hasSizeGreaterThan(0);
-              assertThat(esAdminClient.count(r -> r.index("zeebe-record*")).count())
-                  .isGreaterThan(0);
-            });
   }
 
-  @Test
-  void canArchiveProcessInstances() {
-    // given
-    schemaManager.start();
-    // Configure archiver to run frequently
-    camunda.updateExporterArgs(
-        CamundaExporter.class.getSimpleName(),
-        args ->
-            ((Map) args.computeIfAbsent("history", k -> new HashMap<>()))
-                .put("waitPeriodBeforeArchiving", "1s"));
-    camunda.start();
+  @ParameterizedTest
+  @MethodSource("strategies")
+  void canArchiveProcessInstances(final SearchBackendStrategy strategy) throws Exception {
+    try (strategy) {
+      strategy.initialize(schemaManager, camunda);
+      final long processInstanceKey;
+      try (final var client = camunda.newClientBuilder().build()) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess("simple-process").startEvent().endEvent().done(),
+                "simple-process.bpmn")
+            .send()
+            .join();
 
-    // when - a self-completing process instance is created
-    final long processInstanceKey;
-    try (final var camundaClient = camunda.newClientBuilder().build()) {
-      camundaClient
-          .newDeployResourceCommand()
-          .addProcessModel(
-              Bpmn.createExecutableProcess("simple-process").startEvent().endEvent().done(),
-              "simple-process.bpmn")
-          .send()
-          .join();
+        processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId("simple-process")
+                .latestVersion()
+                .send()
+                .join()
+                .getProcessInstanceKey();
+      }
+      // then - process instance is archived
+      Awaitility.await("process instance should be archived")
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(1))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                // Verify that instance is in archived index
+                assertThat(
+                        strategy.searchByKey("operate-list-view-8.3.0_*-*-*", processInstanceKey))
+                    .isEqualTo(1);
 
-      processInstanceKey =
-          camundaClient
-              .newCreateInstanceCommand()
-              .bpmnProcessId("simple-process")
-              .latestVersion()
-              .send()
-              .join()
-              .getProcessInstanceKey();
+                // Verify it's not in the live index
+                assertThat(strategy.searchByKey("operate-list-view-*_", processInstanceKey))
+                    .isEqualTo(0);
+              });
     }
-
-    // then - process instance is archived
-    Awaitility.await("process instance should be archived")
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              // Verify that instance is in archived index
-              final var searchResponseFromArchive =
-                  esAdminClient.search(
-                      s ->
-                          s.index("operate-list-view-8.3.0_*-*-*")
-                              .query(q -> q.term(t -> t.field("key").value(processInstanceKey))),
-                      ProcessInstance.class);
-              assertThat(searchResponseFromArchive.hits().total().value()).isEqualTo(1);
-
-              // Verify it's not in the live index
-              final var searchResponseFromLive =
-                  esAdminClient.search(
-                      s ->
-                          s.index("operate-list-view-8.3.0_")
-                              .query(q -> q.term(t -> t.field("key").value(processInstanceKey))),
-                      ProcessInstance.class);
-              assertThat(searchResponseFromLive.hits().total().value()).isEqualTo(0);
-            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.schema.strategy;
+
+import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
+import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.application.Profile;
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration;
+import io.camunda.zeebe.exporter.ElasticsearchExporterSchemaManager;
+import java.time.Duration;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+public final class ElasticsearchBackendStrategy implements SearchBackendStrategy {
+
+  public static final String APP_ROLE = "camunda_app_role";
+  public static final String APP_ROLE_DEFINITION =
+      // language=yaml
+      """
+          camunda_app_role:
+            indices:
+              - names: ['zeebe-*', 'operate-*', 'tasklist-*', 'camunda-*']
+                privileges: ['manage', 'read', 'write']
+          """;
+  private static final String ADMIN_USER = "camunda-admin";
+  private static final String ADMIN_PASSWORD = "admin123";
+  private static final String ADMIN_ROLE = "superuser";
+  private static final String APP_USER = "camunda-app";
+  private static final String APP_PASSWORD = "app123";
+  private String url;
+  private ElasticsearchContainer container;
+  private ElasticsearchClient adminClient;
+
+  @Override
+  public void startContainer() throws Exception {
+    if (container != null) {
+      throw new IllegalStateException("Container is already started");
+    }
+    container =
+        new ElasticsearchContainer(
+                DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                    .withTag(SUPPORTED_ELASTICSEARCH_VERSION))
+            .withStartupTimeout(Duration.ofMinutes(5))
+            .withEnv("xpack.security.enabled", "true")
+            .withStartupAttempts(3)
+            .withCopyToContainer(
+                Transferable.of(APP_ROLE_DEFINITION), "/usr/share/elasticsearch/config/roles.yml");
+    container.start();
+    container.execInContainer("elasticsearch-users", "useradd", ADMIN_USER, "-p", ADMIN_PASSWORD);
+    container.execInContainer("elasticsearch-users", "roles", ADMIN_USER, "-a", ADMIN_ROLE);
+    container.execInContainer("elasticsearch-users", "useradd", APP_USER, "-p", APP_PASSWORD);
+    container.execInContainer("elasticsearch-users", "roles", APP_USER, "-a", APP_ROLE);
+    url = "http://" + container.getHttpHostAddress();
+  }
+
+  @Override
+  public GenericContainer<?> getContainer() {
+    return container;
+  }
+
+  @Override
+  public void createAdminClient() throws Exception {
+
+    final var cfg = new ConnectConfiguration();
+    cfg.setUrl(url);
+    cfg.setUsername(ADMIN_USER);
+    cfg.setPassword(ADMIN_PASSWORD);
+    adminClient = new ElasticsearchConnector(cfg).createClient();
+
+    // ES can be slow to assign roles and permissions, so we wait until we can successfully connect
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .until(() -> adminClient.info() != null);
+  }
+
+  @Override
+  public void createSchema() throws Exception {
+    final var adminCfg = exporterAdminConfig();
+    final var schemaManager = new ElasticsearchExporterSchemaManager(adminCfg);
+    schemaManager.createSchema(adminClient.info().version().number());
+  }
+
+  @Override
+  public void configureStandaloneSchemaManager(final TestStandaloneSchemaManager schemaManager) {
+    schemaManager
+        .withProperty(
+            "zeebe.broker.exporters.elasticsearch.class-name",
+            ElasticsearchExporter.class.getName())
+        .withProperty("zeebe.broker.exporters.elasticsearch.args.url", url)
+        .withProperty("camunda.data.secondary-storage.type", "elasticsearch")
+        .withProperty("camunda.data.secondary-storage.elasticsearch.url", url)
+        .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
+        .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
+        .withProperty(
+            "zeebe.broker.exporters.elasticsearch.args.authentication.username", ADMIN_USER)
+        .withProperty(
+            "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD);
+  }
+
+  @Override
+  public void configureCamundaApplication(final TestCamundaApplication camunda) {
+    camunda
+        .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
+        .withProperty(CREATE_SCHEMA_PROPERTY, "false")
+        .withProperty("camunda.operate.elasticsearch.health-check-enabled", "false")
+        .withProperty("camunda.tasklist.elasticsearch.health-check-enabled", "false")
+        .withProperty(
+            "zeebe.broker.exporters.elasticsearch.class-name",
+            ElasticsearchExporter.class.getName())
+        .withProperty("camunda.data.secondary-storage.type", "elasticsearch")
+        .withProperty("camunda.data.secondary-storage.elasticsearch.url", url)
+        .withProperty("camunda.data.secondary-storage.elasticsearch.username", APP_USER)
+        .withProperty("camunda.data.secondary-storage.elasticsearch.password", APP_PASSWORD)
+        .withExporter(
+            CamundaExporter.class.getSimpleName(),
+            cfg -> {
+              cfg.setClassName(CamundaExporter.class.getName());
+              cfg.setArgs(
+                  Map.of(
+                      "connect",
+                      Map.of("username", APP_USER, "password", APP_PASSWORD, "url", url),
+                      "history",
+                      Map.of("waitPeriodBeforeArchiving", "1s"),
+                      "createSchema",
+                      false));
+            })
+        .withExporter(
+            ElasticsearchExporter.class.getSimpleName(),
+            cfg -> {
+              cfg.setClassName(ElasticsearchExporter.class.getName());
+              cfg.setArgs(
+                  Map.of(
+                      "url",
+                      url,
+                      "index",
+                      Map.of("createTemplate", false),
+                      "authentication",
+                      Map.of("username", APP_USER, "password", APP_PASSWORD)));
+            });
+  }
+
+  @Override
+  public long countDocuments(final String indexPattern) throws Exception {
+    return adminClient.count(c -> c.index(indexPattern)).count();
+  }
+
+  @Override
+  public long countTemplates(final String namePattern) throws Exception {
+    return adminClient.indices().getIndexTemplate(c -> c.name(namePattern)).indexTemplates().size();
+  }
+
+  @Override
+  public long searchByKey(final String indexPattern, final long key) throws Exception {
+    final var resp =
+        adminClient.search(
+            s -> s.index(indexPattern).query(q -> q.term(t -> t.field("key").value(key))),
+            Object.class);
+    return resp.hits().total() == null ? 0 : resp.hits().total().value();
+  }
+
+  private ElasticsearchExporterConfiguration exporterAdminConfig() {
+    final var cfg = new ElasticsearchExporterConfiguration();
+    cfg.url = url;
+    cfg.getAuthentication().setUsername(ADMIN_USER);
+    cfg.getAuthentication().setPassword(ADMIN_PASSWORD);
+    cfg.index.createTemplate = true;
+    return cfg;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.schema.strategy;
+
+import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_OPENSEARCH_VERSION;
+
+import io.camunda.application.Profile;
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterSchemaManager;
+import java.time.Duration;
+import java.util.Map;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
+
+  private OpensearchContainer<?> container;
+  private OpenSearchClient adminClient;
+  private String url;
+
+  @Override
+  public void startContainer() throws Exception {
+    if (container != null) {
+      throw new IllegalStateException("Container is already started");
+    }
+    container =
+        new OpensearchContainer<>(
+                DockerImageName.parse("opensearchproject/opensearch")
+                    .withTag(SUPPORTED_OPENSEARCH_VERSION))
+            .withStartupTimeout(Duration.ofMinutes(5))
+            .withStartupAttempts(3);
+
+    container.start();
+    url = container.getHttpHostAddress();
+  }
+
+  @Override
+  public GenericContainer<?> getContainer() {
+    return container;
+  }
+
+  @Override
+  public void createAdminClient() throws Exception {
+    final var cfg = new ConnectConfiguration();
+    cfg.setUrl(url);
+    cfg.setUsername(container.getUsername());
+    cfg.setPassword(container.getPassword());
+    adminClient = new OpensearchConnector(cfg).createClient();
+  }
+
+  @Override
+  public void createSchema() throws Exception {
+    final var adminCfg = exporterAdminConfig();
+    final var schemaManager = new OpensearchExporterSchemaManager(adminCfg);
+    schemaManager.createSchema(adminClient.info().version().number());
+  }
+
+  @Override
+  public void configureStandaloneSchemaManager(final TestStandaloneSchemaManager schemaManager) {
+    schemaManager
+        .withProperty(
+            "zeebe.broker.exporters.opensearch.class-name", OpensearchExporter.class.getName())
+        .withProperty("zeebe.broker.exporters.opensearch.args.url", url)
+        .withProperty("camunda.data.secondary-storage.type", "opensearch")
+        .withProperty("camunda.data.secondary-storage.opensearch.url", url)
+        .withProperty("camunda.data.secondary-storage.opensearch.username", container.getUsername())
+        .withProperty(
+            "camunda.data.secondary-storage.opensearch.password", container.getPassword());
+  }
+
+  @Override
+  public void configureCamundaApplication(final TestCamundaApplication camunda) {
+    camunda
+        .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
+        .withUnauthenticatedAccess()
+        .withProperty("camunda.database.url", url)
+        .withProperty("camunda.database.type", "opensearch")
+        .withProperty("camunda.data.secondary-storage.type", "opensearch")
+        .withProperty("camunda.data.secondary-storage.opensearch.url", url)
+        .withExporter(
+            CamundaExporter.class.getSimpleName(),
+            cfg -> {
+              cfg.setClassName(CamundaExporter.class.getName());
+              cfg.setArgs(
+                  Map.of(
+                      "connect",
+                      Map.of("url", url, "type", "opensearch"),
+                      "history",
+                      Map.of("waitPeriodBeforeArchiving", "1s"),
+                      "createSchema",
+                      false));
+            })
+        .withExporter(
+            OpensearchExporter.class.getSimpleName(),
+            cfg -> {
+              cfg.setClassName(OpensearchExporter.class.getName());
+              cfg.setArgs(Map.of("url", url, "index", Map.of("createTemplate", true)));
+            });
+  }
+
+  @Override
+  public long countDocuments(final String indexPattern) throws Exception {
+    return adminClient.count(c -> c.index(indexPattern)).count();
+  }
+
+  @Override
+  public long countTemplates(final String namePattern) throws Exception {
+    return adminClient.indices().getIndexTemplate(r -> r.name(namePattern)).indexTemplates().size();
+  }
+
+  @Override
+  public long searchByKey(final String indexPattern, final long key) throws Exception {
+    final var resp =
+        adminClient.search(
+            s ->
+                s.index(indexPattern)
+                    .query(
+                        q -> q.term(t -> t.field("key").value(FieldValue.of(String.valueOf(key))))),
+            Object.class);
+    return resp.hits().total() == null ? 0 : resp.hits().total().value();
+  }
+
+  private OpensearchExporterConfiguration exporterAdminConfig() {
+    final var cfg = new OpensearchExporterConfiguration();
+    cfg.url = url;
+    cfg.getAuthentication().setUsername(container.getUsername());
+    cfg.getAuthentication().setPassword(container.getPassword());
+    cfg.index.createTemplate = true;
+    return cfg;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/README.md
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/README.md
@@ -1,0 +1,165 @@
+# Search Backend Strategy (Test Abstraction)
+
+This package implements a lightweight Strategy pattern used by acceptance tests to run the same
+schema manager + Camunda application flows against different search backends (Elasticsearch,
+OpenSearch, etc.). It isolates backend bootstrap concerns (containers, credentials, schema
+creation, exporter wiring) from the functional test assertions.
+
+## Purpose
+
+Provide a uniform contract so tests can:
+- Start a backend (via Testcontainers) with security and schema preconditions.
+- Configure the standalone schema manager and the Camunda test application consistently.
+- Interact with the backend for verification (count documents/templates, search by key).
+- Cleanly tear down resources without bespoke afterEach logic in the test class.
+
+## Core Types
+
+### `SearchBackendStrategy`
+
+Interface that defines the lifecycle and interaction contract. It provides default methods
+(`initialize(...)` and `close()`) and extends `AutoCloseable` so tests can use try-with-resources to
+guarantee container shutdown.
+
+Lifecycle executed by `initialize(...)` in the following order:
+1. `startContainer()` – Start & configure the Testcontainers instance (security env, roles, etc.).
+2. `createAdminClient()` – Build an administrative client (high privileges) to perform schema ops.
+3. `createSchema()` – Create index templates / base schema using exporter schema managers.
+4. `configureStandaloneSchemaManager(...)` – Inject properties into `TestStandaloneSchemaManager`.
+5. `configureCamundaApplication(...)` – Inject properties / exporters into `TestCamundaApplication`.
+6. `schemaManager.start()` + `camunda.start()` – Launch application components.
+
+On `close()` the active container (if any) is stopped.
+
+### Concrete Strategies
+
+- `ElasticsearchBackendStrategy` – Boots an Elasticsearch container with x-pack security, creates
+  users & roles, sets exporter + secondary storage properties.
+- `OpenSearchBackendStrategy` – Boots an OpenSearch container, configures exporters & properties
+  (currently simpler auth model).
+
+## Contract: Interface Methods
+
+```java
+void startContainer() throws Exception;
+GenericContainer<?> getContainer();
+void createAdminClient() throws Exception;
+void createSchema() throws Exception;
+void configureStandaloneSchemaManager(TestStandaloneSchemaManager schemaManager);
+void configureCamundaApplication(TestCamundaApplication camunda);
+long countDocuments(String indexPattern) throws Exception;
+long countTemplates(String namePattern) throws Exception;
+long searchByKey(String indexPattern, long key) throws Exception;
+```
+
+### Responsibilities
+
+- A concrete strategy MUST be self‑sufficient: after `initialize(...)` returns, the backend must be
+  ready for test interaction (indices, templates, credentials valid).
+- `startContainer()` MUST be idempotent per instance; throw if called twice.
+- Where backend role assignment is eventually consistent (e.g. Elasticsearch), the strategy SHOULD
+  internally await readiness (`Awaitility` usage contained in the strategy, not the test).
+- `createSchema()` SHOULD only create what is required for tests; avoid heavy migrations.
+
+## Usage in Tests
+
+```java
+@ParameterizedTest
+@MethodSource("strategies")
+void canUseCamunda(SearchBackendStrategy strategy) throws Exception {
+  try (strategy) { // ensures container stop
+    strategy.initialize(schemaManager, camunda);
+    // ... perform test actions & assertions using strategy helpers
+    assertThat(strategy.countDocuments("zeebe-record*")) .isGreaterThan(0);
+  }
+}
+```
+
+The parameter source typically returns `Stream.of(new ElasticsearchBackendStrategy(), new OpenSearchBackendStrategy())`.
+
+## Adding a New Backend Strategy (e.g. AWS OpenSearch)
+
+1. Create a class `AwsOpenSearchBackendStrategy implements SearchBackendStrategy`.
+2. Implement `startContainer()`:
+   - Reuse existing Testcontainers image or custom image (with credentials bootstrap).
+   - Set any required env vars / plugins.
+3. Implement `createAdminClient()` using the correct connector (may need new connector type).
+4. Implement `createSchema()` via exporter schema manager (ensure version compatibility).
+5. Implement property configuration methods:
+   - Map backend connection details (`url`, `username`, `password`) to
+     `camunda.data.secondary-storage.*` + exporter args.
+6. Implement document/template/query helpers (API differences: adjust query building).
+7. Provide readiness waits if security/role provisioning is eventual.
+8. Add strategy to the `Stream` factory method or a new parameterized source.
+
+## Example: Minimal Skeleton for a New Strategy
+
+```java
+public final class NewBackendStrategy implements SearchBackendStrategy {
+  private GenericContainer<?> container;
+  private SomeClient adminClient;
+  private String url;
+
+  @Override
+  public void startContainer() {
+    container = new GenericContainer<>("image:tag")
+        .withEnv("VAR", "value")
+        .withStartupAttempts(3);
+    container.start();
+    url = "http://" + container.getHost() + ":" + container.getMappedPort(1234);
+  }
+
+  @Override public GenericContainer<?> getContainer() { return container; }
+
+  @Override
+  public void createAdminClient() { /* build client & await readiness */ }
+
+  @Override
+  public void createSchema() { /* use adminClient */ }
+
+  @Override
+  public void configureStandaloneSchemaManager(TestStandaloneSchemaManager mgr) {
+    mgr.withProperty("camunda.data.secondary-storage.type", "newbackend")
+       .withProperty("camunda.data.secondary-storage.newbackend.url", url);
+  }
+
+  @Override
+  public void configureCamundaApplication(TestCamundaApplication camunda) {
+    camunda.withProperty("camunda.data.secondary-storage.type", "newbackend")
+           .withProperty("camunda.data.secondary-storage.newbackend.url", url);
+  }
+
+  @Override
+  public long countDocuments(String indexPattern) { return 0; }
+
+  @Override
+  public long countTemplates(String namePattern) { return 0; }
+
+  @Override
+  public long searchByKey(String indexPattern, long key) { return 0; }
+}
+```
+
+## Potential Future Improvements
+
+- Externalize `configure*` property sets into YAML test resources (`schema/*.yaml`) and load via a
+  small helper to reduce imperative property chains.
+- Introduce a dedicated factory or test annotation (potentially extending `@MultiDbTest`) to
+  replace manual method sources. `@MultiDbTest` currently focuses on provisioning a fully initialized
+  database, whereas these strategies additionally need to provision multiple users (admin + app) and
+  support running schema managers against an initially blank backend.
+- Add health polling abstraction (reusable Awaitility helper) to cut duplication.
+- Provide an interface for mapping index/version expectations to assertions.
+
+## FAQ
+
+**Why not start containers directly in tests?**
+To centralize backend-specific wiring and reduce duplication; tests focus on behavior, not infra.
+
+**Why use try-with-resources?**
+`SearchBackendStrategy` implements `AutoCloseable`, ensuring containers are always stopped even if
+assertions fail.
+
+---
+
+This documentation is test-scope only and not shipped with production artifacts.

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/SearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/SearchBackendStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.schema.strategy;
+
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import org.testcontainers.containers.GenericContainer;
+
+public interface SearchBackendStrategy extends AutoCloseable {
+
+  default void initialize(
+      final TestStandaloneSchemaManager schemaManager, final TestCamundaApplication camunda)
+      throws Exception {
+    startContainer();
+    createAdminClient();
+    createSchema();
+    configureStandaloneSchemaManager(schemaManager);
+    configureCamundaApplication(camunda);
+    schemaManager.start();
+    camunda.start();
+  }
+
+  @Override
+  default void close() {
+    final var container = getContainer();
+    if (container != null) {
+      container.stop();
+    }
+  }
+
+  // Methods to bootstrap the search backend
+  void startContainer() throws Exception;
+
+  GenericContainer<?> getContainer();
+
+  void createAdminClient() throws Exception;
+
+  void createSchema() throws Exception;
+
+  void configureStandaloneSchemaManager(final TestStandaloneSchemaManager schemaManager);
+
+  void configureCamundaApplication(final TestCamundaApplication camunda);
+
+  // Methods to interact with the search backend
+  long countDocuments(final String indexPattern) throws Exception;
+
+  long countTemplates(final String namePattern) throws Exception;
+
+  long searchByKey(final String indexPattern, final long key) throws Exception;
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
@@ -16,5 +16,12 @@ public final class SupportedVersions {
    */
   public static final String SUPPORTED_ELASTICSEARCH_VERSION = "8.16.6";
 
+  /**
+   * Official supported OpenSearch version.
+   *
+   * <p>To be used for client and server dependencies (e.g. in test container tests).
+   */
+  public static final String SUPPORTED_OPENSEARCH_VERSION = "2.19.3";
+
   private SupportedVersions() {}
 }


### PR DESCRIPTION
## Description

This PR implements test coverage for secured schema management against both Elasticsearch and OpenSearch backends, extending the original scope of StandaloneSchemaManagerIT. The integration test now runs for both search engines using a unified approach that externalizes backend configuration, user/role security setup, and connection properties.

## Key Changes

- Unified test execution path (single test class) using backend parametrization.
- Added `io.camunda.it.schema.strategy` package and aligned Elasticsearch and OpenSearch test semantics (startup, schema verification, auth boundaries) to reduce future maintenance cost.

closes #39445
