### PR TITLE
test: fix closing multipart boundary in tests

### DIFF
--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -1005,7 +1005,7 @@ X-Document-Metadata: {"fileName": "test.pdf", "size": 1234567}
 Content-Type: application/pdf
 
 < ../test.pdf
---boundary123
+--boundary123--
 
 > {%
   client.test("Document upload should be successful", function () {
@@ -1045,6 +1045,7 @@ Accept: application/octet-stream
 DELETE {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/documents/{{DOCUMENT_ID}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
+Accept: */*
 
 > {%
   client.test("Document deletion should succeed", function () {

--- a/qa/http/user-authorizations-tests.http
+++ b/qa/http/user-authorizations-tests.http
@@ -777,7 +777,7 @@ X-Document-Metadata: {"fileName": "test.pdf", "size": 1234567}
 Content-Type: application/pdf
 
 < ./test.pdf
---boundary123
+--boundary123--
 
 > {%
   client.test("Document upload should be successful", function () {
@@ -813,7 +813,7 @@ X-Document-Metadata: {"fileName": "test.pdf", "size": 1234567}
 Content-Type: application/pdf
 
 < ./test.pdf
---boundary123
+--boundary123--
 
 > {%
   client.test("Document upload should be unsuccessful", function () {


### PR DESCRIPTION
This pull request updates the HTTP test files to fix multipart boundary formatting and improve request headers for document upload and deletion tests. The main changes ensure proper multipart syntax and enhance compatibility with different content types.

**Multipart boundary formatting fixes:**

* Changed the closing boundary in multipart requests from `---boundary123` to the correct `--boundary123--` in both `c8run-tests.http` and `user-authorizations-tests.http` for document upload tests. [[1]](diffhunk://#diff-04a8d5fedbbe7c8ac77bb81f444849e46aad816d44c367dedf0ac843980c11feL1008-R1008) [[2]](diffhunk://#diff-d09e2d2f8e3d7f109c2c4b26cdd8183bc6b7744e6ec204d453593264eab5b1cfL780-R780) [[3]](diffhunk://#diff-d09e2d2f8e3d7f109c2c4b26cdd8183bc6b7744e6ec204d453593264eab5b1cfL816-R816)

**Request header improvements:**

* Added `Accept: */*` to the document deletion request in `c8run-tests.http` to ensure the client accepts any content type in the response.
