### PR TITLE
feat: add decisionInstanceTTL to cleanup DIs without PI

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RdbmsHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsHistory.java
@@ -20,6 +20,12 @@ public class RdbmsHistory {
    */
   private Duration defaultHistoryTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_HISTORY_TTL;
 
+  /**
+   * The default time to live for decision instances without a process instance. Specified in Java
+   * Duration format.
+   */
+  private Duration decisionInstanceTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_HISTORY_TTL;
+
   /** The default time to live for all batch operations. Specified in Java Duration format. */
   private Duration defaultBatchOperationHistoryTTL =
       RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
@@ -153,6 +159,14 @@ public class RdbmsHistory {
 
   public void setDefaultHistoryTTL(final Duration defaultHistoryTTL) {
     this.defaultHistoryTTL = defaultHistoryTTL;
+  }
+
+  public Duration getDecisionInstanceTTL() {
+    return decisionInstanceTTL;
+  }
+
+  public void setDecisionInstanceTTL(final Duration decisionInstanceTTL) {
+    this.decisionInstanceTTL = decisionInstanceTTL;
   }
 
   public Duration getUsageMetricsCleanup() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -114,7 +114,7 @@ public class RdbmsWriter {
     decisionDefinitionWriter = new DecisionDefinitionWriter(executionQueue);
     decisionInstanceWriter =
         new DecisionInstanceWriter(
-            decisionInstanceMapper, executionQueue, vendorDatabaseProperties);
+            decisionInstanceMapper, executionQueue, vendorDatabaseProperties, config);
     decisionRequirementsWriter = new DecisionRequirementsWriter(executionQueue);
     flowNodeInstanceWriter = new FlowNodeInstanceWriter(executionQueue, flowNodeInstanceMapper);
     groupWriter = new GroupWriter(executionQueue);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -81,6 +81,7 @@ public record RdbmsWriterConfig(
 
   public record HistoryConfig(
       Duration defaultHistoryTTL,
+      Duration decisionInstanceTTL,
       Duration batchOperationCancelProcessInstanceHistoryTTL,
       Duration batchOperationMigrateProcessInstanceHistoryTTL,
       Duration batchOperationModifyProcessInstanceHistoryTTL,
@@ -106,6 +107,7 @@ public record RdbmsWriterConfig(
     public static class Builder implements ObjectBuilder<HistoryConfig> {
 
       private Duration defaultHistoryTTL = DEFAULT_HISTORY_TTL;
+      private Duration decisionInstanceTTL = DEFAULT_HISTORY_TTL;
       private Duration batchOperationCancelProcessInstanceHistoryTTL =
           DEFAULT_BATCH_OPERATION_HISTORY_TTL;
       private Duration batchOperationMigrateProcessInstanceHistoryTTL =
@@ -122,6 +124,11 @@ public record RdbmsWriterConfig(
 
       public HistoryConfig.Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
         this.defaultHistoryTTL = defaultHistoryTTL;
+        return this;
+      }
+
+      public HistoryConfig.Builder decisionInstanceTTL(final Duration decisionInstanceTTL) {
+        this.decisionInstanceTTL = decisionInstanceTTL;
         return this;
       }
 
@@ -183,6 +190,7 @@ public record RdbmsWriterConfig(
       public HistoryConfig build() {
         return new HistoryConfig(
             defaultHistoryTTL,
+            decisionInstanceTTL,
             batchOperationCancelProcessInstanceHistoryTTL,
             batchOperationMigrateProcessInstanceHistoryTTL,
             batchOperationModifyProcessInstanceHistoryTTL,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
@@ -91,6 +91,33 @@ public record DecisionInstanceDbModel(
         historyCleanupDate);
   }
 
+  public Builder toBuilder() {
+    return new Builder()
+        .decisionInstanceId(decisionInstanceId)
+        .decisionInstanceKey(decisionInstanceKey)
+        .state(state)
+        .evaluationDate(evaluationDate)
+        .evaluationFailure(evaluationFailure)
+        .evaluationFailureMessage(evaluationFailureMessage)
+        .result(result)
+        .flowNodeInstanceKey(flowNodeInstanceKey)
+        .flowNodeId(flowNodeId)
+        .processInstanceKey(processInstanceKey)
+        .processDefinitionKey(processDefinitionKey)
+        .processDefinitionId(processDefinitionId)
+        .decisionDefinitionKey(decisionDefinitionKey)
+        .decisionDefinitionId(decisionDefinitionId)
+        .decisionRequirementsKey(decisionRequirementsKey)
+        .decisionRequirementsId(decisionRequirementsId)
+        .rootDecisionDefinitionKey(rootDecisionDefinitionKey)
+        .decisionType(decisionType)
+        .tenantId(tenantId)
+        .partitionId(partitionId)
+        .evaluatedInputs(evaluatedInputs)
+        .evaluatedOutputs(evaluatedOutputs)
+        .historyCleanupDate(historyCleanupDate);
+  }
+
   public static final class Builder implements ObjectBuilder<DecisionInstanceDbModel> {
 
     private String decisionInstanceId;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.sql.ProcessBasedHistoryCleanupMapper;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -24,47 +25,64 @@ public class DecisionInstanceWriter {
   private final DecisionInstanceMapper mapper;
   private final ExecutionQueue executionQueue;
   private final VendorDatabaseProperties vendorDatabaseProperties;
+  private final RdbmsWriterConfig config;
 
   public DecisionInstanceWriter(
       final DecisionInstanceMapper mapper,
       final ExecutionQueue executionQueue,
-      final VendorDatabaseProperties vendorDatabaseProperties) {
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final RdbmsWriterConfig config) {
     this.mapper = mapper;
     this.executionQueue = executionQueue;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
+    this.config = config;
   }
 
   public void create(final DecisionInstanceDbModel decisionInstance) {
+    // Set cleanup date for decision instances without a process instance
+    final DecisionInstanceDbModel processedInstance;
+    if ((decisionInstance.processInstanceKey() == null
+            || decisionInstance.processInstanceKey() == -1L)
+        && decisionInstance.historyCleanupDate() == null) {
+      processedInstance =
+          decisionInstance.toBuilder()
+              .historyCleanupDate(
+                  decisionInstance.evaluationDate().plus(config.history().decisionInstanceTTL()))
+              .build();
+    } else {
+      processedInstance = decisionInstance;
+    }
+
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.DECISION_INSTANCE,
             WriteStatementType.INSERT,
-            decisionInstance.decisionInstanceKey(),
+            processedInstance.decisionInstanceKey(),
             "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insert",
-            decisionInstance.truncateErrorMessage(
+            processedInstance.truncateErrorMessage(
                 vendorDatabaseProperties.errorMessageSize(),
                 vendorDatabaseProperties.charColumnMaxBytes())));
-    if (decisionInstance.evaluatedInputs() != null
-        && !decisionInstance.evaluatedInputs().isEmpty()) {
+    if (processedInstance.evaluatedInputs() != null
+        && !processedInstance.evaluatedInputs().isEmpty()) {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.DECISION_INSTANCE,
               WriteStatementType.INSERT,
-              decisionInstance.decisionInstanceKey(),
+              processedInstance.decisionInstanceKey(),
               "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insertInput",
-              decisionInstance.truncateErrorMessage(
+              processedInstance.truncateErrorMessage(
                   vendorDatabaseProperties.errorMessageSize(),
                   vendorDatabaseProperties.charColumnMaxBytes())));
     }
-    if (decisionInstance.evaluatedOutputs() != null
-        && !decisionInstance.evaluatedOutputs().isEmpty()) {
+    if (processedInstance.evaluatedOutputs() != null
+        && !processedInstance.evaluatedOutputs().isEmpty()) {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.DECISION_INSTANCE,
               WriteStatementType.INSERT,
-              decisionInstance.decisionInstanceKey(),
+              processedInstance.decisionInstanceKey(),
               "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insertOutput",
-              decisionInstance.truncateErrorMessage(
+              processedInstance.truncateErrorMessage(
                   vendorDatabaseProperties.errorMessageSize(),
                   vendorDatabaseProperties.charColumnMaxBytes())));
     }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class DecisionInstanceWriterTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.now();
+  private static final Duration CLEANUP_DURATION = Duration.ofDays(10);
+
+  private final DecisionInstanceMapper decisionInstanceMapper =
+      Mockito.mock(DecisionInstanceMapper.class);
+  private final ExecutionQueue executionQueue = Mockito.mock(ExecutionQueue.class);
+  private final VendorDatabaseProperties vendorDatabaseProperties =
+      Mockito.mock(VendorDatabaseProperties.class);
+  private final RdbmsWriterConfig rdbmsWriterConfig =
+      Mockito.mock(RdbmsWriterConfig.class, Mockito.RETURNS_DEEP_STUBS);
+
+  private final DecisionInstanceWriter decisionInstanceWriter =
+      new DecisionInstanceWriter(
+          decisionInstanceMapper, executionQueue, vendorDatabaseProperties, rdbmsWriterConfig);
+
+  @BeforeEach
+  public void init() {
+    Mockito.when(rdbmsWriterConfig.history().decisionInstanceTTL()).thenReturn(CLEANUP_DURATION);
+  }
+
+  @Test
+  void shouldNotSetHistoryCleanupWhenDecisionInstanceCreatedWithProcessInstance() {
+    final var model =
+        new DecisionInstanceDbModel.Builder()
+            .decisionInstanceId("decision-instance-1")
+            .processInstanceKey(1L)
+            .evaluationDate(NOW)
+            .build();
+
+    decisionInstanceWriter.create(model);
+
+    final var queueItemCaptor = ArgumentCaptor.forClass(QueueItem.class);
+    Mockito.verify(executionQueue).executeInQueue(queueItemCaptor.capture());
+    final var capturedModel = (DecisionInstanceDbModel) queueItemCaptor.getValue().parameter();
+
+    assertThat(capturedModel.historyCleanupDate()).isNull();
+  }
+
+  @Test
+  void shouldSetHistoryCleanupWhenDecisionInstanceCreatedWithoutProcessInstance() {
+    final var model =
+        new DecisionInstanceDbModel.Builder()
+            .decisionInstanceId("decision-instance-1")
+            .evaluationDate(NOW)
+            .build();
+
+    decisionInstanceWriter.create(model);
+
+    final var queueItemCaptor = ArgumentCaptor.forClass(QueueItem.class);
+    Mockito.verify(executionQueue).executeInQueue(queueItemCaptor.capture());
+    final var capturedModel = (DecisionInstanceDbModel) queueItemCaptor.getValue().parameter();
+
+    assertThat(capturedModel.historyCleanupDate()).isEqualTo(NOW.plus(CLEANUP_DURATION));
+  }
+
+  @Test
+  void shouldSetHistoryCleanupWhenDecisionInstanceCreatedWithAbsentProcessInstance() {
+    final var model =
+        new DecisionInstanceDbModel.Builder()
+            .decisionInstanceId("decision-instance-1")
+            .processInstanceKey(-1L)
+            .evaluationDate(NOW)
+            .build();
+
+    decisionInstanceWriter.create(model);
+
+    final var queueItemCaptor = ArgumentCaptor.forClass(QueueItem.class);
+    Mockito.verify(executionQueue).executeInQueue(queueItemCaptor.capture());
+    final var capturedModel = (DecisionInstanceDbModel) queueItemCaptor.getValue().parameter();
+
+    assertThat(capturedModel.historyCleanupDate()).isEqualTo(NOW.plus(CLEANUP_DURATION));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -180,4 +180,34 @@ public class HistoryCleanupIT {
             + "'",
         OffsetDateTime.class);
   }
+
+  @Test
+  public void shouldSetHistoryCleanupDateForDecisionInstanceWithoutProcessInstance() {
+    // GIVEN
+    // Create a decision instance without a processInstanceKey (using -1)
+    // Use a deterministic evaluation date for predictable cleanup date calculation
+    final var evaluationDate = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+    final var decisionInstance =
+        DecisionInstanceFixtures.createAndSaveRandomDecisionInstance(
+            rdbmsWriter,
+            b -> b.processInstanceKey(-1L).evaluationDate(evaluationDate).historyCleanupDate(null));
+    rdbmsWriter.flush();
+
+    // THEN - verify cleanup date is calculated correctly
+    final OffsetDateTime cleanupDate =
+        jdbcTemplate.queryForObject(
+            "SELECT HISTORY_CLEANUP_DATE FROM DECISION_INSTANCE "
+                + "WHERE DECISION_INSTANCE_KEY = "
+                + decisionInstance.decisionInstanceKey(),
+            OffsetDateTime.class);
+
+    // The cleanup date should be evaluationDate + decisionInstanceTTL (default 30 days)
+    final var expectedCleanupDate = evaluationDate.plusDays(30);
+    assertThat(cleanupDate)
+        .describedAs(
+            "should have cleanup date set to evaluationDate + decisionInstanceTTL for decision"
+                + " instance without process instance")
+        .isNotNull()
+        .isEqualTo(expectedCleanupDate);
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -134,6 +134,7 @@ public class ExporterConfiguration {
     final var historyConfig =
         new HistoryConfig.Builder()
             .defaultHistoryTTL(history.getDefaultHistoryTTL())
+            .decisionInstanceTTL(history.getDecisionInstanceTTL())
             .batchOperationCancelProcessInstanceHistoryTTL(
                 history.getBatchOperationCancelProcessInstanceHistoryTTL())
             .batchOperationMigrateProcessInstanceHistoryTTL(
@@ -180,6 +181,7 @@ public class ExporterConfiguration {
   public static class HistoryConfiguration {
     // history cleanup configuration
     private Duration defaultHistoryTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_HISTORY_TTL;
+    private Duration decisionInstanceTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_HISTORY_TTL;
     private Duration defaultBatchOperationHistoryTTL =
         RdbmsWriterConfig.HistoryConfig.DEFAULT_BATCH_OPERATION_HISTORY_TTL;
     // specific history TTLs for batch operations
@@ -206,6 +208,14 @@ public class ExporterConfiguration {
 
     public void setDefaultHistoryTTL(final Duration defaultHistoryTTL) {
       this.defaultHistoryTTL = defaultHistoryTTL;
+    }
+
+    public Duration getDecisionInstanceTTL() {
+      return decisionInstanceTTL;
+    }
+
+    public void setDecisionInstanceTTL(final Duration decisionInstanceTTL) {
+      this.decisionInstanceTTL = decisionInstanceTTL;
     }
 
     public Duration getDefaultBatchOperationHistoryTTL() {


### PR DESCRIPTION
## Description

Adds configuration and logic to schedule decision instances without a related processInstance for history cleanup.

## Related issues

closes #38899 