### PR TITLE
feat: show tags in operate UI

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/processes.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/processes.ts
@@ -30,6 +30,7 @@ const processInstanceSchema = z.object({
 	processDefinitionKey: z.string(),
 	parentProcessInstanceKey: z.string().optional(),
 	parentElementInstanceKey: z.string().optional(),
+	tags: z.array(z.string().min(1).max(100).regex(/^[A-Za-z][A-Za-z0-9_\-:.]{0,99}$/)).max(10).optional(),
 });
 type ProcessInstance = z.infer<typeof processInstanceSchema>;
 

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import isNil from 'lodash/isNil';
+import {isNil, isEmpty} from 'lodash';
 import {formatDate} from 'modules/utils/date';
 import {ProcessInstanceOperations} from './ProcessInstanceOperations';
 import {getProcessDefinitionName} from 'modules/utils/instance';
@@ -16,7 +16,7 @@ import {panelStatesStore} from 'modules/stores/panelStates';
 import {tracking} from 'modules/tracking';
 import {InstanceHeader} from 'modules/components/InstanceHeader';
 import {Skeleton} from 'modules/components/InstanceHeader/Skeleton';
-import {VersionTag} from './styled';
+import {VersionTag, ProcessTags} from './styled';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {hasCalledProcessInstances} from 'modules/bpmn-js/utils/hasCalledProcessInstances';
@@ -28,6 +28,7 @@ const headerColumns = [
   'Process Instance Key',
   'Version',
   'Version Tag',
+  'Tags',
   'Tenant',
   'Start Date',
   'End Date',
@@ -86,6 +87,7 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     hasIncident,
     processDefinitionId,
   } = processInstance;
+  const tags = (processInstance as ProcessInstance & {tags?: string[]}).tags;
   const tenantsById = useAvailableTenants();
   const tenantName = tenantsById[tenantId] ?? tenantId;
 
@@ -106,6 +108,7 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
     isMultiTenancyEnabled ? ` - ${tenantName}` : ''
   }`;
   const hasVersionTag = !isNil(processDefinitionVersionTag);
+  const hasTags = !isNil(tags) && !isEmpty(tags);
   const processInstanceState = hasIncident ? 'INCIDENT' : state;
 
   return (
@@ -118,6 +121,9 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
         }
         if (name === 'Version Tag') {
           return hasVersionTag;
+        }
+        if (name === 'Tags') {
+          return hasTags;
         }
         return true;
       })}
@@ -164,6 +170,22 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
                     {processDefinitionVersionTag}
                   </VersionTag>
                 ),
+              },
+            ]
+          : []),
+        ...(hasTags
+          ? [
+              {
+                title: tags.join(', '),
+                content: tags.map((tag: string, index: number) => (
+                  <ProcessTags
+                    key={`${tag}-${index}`}
+                    size="sm"
+                    type="cool-gray"
+                  >
+                    {tag}
+                  </ProcessTags>
+                )),
               },
             ]
           : []),

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/styled.tsx
@@ -13,4 +13,15 @@ const VersionTag = styled(Tag)`
   margin-left: 0;
 `;
 
-export {VersionTag};
+const ProcessTags = styled(Tag)`
+  margin-left: var(--cds-spacing-03);
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 0;
+
+  &:first-child {
+    margin-left: 0;
+  }
+`;
+
+export {VersionTag, ProcessTags};


### PR DESCRIPTION
### Description
Show tags in operate UI

### Changes
- enhance `processInstanceSchema` with tags
- add optional tags in InstanceHeader at Process Instance View

### Current Tags view
#### Normal Tags View
<img width="2552" height="776" alt="image" src="https://github.com/user-attachments/assets/16c2b47a-b163-4b95-97ff-42fe8b04dc76" />

#### Responsive Tags View
<img width="1271" height="784" alt="image" src="https://github.com/user-attachments/assets/e8ba6c7f-ce02-4e80-9c05-fec1c0095440" />

#### Optional Tags View -- Process Instance with no tags
<img width="2548" height="580" alt="image" src="https://github.com/user-attachments/assets/bb882df5-a8d7-4ec1-b2dd-69c2b23835dc" />

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37210
