### PR TITLE
feat: Creation the API layer for cluster variables

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1892,12 +1892,97 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   VariableGetRequest newVariableGetRequest(long variableKey);
 
+  /**
+   * Creates a request to create a new cluster variable.
+   *
+   * <p>Cluster variables can be created with either global or tenant scope:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newClusterVariableCreateRequest()
+   *       .globalScoped()
+   *       .variable("myVariable", "myValue")
+   *       .send();
+   *
+   *   // or for tenant-scoped variable
+   *   camundaClient
+   *       .newClusterVariableCreateRequest()
+   *       .tenantScoped("my-tenant-id")
+   *       .variable("myVariable", "myValue")
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for creating a cluster variable
+   */
   ClusterVariableCreationCommandStep1 newClusterVariableCreateRequest();
 
+  /**
+   * Creates a request to delete an existing cluster variable.
+   *
+   * <p>Cluster variables can be deleted with either global or tenant scope:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newClusterVariableDeleteRequest()
+   *       .globalScoped()
+   *       .name("myVariable")
+   *       .send();
+   *
+   *   // or for tenant-scoped variable
+   *   camundaClient
+   *       .newClusterVariableDeleteRequest()
+   *       .tenantScoped("my-tenant-id")
+   *       .name("myVariable")
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for deleting a cluster variable
+   */
   ClusterVariableDeletionCommandStep1 newClusterVariableDeleteRequest();
 
+  /**
+   * Creates a request to fetch a cluster variable by name and scope.
+   *
+   * <p>Cluster variables can be fetched with either global or tenant scope:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newClusterVariableGetRequest()
+   *       .atGlobalScope("myVariable")
+   *       .send();
+   *
+   *   // or for tenant-scoped variable
+   *   camundaClient
+   *       .newClusterVariableGetRequest()
+   *       .atTenantScope("myVariable", "my-tenant-id")
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for fetching a cluster variable
+   */
   ClusterVariableGetRequest newClusterVariableGetRequest();
 
+  /**
+   * Creates a request to search for cluster variables.
+   *
+   * <p>Cluster variables can be searched with filtering and sorting capabilities:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newClusterVariableSearchRequest()
+   *       .filter(f -> f.scope(ClusterVariableScope.GLOBAL))
+   *       .sort(s -> s.name().asc())
+   *       .send();
+   *
+   *   // or for tenant-scoped variables
+   *   camundaClient
+   *       .newClusterVariableSearchRequest()
+   *       .filter(f -> f.scope(ClusterVariableScope.TENANT).tenantId("my-tenant-id"))
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for searching cluster variables
+   */
   ClusterVariableSearchRequest newClusterVariableSearchRequest();
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -33,6 +33,8 @@ import io.camunda.client.api.command.AssignUserToTenantCommandStep1;
 import io.camunda.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
+import io.camunda.client.api.command.ClusterVariableCreationCommandStep1;
+import io.camunda.client.api.command.ClusterVariableDeletionCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
@@ -95,6 +97,7 @@ import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.client.api.fetch.AuthorizationGetRequest;
 import io.camunda.client.api.fetch.AuthorizationsSearchRequest;
 import io.camunda.client.api.fetch.BatchOperationGetRequest;
+import io.camunda.client.api.fetch.ClusterVariableGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.DecisionInstanceGetRequest;
@@ -124,6 +127,7 @@ import io.camunda.client.api.search.request.BatchOperationSearchRequest;
 import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
+import io.camunda.client.api.search.request.ClusterVariableSearchRequest;
 import io.camunda.client.api.search.request.CorrelatedMessageSubscriptionSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
@@ -1887,6 +1891,14 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a variable
    */
   VariableGetRequest newVariableGetRequest(long variableKey);
+
+  ClusterVariableCreationCommandStep1 newClusterVariableCreateRequest();
+
+  ClusterVariableDeletionCommandStep1 newClusterVariableDeleteRequest();
+
+  ClusterVariableGetRequest newClusterVariableGetRequest();
+
+  ClusterVariableSearchRequest newClusterVariableSearchRequest();
 
   /**
    * Executes a search request to query variables related to a user task.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1895,20 +1895,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   /**
    * Creates a request to create a new cluster variable.
    *
+   * <p>Cluster variables can be created with either global or tenant scope: /** Creates a request
+   * to create a new cluster variable.
+   *
    * <p>Cluster variables can be created with either global or tenant scope:
    *
    * <pre>
    *   camundaClient
    *       .newClusterVariableCreateRequest()
-   *       .globalScoped()
-   *       .variable("myVariable", "myValue")
+   *       .atGlobalScoped()
+   *       .create("myVariable", "myValue")
    *       .send();
    *
    *   // or for tenant-scoped variable
    *   camundaClient
    *       .newClusterVariableCreateRequest()
-   *       .tenantScoped("my-tenant-id")
-   *       .variable("myVariable", "myValue")
+   *       .atTenantScoped("my-tenant-id")
+   *       .create("myVariable", "myValue")
    *       .send();
    * </pre>
    *
@@ -1917,22 +1920,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   ClusterVariableCreationCommandStep1 newClusterVariableCreateRequest();
 
   /**
-   * Creates a request to delete an existing cluster variable.
+   * Creates a request to delete an existing cluster variable. /** Creates a request to delete an
+   * existing cluster variable.
    *
    * <p>Cluster variables can be deleted with either global or tenant scope:
    *
    * <pre>
    *   camundaClient
    *       .newClusterVariableDeleteRequest()
-   *       .globalScoped()
-   *       .name("myVariable")
+   *       .atGlobalScoped()
+   *       .delete("myVariable")
    *       .send();
    *
    *   // or for tenant-scoped variable
    *   camundaClient
    *       .newClusterVariableDeleteRequest()
-   *       .tenantScoped("my-tenant-id")
-   *       .name("myVariable")
+   *       .atTenantScoped("my-tenant-id")
+   *       .delete("myVariable")
    *       .send();
    * </pre>
    *

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1895,9 +1895,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   /**
    * Creates a request to create a new cluster variable.
    *
-   * <p>Cluster variables can be created with either global or tenant scope: /** Creates a request
-   * to create a new cluster variable.
-   *
    * <p>Cluster variables can be created with either global or tenant scope:
    *
    * <pre>
@@ -1920,8 +1917,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   ClusterVariableCreationCommandStep1 newClusterVariableCreateRequest();
 
   /**
-   * Creates a request to delete an existing cluster variable. /** Creates a request to delete an
-   * existing cluster variable.
+   * Creates a request to delete an existing cluster variable.
    *
    * <p>Cluster variables can be deleted with either global or tenant scope:
    *

--- a/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableCreationCommandStep1.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.CreateClusterVariableResponse;
+
+public interface ClusterVariableCreationCommandStep1 {
+
+  ClusterVariableCreationCommandStep2 tenantScoped(String tenantId);
+
+  ClusterVariableCreationCommandStep2 globalScoped();
+
+  public interface ClusterVariableCreationCommandStep2
+      extends FinalCommandStep<CreateClusterVariableResponse> {
+
+    ClusterVariableCreationCommandStep2 variable(String name, Object value);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableCreationCommandStep1.java
@@ -17,15 +17,67 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateClusterVariableResponse;
 
+/**
+ * Represents the first step of creating a cluster variable. At this step, you must specify the
+ * scope of the variable (either global or tenant-scoped).
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   CreateClusterVariableResponse response = camundaClient
+ *       .newClusterVariableCreateRequest()
+ *       .globalScoped()
+ *       .variable("myVariable", "myValue")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
 public interface ClusterVariableCreationCommandStep1 {
 
+  /**
+   * Specifies that the cluster variable should be created with tenant scope.
+   *
+   * @param tenantId the ID of the tenant for which the variable is scoped. Must not be null or
+   *     empty.
+   * @return the next step in the command building process where you can specify the variable name
+   *     and value
+   */
   ClusterVariableCreationCommandStep2 tenantScoped(String tenantId);
 
+  /**
+   * Specifies that the cluster variable should be created with global scope, making it available to
+   * all tenants.
+   *
+   * @return the next step in the command building process where you can specify the variable name
+   *     and value
+   */
   ClusterVariableCreationCommandStep2 globalScoped();
 
