### PR TITLE
ci: use 8.9 Helm chart for integration tests

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -20,7 +20,7 @@ jobs:
     secrets: inherit
     with:
       identifier: camunda-helm-int
-      camunda-helm-dir: camunda-platform-8.8
+      camunda-helm-dir: camunda-platform-8.9
       test-enabled: true
       caller-git-ref: main
       extra-values: |


### PR DESCRIPTION
## Description

We need to update the Helm chart used for integration tests at some point. https://github.com/camunda/camunda/pull/39981 proposed the same thing, but was closed without details.

Having the Helm chart integration tests back with up2date versions will give confidence in the changes in https://github.com/camunda/camunda/issues/40739

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/40739
