### PR TITLE
Add extensible, composable, reusable Docker Compose set up for local testing

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,9 @@
+# List of environment variables used by the docker-compose files, and their default values
+# Update this version to change the default Camunda image versions
+CAMUNDA_VERSION=SNAPSHOT
+# Default ES version
+ELASTIC_VERSION=8.16.6
+# Default Keycloak version
+KEYCLOAK_VERSION=26.1.0
+KEYCLOAK_ADMIN_USER=admin
+KEYCLOAK_ADMIN_PASSWORD=admin

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,110 @@
+# Orchestration Cluster Docker Compose
+
+This is a repository of reusable, extensible Docker Compose definitions and related application
+configuration options. The goal is to allow contributors to quickly spin up local development
+environments based on pre-defined set ups, but in a way that allows mixing certain core features in
+a composable way.
+
+## Usage
+
+The simplest way to get started is just to run
+
+```sh
+docker compose up -d
+```
+
+This will start a single node OC, using ES as your DB, and basic authentication.
+
+To compose your own OC instances with existing presets, you basically start with the `oc.yml` file,
+and then add any concerns you require. You typically need to specify at least a DB, and you may
+want to specify an authentication concern.
+
+> [!Note]
+> By convention, Docker Compose files for concerns are prefixed with clear identifiers. For example,
+> DB/secondary storage set ups will be `db.es.yml`, or `db.os.yml`. Authentication concerns will be
+> `auth.basic.yml`, or `auth.oidc.yml`.
+
+For example, if you want to run the same OC but with OIDC, you would launch:
+
+```sh
+docker compose -f oc.yml -f db.es.yml -f auth.oidc.yml up -d
+```
+
+> [!Note]
+> Remember that to bring everything down, you need to run the _same_ command as you did to bring
+> them up, but swap `up -d` for `down -v`.
+
+## Conventions
+
+### File names
+
+Files relevant to specific concerns should be prefixed with a clear identifier. Use:
+
+- `db` as a prefix for files configuring the secondary storage
+- `auth` as a prefix for files configuration authentication and security related things
+
+### Locations
+
+Docker Compose files remain in the top level `docker` folder, and configuration files are stored in
+the `config` sub-folder.
+
+### Image versions
+
+To simplify things, keep image versions in the `.env` file. Docker Compose will automatically load
+this and make available, and it makes it easy to dynamically swap the versions via the CLI.
+
+### Fixed ports
+
+We use fixed ports in general to simplify usage, as otherwise it makes it very hard to wire things
+like Keycloak and OC for the authorization flows if you don't know the ports in advance.
+
+## Extending
+
+The whole point of this set up is that we can extend it, and then mix and match concerns to quickly
+set up whatever local environment you need. So keep this in mind when extending it yourself, and if
+in doubt, don't hesitate to ask someone who's already done this.
+
+### The Orchestration Cluster (OC) Service
+
+It starts with the Orchestration Cluster service definition, which you find in [oc.yml](./oc.yml).
+This is a single cluster node definition, with largely default configuration options. It's set up
+with a volume so it can be stopped and restarted without losing data, and also set up to load
+additional configuration. Loading additional configuration is done via normal Spring mechanisms.
+
+Spring will load any `application.yml` it finds under the path
+`/usr/local/camunda/config/additional`, so we mount our additional configuration files in their own
+directory in there, grouped by concerns. For example, configuration for the DB is always mounted as
+`/usr/local/camunda/config/additional/db/application.yml`, or for the authentication configuration,
+under `/usr/local/camunda/config/additional/auth/application.yml`.
+
+Grouping them by concern allows us to make sure the "last" included Docker Compose file will "win",
+and overwrite the previous configuration file for this concern.
+
+Once running, the OC is accessible using the default ports: 8080, 26500, and 9600.
+
+### OIDC
+
+You can quickly set up OC with an OIDC provider by using the `auth.oidc.yml` concern:
+
+```sh
+docker compose up -f oc.yml -f db.es.yml -f auth.oidc.yml up -d
+```
+
+This will set up Keycloak with a prepared realm (see [config/realm.json](./config/realm.json)), with
+a single user (username: `demo`, password: `demo`) who is an admin.
+
+You can then access Keycloak via `http://localhost:18080` (user: `admin`, password: `admin`).
+
+Keycloak is set up with an embedded H2 DB and its own volume to keep its data between restarts.
+
+### ES
+
+You can set up OC with an ES secondary storage by using the `db.es.yml` concern:
+
+```sh
+docker compose up -f oc.yml -f db.es.yml up -d
+```
+
+This will set up a local single node ES cluster, accessible via port 9200. It has its own volume
+so it will keep its data across restarts.
+

