### PR TITLE
test: add explicit delay to download document test

### DIFF
--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -1029,6 +1029,10 @@ Content-Type: application/pdf
 
 ###
 # @name download-document-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}


### PR DESCRIPTION
This pull request introduces a minor update to the `c8run-tests.http` file used for QA HTTP tests. The change adds a delay before performing the `download-document-authorized` request, likely to ensure proper timing or readiness of the system under test.

* Added a 2-second wait using the `wait` function from `../js/wait` before executing the `download-document-authorized` API call in `c8run-tests.http`.