### PR TITLE
34042 node selection reset filter

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type { Locator, Page } from '@playwright/test';
+import type {Locator, Page} from '@playwright/test';
 
 export class OperateDiagramPage {
   private page: Page;
@@ -47,16 +47,14 @@ export class OperateDiagramPage {
   }
 
   clickFlowNode(flowNodeName: string) {
-    return this.getFlowNode(flowNodeName)
-      .first()
-      .click({ timeout: 20000 });
+    return this.getFlowNode(flowNodeName).first().click({timeout: 20000});
   }
 
   clickSubProcess(subProcessName: string) {
     // Click on the top left corner of the sub process.
     // This avoids clicking on child elements inside the sub process.
     return this.getFlowNode(subProcessName).click({
-      position: { x: 5, y: 5 },
+      position: {x: 5, y: 5},
       force: true,
     });
   }
@@ -75,7 +73,7 @@ export class OperateDiagramPage {
   async getLabeledElement(eventName: string) {
     const eventLabel = this.diagram
       .locator('.djs-element')
-      .filter({ hasText: new RegExp(`${eventName}`, 'i') });
+      .filter({hasText: new RegExp(`${eventName}`, 'i')});
 
     const labelId = await eventLabel.getAttribute('data-element-id');
     const eventId = labelId?.split(/_label$/)[0];
@@ -84,20 +82,20 @@ export class OperateDiagramPage {
 
   showMetaData() {
     return this.popover
-      .getByRole('button', { name: 'show more metadata' })
+      .getByRole('button', {name: 'show more metadata'})
       .click();
   }
 
   getExecutionCount(elementId: string) {
     return this.diagram.evaluate(
-      (node, { elementId }) => {
+      (node, {elementId}) => {
         const completedOverlay: HTMLDivElement | null = node.querySelector(
           `[data-container-id="${elementId}"] [data-testid="state-overlay-completed"]`,
         );
 
         return completedOverlay?.innerText;
       },
-      { elementId },
+      {elementId},
     );
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {Locator, Page} from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 export class OperateDiagramPage {
   private page: Page;
@@ -47,22 +47,24 @@ export class OperateDiagramPage {
   }
 
   clickFlowNode(flowNodeName: string) {
-    return this.getFlowNode(flowNodeName).first().click();
+    return this.getFlowNode(flowNodeName)
+      .first()
+      .click({ timeout: 20000 });
   }
 
   clickSubProcess(subProcessName: string) {
     // Click on the top left corner of the sub process.
     // This avoids clicking on child elements inside the sub process.
     return this.getFlowNode(subProcessName).click({
-      position: {x: 5, y: 5},
+      position: { x: 5, y: 5 },
       force: true,
     });
   }
 
   getFlowNode(flowNodeName: string) {
     return this.diagram
-      .locator('.djs-element')
-      .filter({hasText: new RegExp(`^${flowNodeName}$`, 'i')});
+      .locator('.djs-group')
+      .locator(`[data-element-id="${flowNodeName}"]`);
   }
 
   async clickDiagramElement(elementName: string) {
@@ -73,7 +75,7 @@ export class OperateDiagramPage {
   async getLabeledElement(eventName: string) {
     const eventLabel = this.diagram
       .locator('.djs-element')
-      .filter({hasText: new RegExp(`${eventName}`, 'i')});
+      .filter({ hasText: new RegExp(`${eventName}`, 'i') });
 
     const labelId = await eventLabel.getAttribute('data-element-id');
     const eventId = labelId?.split(/_label$/)[0];
@@ -82,20 +84,20 @@ export class OperateDiagramPage {
 
   showMetaData() {
     return this.popover
-      .getByRole('button', {name: 'show more metadata'})
+      .getByRole('button', { name: 'show more metadata' })
       .click();
   }
 
   getExecutionCount(elementId: string) {
     return this.diagram.evaluate(
-      (node, {elementId}) => {
+      (node, { elementId }) => {
         const completedOverlay: HTMLDivElement | null = node.querySelector(
           `[data-container-id="${elementId}"] [data-testid="state-overlay-completed"]`,
         );
 
         return completedOverlay?.innerText;
       },
-      {elementId},
+      { elementId },
     );
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Page, Locator, expect } from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 
 type OptionalFilter =
   | 'Variable'
@@ -56,22 +56,22 @@ export class OperateFiltersPanelPage {
     this.page = page;
     this.runningInstancesCheckbox = this.page
       .locator('label')
-      .filter({ hasText: 'Running' });
+      .filter({hasText: 'Running'});
     this.activeInstancesCheckbox = this.page
       .locator('label')
-      .filter({ hasText: 'Active' });
+      .filter({hasText: 'Active'});
     this.incidentsInstancesCheckbox = this.page
       .locator('label')
-      .filter({ hasText: 'Incidents' });
+      .filter({hasText: 'Incidents'});
     this.completedInstancesCheckbox = this.page
       .locator('label')
-      .filter({ hasText: 'Completed' });
+      .filter({hasText: 'Completed'});
     this.canceledInstancesCheckbox = this.page
       .locator('label')
-      .filter({ hasText: 'Canceled' });
+      .filter({hasText: 'Canceled'});
     this.finishedInstancesCheckbox = this.page
       .locator('label')
-      .filter({ hasText: 'Finished' });
+      .filter({hasText: 'Finished'});
     this.processNameFilter = this.page.getByRole('combobox', {
       name: 'Name',
     });
@@ -157,23 +157,23 @@ export class OperateFiltersPanelPage {
   }
 
   async removeOptionalFilter(filterName: OptionalFilter) {
-    await this.page.getByLabel(filterName, { exact: true }).hover();
+    await this.page.getByLabel(filterName, {exact: true}).hover();
     await this.page.getByLabel(`Remove ${filterName} Filter`).click();
   }
 
   async selectProcess(option: string) {
     await this.processNameFilter.click();
-    await this.page.getByRole('option', { name: option, exact: true }).click();
+    await this.page.getByRole('option', {name: option, exact: true}).click();
   }
 
   async selectVersion(option: string) {
     await this.processVersionFilter.click();
-    await this.page.getByRole('option', { name: option, exact: true }).click();
+    await this.page.getByRole('option', {name: option, exact: true}).click();
   }
 
   async selectFlowNode(option: string) {
     await this.flowNodeFilter.click();
-    await this.page.getByRole('option', { name: option }).click();
+    await this.page.getByRole('option', {name: option}).click();
   }
 
   async fillVariableNameFilter(name: string) {
@@ -216,7 +216,7 @@ export class OperateFiltersPanelPage {
     await expect(this.dateFilterDialog).toBeVisible();
 
     const date = new Date();
-    const monthName = date.toLocaleString('default', { month: 'long' });
+    const monthName = date.toLocaleString('default', {month: 'long'});
     const year = date.getFullYear();
 
     await this.fromDateInput.click();
@@ -257,11 +257,11 @@ export class OperateFiltersPanelPage {
   }
 
   async clickMultipleVariablesSwitch() {
-    await this.multipleVariablesSwitch.click({ force: true });
+    await this.multipleVariablesSwitch.click({force: true});
   }
 
   async clickRunningInstancesCheckbox(): Promise<void> {
-    await this.runningInstancesCheckbox.click({ timeout: 60000 });
+    await this.runningInstancesCheckbox.click({timeout: 60000});
   }
 
   async clickActiveInstancesCheckbox(): Promise<void> {
@@ -269,17 +269,17 @@ export class OperateFiltersPanelPage {
   }
 
   async clickIncidentsInstancesCheckbox(): Promise<void> {
-    await this.incidentsInstancesCheckbox.click({ timeout: 60000 });
+    await this.incidentsInstancesCheckbox.click({timeout: 60000});
   }
 
   async clickFinishedInstancesCheckbox(): Promise<void> {
-    await this.finishedInstancesCheckbox.click({ timeout: 60000 });
+    await this.finishedInstancesCheckbox.click({timeout: 60000});
   }
 
   async clickCompletedInstancesCheckbox(): Promise<void> {
-    await this.completedInstancesCheckbox.click({ timeout: 60000 });
+    await this.completedInstancesCheckbox.click({timeout: 60000});
   }
   async clickCanceledInstancesCheckbox(): Promise<void> {
-    await this.canceledInstancesCheckbox.click({ timeout: 60000 });
+    await this.canceledInstancesCheckbox.click({timeout: 60000});
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Page, Locator, expect } from '@playwright/test';
-import { OperateDiagramPage } from './OperateDiagramPage';
-import { sleep } from '../utils/sleep';
-import { checkUpdateOnVersion } from 'utils/zeebeClient';
+import {Page, Locator, expect} from '@playwright/test';
+import {OperateDiagramPage} from './OperateDiagramPage';
+import {sleep} from '../utils/sleep';
+import {checkUpdateOnVersion} from 'utils/zeebeClient';
 
 class OperateProcessesPage {
   private page: Page;
@@ -43,11 +43,11 @@ class OperateProcessesPage {
     this.processResultCount = page.getByTestId('result-count');
     this.processPageHeading = page
       .getByTestId('expanded-panel')
-      .getByRole('heading', { name: 'Process' });
+      .getByRole('heading', {name: 'Process'});
     this.noMatchingInstancesMessage = page.getByText(
       'There are no Instances matching this filter set',
     );
-    this.processNameFilter = page.getByRole('combobox', { name: 'name' });
+    this.processNameFilter = page.getByRole('combobox', {name: 'name'});
     this.processInstanceLink = page
       .getByRole('link', {
         name: 'view instance',
@@ -87,16 +87,16 @@ class OperateProcessesPage {
     );
     this.applyCancelBatchOperationDialogButton = page
       .getByRole('dialog')
-      .getByRole('button', { name: 'Apply' });
+      .getByRole('button', {name: 'Apply'});
     this.continueMigrationDialogButton = page
       .getByRole('dialog')
-      .getByRole('button', { name: 'Continue' });
+      .getByRole('button', {name: 'Continue'});
     this.cancelProcessInstanceButton = page
-      .getByRole('button', { name: 'Cancel Instance' })
+      .getByRole('button', {name: 'Cancel Instance'})
       .first();
     this.cancelProcessInstanceDialogButton = page
       .getByRole('dialog')
-      .getByRole('button', { name: 'Apply' });
+      .getByRole('button', {name: 'Apply'});
     this.singleCancellationSpinner = page.getByTestId('operation-spinner');
     this.tableLoadingSpinner = page.getByTestId('data-table-loader');
   }
@@ -105,7 +105,7 @@ class OperateProcessesPage {
     await this.processNameFilter.click();
     await this.processNameFilter.fill(name);
     await this.page.keyboard.press('Enter');
-    await this.page.getByRole('heading', { name }).waitFor({ state: 'visible' });
+    await this.page.getByRole('heading', {name}).waitFor({state: 'visible'});
   }
 
   async clickProcessInstanceLink(): Promise<void> {
@@ -225,9 +225,9 @@ class OperateProcessesPage {
       .filter({
         has: page
           .getByTestId('cell-processInstanceKey')
-          .filter({ hasText: keyStr }),
+          .filter({hasText: keyStr}),
       });
   }
 }
 
-export { OperateProcessesPage };
+export {OperateProcessesPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator, expect} from '@playwright/test';
-import {OperateDiagramPage} from './OperateDiagramPage';
-import {sleep} from '../utils/sleep';
-import {checkUpdateOnVersion} from 'utils/zeebeClient';
+import { Page, Locator, expect } from '@playwright/test';
+import { OperateDiagramPage } from './OperateDiagramPage';
+import { sleep } from '../utils/sleep';
+import { checkUpdateOnVersion } from 'utils/zeebeClient';
 
 class OperateProcessesPage {
   private page: Page;
@@ -43,11 +43,11 @@ class OperateProcessesPage {
     this.processResultCount = page.getByTestId('result-count');
     this.processPageHeading = page
       .getByTestId('expanded-panel')
-      .getByRole('heading', {name: 'Process'});
+      .getByRole('heading', { name: 'Process' });
     this.noMatchingInstancesMessage = page.getByText(
       'There are no Instances matching this filter set',
     );
-    this.processNameFilter = page.getByRole('combobox', {name: 'name'});
+    this.processNameFilter = page.getByRole('combobox', { name: 'name' });
     this.processInstanceLink = page
       .getByRole('link', {
         name: 'view instance',
@@ -87,16 +87,16 @@ class OperateProcessesPage {
     );
     this.applyCancelBatchOperationDialogButton = page
       .getByRole('dialog')
-      .getByRole('button', {name: 'Apply'});
+      .getByRole('button', { name: 'Apply' });
     this.continueMigrationDialogButton = page
       .getByRole('dialog')
-      .getByRole('button', {name: 'Continue'});
+      .getByRole('button', { name: 'Continue' });
     this.cancelProcessInstanceButton = page
-      .getByRole('button', {name: 'Cancel Instance'})
+      .getByRole('button', { name: 'Cancel Instance' })
       .first();
     this.cancelProcessInstanceDialogButton = page
       .getByRole('dialog')
-      .getByRole('button', {name: 'Apply'});
+      .getByRole('button', { name: 'Apply' });
     this.singleCancellationSpinner = page.getByTestId('operation-spinner');
     this.tableLoadingSpinner = page.getByTestId('data-table-loader');
   }
@@ -105,7 +105,7 @@ class OperateProcessesPage {
     await this.processNameFilter.click();
     await this.processNameFilter.fill(name);
     await this.page.keyboard.press('Enter');
-    await this.page.getByRole('heading', {name}).waitFor({state: 'visible'});
+    await this.page.getByRole('heading', { name }).waitFor({ state: 'visible' });
   }
 
   async clickProcessInstanceLink(): Promise<void> {
@@ -225,9 +225,9 @@ class OperateProcessesPage {
       .filter({
         has: page
           .getByTestId('cell-processInstanceKey')
-          .filter({hasText: keyStr}),
+          .filter({ hasText: keyStr }),
       });
   }
 }
 
-export {OperateProcessesPage};
+export { OperateProcessesPage };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/NamedEventsProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/NamedEventsProcess.bpmn
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="eb92200" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="NamedEventsProcess" name="NamedEventsProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_OrderReceived" name="Order received">
+      <bpmn:outgoing>Flow_18wuolb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_SendOrderConfirmation" name="Send order confirmation">
+      <bpmn:incoming>Flow_18wuolb</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fudmr8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_18wuolb" sourceRef="StartEvent_OrderReceived" targetRef="Activity_SendOrderConfirmation" />
+    <bpmn:intermediateThrowEvent id="Event_OrderConfirmed" name="Order Confirmed">
+      <bpmn:incoming>Flow_1fudmr8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pwra77</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_1fudmr8" sourceRef="Activity_SendOrderConfirmation" targetRef="Event_OrderConfirmed" />
+    <bpmn:task id="Activity_PackItems" name="Pack Items">
+      <bpmn:incoming>Flow_0pwra77</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mrasjb</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0pwra77" sourceRef="Event_OrderConfirmed" targetRef="Activity_PackItems" />
+    <bpmn:task id="Activity_SendItems" name="Send items">
+      <bpmn:incoming>Flow_1mrasjb</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jqiolh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1mrasjb" sourceRef="Activity_PackItems" targetRef="Activity_SendItems" />
+    <bpmn:endEvent id="Event_OrderFulfilled" name="Order fulfilled">
+      <bpmn:incoming>Flow_1jqiolh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1jqiolh" sourceRef="Activity_SendItems" targetRef="Event_OrderFulfilled" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="NamedEventsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_OrderReceived">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="132" y="143" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lamzw9_di" bpmnElement="Activity_SendOrderConfirmation">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hpaa0w_di" bpmnElement="Event_OrderConfirmed">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="380" y="143" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dgrk0t_di" bpmnElement="Activity_PackItems">
+        <dc:Bounds x="500" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dh6toz_di" bpmnElement="Activity_SendItems">
+        <dc:Bounds x="670" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dy1clr_di" bpmnElement="Event_OrderFulfilled">
+        <dc:Bounds x="842" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="828" y="143" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_18wuolb_di" bpmnElement="Flow_18wuolb">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fudmr8_di" bpmnElement="Flow_1fudmr8">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pwra77_di" bpmnElement="Flow_0pwra77">
+        <di:waypoint x="438" y="118" />
+        <di:waypoint x="500" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mrasjb_di" bpmnElement="Flow_1mrasjb">
+        <di:waypoint x="600" y="118" />
+        <di:waypoint x="670" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jqiolh_di" bpmnElement="Flow_1jqiolh">
+        <di:waypoint x="770" y="118" />
+        <di:waypoint x="842" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -256,6 +256,7 @@ test.describe('Process Instances Filters', () => {
     });
 
     await test.step('Filter by process instance key with one key and assert results', async ({ }) => {
+      await operateFiltersPanelPage.clickResetFilters();
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
 
@@ -295,7 +296,7 @@ test.describe('Process Instances Filters', () => {
       await expect(
         operateFiltersPanelPage.finishedInstancesCheckbox,
       ).toBeEnabled();
-      await operateFiltersPanelPage.finishedInstancesCheckbox.click();
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
 
       await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
         `${variableProcessInstanceKey}, ${callActivityProcessInstanceKey}`,
@@ -403,8 +404,8 @@ test.describe('Process Instances Filters', () => {
       await operateOperationPanelPage.collapseOperationIdField();
 
       await operateFiltersPanelPage.clickResetFilters();
-      await operateFiltersPanelPage.runningInstancesCheckbox.click();
-      await operateFiltersPanelPage.finishedInstancesCheckbox.click();
+      await operateFiltersPanelPage.clickRunningInstancesCheckbox();
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
       await operateFiltersPanelPage.displayOptionalFilter('Operation Id');
       await operateFiltersPanelPage.fillOperationIdFilter(operationId);
 
@@ -504,7 +505,7 @@ test.describe('Process Instances Filters', () => {
         },
       });
 
-      await operateFiltersPanelPage.finishedInstancesCheckbox.click();
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
       await expect
         .poll(() => operateProcessesPage.processInstancesTable.count())
         .toBeGreaterThanOrEqual(2);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -407,6 +407,16 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.clickResetFilters();
       await operateFiltersPanelPage.clickRunningInstancesCheckbox();
       await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.processInstancesTable.first()).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
       await operateFiltersPanelPage.displayOptionalFilter('Operation Id');
       await operateFiltersPanelPage.fillOperationIdFilter(operationId);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -6,16 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { test } from 'fixtures';
-import { expect } from '@playwright/test';
-import { deploy, createInstances, createSingleInstance } from 'utils/zeebeClient';
-import { captureScreenshot, captureFailureVideo } from '@setup';
-import { navigateToApp } from '@pages/UtilitiesPage';
-import { waitForAssertion } from 'utils/waitForAssertion';
-import { sleep } from 'utils/sleep';
-import { OperateOperationPanelPage } from '@pages/OperateOperationPanelPage';
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {sleep} from 'utils/sleep';
+import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 
-type ProcessInstance = { processInstanceKey: number };
+type ProcessInstance = {processInstanceKey: number};
 
 let callActivityProcessInstance: ProcessInstance;
 let orderProcessInstance: ProcessInstance;
@@ -51,7 +51,7 @@ test.beforeAll(async () => {
 
   callActivityProcessInstance = {
     processInstanceKey: Number(
-      (await createSingleInstance('CallActivityProcess', 1, { filtersTest: 456 }))
+      (await createSingleInstance('CallActivityProcess', 1, {filtersTest: 456}))
         .processInstanceKey,
     ),
   };
@@ -59,7 +59,7 @@ test.beforeAll(async () => {
   await deploy(['./resources/Variable_Process.bpmn']);
   variableProcessInstance = {
     processInstanceKey: Number(
-      (await createSingleInstance('Variable_Process', 1, { filtersTest: 604 }))
+      (await createSingleInstance('Variable_Process', 1, {filtersTest: 604}))
         .processInstanceKey,
     ),
   };
@@ -71,14 +71,14 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instances Filters', () => {
-  test.beforeEach(async ({ page, loginPage, operateHomePage }) => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });
 
-  test.afterEach(async ({ page }, testInfo) => {
+  test.afterEach(async ({page}, testInfo) => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
@@ -228,7 +228,7 @@ test.describe('Process Instances Filters', () => {
       await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
     });
 
-    await test.step('Filter by variable and assert results', async ({ }) => {
+    await test.step('Filter by variable and assert results', async ({}) => {
       await operateFiltersPanelPage.displayOptionalFilter('Variable');
       await operateFiltersPanelPage.fillVariableNameFilter('filtersTest');
       await operateFiltersPanelPage.fillVariableValueFilter('604');
@@ -256,7 +256,7 @@ test.describe('Process Instances Filters', () => {
       });
     });
 
-    await test.step('Filter by process instance key with one key and assert results', async ({ }) => {
+    await test.step('Filter by process instance key with one key and assert results', async ({}) => {
       await operateFiltersPanelPage.clickResetFilters();
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
@@ -281,7 +281,7 @@ test.describe('Process Instances Filters', () => {
       });
     });
 
-    await test.step('Filter by process instance key with multiple keys and assert results', async ({ }) => {
+    await test.step('Filter by process instance key with multiple keys and assert results', async ({}) => {
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
       const callActivityProcessInstanceKey =
@@ -326,14 +326,14 @@ test.describe('Process Instances Filters', () => {
     await test.step('Filter by variable and operation id and assert results', async () => {
       const processToCancelMeowInstance = {
         processInstanceKey: Number(
-          (await createSingleInstance('ProcessToCancel', 1, { sound: 'meow' }))
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))
             .processInstanceKey,
         ),
       };
 
       const processToCancelGawInstance = {
         processInstanceKey: Number(
-          (await createSingleInstance('ProcessToCancel', 1, { sound: 'gaw' }))
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'gaw'}))
             .processInstanceKey,
         ),
       };
@@ -372,7 +372,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -410,7 +410,9 @@ test.describe('Process Instances Filters', () => {
 
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessesPage.processInstancesTable.first()).toBeVisible();
+          await expect(
+            operateProcessesPage.processInstancesTable.first(),
+          ).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();
@@ -459,7 +461,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -483,7 +485,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -509,7 +511,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -556,7 +558,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 60000 });
+          ).toBeVisible({timeout: 60000});
         },
         onFailure: async () => {
           await page.reload();
@@ -642,11 +644,11 @@ test.describe('Process Instances Filters', () => {
             exact: true,
           },
         ),
-      ).toBeVisible({ timeout: 60000 });
+      ).toBeVisible({timeout: 60000});
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           callActivityProcessInstanceKey.toString(),
-          { exact: true },
+          {exact: true},
         ),
       ).toBeHidden();
     });
@@ -673,7 +675,7 @@ test.describe('Process Instances Filters', () => {
     });
 
     await test.step('Check that process instances table is filtered correctly', async () => {
-      await expect(page.getByText('2 results')).toBeVisible({ timeout: 60000 });
+      await expect(page.getByText('2 results')).toBeVisible({timeout: 60000});
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           orderProcessInstanceKey.toString(),
@@ -685,7 +687,7 @@ test.describe('Process Instances Filters', () => {
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           callActivityProcessInstanceKey.toString(),
-          { exact: true },
+          {exact: true},
         ),
       ).toBeVisible();
     });
@@ -700,8 +702,9 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.selectProcess('NamedEventsProcess');
       await waitForAssertion({
         assertion: async () => {
-          await expect(
-            operateFiltersPanelPage.processNameFilter).toHaveValue('NamedEventsProcess');
+          await expect(operateFiltersPanelPage.processNameFilter).toHaveValue(
+            'NamedEventsProcess',
+          );
         },
         onFailure: async () => {
           await page.reload();
@@ -712,38 +715,48 @@ test.describe('Process Instances Filters', () => {
 
     await test.step('Click start flow node and assert filter value and results', async () => {
       await operateDiagramPage.clickFlowNode('StartEvent_OrderReceived');
-      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('Order received');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Order received',
+      );
     });
 
     await test.step('Click task flow nodes and assert filter value and results', async () => {
       await operateDiagramPage.clickFlowNode('Activity_SendOrderConfirmation');
-      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('Send order confirmation');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Send order confirmation',
+      );
 
       await operateDiagramPage.clickFlowNode('Activity_PackItems');
-      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('Pack Items');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Pack Items',
+      );
 
       await operateDiagramPage.clickFlowNode('Activity_SendItems');
-      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('Send items');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Send items',
+      );
     });
 
     await test.step('Click end event flow node and assert filter value and results', async () => {
       await operateDiagramPage.clickFlowNode('Event_OrderFulfilled');
-      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('Order fulfilled');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Order fulfilled',
+      );
     });
 
     await test.step('Click intermediate throw event flow node and assert results', async () => {
       await operateDiagramPage.clickFlowNode('Event_OrderConfirmed');
-      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('Order Confirmed');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Order Confirmed',
+      );
     });
 
     await test.step('Click same flow node again and see filter is removed', async () => {
       await operateDiagramPage.clickFlowNode('Event_OrderConfirmed');
 
-      await expect(
-        operateFiltersPanelPage.flowNodeFilter,
-      ).toHaveValue('');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('');
     });
-  })
+  });
 
   test('Reset filters when navigating away and assert results', async ({
     page,
@@ -763,8 +776,9 @@ test.describe('Process Instances Filters', () => {
 
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessesPage.processInstanceKeyCell)
-            .toHaveText(variableProcessInstanceKey);
+          await expect(operateProcessesPage.processInstanceKeyCell).toHaveText(
+            variableProcessInstanceKey,
+          );
         },
         onFailure: async () => {
           await page.reload();
@@ -787,18 +801,23 @@ test.describe('Process Instances Filters', () => {
 
     await test.step('Click on the "Process" link button in the header and assert the results', async () => {
       await operateHomePage.clickProcessesTab();
-      await expect(operateFiltersPanelPage.processInstanceKeysFilter).toBeHidden();
+      await expect(
+        operateFiltersPanelPage.processInstanceKeysFilter,
+      ).toBeHidden();
       await expect(operateFiltersPanelPage.variableNameFilter).toBeHidden();
-      await operateFiltersPanelPage
-        .validateCheckedState(
-          [operateFiltersPanelPage.activeInstancesCheckbox,
+      await operateFiltersPanelPage.validateCheckedState(
+        [
+          operateFiltersPanelPage.activeInstancesCheckbox,
           operateFiltersPanelPage.incidentsInstancesCheckbox,
-          operateFiltersPanelPage.runningInstancesCheckbox],
+          operateFiltersPanelPage.runningInstancesCheckbox,
+        ],
 
-          [operateFiltersPanelPage.finishedInstancesCheckbox,
+        [
+          operateFiltersPanelPage.finishedInstancesCheckbox,
           operateFiltersPanelPage.completedInstancesCheckbox,
-          operateFiltersPanelPage.canceledInstancesCheckbox]
-        );
+          operateFiltersPanelPage.canceledInstancesCheckbox,
+        ],
+      );
     });
-  })
+  });
 });


### PR DESCRIPTION
## Description
In Operate added flow node selection filter and reset filters when navigating away

## Related issues
closes #34042
part of #33949

## Related on demand workflow
[Was successful ](https://github.com/camunda/camunda/actions/runs/19504648329)