--- a/docker/auth.basic.yml
+++ b/docker/auth.basic.yml
@@ -1,0 +1,15 @@
+# This file is not meant to be used directly, but in composition with the root docker-compose.yml
+# If you wish to launch OC with basic auth, then you would run:
+# docker compose -f oc.yml -f auth.basic.yml up -d
+services:
+  oc:
+    extends:
+      file: ./oc.yml
+      service: oc
+    configs:
+      - source: auth-basic
+        target: /usr/local/camunda/config/additional/auth/application.yml
+
+configs:
+  auth-basic:
+    file: ./config/auth.basic.yml

--- a/docker/auth.oidc.yml
+++ b/docker/auth.oidc.yml
@@ -1,5 +1,5 @@
 # This file is not meant to be used directly, but in composition with the root docker-compose.yml
-# If you wish to launch OC with basic auth, then you would run:
+# If you wish to launch OC with OIDC auth, then you would run:
 # docker compose -f oc.yml -f auth.oidc.yml up -d
 services:
   oc:
@@ -15,15 +15,15 @@ services:
   keycloak:
     image: keycloak/keycloak:${KEYCLOAK_VERSION}
     volumes:
-      - keycloak:/opt/jboss/keycloak/standalone/data
+      - keycloak:/opt/keycloak/data
       - ./config/realm.json:/opt/keycloak/data/import/realm.json
     ports:
       - 18080:8080
     environment:
-      - KEYCLOAK_HTTP_PORT=18080
+
       - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN_USER}
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD}
-      - KEYCLOAK_IMPORT=/opt/keycloak/data/import/realm.json
+
     restart: on-failure
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     networks:

