### PR TITLE
fix: os archiver do not copy runtime settings

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -22,9 +22,7 @@ import static io.camunda.operate.store.opensearch.dsl.QueryDSL.lte;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.sortOptions;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.stringTerms;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.term;
-import static io.camunda.operate.store.opensearch.dsl.RequestDSL.createIndexRequestBuilder;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.deleteByQueryRequestBuilder;
-import static io.camunda.operate.store.opensearch.dsl.RequestDSL.getIndexRequestBuilder;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.reindexRequestBuilder;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.time;
@@ -260,9 +258,6 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final String idFieldName,
       final List<Object> processInstanceKeys) {
-    if (!richOpenSearchClient.index().indexExists(destinationIndexName)) {
-      createIndexAs(sourceIndexName, destinationIndexName);
-    }
 
     final Query sourceQuery =
         stringTerms(idFieldName, processInstanceKeys.stream().map(Object::toString).toList());
@@ -294,17 +289,6 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
   private long getAutoSlices() {
     return operateProperties.getOpensearch().getNumberOfShards();
-  }
-
-  private void createIndexAs(final String sourceIndexName, final String destinationIndexName) {
-    final var srcIndex =
-        richOpenSearchClient
-            .index()
-            .get(getIndexRequestBuilder(sourceIndexName))
-            .get(sourceIndexName);
-    richOpenSearchClient
-        .index()
-        .createIndexWithRetries(createIndexRequestBuilder(destinationIndexName, srcIndex).build());
   }
 
   private Either<Throwable, ArchiveBatch> handleSearchResponse(

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
@@ -175,8 +175,6 @@ public class OpensearchArchiverRepositoryTest {
 
   @Test
   public void testReindexDocuments() {
-    when(richOpenSearchClient.index()).thenReturn(openSearchIndexOperations);
-    when(openSearchIndexOperations.indexExists(anyString())).thenReturn(true);
     when(operateProperties.getOpensearch()).thenReturn(operateOpensearchProperties);
     when(operateOpensearchProperties.getNumberOfShards()).thenReturn(5);
     try (final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
@@ -201,8 +199,6 @@ public class OpensearchArchiverRepositoryTest {
 
   @Test
   public void testReindexDocumentsError() {
-    when(richOpenSearchClient.index()).thenReturn(openSearchIndexOperations);
-    when(openSearchIndexOperations.indexExists(anyString())).thenReturn(true);
     when(operateProperties.getOpensearch()).thenReturn(operateOpensearchProperties);
     when(operateOpensearchProperties.getNumberOfShards()).thenReturn(5);
     try (final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Operate's Opensearch archiver was manually creating a mirror index to perform the reindexing into. This resulted in the new index also copying the parent settings.

Using the `updateSchemaSettings` had no effect on Opensearch as the dated indices were not created with the updated template but rather on the parent settings that we never automatically modify regarding the `shard_count`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41172
