### PR TITLE
feat: Add version note to maxHttpConnections property

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
@@ -111,7 +111,7 @@ public class CamundaClientProperties {
    */
   private Duration requestTimeoutOffset = DEFAULT_REQUEST_TIMEOUT_OFFSET;
 
-  /** The maximum number of concurrent HTTP connections the client can open. */
+  /** The maximum number of concurrent HTTP connections the client can open. Available since 8.8.4. */
   private int maxHttpConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
 
   public CamundaClientCloudProperties getCloud() {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
@@ -111,7 +111,7 @@ public class CamundaClientProperties {
    */
   private Duration requestTimeoutOffset = DEFAULT_REQUEST_TIMEOUT_OFFSET;
 
-  /** 
+  /**
    * The maximum number of concurrent HTTP connections the client can open. Available since 8.8.4.
    */
   private int maxHttpConnections = DEFAULT_MAX_HTTP_CONNECTIONS;

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
@@ -111,7 +111,9 @@ public class CamundaClientProperties {
    */
   private Duration requestTimeoutOffset = DEFAULT_REQUEST_TIMEOUT_OFFSET;
 
-  /** The maximum number of concurrent HTTP connections the client can open. Available since 8.8.4. */
+  /** 
+   * The maximum number of concurrent HTTP connections the client can open. Available since 8.8.4.
+   */
   private int maxHttpConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
 
   public CamundaClientCloudProperties getCloud() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a description on the property as suggested here: https://github.com/camunda/camunda-docs/pull/7354#discussion_r2540852881

A backport is not required as the affected properties reference is only generated for docs 8.8 onwards.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