-  public interface ClusterVariableCreationCommandStep2
+  /**
+   * Represents the second step of creating a cluster variable. At this step, you specify the
+   * variable name and value, then send the request.
+   */
+  interface ClusterVariableCreationCommandStep2
       extends FinalCommandStep<CreateClusterVariableResponse> {
 
+    /**
+     * Sets the name and value of the cluster variable.
+     *
+     * <p>The variable value will be serialized to JSON format.
+     *
+     * <pre>
+     *   camundaClient
+     *       .newClusterVariableCreateRequest()
+     *       .globalScoped()
+     *       .variable("myVariable", "myValue")  // for string values
+     *       .variable("myObject", new MyObject())  // for complex objects
+     *       .send();
+     * </pre>
+     *
+     * @param name the name of the variable. Must not be null or empty.
+     * @param value the value of the variable. Must not be null. Will be serialized to JSON.
+     * @return this builder for method chaining
+     */
     ClusterVariableCreationCommandStep2 variable(String name, Object value);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableCreationCommandStep1.java
@@ -26,8 +26,8 @@ import io.camunda.client.api.response.CreateClusterVariableResponse;
  * <pre>
  *   CreateClusterVariableResponse response = camundaClient
  *       .newClusterVariableCreateRequest()
- *       .globalScoped()
- *       .variable("myVariable", "myValue")
+ *       .atGlobalScoped()
+ *       .create("myVariable", "myValue")
  *       .send()
  *       .join();
  * </pre>
@@ -42,7 +42,7 @@ public interface ClusterVariableCreationCommandStep1 {
    * @return the next step in the command building process where you can specify the variable name
    *     and value
    */
-  ClusterVariableCreationCommandStep2 tenantScoped(String tenantId);
+  ClusterVariableCreationCommandStep2 atTenantScoped(String tenantId);
 
   /**
    * Specifies that the cluster variable should be created with global scope, making it available to
@@ -51,7 +51,7 @@ public interface ClusterVariableCreationCommandStep1 {
    * @return the next step in the command building process where you can specify the variable name
    *     and value
    */
-  ClusterVariableCreationCommandStep2 globalScoped();
+  ClusterVariableCreationCommandStep2 atGlobalScoped();
 
   /**
    * Represents the second step of creating a cluster variable. At this step, you specify the
@@ -68,9 +68,8 @@ public interface ClusterVariableCreationCommandStep1 {
      * <pre>
      *   camundaClient
      *       .newClusterVariableCreateRequest()
-     *       .globalScoped()
-     *       .variable("myVariable", "myValue")  // for string values
-     *       .variable("myObject", new MyObject())  // for complex objects
+     *       .atGlobalScoped()
+     *       .create("myVariable", "myValue")  // for string values
      *       .send();
      * </pre>
      *
@@ -78,6 +77,6 @@ public interface ClusterVariableCreationCommandStep1 {
      * @param value the value of the variable. Must not be null. Will be serialized to JSON.
      * @return this builder for method chaining
      */
-    ClusterVariableCreationCommandStep2 variable(String name, Object value);
+    ClusterVariableCreationCommandStep2 create(String name, Object value);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableDeletionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableDeletionCommandStep1.java
@@ -17,15 +17,64 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.DeleteClusterVariableResponse;
 
+/**
+ * Represents the first step of deleting a cluster variable. At this step, you must specify the
+ * scope of the variable (either global or tenant-scoped).
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   camundaClient
+ *       .newClusterVariableDeleteRequest()
+ *       .globalScoped()
+ *       .name("myVariable")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
 public interface ClusterVariableDeletionCommandStep1 {
 
+  /**
+   * Specifies that the cluster variable to delete has tenant scope.
+   *
+   * @param tenantId the ID of the tenant for which the variable is scoped. Must not be null or
+   *     empty.
+   * @return the next step in the command building process where you can specify the variable name
+   */
   ClusterVariableDeletionCommandStep2 tenantScoped(String tenantId);
 
+  /**
+   * Specifies that the cluster variable to delete has global scope.
+   *
+   * @return the next step in the command building process where you can specify the variable name
+   */
   ClusterVariableDeletionCommandStep2 globalScoped();
 
-  public interface ClusterVariableDeletionCommandStep2
+  /**
+   * Represents the second step of deleting a cluster variable. At this step, you specify the
+   * variable name and send the request to delete it.
+   */
+  interface ClusterVariableDeletionCommandStep2
       extends FinalCommandStep<DeleteClusterVariableResponse> {
 
+    /**
+     * Specifies the name of the cluster variable to delete.
+     *
+     * <p>The variable will be deleted only if it exists with the specified name and scope. If the
+     * variable does not exist, a 404 error will be returned.
+     *
+     * <pre>
+     *   camundaClient
+     *       .newClusterVariableDeleteRequest()
+     *       .globalScoped()
+     *       .name("myVariable")
+     *       .send()
+     *       .join();
+     * </pre>
+     *
+     * @param name the name of the variable to delete. Must not be null or empty.
+     * @return this builder for method chaining
+     */
     ClusterVariableDeletionCommandStep2 name(String name);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableDeletionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableDeletionCommandStep1.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DeleteClusterVariableResponse;
+
+public interface ClusterVariableDeletionCommandStep1 {
+
+  ClusterVariableDeletionCommandStep2 tenantScoped(String tenantId);
+
+  ClusterVariableDeletionCommandStep2 globalScoped();
+
+  public interface ClusterVariableDeletionCommandStep2
+      extends FinalCommandStep<DeleteClusterVariableResponse> {
+
+    ClusterVariableDeletionCommandStep2 name(String name);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableDeletionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ClusterVariableDeletionCommandStep1.java
@@ -26,8 +26,8 @@ import io.camunda.client.api.response.DeleteClusterVariableResponse;
  * <pre>
  *   camundaClient
  *       .newClusterVariableDeleteRequest()
- *       .globalScoped()
- *       .name("myVariable")
+ *       .atGlobalScoped()
+ *       .delete("myVariable")
  *       .send()
  *       .join();
  * </pre>
@@ -41,14 +41,14 @@ public interface ClusterVariableDeletionCommandStep1 {
    *     empty.
    * @return the next step in the command building process where you can specify the variable name
    */
-  ClusterVariableDeletionCommandStep2 tenantScoped(String tenantId);
+  ClusterVariableDeletionCommandStep2 atTenantScoped(String tenantId);
 
   /**
    * Specifies that the cluster variable to delete has global scope.
    *
    * @return the next step in the command building process where you can specify the variable name
    */
-  ClusterVariableDeletionCommandStep2 globalScoped();
+  ClusterVariableDeletionCommandStep2 atGlobalScoped();
 
   /**
    * Represents the second step of deleting a cluster variable. At this step, you specify the
@@ -66,8 +66,8 @@ public interface ClusterVariableDeletionCommandStep1 {
      * <pre>
      *   camundaClient
      *       .newClusterVariableDeleteRequest()
-     *       .globalScoped()
-     *       .name("myVariable")
+     *       .atGlobalScoped()
+     *       .delete("myVariable")
      *       .send()
      *       .join();
      * </pre>
@@ -75,6 +75,6 @@ public interface ClusterVariableDeletionCommandStep1 {
      * @param name the name of the variable to delete. Must not be null or empty.
      * @return this builder for method chaining
      */
-    ClusterVariableDeletionCommandStep2 name(String name);
+    ClusterVariableDeletionCommandStep2 delete(String name);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ClusterVariableGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ClusterVariableGetRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.ClusterVariable;
+
+public interface ClusterVariableGetRequest extends FinalCommandStep<ClusterVariable> {
+
+  ClusterVariableGetRequest atTenantScope(String name, String tenantId);
+
+  ClusterVariableGetRequest atGlobalScope(String name);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ClusterVariableGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ClusterVariableGetRequest.java
@@ -18,9 +18,53 @@ package io.camunda.client.api.fetch;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.search.response.ClusterVariable;
 
+/**
+ * Represents a request to fetch a cluster variable by name and scope.
+ *
+ * <p>Cluster variables can be fetched with either global or tenant scope. You must specify the
+ * scope and variable name before sending the request.
+ *
+ * <p>Usage examples:
+ *
+ * <pre>
+ *   // Fetch a global-scoped variable
+ *   ClusterVariable response = camundaClient
+ *       .newClusterVariableGetRequest()
+ *       .atGlobalScope("myVariable")
+ *       .send()
+ *       .join();
+ *
+ *   // Fetch a tenant-scoped variable
+ *   ClusterVariable response = camundaClient
+ *       .newClusterVariableGetRequest()
+ *       .atTenantScope("myVariable", "my-tenant-id")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
 public interface ClusterVariableGetRequest extends FinalCommandStep<ClusterVariable> {
 
+  /**
+   * Specifies that the cluster variable to fetch has tenant scope.
+   *
+   * <p>The variable will be fetched only if it exists with the specified name and tenant ID. If the
+   * variable does not exist, a 404 error will be returned.
+   *
+   * @param name the name of the variable to fetch. Must not be null or empty.
+   * @param tenantId the ID of the tenant for which the variable is scoped. Must not be null or
+   *     empty.
+   * @return this builder for method chaining
+   */
   ClusterVariableGetRequest atTenantScope(String name, String tenantId);
 
+  /**
+   * Specifies that the cluster variable to fetch has global scope.
+   *
+   * <p>The variable will be fetched only if it exists with the specified name and global scope. If
+   * the variable does not exist, a 404 error will be returned.
+   *
+   * @param name the name of the variable to fetch. Must not be null or empty.
+   * @return this builder for method chaining
+   */
   ClusterVariableGetRequest atGlobalScope(String name);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+
+public interface CreateClusterVariableResponse {
+
+  String getName();
+
+  Object getValue();
+
+  ClusterVariableScope getScope();
+
+  String getTenantId();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteClusterVariableResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteClusterVariableResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface DeleteClusterVariableResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableScope.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableScope.java
@@ -17,5 +17,5 @@ package io.camunda.client.api.search.enums;
 
 public enum ClusterVariableScope {
   GLOBAL,
-  TENANT
+  TENANT;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableScope.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableScope.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum ClusterVariableScope {
+  GLOBAL,
+  TENANT
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
@@ -63,10 +64,26 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
   ClusterVariableFilter tenantId(final String tenantId);
 
   /**
+   * Filters cluster variables by the specified tenantId using {@link StringProperty} consumer.
+   *
+   * @param fn the tenantId {@link StringProperty} consumer of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter tenantId(Consumer<StringProperty> fn);
+
+  /**
    * Filters cluster variables by the specified scope.
    *
    * @param scope the scope of the variable (GLOBAL or TENANT)
    * @return the updated filter
    */
   ClusterVariableFilter scope(final ClusterVariableScope scope);
+
+  /**
+   * Filters jobs by the specified kind using {@link ClusterVariableScope} consumer.
+   *
+   * @param fn the kind {@link ClusterVariableScope} consumer of the job
+   * @return the updated filter
+   */
+  ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+public interface ClusterVariableFilter extends SearchRequestFilter {
+
+  /**
+   * Filters cluster variables by the specified value.
+   *
+   * @param value the value of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter value(final String value);
+
+  /**
+   * Filters cluster variables by the specified value using {@link StringProperty} consumer.
+   *
+   * @param fn the value {@link StringProperty} consumer of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter value(final Consumer<StringProperty> fn);
+
+  /**
+   * Filters cluster variables by the specified name.
+   *
+   * @param name the name of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter name(final String name);
+
+  /**
+   * Filters cluster variables by the specified name using {@link StringProperty} consumer.
+   *
+   * @param fn the name {@link StringProperty} consumer of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter name(final Consumer<StringProperty> fn);
+
+  /**
+   * Filters cluster variables by the specified tenant id.
+   *
+   * @param tenantId the tenant id of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter tenantId(final String tenantId);
+
+  /**
+   * Filters cluster variables by the specified scope.
+   *
+   * @param scope the scope of the variable (GLOBAL or TENANT)
+   * @return the updated filter
+   */
+  ClusterVariableFilter scope(final ClusterVariableScope scope);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -80,9 +80,9 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
   ClusterVariableFilter scope(final ClusterVariableScope scope);
 
   /**
-   * Filters jobs by the specified kind using {@link ClusterVariableScope} consumer.
+   * Filters cluster variables by the specified scope using {@link ClusterVariableScope} consumer.
    *
-   * @param fn the kind {@link ClusterVariableScope} consumer of the job
+   * @param fn the scope {@link ClusterVariableScope} consumer of the variable
    * @return the updated filter
    */
   ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableScopeProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableScopeProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+
+public interface ClusterVariableScopeProperty
+    extends LikeProperty<ClusterVariableScope, String, ClusterVariableScopeProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClusterVariableSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClusterVariableSearchRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.ClusterVariableFilter;
+import io.camunda.client.api.search.response.ClusterVariable;
+import io.camunda.client.api.search.sort.ClusterVariableSort;
+
+public interface ClusterVariableSearchRequest
+    extends TypedSearchRequest<
+            ClusterVariableFilter, ClusterVariableSort, ClusterVariableSearchRequest>,
+        FinalSearchRequestStep<ClusterVariable> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.search.request;
 import io.camunda.client.api.search.filter.AuthorizationFilter;
 import io.camunda.client.api.search.filter.BatchOperationFilter;
 import io.camunda.client.api.search.filter.BatchOperationItemFilter;
+import io.camunda.client.api.search.filter.ClusterVariableFilter;
 import io.camunda.client.api.search.filter.CorrelatedMessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
@@ -41,6 +42,7 @@ import io.camunda.client.api.search.sort.AuthorizationSort;
 import io.camunda.client.api.search.sort.BatchOperationItemSort;
 import io.camunda.client.api.search.sort.BatchOperationSort;
 import io.camunda.client.api.search.sort.ClientSort;
+import io.camunda.client.api.search.sort.ClusterVariableSort;
 import io.camunda.client.api.search.sort.CorrelatedMessageSubscriptionSort;
 import io.camunda.client.api.search.sort.DecisionDefinitionSort;
 import io.camunda.client.api.search.sort.DecisionInstanceSort;
@@ -67,6 +69,7 @@ import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter
 import io.camunda.client.impl.search.filter.AuthorizationFilterImpl;
 import io.camunda.client.impl.search.filter.BatchOperationFilterImpl;
 import io.camunda.client.impl.search.filter.BatchOperationItemFilterImpl;
+import io.camunda.client.impl.search.filter.ClusterVariableFilterImpl;
 import io.camunda.client.impl.search.filter.CorrelatedMessageSubscriptionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionInstanceFilterImpl;
@@ -91,6 +94,7 @@ import io.camunda.client.impl.search.sort.AuthorizationSortImpl;
 import io.camunda.client.impl.search.sort.BatchOperationItemSortImpl;
 import io.camunda.client.impl.search.sort.BatchOperationSortImpl;
 import io.camunda.client.impl.search.sort.ClientSortImpl;
+import io.camunda.client.impl.search.sort.ClusterVariableSortImpl;
 import io.camunda.client.impl.search.sort.CorrelatedMessageSubscriptionSortImpl;
 import io.camunda.client.impl.search.sort.DecisionDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.DecisionInstanceSortImpl;
@@ -239,6 +243,19 @@ public final class SearchRequestBuilders {
 
   public static VariableSort variableSort(final Consumer<VariableSort> fn) {
     final VariableSort sort = new VariableSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static ClusterVariableFilter clusterVariableFilter(
+      final Consumer<ClusterVariableFilter> fn) {
+    final ClusterVariableFilter filter = new ClusterVariableFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static ClusterVariableSort clusterVariableSort(final Consumer<ClusterVariableSort> fn) {
+    final ClusterVariableSort sort = new ClusterVariableSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+
+public interface ClusterVariable {
+
+  /* The name of the variable */
+  String getName();
+
+  /* The value of the variable */
+  String getValue();
+
+  /* The tenant id of the variable */
+  String getTenantId();
+
+  /* The scope of the variable */
+  ClusterVariableScope getScope();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ClusterVariableSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ClusterVariableSort.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface ClusterVariableSort extends SearchRequestSort<ClusterVariableSort> {
+  ClusterVariableSort value();
+
+  ClusterVariableSort name();
+
+  ClusterVariableSort scope();
+
+  ClusterVariableSort tenantId();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -135,6 +135,7 @@ import io.camunda.client.api.search.request.BatchOperationSearchRequest;
 import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
+import io.camunda.client.api.search.request.ClusterVariableSearchRequest;
 import io.camunda.client.api.search.request.CorrelatedMessageSubscriptionSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
@@ -190,6 +191,7 @@ import io.camunda.client.impl.command.CompleteUserTaskCommandImpl;
 import io.camunda.client.impl.command.CorrelateMessageCommandImpl;
 import io.camunda.client.impl.command.CreateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.CreateBatchOperationCommandImpl.CreateBatchOperationCommandStep1Impl;
+import io.camunda.client.impl.command.CreateClusterVariableImpl;
 import io.camunda.client.impl.command.CreateDocumentBatchCommandImpl;
 import io.camunda.client.impl.command.CreateDocumentCommandImpl;
 import io.camunda.client.impl.command.CreateDocumentLinkCommandImpl;
@@ -200,6 +202,7 @@ import io.camunda.client.impl.command.CreateRoleCommandImpl;
 import io.camunda.client.impl.command.CreateTenantCommandImpl;
 import io.camunda.client.impl.command.CreateUserCommandImpl;
 import io.camunda.client.impl.command.DeleteAuthorizationCommandImpl;
+import io.camunda.client.impl.command.DeleteClusterVariableImpl;
 import io.camunda.client.impl.command.DeleteDocumentCommandImpl;
 import io.camunda.client.impl.command.DeleteGroupCommandImpl;
 import io.camunda.client.impl.command.DeleteMappingRuleCommandImpl;
@@ -248,6 +251,7 @@ import io.camunda.client.impl.command.UpdateUserCommandImpl;
 import io.camunda.client.impl.command.UpdateUserTaskCommandImpl;
 import io.camunda.client.impl.fetch.AuthorizationGetRequestImpl;
 import io.camunda.client.impl.fetch.BatchOperationGetRequestImpl;
+import io.camunda.client.impl.fetch.ClusterVariableGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.DecisionInstanceGetRequestImpl;
@@ -277,6 +281,7 @@ import io.camunda.client.impl.search.request.BatchOperationSearchRequestImpl;
 import io.camunda.client.impl.search.request.ClientsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.ClientsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.ClientsByTenantSearchRequestImpl;
+import io.camunda.client.impl.search.request.ClusterVariableSearchRequestImpl;
 import io.camunda.client.impl.search.request.CorrelatedMessageSubscriptionSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
@@ -1141,6 +1146,26 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public VariableGetRequest newVariableGetRequest(final long variableKey) {
     return new VariableGetRequestImpl(httpClient, variableKey);
+  }
+
+  @Override
+  public CreateClusterVariableImpl newClusterVariableCreateRequest() {
+    return new CreateClusterVariableImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public DeleteClusterVariableImpl newClusterVariableDeleteRequest() {
+    return new DeleteClusterVariableImpl(httpClient);
+  }
+
+  @Override
+  public ClusterVariableGetRequestImpl newClusterVariableGetRequest() {
+    return new ClusterVariableGetRequestImpl(httpClient);
+  }
+
+  @Override
+  public ClusterVariableSearchRequest newClusterVariableSearchRequest() {
+    return new ClusterVariableSearchRequestImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
@@ -92,7 +92,7 @@ public final class ArgumentUtil {
   public static void ensureNotNullIf(
       final String tenantId, final boolean equals, final String tenantId1) {
     if (equals) {
-      ensureNotNull(tenantId, tenantId1);
+      ensureNotNullNorEmpty(tenantId, tenantId1);
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
@@ -88,4 +88,11 @@ public final class ArgumentUtil {
       throw new IllegalArgumentException(property + " must not be empty");
     }
   }
+
+  public static void ensureNotNullIf(
+      final String tenantId, final boolean equals, final String tenantId1) {
+    if (equals) {
+      ensureNotNull(tenantId, tenantId1);
+    }
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
@@ -88,11 +88,4 @@ public final class ArgumentUtil {
       throw new IllegalArgumentException(property + " must not be empty");
     }
   }
-
-  public static void ensureNotNullIf(
-      final String tenantId, final boolean equals, final String tenantId1) {
-    if (equals) {
-      ensureNotNullNorEmpty(tenantId, tenantId1);
-    }
-  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateClusterVariableImpl.java
@@ -50,6 +50,7 @@ public class CreateClusterVariableImpl
 
   @Override
   public ClusterVariableCreationCommandStep2 atTenantScoped(final String tenantId) {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
     this.tenantId = tenantId;
     scope = ClusterVariableScope.TENANT;
     return this;
@@ -63,6 +64,8 @@ public class CreateClusterVariableImpl
 
   @Override
   public ClusterVariableCreationCommandStep2 create(final String name, final Object value) {
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
+    ArgumentUtil.ensureNotNull("value", value);
     createVariableRequest.name(name).value(value);
     return this;
   }
@@ -76,10 +79,6 @@ public class CreateClusterVariableImpl
 
   @Override
   public CamundaFuture<CreateClusterVariableResponse> send() {
-    ArgumentUtil.ensureNotNullNorEmpty("name", createVariableRequest.getName());
-    ArgumentUtil.ensureNotNull("value", createVariableRequest.getValue());
-    ArgumentUtil.ensureNotNull("scope", scope);
-    ArgumentUtil.ensureNotNullIf("tenantId", ClusterVariableScope.TENANT.equals(scope), tenantId);
     final HttpCamundaFuture<CreateClusterVariableResponse> result = new HttpCamundaFuture<>();
     final CreateClusterVariableResponseImpl response = new CreateClusterVariableResponseImpl();
     final String path;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateClusterVariableImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ClusterVariableCreationCommandStep1;
+import io.camunda.client.api.command.ClusterVariableCreationCommandStep1.ClusterVariableCreationCommandStep2;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.CreateClusterVariableResponseImpl;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.CreateClusterVariableRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class CreateClusterVariableImpl
+    implements ClusterVariableCreationCommandStep1, ClusterVariableCreationCommandStep2 {
+
+  private final CreateClusterVariableRequest createVariableRequest;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CreateClusterVariableImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    createVariableRequest = new CreateClusterVariableRequest();
+  }
+
+  @Override
+  public ClusterVariableCreationCommandStep2 tenantScoped(final String tenantId) {
+    createVariableRequest.scope(ClusterVariableScopeEnum.TENANT).tenantId(tenantId);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableCreationCommandStep2 globalScoped() {
+    createVariableRequest.scope(ClusterVariableScopeEnum.GLOBAL);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableCreationCommandStep2 variable(final String name, final Object value) {
+    createVariableRequest.name(name).value(value);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<CreateClusterVariableResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<CreateClusterVariableResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("name", createVariableRequest.getName());
+    ArgumentUtil.ensureNotNull("value", createVariableRequest.getValue());
+    ArgumentUtil.ensureNotNull("scope", createVariableRequest.getScope());
+    final HttpCamundaFuture<CreateClusterVariableResponse> result = new HttpCamundaFuture<>();
+    final CreateClusterVariableResponseImpl response = new CreateClusterVariableResponseImpl();
+    httpClient.post(
+        "/cluster-variables",
+        jsonMapper.toJson(createVariableRequest),
+        httpRequestConfig.build(),
+        ClusterVariableResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateClusterVariableImpl.java
@@ -76,6 +76,10 @@ public class CreateClusterVariableImpl
     ArgumentUtil.ensureNotNullNorEmpty("name", createVariableRequest.getName());
     ArgumentUtil.ensureNotNull("value", createVariableRequest.getValue());
     ArgumentUtil.ensureNotNull("scope", createVariableRequest.getScope());
+    ArgumentUtil.ensureNotNullIf(
+        "tenantId",
+        ClusterVariableScopeEnum.TENANT.equals(createVariableRequest.getScope()),
+        createVariableRequest.getTenantId());
     final HttpCamundaFuture<CreateClusterVariableResponse> result = new HttpCamundaFuture<>();
     final CreateClusterVariableResponseImpl response = new CreateClusterVariableResponseImpl();
     httpClient.post(

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteClusterVariableImpl.java
@@ -74,6 +74,8 @@ public class DeleteClusterVariableImpl
   public CamundaFuture<DeleteClusterVariableResponse> send() {
     ArgumentUtil.ensureNotNullNorEmpty("name", name);
     ArgumentUtil.ensureNotNull("scope", scope);
+    ArgumentUtil.ensureNotNullIf(
+        "tenantId", ClusterVariableScopeEnum.TENANT.equals(scope), tenantId);
     final HttpCamundaFuture<DeleteClusterVariableResponse> result = new HttpCamundaFuture<>();
     final StringJoiner path = new StringJoiner("/", "/cluster-variables/", "");
     path.add(name).add(scope.name());

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteClusterVariableImpl.java
@@ -45,6 +45,7 @@ public class DeleteClusterVariableImpl
 
   @Override
   public ClusterVariableDeletionCommandStep2 atTenantScoped(final String tenantId) {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
     scope = ClusterVariableScope.TENANT;
     this.tenantId = tenantId;
     return this;
@@ -58,6 +59,7 @@ public class DeleteClusterVariableImpl
 
   @Override
   public ClusterVariableDeletionCommandStep2 delete(final String name) {
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
     this.name = name;
     return this;
   }
@@ -71,9 +73,6 @@ public class DeleteClusterVariableImpl
 
   @Override
   public CamundaFuture<DeleteClusterVariableResponse> send() {
-    ArgumentUtil.ensureNotNullNorEmpty("name", name);
-    ArgumentUtil.ensureNotNull("scope", scope);
-    ArgumentUtil.ensureNotNullIf("tenantId", ClusterVariableScope.TENANT.equals(scope), tenantId);
     final HttpCamundaFuture<DeleteClusterVariableResponse> result = new HttpCamundaFuture<>();
     final String path;
     if (ClusterVariableScope.TENANT.equals(scope)) {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteClusterVariableImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.ClusterVariableDeletionCommandStep1;
+import io.camunda.client.api.command.ClusterVariableDeletionCommandStep1.ClusterVariableDeletionCommandStep2;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.DeleteClusterVariableResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteClusterVariableResponseImpl;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import java.time.Duration;
+import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteClusterVariableImpl
+    implements ClusterVariableDeletionCommandStep1, ClusterVariableDeletionCommandStep2 {
+
+  private String name;
+  private ClusterVariableScopeEnum scope;
+  private String tenantId;
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteClusterVariableImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public ClusterVariableDeletionCommandStep2 tenantScoped(final String tenantId) {
+    scope = ClusterVariableScopeEnum.TENANT;
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public ClusterVariableDeletionCommandStep2 globalScoped() {
+    scope = ClusterVariableScopeEnum.GLOBAL;
+    return this;
+  }
+
+  @Override
+  public ClusterVariableDeletionCommandStep2 name(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<DeleteClusterVariableResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeleteClusterVariableResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
+    ArgumentUtil.ensureNotNull("scope", scope);
+    final HttpCamundaFuture<DeleteClusterVariableResponse> result = new HttpCamundaFuture<>();
+    final StringJoiner path = new StringJoiner("/", "/cluster-variables/", "");
+    path.add(name).add(scope.name());
+    if (scope.equals(ClusterVariableScopeEnum.TENANT)) {
+      path.add(tenantId);
+    }
+    httpClient.delete(
+        path.toString(), httpRequestConfig.build(), DeleteClusterVariableResponseImpl::new, result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ClusterVariableGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ClusterVariableGetRequestImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.fetch.ClusterVariableGetRequest;
+import io.camunda.client.api.search.response.ClusterVariable;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.ClusterVariableImpl;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import java.time.Duration;
+import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ClusterVariableGetRequestImpl implements ClusterVariableGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private String name;
+  private ClusterVariableScopeEnum scope;
+  private String tenantId;
+
+  public ClusterVariableGetRequestImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public ClusterVariableGetRequest requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<ClusterVariable> send() {
+    final HttpCamundaFuture<ClusterVariable> result = new HttpCamundaFuture<>();
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
+    ArgumentUtil.ensureNotNull("scope", scope);
+    final StringJoiner path = new StringJoiner("/", "/cluster-variables/", "");
+    path.add(name).add(scope.name());
+    if (scope.equals(ClusterVariableScopeEnum.TENANT)) {
+      path.add(tenantId);
+    }
+    httpClient.get(
+        path.toString(),
+        httpRequestConfig.build(),
+        ClusterVariableResult.class,
+        ClusterVariableImpl::new,
+        result);
+    return result;
+  }
+
+  @Override
+  public ClusterVariableGetRequest atTenantScope(final String name, final String tenantId) {
+    this.name = name;
+    scope = ClusterVariableScopeEnum.TENANT;
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public ClusterVariableGetRequest atGlobalScope(final String name) {
+    this.name = name;
+    scope = ClusterVariableScopeEnum.GLOBAL;
+    tenantId = null;
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ClusterVariableGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ClusterVariableGetRequestImpl.java
@@ -50,9 +50,6 @@ public class ClusterVariableGetRequestImpl implements ClusterVariableGetRequest 
   @Override
   public CamundaFuture<ClusterVariable> send() {
     final HttpCamundaFuture<ClusterVariable> result = new HttpCamundaFuture<>();
-    ArgumentUtil.ensureNotNullNorEmpty("name", name);
-    ArgumentUtil.ensureNotNull("scope", scope);
-    ArgumentUtil.ensureNotNullIf("tenantId", ClusterVariableScope.TENANT.equals(scope), tenantId);
     final String path;
     if (ClusterVariableScope.TENANT.equals(scope)) {
       path = "/cluster-variables/tenants/" + tenantId + "/" + name;
@@ -70,6 +67,8 @@ public class ClusterVariableGetRequestImpl implements ClusterVariableGetRequest 
 
   @Override
   public ClusterVariableGetRequest atTenantScope(final String name, final String tenantId) {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    ArgumentUtil.ensureNotNullNorEmpty("name", tenantId);
     this.name = name;
     scope = ClusterVariableScope.TENANT;
     this.tenantId = tenantId;
@@ -78,6 +77,7 @@ public class ClusterVariableGetRequestImpl implements ClusterVariableGetRequest 
 
   @Override
   public ClusterVariableGetRequest atGlobalScope(final String name) {
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
     this.name = name;
     scope = ClusterVariableScope.GLOBAL;
     tenantId = null;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ClusterVariableGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ClusterVariableGetRequestImpl.java
@@ -53,6 +53,8 @@ public class ClusterVariableGetRequestImpl implements ClusterVariableGetRequest 
     final HttpCamundaFuture<ClusterVariable> result = new HttpCamundaFuture<>();
     ArgumentUtil.ensureNotNullNorEmpty("name", name);
     ArgumentUtil.ensureNotNull("scope", scope);
+    ArgumentUtil.ensureNotNullIf(
+        "tenantId", ClusterVariableScopeEnum.TENANT.equals(scope), tenantId);
     final StringJoiner path = new StringJoiner("/", "/cluster-variables/", "");
     path.add(name).add(scope.name());
     if (scope.equals(ClusterVariableScopeEnum.TENANT)) {

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+
+public class CreateClusterVariableResponseImpl implements CreateClusterVariableResponse {
+
+  private String name;
+  private String value;
+  private ClusterVariableScope scope;
+  private String tenantId;
+
+  public CreateClusterVariableResponse setResponse(
+      final ClusterVariableResult clusterVariableResult) {
+    name = clusterVariableResult.getName();
+    value = clusterVariableResult.getValue();
+    tenantId = clusterVariableResult.getTenantId();
+    scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
+    return this;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Object getValue() {
+    return value;
+  }
+
+  @Override
+  public ClusterVariableScope getScope() {
+    return scope;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteClusterVariableResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteClusterVariableResponseImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.DeleteClusterVariableResponse;
+
+public class DeleteClusterVariableResponseImpl implements DeleteClusterVariableResponse {
+  public DeleteClusterVariableResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.filter.ClusterVariableFilter;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.ClusterVariableSearchQueryFilterRequest;
+import java.util.function.Consumer;
+
+public class ClusterVariableFilterImpl
+    extends TypedSearchRequestPropertyProvider<ClusterVariableSearchQueryFilterRequest>
+    implements ClusterVariableFilter {
+
+  private final ClusterVariableSearchQueryFilterRequest filter;
+
+  public ClusterVariableFilterImpl() {
+    filter = new ClusterVariableSearchQueryFilterRequest();
+  }
+
+  @Override
+  public ClusterVariableFilter value(final String value) {
+    value(b -> b.eq(value));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter value(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setValue(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter name(final String name) {
+    name(b -> b.eq(name));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter tenantId(final String tenantId) {
+    filter.setTenantId(tenantId);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter scope(final ClusterVariableScope scope) {
+    filter.setScope(ClusterVariableScopeEnum.valueOf(scope.name()));
+    return this;
+  }
+
+  @Override
+  protected ClusterVariableSearchQueryFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
@@ -17,10 +17,11 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.filter.ClusterVariableFilter;
+import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.ClusterVariableScopePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.client.protocol.rest.ClusterVariableSearchQueryFilterRequest;
 import java.util.function.Consumer;
 
@@ -64,13 +65,29 @@ public class ClusterVariableFilterImpl
 
   @Override
   public ClusterVariableFilter tenantId(final String tenantId) {
-    filter.setTenantId(tenantId);
+    tenantId(b -> b.eq(tenantId));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter tenantId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setTenantId(provideSearchRequestProperty(property));
     return this;
   }
 
   @Override
   public ClusterVariableFilter scope(final ClusterVariableScope scope) {
-    filter.setScope(ClusterVariableScopeEnum.valueOf(scope.name()));
+    scope(b -> b.eq(scope));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn) {
+    final ClusterVariableScopeProperty property = new ClusterVariableScopePropertyImpl();
+    fn.accept(property);
+    filter.setScope(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableScopePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableScopePropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.ClusterVariableScopeFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClusterVariableScopePropertyImpl
+    extends TypedSearchRequestPropertyProvider<ClusterVariableScopeFilterProperty>
+    implements ClusterVariableScopeProperty {
+
+  private final ClusterVariableScopeFilterProperty filterProperty =
+      new ClusterVariableScopeFilterProperty();
+
+  @Override
+  public ClusterVariableScopeProperty eq(final ClusterVariableScope value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, ClusterVariableScopeEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableScopeProperty neq(final ClusterVariableScope value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, ClusterVariableScopeEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableScopeProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableScopeProperty in(final List<ClusterVariableScope> value) {
+    filterProperty.set$In(
+        value.stream()
+            .map(source -> (EnumUtil.convert(source, ClusterVariableScopeEnum.class)))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableScopeProperty in(final ClusterVariableScope... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected ClusterVariableScopeFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public ClusterVariableScopeProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClusterVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClusterVariableSearchRequestImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.clusterVariableFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.clusterVariableSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.ClusterVariableFilter;
+import io.camunda.client.api.search.request.ClusterVariableSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.ClusterVariable;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.ClusterVariableSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest;
+import io.camunda.client.protocol.rest.ClusterVariableSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ClusterVariableSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<ClusterVariableSearchQueryRequest>
+    implements ClusterVariableSearchRequest {
+
+  private final ClusterVariableSearchQueryRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ClusterVariableSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    request = new ClusterVariableSearchQueryRequest();
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalSearchRequestStep<ClusterVariable> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<ClusterVariable>> send() {
+    final HttpCamundaFuture<SearchResponse<ClusterVariable>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/cluster-variables/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        ClusterVariableSearchQueryResult.class,
+        SearchResponseMapper::toClusterVariableSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public ClusterVariableSearchRequest filter(final ClusterVariableFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableSearchRequest filter(final Consumer<ClusterVariableFilter> fn) {
+    return filter(clusterVariableFilter(fn));
+  }
+
+  @Override
+  public ClusterVariableSearchRequest sort(final ClusterVariableSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toClusterVariableSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableSearchRequest sort(final Consumer<ClusterVariableSort> fn) {
+    return sort(clusterVariableSort(fn));
+  }
+
+  @Override
+  public ClusterVariableSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected ClusterVariableSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -400,6 +400,21 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<ClusterVariableSearchQuerySortRequest> toClusterVariableSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final ClusterVariableSearchQuerySortRequest request =
+                  new ClusterVariableSearchQuerySortRequest();
+              request.setField(
+                  ClusterVariableSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<UserSearchQuerySortRequest> toUserSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ClusterVariableImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.response.ClusterVariable;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+
+public class ClusterVariableImpl implements ClusterVariable {
+
+  private final String name;
+  private final String value;
+  private final String tenantId;
+  private final ClusterVariableScope scope;
+
+  public ClusterVariableImpl(final ClusterVariableResult item) {
+    name = item.getName();
+    value = item.getValue();
+    tenantId = item.getTenantId();
+    scope = EnumUtil.convert(item.getScope(), ClusterVariableScope.class);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public ClusterVariableScope getScope() {
+    return scope;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationItems;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
 import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
@@ -115,6 +116,14 @@ public final class SearchResponseMapper {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Variable> instances =
         toSearchResponseInstances(response.getItems(), VariableImpl::new);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<ClusterVariable> toClusterVariableSearchResponse(
+      final ClusterVariableSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<ClusterVariable> instances =
+        toSearchResponseInstances(response.getItems(), ClusterVariableImpl::new);
     return new SearchResponseImpl<>(instances, page);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/ClusterVariableSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/ClusterVariableSortImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.ClusterVariableSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class ClusterVariableSortImpl extends SearchRequestSortBase<ClusterVariableSort>
+    implements ClusterVariableSort {
+
+  @Override
+  public ClusterVariableSort value() {
+    return field("value");
+  }
+
+  @Override
+  public ClusterVariableSort name() {
+    return field("name");
+  }
+
+  @Override
+  public ClusterVariableSort scope() {
+    return field("scope");
+  }
+
+  @Override
+  public ClusterVariableSort tenantId() {
+    return field("tenantId");
+  }
+
+  @Override
+  protected ClusterVariableSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -39,40 +39,42 @@ public class CreateClusterVariableTest extends ClientRestTest {
   @Test
   void shouldCreateGlobalScopedClusterVariable() {
     // given
-    gatewayService.onCreateClusterVariableRequest(
+    gatewayService.onCreateGlobalClusterVariableRequest(
         Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
 
     // when
     client
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(VARIABLE_NAME, VARIABLE_VALUE)
+        .atGlobalScoped()
+        .create(VARIABLE_NAME, VARIABLE_VALUE)
         .send()
         .join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl());
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesCreateGlobalUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 
   @Test
   void shouldCreateTenantScopedClusterVariable() {
     // given
-    gatewayService.onCreateClusterVariableRequest(
+    gatewayService.onCreateTenantClusterVariableRequest(
+        TENANT_ID,
         Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
 
     // when
     client
         .newClusterVariableCreateRequest()
-        .tenantScoped(TENANT_ID)
-        .variable(VARIABLE_NAME, VARIABLE_VALUE)
+        .atTenantScoped(TENANT_ID)
+        .create(VARIABLE_NAME, VARIABLE_VALUE)
         .send()
         .join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl());
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getClusterVariablesCreateTenantUrl(TENANT_ID));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 
@@ -80,7 +82,7 @@ public class CreateClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnRequestError() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl(),
+        RestGatewayPaths.getClusterVariablesCreateGlobalUrl(),
         () -> new ProblemDetail().title("Bad Request").status(400));
 
     // when / then
@@ -88,8 +90,8 @@ public class CreateClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable(VARIABLE_NAME, VARIABLE_VALUE)
+                    .atGlobalScoped()
+                    .create(VARIABLE_NAME, VARIABLE_VALUE)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -100,7 +102,7 @@ public class CreateClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnServerError() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl(),
+        RestGatewayPaths.getClusterVariablesCreateGlobalUrl(),
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
@@ -108,8 +110,8 @@ public class CreateClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable(VARIABLE_NAME, VARIABLE_VALUE)
+                    .atGlobalScoped()
+                    .create(VARIABLE_NAME, VARIABLE_VALUE)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -123,8 +125,8 @@ public class CreateClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable(null, VARIABLE_VALUE)
+                    .atGlobalScoped()
+                    .create(null, VARIABLE_VALUE)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -138,8 +140,8 @@ public class CreateClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable("", VARIABLE_VALUE)
+                    .atGlobalScoped()
+                    .create("", VARIABLE_VALUE)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+public class CreateClusterVariableTest extends ClientRestTest {
+
+  private static final String VARIABLE_NAME = "myVariable";
+  private static final Object VARIABLE_VALUE = "myValue";
+  private static final String TENANT_ID = "tenant_1";
+
+  @Test
+  void shouldCreateGlobalScopedClusterVariable() {
+    // given
+    gatewayService.onCreateClusterVariableRequest(
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
+
+    // when
+    client
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(VARIABLE_NAME, VARIABLE_VALUE)
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldCreateTenantScopedClusterVariable() {
+    // given
+    gatewayService.onCreateClusterVariableRequest(
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
+
+    // when
+    client
+        .newClusterVariableCreateRequest()
+        .tenantScoped(TENANT_ID)
+        .variable(VARIABLE_NAME, VARIABLE_VALUE)
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnRequestError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl(),
+        () -> new ProblemDetail().title("Bad Request").status(400));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable(VARIABLE_NAME, VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 400: 'Bad Request'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl(),
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable(VARIABLE_NAME, VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable(null, VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable("", VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/DeleteClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/DeleteClusterVariableTest.java
@@ -33,12 +33,12 @@ public class DeleteClusterVariableTest extends ClientRestTest {
   @Test
   void shouldDeleteGlobalScopedClusterVariable() {
     // when
-    client.newClusterVariableDeleteRequest().globalScoped().name(VARIABLE_NAME).send().join();
+    client.newClusterVariableDeleteRequest().atGlobalScoped().delete(VARIABLE_NAME).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL");
+        .isEqualTo(RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME));
   }
 
   @Test
@@ -46,27 +46,22 @@ public class DeleteClusterVariableTest extends ClientRestTest {
     // when
     client
         .newClusterVariableDeleteRequest()
-        .tenantScoped(TENANT_ID)
-        .name(VARIABLE_NAME)
+        .atTenantScoped(TENANT_ID)
+        .delete(VARIABLE_NAME)
         .send()
         .join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(
-            RestGatewayPaths.getClusterVariablesUrl()
-                + "/"
-                + VARIABLE_NAME
-                + "/TENANT/"
-                + TENANT_ID);
+        .isEqualTo(RestGatewayPaths.getClusterVariablesGetTenantUrl(TENANT_ID, VARIABLE_NAME));
   }
 
   @Test
   void shouldRaiseExceptionOnNotFound() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME),
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
@@ -74,8 +69,8 @@ public class DeleteClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name(VARIABLE_NAME)
+                    .atGlobalScoped()
+                    .delete(VARIABLE_NAME)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -86,7 +81,7 @@ public class DeleteClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnServerError() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME),
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
@@ -94,8 +89,8 @@ public class DeleteClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name(VARIABLE_NAME)
+                    .atGlobalScoped()
+                    .delete(VARIABLE_NAME)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -106,7 +101,7 @@ public class DeleteClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME),
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
@@ -114,8 +109,8 @@ public class DeleteClusterVariableTest extends ClientRestTest {
             () ->
                 client
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name(VARIABLE_NAME)
+                    .atGlobalScoped()
+                    .delete(VARIABLE_NAME)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -126,7 +121,13 @@ public class DeleteClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnNullVariableName() {
     // when / then
     assertThatThrownBy(
-            () -> client.newClusterVariableDeleteRequest().globalScoped().name(null).send().join())
+            () ->
+                client
+                    .newClusterVariableDeleteRequest()
+                    .atGlobalScoped()
+                    .delete(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("name must not be null");
   }
@@ -135,7 +136,8 @@ public class DeleteClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnEmptyVariableName() {
     // when / then
     assertThatThrownBy(
-            () -> client.newClusterVariableDeleteRequest().globalScoped().name("").send().join())
+            () ->
+                client.newClusterVariableDeleteRequest().atGlobalScoped().delete("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("name must not be empty");
   }

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/DeleteClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/DeleteClusterVariableTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class DeleteClusterVariableTest extends ClientRestTest {
+
+  private static final String VARIABLE_NAME = "myVariable";
+  private static final String TENANT_ID = "tenant_1";
+
+  @Test
+  void shouldDeleteGlobalScopedClusterVariable() {
+    // when
+    client.newClusterVariableDeleteRequest().globalScoped().name(VARIABLE_NAME).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath)
+        .isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL");
+  }
+
+  @Test
+  void shouldDeleteTenantScopedClusterVariable() {
+    // when
+    client
+        .newClusterVariableDeleteRequest()
+        .tenantScoped(TENANT_ID)
+        .name(VARIABLE_NAME)
+        .send()
+        .join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath)
+        .isEqualTo(
+            RestGatewayPaths.getClusterVariablesUrl()
+                + "/"
+                + VARIABLE_NAME
+                + "/TENANT/"
+                + TENANT_ID);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFound() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name(VARIABLE_NAME)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name(VARIABLE_NAME)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnForbiddenRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        () -> new ProblemDetail().title("Forbidden").status(403));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name(VARIABLE_NAME)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 403: 'Forbidden'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newClusterVariableDeleteRequest().globalScoped().name(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newClusterVariableDeleteRequest().globalScoped().name("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/GetClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/GetClusterVariableTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+public class GetClusterVariableTest extends ClientRestTest {
+
+  private static final String VARIABLE_NAME = "myVariable";
+  private static final String TENANT_ID = "tenant_1";
+
+  @Test
+  void shouldGetGlobalScopedClusterVariable() {
+    // given
+    gatewayService.onGetClusterVariableRequest(
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL),
+        VARIABLE_NAME);
+    // when
+    client.newClusterVariableGetRequest().atGlobalScope(VARIABLE_NAME).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  void shouldGetTenantScopedClusterVariable() {
+
+    // given
+    gatewayService.onGetClusterVariableRequest(
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT),
+        VARIABLE_NAME,
+        TENANT_ID);
+
+    // when
+    client.newClusterVariableGetRequest().atTenantScope(VARIABLE_NAME, TENANT_ID).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .isEqualTo(
+            RestGatewayPaths.getClusterVariablesUrl()
+                + "/"
+                + VARIABLE_NAME
+                + "/TENANT/"
+                + TENANT_ID);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFound() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () -> client.newClusterVariableGetRequest().atGlobalScope(VARIABLE_NAME).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(
+            () -> client.newClusterVariableGetRequest().atGlobalScope(VARIABLE_NAME).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newClusterVariableGetRequest().atGlobalScope(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyVariableName() {
+    // when / then
+    assertThatThrownBy(() -> client.newClusterVariableGetRequest().atGlobalScope("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/GetClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/GetClusterVariableTest.java
@@ -38,16 +38,16 @@ public class GetClusterVariableTest extends ClientRestTest {
   @Test
   void shouldGetGlobalScopedClusterVariable() {
     // given
-    gatewayService.onGetClusterVariableRequest(
-        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL),
-        VARIABLE_NAME);
+    gatewayService.onGetGlobalClusterVariableRequest(
+        VARIABLE_NAME,
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
     // when
     client.newClusterVariableGetRequest().atGlobalScope(VARIABLE_NAME).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
     assertThat(request.getUrl())
-        .isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL");
+        .isEqualTo(RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 
@@ -55,10 +55,10 @@ public class GetClusterVariableTest extends ClientRestTest {
   void shouldGetTenantScopedClusterVariable() {
 
     // given
-    gatewayService.onGetClusterVariableRequest(
-        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT),
+    gatewayService.onGetTenantClusterVariableRequest(
+        TENANT_ID,
         VARIABLE_NAME,
-        TENANT_ID);
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
 
     // when
     client.newClusterVariableGetRequest().atTenantScope(VARIABLE_NAME, TENANT_ID).send().join();
@@ -66,12 +66,7 @@ public class GetClusterVariableTest extends ClientRestTest {
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
     assertThat(request.getUrl())
-        .isEqualTo(
-            RestGatewayPaths.getClusterVariablesUrl()
-                + "/"
-                + VARIABLE_NAME
-                + "/TENANT/"
-                + TENANT_ID);
+        .isEqualTo(RestGatewayPaths.getClusterVariablesGetTenantUrl(TENANT_ID, VARIABLE_NAME));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 
@@ -79,7 +74,7 @@ public class GetClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFound() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME),
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
@@ -93,7 +88,7 @@ public class GetClusterVariableTest extends ClientRestTest {
   void shouldRaiseExceptionOnServerError() {
     // given
     gatewayService.errorOnRequest(
-        RestGatewayPaths.getClusterVariablesUrl() + "/" + VARIABLE_NAME + "/GLOBAL",
+        RestGatewayPaths.getClusterVariablesGetGlobalUrl(VARIABLE_NAME),
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class SearchClusterVariableTest extends ClientRestTest {
+
+  @Test
+  void shouldSearchClusterVariables() {
+    // when
+    client.newClusterVariableSearchRequest().send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByName() {
+    // when
+    client.newClusterVariableSearchRequest().filter(f -> f.name("myVariable")).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByNameStringFilter() {
+    // when
+    client
+        .newClusterVariableSearchRequest()
+        .filter(f -> f.name(b -> b.in("var1", "var2")))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByValue() {
+    // when
+    client.newClusterVariableSearchRequest().filter(f -> f.value("myValue")).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByScope() {
+    // when
+    client
+        .newClusterVariableSearchRequest()
+        .filter(f -> f.scope(ClusterVariableScope.GLOBAL))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByTenantId() {
+    // when
+    client.newClusterVariableSearchRequest().filter(f -> f.tenantId("tenant_1")).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+  }
+
+  @Test
+  void shouldSearchClusterVariablesWithMultipleFilters() {
+    // when
+    client
+        .newClusterVariableSearchRequest()
+        .filter(f -> f.name("myVariable").scope(ClusterVariableScope.TENANT).tenantId("tenant_1"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSearchClusterVariablesWithSort() {
+    // when
+    client.newClusterVariableSearchRequest().sort(s -> s.name().asc().scope()).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -34,7 +34,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 
@@ -45,7 +45,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 
@@ -60,7 +60,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
   }
 
   @Test
@@ -70,7 +70,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
   }
 
   @Test
@@ -84,7 +84,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
   }
 
   @Test
@@ -94,7 +94,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
   }
 
   @Test
@@ -108,7 +108,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 
@@ -119,7 +119,7 @@ public class SearchClusterVariableTest extends ClientRestTest {
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesUrl() + "/search");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -23,9 +23,15 @@ public class RestGatewayPaths {
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
   private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
   private static final String URL_CLUSTER_VARIABLES = REST_API_PATH + "/cluster-variables";
-  private static final String URL_CLUSTER_VARIABLES_GLOBAL = URL_CLUSTER_VARIABLES + "/%s/GLOBAL";
-  private static final String URL_CLUSTER_VARIABLES_TENANT =
-      URL_CLUSTER_VARIABLES + "/%s/TENANT/%s";
+  private static final String URL_CLUSTER_VARIABLES_CREATE_GLOBAL =
+      URL_CLUSTER_VARIABLES + "/global";
+  private static final String URL_CLUSTER_VARIABLES_CREATE_TENANT =
+      URL_CLUSTER_VARIABLES + "/tenants/%s";
+  private static final String URL_CLUSTER_VARIABLES_GET_GLOBAL =
+      URL_CLUSTER_VARIABLES + "/global/%s";
+  private static final String URL_CLUSTER_VARIABLES_GET_TENANT =
+      URL_CLUSTER_VARIABLES + "/tenants/%s/%s";
+  private static final String URL_CLUSTER_VARIABLES_SEARCH = URL_CLUSTER_VARIABLES + "/search";
   private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
   private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
   private static final String URL_DECISION_DEFINITION = REST_API_PATH + "/decision-definitions/%s";
@@ -322,11 +328,34 @@ public class RestGatewayPaths {
     return URL_CLUSTER_VARIABLES;
   }
 
-  public static String getClusterVariablesUrl(final String variableName) {
-    return String.format(URL_CLUSTER_VARIABLES_GLOBAL, variableName);
+  public static String getClusterVariablesCreateGlobalUrl() {
+    return URL_CLUSTER_VARIABLES_CREATE_GLOBAL;
   }
 
+  public static String getClusterVariablesCreateTenantUrl(final String tenantId) {
+    return String.format(URL_CLUSTER_VARIABLES_CREATE_TENANT, tenantId);
+  }
+
+  public static String getClusterVariablesGetGlobalUrl(final String variableName) {
+    return String.format(URL_CLUSTER_VARIABLES_GET_GLOBAL, variableName);
+  }
+
+  public static String getClusterVariablesGetTenantUrl(
+      final String tenantId, final String variableName) {
+    return String.format(URL_CLUSTER_VARIABLES_GET_TENANT, tenantId, variableName);
+  }
+
+  public static String getClusterVariablesSearchUrl() {
+    return URL_CLUSTER_VARIABLES_SEARCH;
+  }
+
+  @Deprecated
+  public static String getClusterVariablesUrl(final String variableName) {
+    return String.format(URL_CLUSTER_VARIABLES_GET_GLOBAL, variableName);
+  }
+
+  @Deprecated
   public static String getClusterVariablesUrl(final String variableName, final String tenantId) {
-    return String.format(URL_CLUSTER_VARIABLES_TENANT, variableName, tenantId);
+    return String.format(URL_CLUSTER_VARIABLES_GET_TENANT, tenantId, variableName);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -22,6 +22,10 @@ public class RestGatewayPaths {
   private static final String URL_AUTHORIZATION = REST_API_PATH + "/authorizations/%s";
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
   private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
+  private static final String URL_CLUSTER_VARIABLES = REST_API_PATH + "/cluster-variables";
+  private static final String URL_CLUSTER_VARIABLES_GLOBAL = URL_CLUSTER_VARIABLES + "/%s/GLOBAL";
+  private static final String URL_CLUSTER_VARIABLES_TENANT =
+      URL_CLUSTER_VARIABLES + "/%s/TENANT/%s";
   private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
   private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
   private static final String URL_DECISION_DEFINITION = REST_API_PATH + "/decision-definitions/%s";
@@ -312,5 +316,17 @@ public class RestGatewayPaths {
 
   public static String getElementInstanceUrl(final long elementInstanceKey) {
     return String.format(URL_ELEMENT_INSTANCE, elementInstanceKey);
+  }
+
+  public static String getClusterVariablesUrl() {
+    return URL_CLUSTER_VARIABLES;
+  }
+
+  public static String getClusterVariablesUrl(final String variableName) {
+    return String.format(URL_CLUSTER_VARIABLES_GLOBAL, variableName);
+  }
+
+  public static String getClusterVariablesUrl(final String variableName, final String tenantId) {
+    return String.format(URL_CLUSTER_VARIABLES_TENANT, variableName, tenantId);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -25,6 +25,7 @@ import io.camunda.client.protocol.rest.AuthorizationCreateResult;
 import io.camunda.client.protocol.rest.AuthorizationResult;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.protocol.rest.DecisionRequirementsResult;
@@ -346,6 +347,20 @@ public class RestGatewayService {
   public void onElementInstanceRequest(
       final long elementInstanceKey, final ElementInstanceResult response) {
     registerGet(RestGatewayPaths.getElementInstanceUrl(elementInstanceKey), response);
+  }
+
+  public void onCreateClusterVariableRequest(final ClusterVariableResult response) {
+    registerPost(RestGatewayPaths.getClusterVariablesUrl(), response);
+  }
+
+  public void onGetClusterVariableRequest(
+      final ClusterVariableResult response, final String variableName) {
+    registerGet(RestGatewayPaths.getClusterVariablesUrl(variableName), response);
+  }
+
+  public void onGetClusterVariableRequest(
+      final ClusterVariableResult response, final String variableName, final String tenantId) {
+    registerGet(RestGatewayPaths.getClusterVariablesUrl(variableName, tenantId), response);
   }
 
   public void onBroadcastSignalRequest(final SignalBroadcastResult response) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -353,14 +353,37 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getClusterVariablesUrl(), response);
   }
 
+  public void onCreateGlobalClusterVariableRequest(final ClusterVariableResult response) {
+    registerPost(RestGatewayPaths.getClusterVariablesCreateGlobalUrl(), response);
+  }
+
+  public void onCreateTenantClusterVariableRequest(
+      final String tenantId, final ClusterVariableResult response) {
+    registerPost(RestGatewayPaths.getClusterVariablesCreateTenantUrl(tenantId), response);
+  }
+
   public void onGetClusterVariableRequest(
       final ClusterVariableResult response, final String variableName) {
-    registerGet(RestGatewayPaths.getClusterVariablesUrl(variableName), response);
+    registerGet(RestGatewayPaths.getClusterVariablesGetGlobalUrl(variableName), response);
   }
 
   public void onGetClusterVariableRequest(
       final ClusterVariableResult response, final String variableName, final String tenantId) {
-    registerGet(RestGatewayPaths.getClusterVariablesUrl(variableName, tenantId), response);
+    registerGet(RestGatewayPaths.getClusterVariablesGetTenantUrl(tenantId, variableName), response);
+  }
+
+  public void onGetGlobalClusterVariableRequest(
+      final String variableName, final ClusterVariableResult response) {
+    registerGet(RestGatewayPaths.getClusterVariablesGetGlobalUrl(variableName), response);
+  }
+
+  public void onGetTenantClusterVariableRequest(
+      final String tenantId, final String variableName, final ClusterVariableResult response) {
+    registerGet(RestGatewayPaths.getClusterVariablesGetTenantUrl(tenantId, variableName), response);
+  }
+
+  public void onSearchClusterVariableRequest(final SearchQueryResponse response) {
+    registerPost(RestGatewayPaths.getClusterVariablesSearchUrl(), response);
   }
 
   public void onBroadcastSignalRequest(final SignalBroadcastResult response) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -65,7 +65,7 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
 
   @Override
   public ClusterVariableEntity getTenantScopedClusterVariable(
-      final String tenant, final String name, final ResourceAccessChecks resourceAccessChecks) {
+      final String name, final String tenant, final ResourceAccessChecks resourceAccessChecks) {
     return clusterVariableMapper.get(
         ClusterVariableUtil.generateID(name, tenant, ClusterVariableScope.TENANT));
   }

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -158,6 +158,12 @@
         OR VAR_FULL_VALUE LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}
           ESCAPE ${escapeChar}
       </when>
+      <when test="operation.operator.name().equals('EXISTS')">
+        VAR_VALUE IS NOT NULL
+      </when>
+      <when test="operation.operator.name().equals('NOT_EXISTS')">
+        VAR_VALUE IS NULL
+      </when>
     </choose>
   </sql>
 

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.document.store.EnvironmentConfigurationLoader;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.BatchOperationSearchClient;
+import io.camunda.search.clients.ClusterVariableSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
 import io.camunda.search.clients.DecisionInstanceSearchClient;
 import io.camunda.search.clients.DecisionRequirementSearchClient;
@@ -38,6 +39,7 @@ import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.service.ClockServices;
+import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.DecisionInstanceServices;
 import io.camunda.service.DecisionRequirementsServices;
@@ -356,6 +358,22 @@ public class CamundaServicesConfiguration {
         brokerClient,
         securityContextProvider,
         variableSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Bean
+  public ClusterVariableServices clusterVariableServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ClusterVariableSearchClient clusterVariableSearchClient,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new ClusterVariableServices(
+        brokerClient,
+        securityContextProvider,
+        clusterVariableSearchClient,
         null,
         executorProvider,
         brokerRequestAuthorizationConverter);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandTest.java
@@ -36,8 +36,8 @@ public class ClusterVariableCommandTest {
     final var response =
         camundaClient
             .newClusterVariableCreateRequest()
-            .globalScoped()
-            .variable(variableName, variableValue)
+            .atGlobalScoped()
+            .create(variableName, variableValue)
             .send()
             .join();
 
@@ -58,8 +58,8 @@ public class ClusterVariableCommandTest {
     final var response =
         camundaClient
             .newClusterVariableCreateRequest()
-            .tenantScoped(tenantId)
-            .variable(variableName, variableValue)
+            .atTenantScoped(tenantId)
+            .create(variableName, variableValue)
             .send()
             .join();
 
@@ -76,8 +76,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable(null, "value")
+                    .atGlobalScoped()
+                    .create(null, "value")
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -91,8 +91,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable("", "value")
+                    .atGlobalScoped()
+                    .create("", "value")
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -106,8 +106,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableCreateRequest()
-                    .tenantScoped("")
-                    .variable("variableName", "value")
+                    .atTenantScoped("")
+                    .create("variableName", "value")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -123,8 +123,8 @@ public class ClusterVariableCommandTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(variableName, variableValue)
+        .atGlobalScoped()
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -133,8 +133,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable(variableName, "newValue")
+                    .atGlobalScoped()
+                    .create(variableName, "newValue")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -150,8 +150,8 @@ public class ClusterVariableCommandTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(variableName, variableValue)
+        .atTenantScoped(tenantId)
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -160,8 +160,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableCreateRequest()
-                    .tenantScoped(tenantId)
-                    .variable(variableName, "newValue")
+                    .atTenantScoped(tenantId)
+                    .create(variableName, "newValue")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -180,8 +180,8 @@ public class ClusterVariableCommandTest {
     final var response1 =
         camundaClient
             .newClusterVariableCreateRequest()
-            .globalScoped()
-            .variable(variableName, globalValue)
+            .atGlobalScoped()
+            .create(variableName, globalValue)
             .send()
             .join();
 
@@ -189,8 +189,8 @@ public class ClusterVariableCommandTest {
     final var response2 =
         camundaClient
             .newClusterVariableCreateRequest()
-            .tenantScoped(tenantId)
-            .variable(variableName, tenantValue)
+            .atTenantScoped(tenantId)
+            .create(variableName, tenantValue)
             .send()
             .join();
 
@@ -213,21 +213,26 @@ public class ClusterVariableCommandTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(variableName, variableValue)
+        .atGlobalScoped()
+        .create(variableName, variableValue)
         .send()
         .join();
 
     // when
-    camundaClient.newClusterVariableDeleteRequest().globalScoped().name(variableName).send().join();
+    camundaClient
+        .newClusterVariableDeleteRequest()
+        .atGlobalScoped()
+        .delete(variableName)
+        .send()
+        .join();
 
     // then - verify deletion by attempting to recreate
     assertThatCode(
             () ->
                 camundaClient
                     .newClusterVariableCreateRequest()
-                    .globalScoped()
-                    .variable(variableName, variableValue)
+                    .atGlobalScoped()
+                    .create(variableName, variableValue)
                     .send()
                     .join())
         .doesNotThrowAnyException();
@@ -242,8 +247,8 @@ public class ClusterVariableCommandTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(variableName, variableValue)
+        .atTenantScoped(tenantId)
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -252,8 +257,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .tenantScoped(tenantId)
-                    .name(variableName)
+                    .atTenantScoped(tenantId)
+                    .delete(variableName)
                     .send()
                     .join())
         .doesNotThrowAnyException();
@@ -266,8 +271,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name(null)
+                    .atGlobalScoped()
+                    .delete(null)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -281,8 +286,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name("")
+                    .atGlobalScoped()
+                    .delete("")
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -296,8 +301,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name("nonExistentVar_" + UUID.randomUUID())
+                    .atGlobalScoped()
+                    .delete("nonExistentVar_" + UUID.randomUUID())
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -311,8 +316,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .tenantScoped("tenant_" + UUID.randomUUID())
-                    .name("nonExistentVar_" + UUID.randomUUID())
+                    .atTenantScoped("tenant_" + UUID.randomUUID())
+                    .delete("nonExistentVar_" + UUID.randomUUID())
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -327,8 +332,8 @@ public class ClusterVariableCommandTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(variableName, variableValue)
+        .atGlobalScoped()
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -339,8 +344,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .tenantScoped(tenantId)
-                    .name(variableName)
+                    .atTenantScoped(tenantId)
+                    .delete(variableName)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -356,8 +361,8 @@ public class ClusterVariableCommandTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(variableName, variableValue)
+        .atTenantScoped(tenantId)
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -366,8 +371,8 @@ public class ClusterVariableCommandTest {
             () ->
                 camundaClient
                     .newClusterVariableDeleteRequest()
-                    .globalScoped()
-                    .name(variableName)
+                    .atGlobalScoped()
+                    .delete(variableName)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandTest.java
@@ -110,9 +110,8 @@ public class ClusterVariableCommandTest {
                     .create("variableName", "value")
                     .send()
                     .join())
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining(
-            "Invalid cluster variable scope. Tenant-scoped variables must have a non-blank tenant ID.");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ClusterVariableCommandTest {
+
+  private static final String VALUE_RESULT = "\"%s\"";
+
+  private static CamundaClient camundaClient;
+
+  // ============ CREATE TESTS ============
+
+  @Test
+  void shouldCreateGlobalScopedClusterVariable() {
+    // given
+    final var variableName = "globalVar_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableCreateRequest()
+            .globalScoped()
+            .variable(variableName, variableValue)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo(variableName);
+    assertThat(response.getValue()).isEqualTo(VALUE_RESULT.formatted(variableValue));
+  }
+
+  @Test
+  void shouldCreateTenantScopedClusterVariable() {
+    // given
+    final var variableName = "tenantVar_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableCreateRequest()
+            .tenantScoped(tenantId)
+            .variable(variableName, variableValue)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo(variableName);
+    assertThat(response.getValue()).isEqualTo(VALUE_RESULT.formatted(variableValue));
+  }
+
+  @Test
+  void shouldRejectCreationIfVariableNameIsNull() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable(null, "value")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRejectCreationIfVariableNameIsEmpty() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable("", "value")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+
+  @Test
+  void shouldRejectCreationIfTenantIdIsEmpty() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableCreateRequest()
+                    .tenantScoped("")
+                    .variable("variableName", "value")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining(
+            "Invalid cluster variable scope. Tenant-scoped variables must have a non-blank tenant ID.");
+  }
+
+  @Test
+  void shouldRejectCreationIfDuplicateGlobalVariable() {
+    // given
+    final var variableName = "duplicateGlobalVar_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable(variableName, "newValue")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 409: 'Conflict'");
+  }
+
+  @Test
+  void shouldRejectCreationIfDuplicateTenantVariable() {
+    // given
+    final var variableName = "duplicateTenantVar_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableCreateRequest()
+                    .tenantScoped(tenantId)
+                    .variable(variableName, "newValue")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 409: 'Conflict'");
+  }
+
+  @Test
+  void shouldAllowSameNameInDifferentScopes() {
+    // given
+    final var variableName = "sameNameVar_" + UUID.randomUUID();
+    final var globalValue = "globalValue_" + UUID.randomUUID();
+    final var tenantValue = "tenantValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    // when - create in global scope
+    final var response1 =
+        camundaClient
+            .newClusterVariableCreateRequest()
+            .globalScoped()
+            .variable(variableName, globalValue)
+            .send()
+            .join();
+
+    // then - should be able to create same name in tenant scope
+    final var response2 =
+        camundaClient
+            .newClusterVariableCreateRequest()
+            .tenantScoped(tenantId)
+            .variable(variableName, tenantValue)
+            .send()
+            .join();
+
+    assertThat(response1).isNotNull();
+    assertThat(response1.getName()).isEqualTo(variableName);
+    assertThat(response1.getValue()).isEqualTo(VALUE_RESULT.formatted(globalValue));
+
+    assertThat(response2).isNotNull();
+    assertThat(response2.getName()).isEqualTo(variableName);
+    assertThat(response2.getValue()).isEqualTo(VALUE_RESULT.formatted(tenantValue));
+    assertThat(response2.getTenantId()).isEqualTo(tenantId);
+  }
+
+  // ============ DELETE TESTS ============
+  @Test
+  void shouldDeleteGlobalScopedClusterVariable() {
+    // given
+    final var variableName = "globalVarDelete_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // when
+    camundaClient.newClusterVariableDeleteRequest().globalScoped().name(variableName).send().join();
+
+    // then - verify deletion by attempting to recreate
+    assertThatCode(
+            () ->
+                camundaClient
+                    .newClusterVariableCreateRequest()
+                    .globalScoped()
+                    .variable(variableName, variableValue)
+                    .send()
+                    .join())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldDeleteTenantScopedClusterVariable() {
+    // given
+    final var variableName = "tenantVarDelete_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // when
+    assertThatCode(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .tenantScoped(tenantId)
+                    .name(variableName)
+                    .send()
+                    .join())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectDeletionIfVariableNameIsNull() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRejectDeletionIfVariableNameIsEmpty() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+
+  @Test
+  void shouldRejectDeletionIfGlobalVariableDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name("nonExistentVar_" + UUID.randomUUID())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRejectDeletionIfTenantVariableDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .tenantScoped("tenant_" + UUID.randomUUID())
+                    .name("nonExistentVar_" + UUID.randomUUID())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldNotAllowDeletingGlobalVariableWithTenantScope() {
+    // given
+    final var variableName = "globalVarNoTenantDelete_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .tenantScoped(tenantId)
+                    .name(variableName)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldNotAllowDeletingTenantVariableWithGlobalScope() {
+    // given
+    final var variableName = "tenantVarNoGlobalDelete_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableDeleteRequest()
+                    .globalScoped()
+                    .name(variableName)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ClusterVariableFetchTest {
+
+  private static final String VALUE_RESULT = "\"%s\"";
+
+  private static CamundaClient camundaClient;
+
+  // ============ GET TESTS ============
+  @Test
+  void shouldGetGlobalScopedClusterVariable() {
+    // given
+    final var variableName = "globalVarGet_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // wait for data to be indexed
+    TestHelper.waitForClusterVariableToBeIndexed(camundaClient, variableName, variableValue);
+
+    // when
+    final var response =
+        camundaClient.newClusterVariableGetRequest().atGlobalScope(variableName).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo(variableName);
+    assertThat(response.getValue()).isEqualTo(VALUE_RESULT.formatted(variableValue));
+  }
+
+  @Test
+  void shouldGetTenantScopedClusterVariable() {
+    // given
+    final var variableName = "tenantVarGet_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // wait for data to be indexed
+    TestHelper.waitForClusterVariableToBeIndexed(
+        camundaClient, variableName, tenantId, variableValue);
+
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableGetRequest()
+            .atTenantScope(variableName, tenantId)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo(variableName);
+    assertThat(response.getValue()).isEqualTo(VALUE_RESULT.formatted(variableValue));
+    assertThat(response.getTenantId()).isEqualTo(tenantId);
+  }
+
+  @Test
+  void shouldRejectGetIfVariableNameIsNull() {
+    // when / then
+    assertThatThrownBy(
+            () -> camundaClient.newClusterVariableGetRequest().atGlobalScope(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRejectGetIfVariableNameIsEmpty() {
+    // when / then
+    assertThatThrownBy(
+            () -> camundaClient.newClusterVariableGetRequest().atGlobalScope("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+
+  @Test
+  void shouldRejectGetIfGlobalVariableDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableGetRequest()
+                    .atGlobalScope("nonExistentVar_" + UUID.randomUUID())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRejectGetIfTenantVariableDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableGetRequest()
+                    .atTenantScope(
+                        "nonExistentVar_" + UUID.randomUUID(), "tenant_" + UUID.randomUUID())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldNotAllowGettingGlobalVariableWithTenantScope() {
+    // given
+    final var variableName = "globalVarNoTenantGet_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableGetRequest()
+                    .atTenantScope(variableName, tenantId)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldNotAllowGettingTenantVariableWithGlobalScope() {
+    // given
+    final var variableName = "tenantVarNoGlobalGet_" + UUID.randomUUID();
+    final var variableValue = "testValue_" + UUID.randomUUID();
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(variableName, variableValue)
+        .send()
+        .join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newClusterVariableGetRequest()
+                    .atGlobalScope(variableName)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchTest.java
@@ -33,8 +33,8 @@ public class ClusterVariableFetchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(variableName, variableValue)
+        .atGlobalScoped()
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -60,8 +60,8 @@ public class ClusterVariableFetchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(variableName, variableValue)
+        .atTenantScoped(tenantId)
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -139,8 +139,8 @@ public class ClusterVariableFetchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(variableName, variableValue)
+        .atGlobalScoped()
+        .create(variableName, variableValue)
         .send()
         .join();
 
@@ -167,8 +167,8 @@ public class ClusterVariableFetchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(variableName, variableValue)
+        .atTenantScoped(tenantId)
+        .create(variableName, variableValue)
         .send()
         .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
@@ -64,15 +64,15 @@ public class ClusterVariableSearchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(globalVarName1, globalVarValue1)
+        .atGlobalScoped()
+        .create(globalVarName1, globalVarValue1)
         .send()
         .join();
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(globalVarName2, globalVarValue2)
+        .atGlobalScoped()
+        .create(globalVarName2, globalVarValue2)
         .send()
         .join();
 
@@ -85,15 +85,15 @@ public class ClusterVariableSearchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(tenantVarName1, tenantVarValue1)
+        .atTenantScoped(tenantId)
+        .create(tenantVarName1, tenantVarValue1)
         .send()
         .join();
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantId)
-        .variable(tenantVarName2, tenantVarValue2)
+        .atTenantScoped(tenantId)
+        .create(tenantVarName2, tenantVarValue2)
         .send()
         .join();
 
@@ -106,15 +106,15 @@ public class ClusterVariableSearchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(globalVarNameMixed, globalVarValueMixed)
+        .atGlobalScoped()
+        .create(globalVarNameMixed, globalVarValueMixed)
         .send()
         .join();
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantIdMixed)
-        .variable(tenantVarNameMixed, tenantVarValueMixed)
+        .atTenantScoped(tenantIdMixed)
+        .create(tenantVarNameMixed, tenantVarValueMixed)
         .send()
         .join();
 
@@ -127,15 +127,15 @@ public class ClusterVariableSearchTest {
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .globalScoped()
-        .variable(globalVarNameTenantOnly, globalVarValueTenantOnly)
+        .atGlobalScoped()
+        .create(globalVarNameTenantOnly, globalVarValueTenantOnly)
         .send()
         .join();
 
     camundaClient
         .newClusterVariableCreateRequest()
-        .tenantScoped(tenantIdTenantOnly)
-        .variable(tenantVarNameTenantOnly, tenantVarValueTenantOnly)
+        .atTenantScoped(tenantIdTenantOnly)
+        .create(tenantVarNameTenantOnly, tenantVarValueTenantOnly)
         .send()
         .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.response.ClusterVariable;
+import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ClusterVariableSearchTest {
+
+  private static final String VALUE_RESULT = "\"%s\"";
+
+  private static CamundaClient camundaClient;
+
+  // Test data - Global scoped variables
+  private static String globalVarName1;
+  private static String globalVarValue1;
+  private static String globalVarName2;
+  private static String globalVarValue2;
+
+  // Test data - Tenant scoped variables
+  private static String tenantVarName1;
+  private static String tenantVarValue1;
+  private static String tenantVarName2;
+  private static String tenantVarValue2;
+  private static String tenantId;
+
+  // Test data - Mixed scope variables
+  private static String globalVarNameMixed;
+  private static String globalVarValueMixed;
+  private static String tenantVarNameMixed;
+  private static String tenantVarValueMixed;
+  private static String tenantIdMixed;
+
+  // Test data - Tenant-only variables
+  private static String globalVarNameTenantOnly;
+  private static String globalVarValueTenantOnly;
+  private static String tenantVarNameTenantOnly;
+  private static String tenantVarValueTenantOnly;
+  private static String tenantIdTenantOnly;
+
+  @BeforeAll
+  static void setupClusterVariables() {
+    // Setup global scoped variables
+    globalVarName1 = "globalVarSearch1_" + UUID.randomUUID();
+    globalVarValue1 = "testValue1_" + UUID.randomUUID();
+    globalVarName2 = "globalVarSearch2_" + UUID.randomUUID();
+    globalVarValue2 = "testValue2_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(globalVarName1, globalVarValue1)
+        .send()
+        .join();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(globalVarName2, globalVarValue2)
+        .send()
+        .join();
+
+    // Setup tenant scoped variables
+    tenantVarName1 = "tenantVarSearch1_" + UUID.randomUUID();
+    tenantVarValue1 = "testValue1_" + UUID.randomUUID();
+    tenantVarName2 = "tenantVarSearch2_" + UUID.randomUUID();
+    tenantVarValue2 = "testValue2_" + UUID.randomUUID();
+    tenantId = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(tenantVarName1, tenantVarValue1)
+        .send()
+        .join();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantId)
+        .variable(tenantVarName2, tenantVarValue2)
+        .send()
+        .join();
+
+    // Setup mixed scope variables
+    globalVarNameMixed = "globalVarSearchOnly_" + UUID.randomUUID();
+    globalVarValueMixed = "globalValue_" + UUID.randomUUID();
+    tenantVarNameMixed = "tenantVarSearchOnly_" + UUID.randomUUID();
+    tenantVarValueMixed = "tenantValue_" + UUID.randomUUID();
+    tenantIdMixed = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(globalVarNameMixed, globalVarValueMixed)
+        .send()
+        .join();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantIdMixed)
+        .variable(tenantVarNameMixed, tenantVarValueMixed)
+        .send()
+        .join();
+
+    // Setup tenant-only variables
+    globalVarNameTenantOnly = "globalVarTenantSearch_" + UUID.randomUUID();
+    globalVarValueTenantOnly = "globalValue_" + UUID.randomUUID();
+    tenantVarNameTenantOnly = "tenantVarTenantSearch_" + UUID.randomUUID();
+    tenantVarValueTenantOnly = "tenantValue_" + UUID.randomUUID();
+    tenantIdTenantOnly = "tenant_" + UUID.randomUUID();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .globalScoped()
+        .variable(globalVarNameTenantOnly, globalVarValueTenantOnly)
+        .send()
+        .join();
+
+    camundaClient
+        .newClusterVariableCreateRequest()
+        .tenantScoped(tenantIdTenantOnly)
+        .variable(tenantVarNameTenantOnly, tenantVarValueTenantOnly)
+        .send()
+        .join();
+
+    // Wait for all variables to be indexed
+    TestHelper.waitForClusterVariablesToBeIndexed(
+        camundaClient,
+        Map.of(
+            globalVarName1, globalVarValue1,
+            globalVarName2, globalVarValue2,
+            tenantVarName1, tenantVarValue1,
+            tenantVarName2, tenantVarValue2,
+            globalVarNameMixed, globalVarValueMixed,
+            tenantVarNameMixed, tenantVarValueMixed,
+            globalVarNameTenantOnly, globalVarValueTenantOnly,
+            tenantVarNameTenantOnly, tenantVarValueTenantOnly));
+  }
+
+  // ============ SEARCH TESTS ============
+
+  @Test
+  void shouldSearchGlobalScopedClusterVariables() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(ClusterVariableScope.GLOBAL))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(globalVarName1);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue1));
+            });
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(globalVarName2);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue2));
+            });
+  }
+
+  @Test
+  void shouldSearchTenantScopedClusterVariables() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(ClusterVariableScope.TENANT).tenantId(tenantId))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(tenantVarName1);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(tenantVarValue1));
+            });
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(tenantVarName2);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(tenantVarValue2));
+            });
+  }
+
+  @Test
+  void shouldSearchReturnOnlyGlobalVariablesWhenSearchingGlobalScope() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(ClusterVariableScope.GLOBAL))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(globalVarNameMixed);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValueMixed));
+              assertThat(item.getTenantId()).isNull();
+            });
+    assertThat(response.items())
+        .noneSatisfy(item -> assertThat(item.getName()).isEqualTo(tenantVarNameMixed));
+  }
+
+  @Test
+  void shouldSearchReturnOnlyTenantVariablesWhenSearchingTenantScope() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(ClusterVariableScope.TENANT).tenantId(tenantIdTenantOnly))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(tenantVarNameTenantOnly);
+              assertThat(item.getValue())
+                  .isEqualTo(VALUE_RESULT.formatted(tenantVarValueTenantOnly));
+              assertThat(item.getTenantId()).isEqualTo(tenantIdTenantOnly);
+            });
+    assertThat(response.items())
+        .noneSatisfy(item -> assertThat(item.getName()).isEqualTo(globalVarNameTenantOnly));
+  }
+
+  @Test
+  void shouldSearchReturnEmptyResultsIfNoVariablesExist() {
+    // given
+    final var tenantId = "tenant_" + UUID.randomUUID();
+
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(ClusterVariableScope.TENANT).tenantId(tenantId))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSearchSortClusterVariablesByName() {
+    // when
+    final var response =
+        camundaClient.newClusterVariableSearchRequest().sort(s -> s.name().asc()).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+
+    // Verify that the results are sorted by name in ascending order
+    final var names = response.items().stream().map(ClusterVariable::getName).toList();
+    final var sortedNames = names.stream().sorted().toList();
+    assertThat(names).containsExactlyElementsOf(sortedNames);
+  }
+
+  @Test
+  void shouldSearchSortClusterVariablesByScope() {
+    // when
+    final var response =
+        camundaClient.newClusterVariableSearchRequest().sort(s -> s.scope().asc()).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+
+    // Verify that the results are sorted by scope (GLOBAL comes before TENANT alphabetically)
+    final var scopes = response.items().stream().map(item -> item.getScope().toString()).toList();
+    final var sortedScopes = scopes.stream().sorted().toList();
+    assertThat(scopes).containsExactlyElementsOf(sortedScopes);
+  }
+
+  @Test
+  void shouldSearchSortClusterVariablesDescending() {
+    // when
+    final var response =
+        camundaClient.newClusterVariableSearchRequest().sort(s -> s.name().desc()).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+
+    // Verify that the results are sorted by name in descending order
+    final var names = response.items().stream().map(ClusterVariable::getName).toList();
+    final var sortedNames = names.stream().sorted(Comparator.reverseOrder()).toList();
+    assertThat(names).containsExactlyElementsOf(sortedNames);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
@@ -323,4 +323,453 @@ public class ClusterVariableSearchTest {
     final var sortedNames = names.stream().sorted(Comparator.reverseOrder()).toList();
     assertThat(names).containsExactlyElementsOf(sortedNames);
   }
+
+  // ============ ADVANCED FILTER TESTS ============
+
+  @Test
+  void shouldSearchClusterVariablesByNameWithLike() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.like("globalVarSearch*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items()).anyMatch(item -> item.getName().contains("globalVarSearch"));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByNameWithExactMatch() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.eq(globalVarName1)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(globalVarName1);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue1));
+            });
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByNameNotEqual() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.neq(globalVarName1)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .noneSatisfy(item -> assertThat(item.getName()).isEqualTo(globalVarName1));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByNameExists() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(item -> assertThat(item.getName()).isNotNull().isNotEmpty());
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByNameWithMultipleValues() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.in(globalVarName1, globalVarName2)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(item -> assertThat(item.getName()).isEqualTo(globalVarName1))
+        .anySatisfy(item -> assertThat(item.getName()).isEqualTo(globalVarName2));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByValueWithLike() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.value(v -> v.like("*testValue*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items()).anyMatch(item -> item.getValue().contains("testValue"));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByValueWithExactMatch() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.value(v -> v.eq(VALUE_RESULT.formatted(globalVarValue1))))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(globalVarName1);
+              assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue1));
+            });
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByValueNotEqual() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.value(v -> v.neq(VALUE_RESULT.formatted(globalVarValue1))))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .noneSatisfy(
+            item -> assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue1)));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByValueWithMultipleValues() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(
+                f ->
+                    f.value(
+                        v ->
+                            v.in(
+                                VALUE_RESULT.formatted(globalVarValue1),
+                                VALUE_RESULT.formatted(globalVarValue2))))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(
+            item -> assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue1)))
+        .anySatisfy(
+            item -> assertThat(item.getValue()).isEqualTo(VALUE_RESULT.formatted(globalVarValue2)));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByValueExists() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.value(v -> v.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(item -> assertThat(item.getValue()).isNotNull().isNotEmpty());
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByScopeWithLike() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(s -> s.like("GLOBAL")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anySatisfy(item -> assertThat(item.getScope()).isEqualTo(ClusterVariableScope.GLOBAL));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByScopeWithEquality() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(s -> s.eq(ClusterVariableScope.GLOBAL)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(item -> assertThat(item.getScope()).isEqualTo(ClusterVariableScope.GLOBAL));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByScopeWithNotEqual() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(s -> s.neq(ClusterVariableScope.GLOBAL)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    // Should return only TENANT scoped variables or empty
+    assertThat(response.items())
+        .noneSatisfy(item -> assertThat(item.getScope()).isEqualTo(ClusterVariableScope.GLOBAL));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByScopeExists() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(s -> s.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items()).allSatisfy(item -> assertThat(item.getScope()).isNotNull());
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByScopeWithMultipleValues() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(
+                f -> f.scope(s -> s.in(ClusterVariableScope.GLOBAL, ClusterVariableScope.TENANT)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(
+            item ->
+                assertThat(item.getScope())
+                    .isIn(ClusterVariableScope.GLOBAL, ClusterVariableScope.TENANT));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByTenantIdWithLike() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.tenantId(t -> t.like("tenant_*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items())
+        .anyMatch(item -> item.getTenantId() != null && item.getTenantId().startsWith("tenant_"));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByTenantIdWithExactMatch() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.tenantId(t -> t.eq(tenantId)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(item -> assertThat(item.getTenantId()).isEqualTo(tenantId));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByTenantIdNotEqual() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.tenantId(t -> t.neq(tenantId)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items())
+        .noneSatisfy(item -> assertThat(item.getTenantId()).isEqualTo(tenantId));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByTenantIdExists() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.tenantId(t -> t.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).allSatisfy(item -> assertThat(item.getTenantId()).isNotNull());
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByTenantIdWithMultipleValues() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.tenantId(t -> t.in(tenantId, tenantIdMixed)))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(item -> assertThat(item.getTenantId()).isIn(tenantId, tenantIdMixed));
+  }
+
+  @Test
+  void shouldSearchClusterVariablesWithCombinedFilters() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(ClusterVariableScope.GLOBAL).name(n -> n.like("globalVarSearch*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(
+            item -> {
+              assertThat(item.getScope()).isEqualTo(ClusterVariableScope.GLOBAL);
+              assertThat(item.getName()).contains("globalVarSearch");
+            });
+  }
+
+  @Test
+  void shouldSearchClusterVariablesWithMultipleCombinedFilters() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(
+                f ->
+                    f.scope(s -> s.eq(ClusterVariableScope.TENANT))
+                        .tenantId(t -> t.eq(tenantIdMixed))
+                        .name(n -> n.like("tenantVarSearchOnly*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(
+            item -> {
+              assertThat(item.getScope()).isEqualTo(ClusterVariableScope.TENANT);
+              assertThat(item.getTenantId()).isEqualTo(tenantIdMixed);
+              assertThat(item.getName()).contains("tenantVarSearchOnly");
+            });
+  }
+
+  @Test
+  void shouldSearchClusterVariablesWithValueAndNameFilters() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.like("globalVarSearch*")).value(v -> v.like("*testValue*")))
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(
+            item -> {
+              assertThat(item.getName()).contains("globalVarSearch");
+              assertThat(item.getValue()).contains("testValue");
+            });
+  }
+
+  @Test
+  void shouldSearchClusterVariablesSortByScopeAndFilter() {
+    // when
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.scope(s -> s.eq(ClusterVariableScope.GLOBAL)))
+            .sort(s -> s.name().asc())
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .allSatisfy(item -> assertThat(item.getScope()).isEqualTo(ClusterVariableScope.GLOBAL));
+
+    // Verify sorting
+    final var names = response.items().stream().map(ClusterVariable::getName).toList();
+    final var sortedNames = names.stream().sorted().toList();
+    assertThat(names).containsExactlyElementsOf(sortedNames);
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -370,6 +370,20 @@ class VariableSearchTest {
         .isEqualTo(thirdKey);
   }
 
+  @Test
+  void shouldSearchAllWhereValueExists() {
+    // when
+    final var resultSearchFrom =
+        camundaClient
+            .newVariableSearchRequest()
+            .filter(f -> f.value(v -> v.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(resultSearchFrom.items().size()).isEqualTo(5);
+  }
+
   private static void waitForTasksBeingExported() {
     Awaitility.await("should receive data from ES")
         .atMost(TIMEOUT_DATA_AVAILABILITY)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -381,7 +381,7 @@ class VariableSearchTest {
             .join();
 
     // then
-    assertThat(resultSearchFrom.items().size()).isEqualTo(5);
+    assertThat(resultSearchFrom.items().size()).isEqualTo(6);
   }
 
   private static void waitForTasksBeingExported() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -50,8 +50,8 @@ public class ClusterVariableIT {
             .getRdbmsService()
             .getClusterVariableReader()
             .getTenantScopedClusterVariable(
-                randomizedVariable.tenantId(),
                 randomizedVariable.name(),
+                randomizedVariable.tenantId(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
@@ -94,8 +94,8 @@ public class ClusterVariableIT {
         rdbmsService
             .getClusterVariableReader()
             .getTenantScopedClusterVariable(
-                randomizedVariable.tenantId(),
                 randomizedVariable.name(),
+                randomizedVariable.tenantId(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(randomizedVariable.name()));
 
     assertThat(instance).isNotNull();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -259,8 +259,8 @@ class RdbmsExporterIT {
         rdbmsService
             .getClusterVariableReader()
             .getTenantScopedClusterVariable(
-                clusterVariableRecordValue.getTenantId(),
                 clusterVariableRecordValue.getName(),
+                clusterVariableRecordValue.getTenantId(),
                 ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     assertThat(variable).isNotNull();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ClusterVariableDocumentReader.java
@@ -35,7 +35,7 @@ public class ClusterVariableDocumentReader extends DocumentBasedReader
 
   @Override
   public ClusterVariableEntity getTenantScopedClusterVariable(
-      final String tenant, final String name, final ResourceAccessChecks resourceAccessChecks) {
+      final String name, final String tenant, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .getById(
             ClusterVariableUtil.generateID(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
@@ -24,7 +24,7 @@ public class ClusterVariableEntityTransformer
         value.getName(),
         value.getValue(),
         value.getFullValue(),
-        value.isPreview(),
+        value.getIsPreview(),
         ClusterVariableScope.valueOf(value.getScope().name()),
         value.getTenantId());
   }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
@@ -15,7 +15,7 @@ public interface ClusterVariableReader
     extends SearchEntityReader<ClusterVariableEntity, ClusterVariableQuery> {
 
   ClusterVariableEntity getTenantScopedClusterVariable(
-      String tenant, String name, ResourceAccessChecks resourceAccessChecks);
+      String name, String tenant, ResourceAccessChecks resourceAccessChecks);
 
   ClusterVariableEntity getGloballyScopedClusterVariable(
       String name, ResourceAccessChecks resourceAccessChecks);

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -143,12 +143,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
-  public ClusterVariableEntity getClusterVariable(final String tenant, final String name) {
+  public ClusterVariableEntity getClusterVariable(final String name, final String tenant) {
     return doGet(
             resourceAccessChecks ->
                 readers
                     .clusterVariableReader()
-                    .getTenantScopedClusterVariable(tenant, name, resourceAccessChecks))
+                    .getTenantScopedClusterVariable(name, tenant, resourceAccessChecks))
         .orElseThrow(
             () ->
                 entityByIdNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -170,8 +170,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
-      final ClusterVariableQuery filter) {
-    return doSearchWithReader(readers.clusterVariableReader(), filter);
+      final ClusterVariableQuery query) {
+    return doSearchWithReader(readers.clusterVariableReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
@@ -18,7 +18,7 @@ public interface ClusterVariableSearchClient {
 
   ClusterVariableEntity getClusterVariable(final String name);
 
-  SearchQueryResult<ClusterVariableEntity> searchClusterVariables(ClusterVariableQuery filter);
+  SearchQueryResult<ClusterVariableEntity> searchClusterVariables(ClusterVariableQuery query);
 
   ClusterVariableSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
@@ -14,7 +14,7 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface ClusterVariableSearchClient {
 
-  ClusterVariableEntity getClusterVariable(final String tenant, final String name);
+  ClusterVariableEntity getClusterVariable(final String name, final String tenant);
 
   ClusterVariableEntity getClusterVariable(final String name);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -332,7 +332,7 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
-      final ClusterVariableQuery filter) {
+      final ClusterVariableQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -334,7 +334,7 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
-      final ClusterVariableQuery filter) {
+      final ClusterVariableQuery query) {
     return SearchQueryResult.empty();
   }
 

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.ClusterVariableSearchClient;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateClusterVariableRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteClusterVariableRequest;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class ClusterVariableServices
+    extends SearchQueryService<
+        ClusterVariableServices, ClusterVariableQuery, ClusterVariableEntity> {
+
+  private final ClusterVariableSearchClient clusterVariableSearchClient;
+
+  public ClusterVariableServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ClusterVariableSearchClient clusterVariableSearchClient,
+      final CamundaAuthentication authentication,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+    this.clusterVariableSearchClient = clusterVariableSearchClient;
+  }
+
+  @Override
+  public ClusterVariableServices withAuthentication(final CamundaAuthentication authentication) {
+    return new ClusterVariableServices(
+        brokerClient,
+        securityContextProvider,
+        clusterVariableSearchClient,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public CompletableFuture<ClusterVariableRecord> createGloballyScopedClusterVariable(
+      final String name, final Object value) {
+    return sendBrokerRequest(
+        new BrokerCreateClusterVariableRequest()
+            .setName(name)
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value)))
+            .setGlobalScope());
+  }
+
+  public CompletableFuture<ClusterVariableRecord> createTenantScopedClusterVariable(
+      final String name, final Object value, final String tenantId) {
+    return sendBrokerRequest(
+        new BrokerCreateClusterVariableRequest()
+            .setName(name)
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value)))
+            .setTenantScope(tenantId));
+  }
+
+  public CompletableFuture<ClusterVariableRecord> deleteGloballyScopedClusterVariable(
+      final String name) {
+    return sendBrokerRequest(
+        new BrokerDeleteClusterVariableRequest().setName(name).setGlobalScope());
+  }
+
+  public CompletableFuture<ClusterVariableRecord> deleteTenantScopedClusterVariable(
+      final String name, final String tenantId) {
+    return sendBrokerRequest(
+        new BrokerDeleteClusterVariableRequest().setName(name).setTenantScope(tenantId));
+  }
+
+  public ClusterVariableEntity getGloballyScopedClusterVariable(final String name) {
+    return executeSearchRequest(
+        () ->
+            clusterVariableSearchClient
+                // TODO : Uncomment and fix authorization once implemented
+                /*                .withSecurityContext(
+                securityContextProvider.provideSecurityContext(
+                    authentication,
+                    withAuthorization())*/
+                .getClusterVariable(name));
+  }
+
+  public ClusterVariableEntity getTenantScopedClusterVariable(
+      final String name, final String tenantId) {
+    return executeSearchRequest(
+        () ->
+            clusterVariableSearchClient
+                // TODO : Uncomment and fix authorization once implemented
+                /*                .withSecurityContext(
+                securityContextProvider.provideSecurityContext(
+                    authentication,
+                    withAuthorization()))*/
+                .getClusterVariable(name, tenantId));
+  }
+
+  @Override
+  public SearchQueryResult<ClusterVariableEntity> search(final ClusterVariableQuery query) {
+    return null;
+  }
+}

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -90,11 +90,9 @@ public final class ClusterVariableServices
     return executeSearchRequest(
         () ->
             clusterVariableSearchClient
-                // TODO : Uncomment and fix authorization once implemented
-                /*                .withSecurityContext(
-                securityContextProvider.provideSecurityContext(
-                    authentication,
-                    withAuthorization())*/
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        CamundaAuthentication.anonymous()))
                 .getClusterVariable(name));
   }
 
@@ -103,16 +101,20 @@ public final class ClusterVariableServices
     return executeSearchRequest(
         () ->
             clusterVariableSearchClient
-                // TODO : Uncomment and fix authorization once implemented
-                /*                .withSecurityContext(
-                securityContextProvider.provideSecurityContext(
-                    authentication,
-                    withAuthorization()))*/
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        CamundaAuthentication.anonymous()))
                 .getClusterVariable(name, tenantId));
   }
 
   @Override
   public SearchQueryResult<ClusterVariableEntity> search(final ClusterVariableQuery query) {
-    return null;
+    return executeSearchRequest(
+        () ->
+            clusterVariableSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        CamundaAuthentication.anonymous()))
+                .searchClusterVariables(query));
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -20,11 +20,11 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
   private ClusterVariableScope scope;
   private String tenantId;
 
-  public boolean isPreview() {
+  public boolean getIsPreview() {
     return isPreview;
   }
 
-  public ClusterVariableEntity setPreview(final boolean preview) {
+  public ClusterVariableEntity setIsPreview(final boolean preview) {
     isPreview = preview;
     return this;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -68,6 +69,7 @@ public class CommandApiRequestReader implements RequestReader {
     RECORDS_BY_TYPE.put(ValueType.JOB_BATCH, JobBatchRecord::new);
     RECORDS_BY_TYPE.put(ValueType.INCIDENT, IncidentRecord::new);
     RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.CLUSTER_VARIABLE, ClusterVariableRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord::new);
     RECORDS_BY_TYPE.put(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandler.java
@@ -77,11 +77,11 @@ public class ClusterVariableCreatedHandler
     if (recordValue.getValue().length() > variableSizeThreshold) {
       entity.setValue(recordValue.getValue().substring(0, variableSizeThreshold));
       entity.setFullValue(recordValue.getValue());
-      entity.setPreview(true);
+      entity.setIsPreview(true);
     } else {
       entity.setValue(recordValue.getValue());
       entity.setFullValue(null);
-      entity.setPreview(false);
+      entity.setIsPreview(false);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedHandlerTest.java
@@ -175,7 +175,7 @@ public class ClusterVariableCreatedHandlerTest {
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
                 clusterVariableRecordValue.getScope()));
     assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
-    assertThat(clusterVariableEntity.isPreview()).isFalse();
+    assertThat(clusterVariableEntity.getIsPreview()).isFalse();
     assertThat(clusterVariableEntity.getFullValue()).isNull();
   }
 
@@ -208,7 +208,7 @@ public class ClusterVariableCreatedHandlerTest {
             io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.fromProtocol(
                 clusterVariableRecordValue.getScope()));
     assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
-    assertThat(clusterVariableEntity.isPreview()).isFalse();
+    assertThat(clusterVariableEntity.getIsPreview()).isFalse();
     assertThat(clusterVariableEntity.getFullValue()).isNull();
   }
 
@@ -236,6 +236,6 @@ public class ClusterVariableCreatedHandlerTest {
     assertThat(clusterVariableEntity.getValue()).isEqualTo("v".repeat(variableSizeThreshold));
     assertThat(clusterVariableEntity.getFullValue())
         .isEqualTo("v".repeat(variableSizeThreshold + 1));
-    assertThat(clusterVariableEntity.isPreview()).isTrue();
+    assertThat(clusterVariableEntity.getIsPreview()).isTrue();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -3,6 +3,7 @@
 paths:
   /cluster-variables:
     post:
+      operationId: createClusterVariable
       tags:
         - Cluster Variable
       summary: Create a new cluster variable
@@ -58,6 +59,7 @@ paths:
       x-eventually-consistent: true
   /cluster-variables/{name}/GLOBAL:
     delete:
+      operationId: deleteGlobalClusterVariable
       tags:
         - Cluster Variable
       summary: Delete a global-scoped cluster variable
@@ -82,6 +84,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
     get:
+      operationId: getGlobalClusterVariable
       tags:
         - Cluster Variable
       summary: Get a global-scoped cluster variable
@@ -111,6 +114,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
   /cluster-variables/{name}/TENANT/{tenantId}:
     delete:
+      operationId: deleteTenantClusterVariable
       tags:
         - Cluster Variable
       summary: Delete a tenant-scoped cluster variable
@@ -141,6 +145,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
     get:
+      operationId: getTenantClusterVariable
       tags:
         - Cluster Variable
       summary: Get a tenant-scoped cluster variable

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -323,7 +323,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
     ClusterVariableScopeFilterProperty:
-      description: JobKindEnum property with full advanced search capabilities.
+      description: ClusterVariableScopeEnum property with full advanced search capabilities.
       type: object
       oneOf:
         - type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -1,12 +1,48 @@
 ## Endpoint definitions
 
 paths:
-  /cluster-variables:
+  /cluster-variables/global:
     post:
-      operationId: createClusterVariable
+      operationId: createGlobalClusterVariable
+      x-eventually-consistent: false
       tags:
         - Cluster Variable
-      summary: Create a new cluster variable
+      summary: Create a global-scoped cluster variable
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateClusterVariableRequest'
+      responses:
+        '200':
+          description: Cluster variable created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterVariableResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+  /cluster-variables/tenants/{tenantId}:
+    post:
+      operationId: createTenantClusterVariable
+      x-eventually-consistent: false
+      tags:
+        - Cluster Variable
+      summary: Create a tenant-scoped cluster variable
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The tenant ID
       requestBody:
         required: true
         content:
@@ -33,7 +69,7 @@ paths:
       tags:
         - Cluster Variable
       operationId: searchClusterVariables
-      summary: Search cluster variables
+      x-eventually-consistent: true
       description: Search for cluster variables based on given criteria.
       requestBody:
         required: false
@@ -56,35 +92,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
-      x-eventually-consistent: true
-  /cluster-variables/{name}/GLOBAL:
-    delete:
-      operationId: deleteGlobalClusterVariable
-      tags:
-        - Cluster Variable
-      summary: Delete a global-scoped cluster variable
-      parameters:
-        - name: name
-          in: path
-          required: true
-          schema:
-            type: string
-          description: The name of the cluster variable
-      responses:
-        '204':
-          description: Cluster variable deleted successfully
-        "400":
-          $ref: 'common-responses.yaml#/components/responses/InvalidData'
-        "401":
-          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
-        "403":
-          $ref: 'common-responses.yaml#/components/responses/Forbidden'
-        "404":
-          description: Cluster variable not found
-        "500":
-          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+  /cluster-variables/global/{name}:
     get:
       operationId: getGlobalClusterVariable
+      x-eventually-consistent: true
       tags:
         - Cluster Variable
       summary: Get a global-scoped cluster variable
@@ -112,12 +123,12 @@ paths:
           description: Cluster variable not found
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
-  /cluster-variables/{name}/TENANT/{tenantId}:
     delete:
-      operationId: deleteTenantClusterVariable
+      operationId: deleteGlobalClusterVariable
+      x-eventually-consistent: false
       tags:
         - Cluster Variable
-      summary: Delete a tenant-scoped cluster variable
+      summary: Delete a global-scoped cluster variable
       parameters:
         - name: name
           in: path
@@ -125,12 +136,6 @@ paths:
           schema:
             type: string
           description: The name of the cluster variable
-        - name: tenantId
-          in: path
-          required: true
-          schema:
-            type: string
-          description: The tenant ID
       responses:
         '204':
           description: Cluster variable deleted successfully
@@ -144,24 +149,26 @@ paths:
           description: Cluster variable not found
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+  /cluster-variables/tenants/{tenantId}/{name}:
     get:
       operationId: getTenantClusterVariable
+      x-eventually-consistent: true
       tags:
         - Cluster Variable
       summary: Get a tenant-scoped cluster variable
       parameters:
-        - name: name
-          in: path
-          required: true
-          schema:
-            type: string
-          description: The name of the cluster variable
         - name: tenantId
           in: path
           required: true
           schema:
             type: string
           description: The tenant ID
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the cluster variable
       responses:
         '200':
           description: Cluster variable found
@@ -169,6 +176,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClusterVariableResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: Cluster variable not found
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+    delete:
+      operationId: deleteTenantClusterVariable
+      x-eventually-consistent: false
+      tags:
+        - Cluster Variable
+      summary: Delete a tenant-scoped cluster variable
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The tenant ID
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the cluster variable
+      responses:
+        '204':
+          description: Cluster variable deleted successfully
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "401":
@@ -191,18 +230,13 @@ components:
       required:
         - name
         - value
-        - scope
       properties:
         name:
           type: string
+          description: The name of the cluster variable
         value:
           type: object
-        scope:
-          $ref: '#/components/schemas/ClusterVariableScopeEnum'
-        tenantId:
-          type: string
-          nullable: true
-          description: Required if scope is TENANT, must be null or undefined for GLOBAL
+          description: The value of the cluster variable
     ClusterVariableResult:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -39,7 +39,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClusterVariableSearchQuery'
+              $ref: '#/components/schemas/ClusterVariableSearchQueryRequest'
       responses:
         "200":
           description: The cluster variable search result.
@@ -76,8 +76,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            enum: [ GLOBAL, TENANT ]
+            $ref: '#/components/schemas/ClusterVariableScopeEnum'
           description: The scope of the variable
         - name: tenantId
           in: path
@@ -118,8 +117,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-            enum: [ GLOBAL, TENANT ]
+            $ref: '#/components/schemas/ClusterVariableScopeEnum'
           description: The scope of the variable
         - name: tenantId
           in: path
@@ -147,18 +145,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 components:
   schemas:
-    ClusterVariableScope:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [ GLOBAL, TENANT ]
-        tenantId:
-          type: string
-          nullable: true
-          description: Required if type is TENANT, must be null or undefined for GLOBAL
+    ClusterVariableScopeEnum:
+      type: string
+      enum: [ GLOBAL, TENANT ]
+      description: The scope of a cluster variable - either GLOBAL or TENANT
     CreateClusterVariableRequest:
       type: object
       required:
@@ -169,11 +159,13 @@ components:
         name:
           type: string
         value:
-          oneOf:
-            - type: string
-            - type: object
+          type: object
         scope:
-          $ref: '#/components/schemas/ClusterVariableScope'
+          $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        tenantId:
+          type: string
+          nullable: true
+          description: Required if scope is TENANT, must be null or undefined for GLOBAL
     ClusterVariableResult:
       type: object
       properties:
@@ -182,8 +174,12 @@ components:
         value:
           type: string
         scope:
-          $ref: '#/components/schemas/ClusterVariableScope'
-    ClusterVariableSearchQuery:
+          $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        tenantId:
+          type: string
+          nullable: true
+          description: Required if scope is TENANT, must be null or undefined for GLOBAL
+    ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false
       type: object
@@ -198,7 +194,7 @@ components:
         filter:
           description: The cluster variable search filters.
           allOf:
-            - $ref: '#/components/schemas/ClusterVariableFilter'
+            - $ref: '#/components/schemas/ClusterVariableSearchQueryFilterRequest'
     ClusterVariableSearchQuerySortRequest:
       type: object
       properties:
@@ -211,10 +207,10 @@ components:
             - tenantId
             - scope
         order:
-          $ref: 'enums.yaml#/components/schemas/SortOrderEnum'
+          $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
         - field
-    ClusterVariableFilter:
+    ClusterVariableSearchQueryFilterRequest:
       description: Cluster variable filter request.
       type: object
       properties:
@@ -229,17 +225,11 @@ components:
         scope:
           description: The scope filter for cluster variables.
           allOf:
-            - $ref: '#/components/schemas/ClusterVariableScopeFilter'
-    ClusterVariableScopeFilter:
-      type: object
-      properties:
-        type:
-          type: string
-          enum: [ GLOBAL, TENANT ]
+            - $ref: '#/components/schemas/ClusterVariableScopeEnum'
         tenantId:
-          description: Tenant identifier when type is TENANT.
+          description: Tenant ID of this variable.
           allOf:
-            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+            - $ref: 'identifiers.yaml#/components/schemas/TenantId'
     ClusterVariableSearchQueryResult:
       description: Cluster variable search query response.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -56,15 +56,11 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-eventually-consistent: true
-  /cluster-variables/{name}/{scope}/{tenantId}:
+  /cluster-variables/{name}/GLOBAL:
     delete:
       tags:
         - Cluster Variable
-      summary: Delete a cluster variable
-      description: |
-        Deletes a cluster variable by name and scope.
-        - If scope is GLOBAL, tenantId must be omitted or null.
-        - If scope is TENANT, tenantId is required.
+      summary: Delete a global-scoped cluster variable
       parameters:
         - name: name
           in: path
@@ -72,19 +68,6 @@ paths:
           schema:
             type: string
           description: The name of the cluster variable
-        - name: scope
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/ClusterVariableScopeEnum'
-          description: The scope of the variable
-        - name: tenantId
-          in: path
-          required: false
-          schema:
-            type: string
-            nullable: true
-          description: Required if scope is TENANT, must be omitted or null for GLOBAL
       responses:
         '204':
           description: Cluster variable deleted successfully
@@ -101,11 +84,7 @@ paths:
     get:
       tags:
         - Cluster Variable
-      summary: Get a cluster variable
-      description: |
-        Retrieves a cluster variable by name and scope.
-        - If scope is GLOBAL, tenantId must be omitted or null.
-        - If scope is TENANT, tenantId is required.
+      summary: Get a global-scoped cluster variable
       parameters:
         - name: name
           in: path
@@ -113,19 +92,6 @@ paths:
           schema:
             type: string
           description: The name of the cluster variable
-        - name: scope
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/ClusterVariableScopeEnum'
-          description: The scope of the variable
-        - name: tenantId
-          in: path
-          required: false
-          schema:
-            type: string
-            nullable: true
-          description: Required if scope is TENANT, must be omitted or null for GLOBAL
       responses:
         '200':
           description: Cluster variable found
@@ -143,6 +109,72 @@ paths:
           description: Cluster variable not found
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+  /cluster-variables/{name}/TENANT/{tenantId}:
+    delete:
+      tags:
+        - Cluster Variable
+      summary: Delete a tenant-scoped cluster variable
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the cluster variable
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The tenant ID
+      responses:
+        '204':
+          description: Cluster variable deleted successfully
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: Cluster variable not found
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+    get:
+      tags:
+        - Cluster Variable
+      summary: Get a tenant-scoped cluster variable
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the cluster variable
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The tenant ID
+      responses:
+        '200':
+          description: Cluster variable found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterVariableResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: Cluster variable not found
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+
 components:
   schemas:
     ClusterVariableScopeEnum:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -41,7 +41,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID
       requestBody:
         required: true
@@ -121,6 +121,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "404":
           description: Cluster variable not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
     delete:
@@ -147,6 +151,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "404":
           description: Cluster variable not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
   /cluster-variables/tenants/{tenantId}/{name}:
@@ -161,7 +169,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID
         - name: name
           in: path
@@ -184,6 +192,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "404":
           description: Cluster variable not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
     delete:
@@ -197,7 +209,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID
         - name: name
           in: path
@@ -216,6 +228,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "404":
           description: Cluster variable not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
@@ -224,7 +240,7 @@ components:
     ClusterVariableScopeEnum:
       type: string
       enum: [ GLOBAL, TENANT ]
-      description: The scope of a cluster variable - either GLOBAL or TENANT
+      description: The scope of a cluster variable.
     CreateClusterVariableRequest:
       type: object
       required:
@@ -233,23 +249,28 @@ components:
       properties:
         name:
           type: string
-          description: The name of the cluster variable
+          description: The name of the cluster variable. Must be unique within its scope (global or tenant-specific).
         value:
           type: object
-          description: The value of the cluster variable
+          description: The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
     ClusterVariableResult:
       type: object
+      required:
+        - name
+        - value
+        - scope
       properties:
         name:
           type: string
+          description: The name of the cluster variable. Unique within its scope (global or tenant-specific).
         value:
           type: string
+          description: The value of the cluster variable as a JSON-serialized string. Regardless of the input type during creation, values are returned as strings.
         scope:
           $ref: '#/components/schemas/ClusterVariableScopeEnum'
         tenantId:
           type: string
-          nullable: true
-          description: Required if scope is TENANT, must be null or undefined for GLOBAL
+          description: Only provided if the cluster variable scope is TENANT.
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false
@@ -296,11 +317,44 @@ components:
         scope:
           description: The scope filter for cluster variables.
           allOf:
-            - $ref: '#/components/schemas/ClusterVariableScopeEnum'
+            - $ref: '#/components/schemas/ClusterVariableScopeFilterProperty'
         tenantId:
           description: Tenant ID of this variable.
           allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+    ClusterVariableScopeFilterProperty:
+      description: JobKindEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        - $ref: '#/components/schemas/AdvancedClusterVariableScopeFilter'
+    AdvancedClusterVariableScopeFilter:
+      title: Advanced filter
+      description: Advanced ClusterVariableScopeEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"
     ClusterVariableSearchQueryResult:
       description: Cluster variable search query response.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -1,0 +1,253 @@
+## Endpoint definitions
+
+paths:
+  /cluster-variables:
+    post:
+      tags:
+        - Cluster Variable
+      summary: Create a new cluster variable
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateClusterVariableRequest'
+      responses:
+        '200':
+          description: Cluster variable created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterVariableResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+  /cluster-variables/search:
+    post:
+      tags:
+        - Cluster Variable
+      operationId: searchClusterVariables
+      summary: Search cluster variables
+      description: Search for cluster variables based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClusterVariableSearchQuery'
+      responses:
+        "200":
+          description: The cluster variable search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterVariableSearchQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-eventually-consistent: true
+  /cluster-variables/{name}/{scope}/{tenantId}:
+    delete:
+      tags:
+        - Cluster Variable
+      summary: Delete a cluster variable
+      description: |
+        Deletes a cluster variable by name and scope.
+        - If scope is GLOBAL, tenantId must be omitted or null.
+        - If scope is TENANT, tenantId is required.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the cluster variable
+        - name: scope
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [ GLOBAL, TENANT ]
+          description: The scope of the variable
+        - name: tenantId
+          in: path
+          required: false
+          schema:
+            type: string
+            nullable: true
+          description: Required if scope is TENANT, must be omitted or null for GLOBAL
+      responses:
+        '204':
+          description: Cluster variable deleted successfully
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: Cluster variable not found
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+    get:
+      tags:
+        - Cluster Variable
+      summary: Get a cluster variable
+      description: |
+        Retrieves a cluster variable by name and scope.
+        - If scope is GLOBAL, tenantId must be omitted or null.
+        - If scope is TENANT, tenantId is required.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the cluster variable
+        - name: scope
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [ GLOBAL, TENANT ]
+          description: The scope of the variable
+        - name: tenantId
+          in: path
+          required: false
+          schema:
+            type: string
+            nullable: true
+          description: Required if scope is TENANT, must be omitted or null for GLOBAL
+      responses:
+        '200':
+          description: Cluster variable found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterVariableResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: Cluster variable not found
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+components:
+  schemas:
+    ClusterVariableScope:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [ GLOBAL, TENANT ]
+        tenantId:
+          type: string
+          nullable: true
+          description: Required if type is TENANT, must be null or undefined for GLOBAL
+    CreateClusterVariableRequest:
+      type: object
+      required:
+        - name
+        - value
+        - scope
+      properties:
+        name:
+          type: string
+        value:
+          oneOf:
+            - type: string
+            - type: object
+        scope:
+          $ref: '#/components/schemas/ClusterVariableScope'
+    ClusterVariableResult:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+        scope:
+          $ref: '#/components/schemas/ClusterVariableScope'
+    ClusterVariableSearchQuery:
+      description: Cluster variable search query request.
+      additionalProperties: false
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryRequest'
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterVariableSearchQuerySortRequest'
+        filter:
+          description: The cluster variable search filters.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableFilter'
+    ClusterVariableSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - name
+            - value
+            - tenantId
+            - scope
+        order:
+          $ref: 'enums.yaml#/components/schemas/SortOrderEnum'
+      required:
+        - field
+    ClusterVariableFilter:
+      description: Cluster variable filter request.
+      type: object
+      properties:
+        name:
+          description: Name of the cluster variable.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        value:
+          description: The value of the cluster variable.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        scope:
+          description: The scope filter for cluster variables.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableScopeFilter'
+    ClusterVariableScopeFilter:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [ GLOBAL, TENANT ]
+        tenantId:
+          description: Tenant identifier when type is TENANT.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+    ClusterVariableSearchQueryResult:
+      description: Cluster variable search query response.
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching cluster variables.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterVariableResult'

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -374,8 +374,10 @@ paths:
   # Cluster variables endpoints
   /cluster-variables:
     $ref: 'cluster-variables.yaml#/paths/~1cluster-variables'
-  /cluster-variables/{name}/{scope}/{tenantId}:
-    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1{name}~1{scope}~1{tenantId}'
+  /cluster-variables/{name}/GLOBAL:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1{name}~1GLOBAL'
+  /cluster-variables/{name}/TENANT/{tenantId}:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1{name}~1TENANT~1{tenantId}'
   /cluster-variables/search:
     $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1search'
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -371,6 +371,15 @@ paths:
   /variables/{variableKey}:
     $ref: 'variables.yaml#/paths/~1variables~1{variableKey}'
 
+  # Cluster variables endpoints
+  /cluster-variables:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables'
+  /cluster-variables/{name}/{scope}/{tenantId}:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1{name}~1{scope}~1{tenantId}'
+  /cluster-variables/search:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1search'
+
+
 components:
   securitySchemes:
     BearerAuth:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -32,6 +32,7 @@ tags:
   - name: Batch operation
   - name: Clock
   - name: Cluster
+  - name: Cluster Variable
   - name: Decision definition
   - name: Decision instance
   - name: Decision requirements

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -96,6 +96,18 @@ paths:
   /clock/reset:
     $ref: 'clock.yaml#/paths/~1clock~1reset'
 
+  # Cluster variables endpoints
+  /cluster-variables/global:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1global'
+  /cluster-variables/global/{name}:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1global~1{name}'
+  /cluster-variables/search:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1search'
+  /cluster-variables/tenants/{tenantId}:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1tenants~1{tenantId}'
+  /cluster-variables/tenants/{tenantId}/{name}:
+    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1tenants~1{tenantId}~1{name}'
+
   # Message endpoints
   /correlated-message-subscriptions/search:
     $ref: 'messages.yaml#/paths/~1correlated-message-subscriptions~1search'
@@ -371,17 +383,6 @@ paths:
     $ref: 'variables.yaml#/paths/~1variables~1search'
   /variables/{variableKey}:
     $ref: 'variables.yaml#/paths/~1variables~1{variableKey}'
-
-  # Cluster variables endpoints
-  /cluster-variables:
-    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables'
-  /cluster-variables/{name}/GLOBAL:
-    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1{name}~1GLOBAL'
-  /cluster-variables/{name}/TENANT/{tenantId}:
-    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1{name}~1TENANT~1{tenantId}'
-  /cluster-variables/search:
-    $ref: 'cluster-variables.yaml#/paths/~1cluster-variables~1search'
-
 
 components:
   securitySchemes:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.gateway.protocol.rest.BasicStringFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.DateTimeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionEvaluationInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionInstanceStateFilterProperty;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeser
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperatioItemStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationTypeFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.ClusterVariableScopeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.DateTimeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.DecisionEvaluationInstructionDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.DecisionInstanceStateFilterPropertyDeserializer;
@@ -83,6 +85,9 @@ public class JacksonConfig {
         new BatchOperationStateFilterPropertyDeserializer());
     module.addDeserializer(
         BatchOperationTypeFilterProperty.class, new BatchOperationTypeFilterPropertyDeserializer());
+    module.addDeserializer(
+        ClusterVariableScopeFilterProperty.class,
+        new ClusterVariableScopeFilterPropertyDeserializer());
     module.addDeserializer(
         BatchOperationItemStateFilterProperty.class,
         new BatchOperatioItemStateFilterPropertyDeserializer());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
@@ -44,48 +44,53 @@ public class ClusterVariableController {
     this.authenticationProvider = authenticationProvider;
   }
 
-  @CamundaPostMapping
-  public CompletableFuture<ResponseEntity<Object>> createClusterVariable(
+  @CamundaPostMapping(path = "/global")
+  public CompletableFuture<ResponseEntity<Object>> createGlobalClusterVariable(
       @RequestBody final CreateClusterVariableRequest createClusterVariableRequest) {
-    return RequestMapper.executeServiceMethod(
-        () ->
-            switch (createClusterVariableRequest.getScope()) {
-              case GLOBAL ->
-                  clusterVariableServices
-                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                      .createGloballyScopedClusterVariable(
-                          createClusterVariableRequest.getName(),
-                          createClusterVariableRequest.getValue());
-              case TENANT ->
-                  clusterVariableServices
-                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                      .createTenantScopedClusterVariable(
-                          createClusterVariableRequest.getName(),
-                          createClusterVariableRequest.getValue(),
-                          createClusterVariableRequest.getTenantId());
-            },
-        ResponseMapper::toClusterVariableCreateResponse);
-  }
-
-  @CamundaDeleteMapping(path = "/{name}/TENANT/{tenantId}")
-  public CompletableFuture<ResponseEntity<Object>> deleteTenantScopedClusterVariable(
-      @PathVariable("name") final String name, @PathVariable("tenantId") final String tenantId) {
     return RequestMapper.executeServiceMethod(
         () ->
             clusterVariableServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .deleteTenantScopedClusterVariable(name, tenantId),
-        ResponseMapper::toClusterVariableDeleteResponse);
+                .createGloballyScopedClusterVariable(
+                    createClusterVariableRequest.getName(),
+                    createClusterVariableRequest.getValue()),
+        ResponseMapper::toClusterVariableCreateResponse);
   }
 
-  @CamundaDeleteMapping(path = "/{name}/GLOBAL")
-  public CompletableFuture<ResponseEntity<Object>> deleteGloballyScopedClusterVariable(
+  @CamundaPostMapping(path = "/tenants/{tenantId}")
+  public CompletableFuture<ResponseEntity<Object>> createTenantClusterVariable(
+      @PathVariable("tenantId") final String tenantId,
+      @RequestBody final CreateClusterVariableRequest createClusterVariableRequest) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            clusterVariableServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .createTenantScopedClusterVariable(
+                    createClusterVariableRequest.getName(),
+                    createClusterVariableRequest.getValue(),
+                    tenantId),
+        ResponseMapper::toClusterVariableCreateResponse);
+  }
+
+  @CamundaDeleteMapping(path = "/global/{name}")
+  public CompletableFuture<ResponseEntity<Object>> deleteGlobalClusterVariable(
       @PathVariable("name") final String name) {
     return RequestMapper.executeServiceMethod(
         () ->
             clusterVariableServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteGloballyScopedClusterVariable(name),
+        ResponseMapper::toClusterVariableDeleteResponse);
+  }
+
+  @CamundaDeleteMapping(path = "/tenants/{tenantId}/{name}")
+  public CompletableFuture<ResponseEntity<Object>> deleteTenantClusterVariable(
+      @PathVariable("tenantId") final String tenantId, @PathVariable("name") final String name) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            clusterVariableServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .deleteTenantScopedClusterVariable(name, tenantId),
         ResponseMapper::toClusterVariableDeleteResponse);
   }
 
@@ -109,9 +114,8 @@ public class ClusterVariableController {
     }
   }
 
-  @CamundaGetMapping(path = "/{name}/GLOBAL")
-  public ResponseEntity<Object> getGloballyScopedClusterVariable(
-      @PathVariable("name") final String name) {
+  @CamundaGetMapping(path = "/global/{name}")
+  public ResponseEntity<Object> getGlobalClusterVariable(@PathVariable("name") final String name) {
     try {
       return ResponseEntity.ok()
           .body(
@@ -124,9 +128,9 @@ public class ClusterVariableController {
     }
   }
 
-  @CamundaGetMapping(path = "/{name}/TENANT/{tenantId}")
-  public ResponseEntity<Object> getTenantScopedClusterVariable(
-      @PathVariable("name") final String name, @PathVariable("tenantId") final String tenantId) {
+  @CamundaGetMapping(path = "/tenants/{tenantId}/{name}")
+  public ResponseEntity<Object> getTenantClusterVariable(
+      @PathVariable("tenantId") final String tenantId, @PathVariable("name") final String name) {
     try {
       return ResponseEntity.ok()
           .body(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.ClusterVariableServices;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScope;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableSearchQuery;
+import io.camunda.zeebe.gateway.protocol.rest.CreateClusterVariableRequest;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.mapper.RequestMapper;
+import io.camunda.zeebe.gateway.rest.mapper.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryResponseMapper;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequiresSecondaryStorage
+@RequestMapping("/v2/cluster-variables")
+public class ClusterVariableController {
+
+  private final ClusterVariableServices clusterVariableServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public ClusterVariableController(
+      final ClusterVariableServices clusterVariableServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.clusterVariableServices = clusterVariableServices;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaPostMapping
+  public CompletableFuture<ResponseEntity<Object>> createClusterVariable(
+      @RequestBody final CreateClusterVariableRequest createClusterVariableRequest) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            switch (createClusterVariableRequest.getScope().getType()) {
+              case GLOBAL ->
+                  clusterVariableServices
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                      .createGloballyScopedClusterVariable(
+                          createClusterVariableRequest.getName(),
+                          createClusterVariableRequest.getValue());
+              case TENANT ->
+                  clusterVariableServices
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                      .createTenantScopedClusterVariable(
+                          createClusterVariableRequest.getName(),
+                          createClusterVariableRequest.getValue(),
+                          createClusterVariableRequest.getScope().getTenantId());
+            },
+        ResponseMapper::toClusterVariableCreateResponse);
+  }
+
+  @CamundaDeleteMapping(path = "/{name}/{scope}/{tenantId}")
+  public CompletableFuture<ResponseEntity<Object>> deleteClusterVariable(
+      @PathVariable("name") final String name,
+      @PathVariable("scope") final ClusterVariableScope.TypeEnum scope,
+      @PathVariable(value = "tenantId", required = false) final String tenantId) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            switch (scope) {
+              case GLOBAL ->
+                  clusterVariableServices
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                      .deleteGloballyScopedClusterVariable(name);
+              case TENANT ->
+                  clusterVariableServices
+                      .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                      .deleteTenantScopedClusterVariable(name, tenantId);
+            },
+        ResponseMapper::toClusterVariableDeleteResponse);
+  }
+
+  @CamundaPostMapping(path = "/search")
+  private ResponseEntity<Object> search(final ClusterVariableSearchQuery query) {
+    return SearchQueryRequestMapper.toClusterVariableQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<Object> search(final ClusterVariableQuery query) {
+    try {
+      final var result =
+          clusterVariableServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .search(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toClusterVariableSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  @CamundaGetMapping(path = "/{name}/{scope}/{tenantId}")
+  public ResponseEntity<Object> getClusterVariable(
+      @PathVariable("name") final String name,
+      @PathVariable("scope") final ClusterVariableScope.TypeEnum scope,
+      @PathVariable(value = "tenantId", required = false) final String tenantId) {
+    try {
+      return switch (scope) {
+        case GLOBAL ->
+            ResponseEntity.ok()
+                .body(
+                    SearchQueryResponseMapper.toClusterVariable(
+                        clusterVariableServices
+                            .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                            .getGloballyScopedClusterVariable(name)));
+        case TENANT ->
+            ResponseEntity.ok()
+                .body(
+                    SearchQueryResponseMapper.toClusterVariable(
+                        clusterVariableServices
+                            .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                            .getTenantScopedClusterVariable(name, tenantId)));
+      };
+    } catch (final Exception e) {
+      return RestErrorMapper.mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/ClusterVariableScopeFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/ClusterVariableScopeFilterPropertyDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedClusterVariableScopeFilter;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeFilterProperty;
+
+public class ClusterVariableScopeFilterPropertyDeserializer
+    extends FilterDeserializer<ClusterVariableScopeFilterProperty, ClusterVariableScopeEnum> {
+
+  @Override
+  protected Class<? extends ClusterVariableScopeFilterProperty> getFinalType() {
+    return AdvancedClusterVariableScopeFilter.class;
+  }
+
+  @Override
+  protected Class<ClusterVariableScopeEnum> getImplicitValueType() {
+    return ClusterVariableScopeEnum.class;
+  }
+
+  @Override
+  protected ClusterVariableScopeFilterProperty createFromImplicitValue(
+      final ClusterVariableScopeEnum value) {
+    final var filter = new AdvancedClusterVariableScopeFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ResponseMapper.java
@@ -29,8 +29,7 @@ import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableResult;
-import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScope;
-import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScope.TypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionRequirementsResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionResult;
@@ -751,18 +750,16 @@ public final class ResponseMapper {
 
   public static ResponseEntity<Object> toClusterVariableCreateResponse(
       final ClusterVariableRecord clusterVariableRecord) {
-
-    final ClusterVariableScope clusterVariableScope =
-        new ClusterVariableScope()
-            .type(TypeEnum.fromValue(clusterVariableRecord.getScope().name()));
-    if (clusterVariableRecord.isTenantScoped()) {
-      clusterVariableScope.setTenantId(clusterVariableRecord.getTenantId());
-    }
-    return ResponseEntity.ok(
+    final var response =
         new ClusterVariableResult()
             .name(clusterVariableRecord.getName())
-            .value(clusterVariableRecord.getValue())
-            .scope(clusterVariableScope));
+            .value(clusterVariableRecord.getValue());
+    if (clusterVariableRecord.isTenantScoped()) {
+      response.scope(ClusterVariableScopeEnum.TENANT).tenantId(clusterVariableRecord.getTenantId());
+    } else {
+      response.scope(ClusterVariableScopeEnum.GLOBAL);
+    }
+    return ResponseEntity.ok(response);
   }
 
   public static ResponseEntity<Object> toClusterVariableDeleteResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/ResponseMapper.java
@@ -28,6 +28,9 @@ import io.camunda.zeebe.gateway.protocol.rest.ActivatedJobResult;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableResult;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScope;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScope.TypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionRequirementsResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionResult;
@@ -71,6 +74,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
@@ -743,6 +747,27 @@ public final class ResponseMapper {
                     .inputName(evaluatedInputValue.getInputName())
                     .inputValue(evaluatedInputValue.getInputValue()))
         .toList();
+  }
+
+  public static ResponseEntity<Object> toClusterVariableCreateResponse(
+      final ClusterVariableRecord clusterVariableRecord) {
+
+    final ClusterVariableScope clusterVariableScope =
+        new ClusterVariableScope()
+            .type(TypeEnum.fromValue(clusterVariableRecord.getScope().name()));
+    if (clusterVariableRecord.isTenantScoped()) {
+      clusterVariableScope.setTenantId(clusterVariableRecord.getTenantId());
+    }
+    return ResponseEntity.ok(
+        new ClusterVariableResult()
+            .name(clusterVariableRecord.getName())
+            .value(clusterVariableRecord.getValue())
+            .scope(clusterVariableScope));
+  }
+
+  public static ResponseEntity<Object> toClusterVariableDeleteResponse(
+      final ClusterVariableRecord unused) {
+    return ResponseEntity.noContent().build();
   }
 
   static class RestJobActivationResult

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -310,8 +310,12 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getValue())
         .map(mapToOperations(String.class))
         .ifPresent(builder::valueOperations);
-    ofNullable(filter.getScope()).map(Enum::name).ifPresent(builder::scopes);
-    ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+    ofNullable(filter.getScope())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::scopeOperations);
+    ofNullable(filter.getTenantId())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::tenantIdOperations);
 
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -18,6 +18,7 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
+import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.CorrelatedMessageSubscriptionFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
@@ -41,6 +42,7 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.zeebe.gateway.protocol.rest.BaseProcessInstanceFilterFields;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilterFields;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskVariableFilter;
@@ -289,6 +291,34 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getValue())
         .map(mapToOperations(String.class))
         .ifPresent(builder::valueOperations);
+
+    return builder.build();
+  }
+
+  static ClusterVariableFilter toClusterVariableFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.ClusterVariableFilter filter) {
+
+    if (filter == null) {
+      return FilterBuilders.clusterVariable().build();
+    }
+
+    final var builder = FilterBuilders.clusterVariable();
+
+    ofNullable(filter.getName())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::nameOperations);
+    ofNullable(filter.getValue())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::valueOperations);
+    ofNullable(filter.getScope())
+        .map(ClusterVariableScopeFilter::getType)
+        .map(Enum::name)
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::scopeOperations);
+    ofNullable(filter.getScope())
+        .map(ClusterVariableScopeFilter::getTenantId)
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::tenantIdOperations);
 
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -42,7 +42,7 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.zeebe.gateway.protocol.rest.BaseProcessInstanceFilterFields;
-import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeFilter;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableSearchQueryFilterRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilterFields;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskVariableFilter;
@@ -296,7 +296,7 @@ public class SearchQueryFilterMapper {
   }
 
   static ClusterVariableFilter toClusterVariableFilter(
-      final io.camunda.zeebe.gateway.protocol.rest.ClusterVariableFilter filter) {
+      final ClusterVariableSearchQueryFilterRequest filter) {
 
     if (filter == null) {
       return FilterBuilders.clusterVariable().build();
@@ -310,15 +310,8 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getValue())
         .map(mapToOperations(String.class))
         .ifPresent(builder::valueOperations);
-    ofNullable(filter.getScope())
-        .map(ClusterVariableScopeFilter::getType)
-        .map(Enum::name)
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::scopeOperations);
-    ofNullable(filter.getScope())
-        .map(ClusterVariableScopeFilter::getTenantId)
-        .map(mapToOperations(String.class))
-        .ifPresent(builder::tenantIdOperations);
+    ofNullable(filter.getScope()).map(Enum::name).ifPresent(builder::scopes);
+    ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
 
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.*;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateDate;
 
+import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
@@ -23,6 +24,7 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -458,6 +460,24 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyVariableSortField);
     final VariableFilter filter = SearchQueryFilterMapper.toVariableFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
+  }
+
+  public static Either<ProblemDetail, ClusterVariableQuery> toClusterVariableQuery(
+      final ClusterVariableSearchQuery request) {
+
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.clusterVariableSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromClusterVariableSearchQuerySortRequest(
+                request.getSort()),
+            SortOptionBuilders::clusterVariable,
+            SearchQuerySortRequestMapper::applyClusterVariableSortField);
+    final ClusterVariableFilter filter =
+        SearchQueryFilterMapper.toClusterVariableFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::clusterVariableSearchQuery);
   }
 
   public static Either<ProblemDetail, UserQuery> toUserQuery(final UserSearchQueryRequest request) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -463,7 +463,7 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, ClusterVariableQuery> toClusterVariableQuery(
-      final ClusterVariableSearchQuery request) {
+      final ClusterVariableSearchQueryRequest request) {
 
     if (request == null) {
       return Either.right(SearchQueryBuilders.clusterVariableSearchQuery().build());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -65,7 +65,7 @@ import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.CamundaUserResult;
 import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableResult;
-import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScope;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.CorrelatedMessageSubscriptionResult;
 import io.camunda.zeebe.gateway.protocol.rest.CorrelatedMessageSubscriptionSearchQueryResult;
@@ -1217,21 +1217,19 @@ public final class SearchQueryResponseMapper {
   public static ClusterVariableResult toClusterVariable(
       final ClusterVariableEntity clusterVariableEntity) {
 
-    final ClusterVariableScope scope = new ClusterVariableScope();
-    switch (clusterVariableEntity.scope()) {
-      case GLOBAL -> scope.setType(ClusterVariableScope.TypeEnum.GLOBAL);
-      case TENANT -> {
-        scope.setType(ClusterVariableScope.TypeEnum.TENANT);
-        scope.setTenantId(clusterVariableEntity.tenantId());
-      }
-      // This case should never happen, because we can not export a cluster variable
-      // with a scope that is not GLOBAL or TENANT. But we handle it gracefully
-      default -> {}
-    }
-    return new ClusterVariableResult()
-        .name(clusterVariableEntity.name())
-        .value(clusterVariableEntity.value())
-        .scope(scope);
+    ClusterVariableResult clusterVariableResult =
+        new ClusterVariableResult()
+            .name(clusterVariableEntity.name())
+            .value(clusterVariableEntity.value());
+    clusterVariableResult =
+        switch (clusterVariableEntity.scope()) {
+          case GLOBAL -> clusterVariableResult.scope(ClusterVariableScopeEnum.GLOBAL);
+          case TENANT ->
+              clusterVariableResult
+                  .scope(ClusterVariableScopeEnum.TENANT)
+                  .tenantId(clusterVariableEntity.tenantId());
+        };
+    return clusterVariableResult;
   }
 
   public static AuthorizationSearchResult toAuthorizationSearchQueryResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -1216,20 +1216,17 @@ public final class SearchQueryResponseMapper {
 
   public static ClusterVariableResult toClusterVariable(
       final ClusterVariableEntity clusterVariableEntity) {
-
-    ClusterVariableResult clusterVariableResult =
+    final var clusterVariableResult =
         new ClusterVariableResult()
             .name(clusterVariableEntity.name())
             .value(clusterVariableEntity.value());
-    clusterVariableResult =
-        switch (clusterVariableEntity.scope()) {
-          case GLOBAL -> clusterVariableResult.scope(ClusterVariableScopeEnum.GLOBAL);
-          case TENANT ->
-              clusterVariableResult
-                  .scope(ClusterVariableScopeEnum.TENANT)
-                  .tenantId(clusterVariableEntity.tenantId());
-        };
-    return clusterVariableResult;
+    return switch (clusterVariableEntity.scope()) {
+      case GLOBAL -> clusterVariableResult.scope(ClusterVariableScopeEnum.GLOBAL);
+      case TENANT ->
+          clusterVariableResult
+              .scope(ClusterVariableScopeEnum.TENANT)
+              .tenantId(clusterVariableEntity.tenantId());
+    };
   }
 
   public static AuthorizationSearchResult toAuthorizationSearchQueryResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_UNKNOW
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
 import io.camunda.search.sort.BatchOperationSort;
+import io.camunda.search.sort.ClusterVariableSort;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.DecisionRequirementsSort;
@@ -165,6 +166,12 @@ public class SearchQuerySortRequestMapper {
 
   static List<SearchQuerySortRequest<VariableSearchQuerySortRequest.FieldEnum>>
       fromVariableSearchQuerySortRequest(final List<VariableSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  static List<SearchQuerySortRequest<ClusterVariableSearchQuerySortRequest.FieldEnum>>
+      fromClusterVariableSearchQuerySortRequest(
+          final List<ClusterVariableSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
@@ -655,6 +662,24 @@ public class SearchQuerySortRequestMapper {
         case VARIABLE_KEY -> builder.variableKey();
         case SCOPE_KEY -> builder.scopeKey();
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  static List<String> applyClusterVariableSortField(
+      final ClusterVariableSearchQuerySortRequest.FieldEnum field,
+      final ClusterVariableSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case VALUE -> builder.value();
+        case NAME -> builder.name();
+        case TENANT_ID -> builder.tenantId();
+        case SCOPE -> builder.scope();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerCreateClusterVariableRequest
+    extends BrokerExecuteCommand<ClusterVariableRecord> {
+
+  private final ClusterVariableRecord requestDto = new ClusterVariableRecord();
+
+  public BrokerCreateClusterVariableRequest() {
+    super(ValueType.CLUSTER_VARIABLE, ClusterVariableIntent.CREATE);
+  }
+
+  public BrokerCreateClusterVariableRequest setGlobalScope() {
+    requestDto.setScope(ClusterVariableScope.GLOBAL);
+    return this;
+  }
+
+  public BrokerCreateClusterVariableRequest setTenantScope(final String tenantId) {
+    requestDto.setScope(ClusterVariableScope.TENANT).setTenantId(tenantId);
+    return this;
+  }
+
+  public BrokerCreateClusterVariableRequest setName(final String name) {
+    requestDto.setName(name);
+    return this;
+  }
+
+  public BrokerCreateClusterVariableRequest setValue(final DirectBuffer value) {
+    requestDto.setValue(value);
+    return this;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ClusterVariableRecord toResponseDto(final DirectBuffer buffer) {
+    final ClusterVariableRecord responseDto = new ClusterVariableRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteClusterVariableRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteClusterVariableRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerDeleteClusterVariableRequest
+    extends BrokerExecuteCommand<ClusterVariableRecord> {
+
+  private final ClusterVariableRecord requestDto = new ClusterVariableRecord();
+
+  public BrokerDeleteClusterVariableRequest() {
+    super(ValueType.CLUSTER_VARIABLE, ClusterVariableIntent.DELETE);
+  }
+
+  public BrokerDeleteClusterVariableRequest setGlobalScope() {
+    requestDto.setScope(ClusterVariableScope.GLOBAL);
+    return this;
+  }
+
+  public BrokerDeleteClusterVariableRequest setTenantScope(final String tenantId) {
+    requestDto.setScope(ClusterVariableScope.TENANT).setTenantId(tenantId);
+    return this;
+  }
+
+  public BrokerDeleteClusterVariableRequest setName(final String name) {
+    requestDto.setName(name);
+    return this;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ClusterVariableRecord toResponseDto(final DirectBuffer buffer) {
+    final ClusterVariableRecord responseDto = new ClusterVariableRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
This pull request introduces support for managing cluster-wide variables in the Camunda Java client. The main changes add new APIs for creating, deleting, fetching, and searching cluster variables, as well as related filtering and sorting capabilities. This expands the client’s ability to handle variables at both global and tenant scopes.

**Cluster Variable Management API:**

* Added new interfaces for creating (`ClusterVariableCreationCommandStep1`) and deleting (`ClusterVariableDeletionCommandStep1`) cluster variables, supporting both global and tenant scopes. [[1]](diffhunk://#diff-6c7a2c58966f1f09052604cc6b089283c1b884ce68f320cb83389322b5caafa6R1-R31) [[2]](diffhunk://#diff-b5c1a100fc53273f73cffd6b37422c414576820283c8cec1ff3e1409e79fa902R1-R31)
* Introduced response types for cluster variable creation and deletion (`CreateClusterVariableResponse`, `DeleteClusterVariableResponse`). [[1]](diffhunk://#diff-0885537f7afd450afe8fa73fc4afd8648a005c61264a8947e98a869e3a76f5e0R1-R29) [[2]](diffhunk://#diff-631428c48a30459fe4160d15b1ca2e9ba1e174aa26f494f747849cf43bdff8efR1-R18)
* Implemented a fetch request interface (`ClusterVariableGetRequest`) to retrieve cluster variables by name and scope.

**Cluster Variable Search and Filtering:**

* Added a search request interface (`ClusterVariableSearchRequest`) for querying cluster variables, along with filter (`ClusterVariableFilter`) and sort (`ClusterVariableSort`) interfaces for advanced search capabilities. [[1]](diffhunk://#diff-3dbe93e9c3506506114c1ae2feaef5f7d26940bd0056f0aa326c461fe202d47cR1-R25) [[2]](diffhunk://#diff-1cba3a0c14c7da229e87b617c011d0b2e3972b4d6f1da42115ac080d96caa4ffR1-R72) [[3]](diffhunk://#diff-be9a7f4245813a44ad1513aa8b0ac464e90ff04580714c326070eb0edc4699f9R1-R28)
* Updated the `SearchRequestBuilders` utility to support building cluster variable filters and sorts.

**Supporting Types and Integration:**

* Defined the `ClusterVariableScope` enum to distinguish between global and tenant scopes.
* Added the `ClusterVariable` response interface to represent cluster variable data in search results.
* Integrated the new cluster variable APIs into the main `CamundaClient` and its implementation, making them available for use. [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR1892-R1899) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R138) [[3]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R194)

These changes collectively enable robust cluster variable management and querying directly from the Camunda Java client.


closes https://github.com/camunda/camunda/issues/39060
