### PR TITLE
Default bulk flush delay now 1s

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Bulk.java
+++ b/configuration/src/main/java/io/camunda/configuration/Bulk.java
@@ -14,7 +14,7 @@ import org.springframework.util.unit.DataSize;
 
 public class Bulk {
 
-  private static final Duration DEFAULT_DELAY = Duration.ofSeconds(5);
+  private static final Duration DEFAULT_DELAY = Duration.ofSeconds(1);
   private static final int DEFAULT_SIZE = 1_000;
   private static final DataSize DEFAULT_MEMORY_LIMIT = DataSize.ofMegabytes(20);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -141,7 +141,7 @@ public class ExporterConfiguration {
 
   public static class BulkConfiguration {
     // delay before forced flush
-    private int delay = 5;
+    private int delay = 1;
     // bulk size before flush
     private int size = 1_000;
     // bulk memory utilisation before flush (in Mb)


### PR DESCRIPTION
## Description

According to the findings documented in https://github.com/camunda/camunda/issues/33165, a 1s flush interval should have no effect on throughput but decrease the time to visibility for low load environments.

Matching docs PR https://github.com/camunda/camunda-docs/pull/7215

## Related issues

closes #33165 
