### PR TITLE
ci: speedup MacOS Intel smoke tests

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -46,7 +46,7 @@ jobs:
         arch: [ amd64 ]
         include:
           - os: macos
-            runner: macos-15-intel
+            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
## Description

After (re-)introducing MacOS on Intel runners for Zeebe smoke tests with https://github.com/camunda/camunda/pull/40893, we are close to breaching our CI SLOs:

<img width="546" height="305" alt="image" src="https://github.com/user-attachments/assets/b6d2c6b7-b55e-4eb6-9d5b-c437d5ad8cf1" />

Hypothesis: Use [12-core](https://docs.github.com/en/actions/reference/runners/larger-runners) instead of 4-core MacOS Intel runners from GitHub will speed the job up. It will [increase price per runtime minute](https://docs.github.com/en/billing/reference/actions-runner-pricing#x64-powered-larger-runners) by 50%.

https://github.com/camunda/camunda/actions/runs/19503262488/job/55822558358?pr=41223 shows a **reduction of runtime from >13min down to 6min.** Overall, this means **we save money** since we managed to reduce runtime by more than 100% + **achieving our CI SLO again**.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