--- a/docker/auth.oidc.yml
+++ b/docker/auth.oidc.yml
@@ -1,0 +1,44 @@
+# This file is not meant to be used directly, but in composition with the root docker-compose.yml
+# If you wish to launch OC with basic auth, then you would run:
+# docker compose -f oc.yml -f auth.oidc.yml up -d
+services:
+  oc:
+    extends:
+      file: ./oc.yml
+      service: oc
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    configs:
+      - source: auth-oidc
+        target: /usr/local/camunda/config/additional/auth/application.yml
+  keycloak:
+    image: keycloak/keycloak:${KEYCLOAK_VERSION}
+    volumes:
+      - keycloak:/opt/jboss/keycloak/standalone/data
+      - ./config/realm.json:/opt/keycloak/data/import/realm.json
+    ports:
+      - 18080:8080
+    environment:
+      - KEYCLOAK_HTTP_PORT=18080
+      - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN_USER}
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD}
+      - KEYCLOAK_IMPORT=/opt/keycloak/data/import/realm.json
+    restart: on-failure
+    command: ["start-dev", "--import-realm", "--health-enabled=true"]
+    networks:
+      - camunda
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: [ "CMD-SHELL", "{ printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  keycloak:
+
+configs:
+  auth-oidc:
+    file: ./config/auth.oidc.yml

--- a/docker/config/application.yml
+++ b/docker/config/application.yml
@@ -1,0 +1,9 @@
+zeebe:
+  broker:
+    gateway:
+      enabled: true
+    cluster:
+      nodeId: 0
+      partitionsCount: 1
+      replicationFactor: 1
+      clusterSize: 1

--- a/docker/config/auth.basic.yml
+++ b/docker/config/auth.basic.yml
@@ -1,0 +1,14 @@
+camunda.security:
+  authorizations:
+    enabled: true
+  authentication:
+    method: basic
+    unprotected-api: false
+  initialization:
+    users:
+      - username: demo
+        password: demo
+    default-roles:
+      admin:
+        users:
+          - demo

--- a/docker/config/auth.oidc.yml
+++ b/docker/config/auth.oidc.yml
@@ -1,0 +1,27 @@
+camunda.security:
+  authorizations:
+    enabled: true
+  authentication:
+    method: oidc
+    unprotected-api: false
+    oidc:
+      client-id: camunda
+      client-secret: camunda
+      redirect-uri: http://localhost:8080/sso-callback
+      authorization-uri: http://localhost:18080/realms/camunda/protocol/openid-connect/auth
+      token-uri: http://keycloak:8080/realms/camunda/protocol/openid-connect/token
+      jwk-set-uri: http://keycloak:8080/realms/camunda/protocol/openid-connect/certs
+      audiences:
+        - camunda
+      usernameClaim: preferred_username
+      clientIdClaim: client_id
+      scope:
+        - openid
+  initialization:
+    default-roles:
+      admin:
+        users:
+          - demo
+zeebe.broker.gateway:
+  security.authentication.identity:
+    issuer-backend-url: http://keycloak:8080/auth/realms/camunda-platform

--- a/docker/config/auth.oidc.yml
+++ b/docker/config/auth.oidc.yml
@@ -24,4 +24,4 @@ camunda.security:
           - demo
 zeebe.broker.gateway:
   security.authentication.identity:
-    issuer-backend-url: http://keycloak:8080/auth/realms/camunda-platform
+    issuer-backend-url: http://keycloak:8080/realms/camunda

--- a/docker/config/db.es.yml
+++ b/docker/config/db.es.yml
@@ -1,0 +1,7 @@
+camunda.data.secondary-storage:
+  type: elasticsearch
+  autoconfigure-camunda-exporter: true
+  elasticsearch:
+    url: http://elastic:9200
+    history:
+      process-instance-enabled: true

--- a/docker/config/realm.json
+++ b/docker/config/realm.json
@@ -1,0 +1,39 @@
+{
+  "realm": "camunda",
+  "enabled": true,
+  "users": [
+    {
+      "username" : "demo",
+      "firstName" : "Demo",
+      "lastName" : "Demo",
+      "email" : "demo@camunda.com",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "demo"
+        }
+      ],
+      "realmRoles": ["admin"]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "admin"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "camunda",
+      "secret": "camunda",
+      "name": "camunda",
+      "clientAuthenticatorType": "client-secret",
+      "publicClient": true,
+      "redirectUris": ["*"],
+      "directAccessGrantsEnabled": true
+    }
+  ]
+}

--- a/docker/db.es.yml
+++ b/docker/db.es.yml
@@ -1,0 +1,43 @@
+# This file is not meant to be used directly, but in composition with the root docker-compose.yml
+# If you wish to launch OC with ES as DB, then you would run:
+# docker compose -f oc.yml -f db.es.yml up -d
+services:
+  oc:
+    extends:
+      file: ./oc.yml
+      service: oc
+    configs:
+      - source: db-es
+        target: /usr/local/camunda/config/additional/db/application.yml
+    depends_on:
+      elastic:
+        condition: service_healthy
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.6
+    environment:
+      - ES_JAVA_OPTS=-Xmx2147483648
+      - action.auto_create_index=true
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+      - action.destructive_requires_name=false
+      - indices.lifecycle.poll_interval=1s
+    ports:
+      - 9200:9200
+    networks:
+      - camunda
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+    healthcheck:
+      test: [ "CMD", "curl", "--silent", "--fail", "http://localhost:9200/_cluster/health" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+      start_interval: 5s
+
+volumes:
+  elastic:
+
+configs:
+  db-es:
+    file: ./config/db.es.yml

--- a/docker/db.es.yml
+++ b/docker/db.es.yml
@@ -13,7 +13,7 @@ services:
       elastic:
         condition: service_healthy
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.6
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
     environment:
       - ES_JAVA_OPTS=-Xmx2147483648
       - action.auto_create_index=true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,7 @@
+# A default compose file which will launch OC with basic auth and ES as a DB
+# Equivalent to running docker compose -f oc.yml -f auth.basic.yml -f db.es.yml up -d
+include:
+  - path:
+    - oc.yml
+    - auth.basic.yml
+    - db.es.yml

--- a/docker/oc.yml
+++ b/docker/oc.yml
@@ -1,0 +1,51 @@
+# Base docker compose file for a single node Orchestration Cluster
+# By default will not start properly, and you need to configure it with additional files, e.g.
+# docker compose -f oc.yml -f db.es.yml -f auth.basic.yml up -d
+name: oc
+
+networks:
+  camunda: { }
+
+services:
+  oc:
+    image: camunda/camunda:${CAMUNDA_VERSION:-}
+    build:
+      context: ../
+      args:
+        - DISTBALL=dist/target/camunda-zeebe-*-SNAPSHOT.tar.gz
+      dockerfile: camunda.Dockerfile
+    ports:
+      - 8080:8080 # REST
+      - 26500:26500 # gRPC
+      - 9600:9600 # actuators
+    environment:
+      - SPRING_CONFIG_ADDITIONALLOCATION=file:/usr/local/camunda/config/additional/*/
+    env_file:
+      - path: .env
+        required: true
+    configs:
+      - source: application
+        target: /usr/local/camunda/config/additional/application.yml
+    depends_on:
+      elastic:
+        condition: service_healthy
+    networks:
+      - camunda
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - oc:/usr/local/camunda/data
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1" ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  oc:
+
+configs:
+  application:
+    file: ./config/application.yml

--- a/docker/oc.yml
+++ b/docker/oc.yml
@@ -26,9 +26,7 @@ services:
     configs:
       - source: application
         target: /usr/local/camunda/config/additional/application.yml
-    depends_on:
-      elastic:
-        condition: service_healthy
+
     networks:
       - camunda
     extra_hosts:


### PR DESCRIPTION
## Description

This PR adds a set of Docker Compose files which can be composed together to set up simple Orchestration Cluster instance. It supports:

- Setting up a single cluster node OC with ES and basic authentication
- Setting up a single cluster node OC with ES and OIDC

Composition is achieved through a mix of `include` and `extends` statement. The idea is that you start with the basic `oc.yml`, which describes a single node Orchestration Cluster service. 

> [!Note]
> By itself, it's unusable, because by default ES is expected. But this can be changed to start as H2 in the future.

To choose ES as your DB, you then add the `db.es.yml` to your set of compose files, e.g.

```sh
docker compose -f oc.yml -f db.es.yml up -d
```

To enable basic authentication, you would add `auth.basic.yml`:

```sh
docker compose -f oc.yml -f db.es.yml -f auth.basic.yml up -d
```

To use with OIDC, you'd instead swap `auth.basic.yml` for `auth.oidc.yml`:

```sh
docker compose -f oc.yml -f db.es.yml -f auth.oidc.yml up -d
```

An easy to use starting point `docker-compose.yml` already wires together ES and basic auth, so you can also just do `docker compose up -d` from the `/docker` folder.

The idea in the future is we can add `db.h2.yml`, `db.pgsql.yml`, `auth.saml.yml`, etc., and keep composing things, without having to repeat with tons of `docker-compose` files.

I'll be honest, I don't know how well these things scale. It looks fine with 2-3 files for composition, but I don't know if it becomes a maintenance hell with 5, 6, or more. Open to criticism :)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes camunda/identity#29205
