### PR TITLE
fix: Lease.isStillValid was adding leaseDuration incorrectly to verify validity

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -138,7 +138,7 @@ public class DynamicNodeIdIT {
       final var payload = lease.readAllBytes();
       if (payload.length > 0) {
         final var parsed = Lease.fromJsonBytes(OBJECT_MAPPER, payload);
-        if (parsed.isStillValid(System.currentTimeMillis(), LEASE_DURATION)) {
+        if (parsed.isStillValid(System.currentTimeMillis())) {
           leases.add(parsed);
         }
       }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -43,12 +43,12 @@ public record Lease(String taskId, long timestamp, NodeInstance nodeInstance) {
     return objectMapper.readValue(json, Lease.class);
   }
 
-  public boolean isStillValid(final long now, final Duration leaseDuration) {
-    return timestamp + leaseDuration.toMillis() > now;
+  public boolean isStillValid(final long now) {
+    return now <= timestamp;
   }
 
   public Lease renew(final long now, final Duration leaseDuration) {
-    if (!isStillValid(now, leaseDuration)) {
+    if (!isStillValid(now)) {
       throw new IllegalStateException(
           "Lease is not valid anymore("
               + Instant.ofEpochMilli(now)

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -83,8 +83,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   public CompletableFuture<Boolean> isValid() {
     final var now = clock.millis();
     return CompletableFuture.supplyAsync(
-            () -> currentLease != null && currentLease.lease().isStillValid(now, leaseDuration),
-            executor)
+            () -> currentLease != null && currentLease.lease().isStillValid(now), executor)
         .orTimeout(leaseDuration.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS)
         .exceptionally(
             t -> {
@@ -160,7 +159,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     try {
       switch (lease) {
         case final Initialized initialized -> {
-          if (initialized.lease().isStillValid(clock.millis(), leaseDuration)) {
+          if (initialized.lease().isStillValid(clock.millis())) {
             LOG.debug("Lease {} is held by another process, skipping it", initialized);
             return null;
           } else {
@@ -216,8 +215,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
       if (renewalTask != null) {
         renewalTask.cancel(true);
       }
-      if (currentLease != null
-          && currentLease.lease().isStillValid(clock.millis(), leaseDuration)) {
+      if (currentLease != null && currentLease.lease().isStillValid(clock.millis())) {
         nodeIdRepository.release(currentLease);
       }
     } finally {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -93,7 +93,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
     final PutObjectRequest putRequest =
         createPutObjectRequest(nodeId, Optional.of(metadata), Optional.of(previousETag)).build();
     try {
-      if (!lease.isStillValid(clock.millis(), config.leaseDuration)) {
+      if (!lease.isStillValid(clock.millis())) {
         throw new IllegalArgumentException("The provided lease is not valid anymore: " + lease);
       }
       LOG.debug("Acquiring lease {}, previous ETag {}", lease, previousETag);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -21,9 +21,17 @@ public class LeaseTest {
   final Lease lease = new Lease("task1", originalTimestamp, nodeInstance);
 
   @Test
+  public void shouldReturnIfValid() {
+    assertThat(lease.isStillValid(originalTimestamp)).isTrue();
+    assertThat(lease.isStillValid(originalTimestamp + 1)).isFalse();
+    assertThat(lease.isStillValid(originalTimestamp - 1)).isTrue();
+    assertThat(lease.isStillValid(0)).isTrue();
+  }
+
+  @Test
   public void shouldRenewCorrectlyWhenValid() {
     // given
-    final var currentTime = 2000L;
+    final var currentTime = 500L;
     final var renewalDuration = Duration.ofSeconds(5);
 
     // when
@@ -40,7 +48,7 @@ public class LeaseTest {
     // given
     final var currentTime = 10000L;
     final var renewalDuration = Duration.ofSeconds(5);
-    assertThat(lease.isStillValid(currentTime, renewalDuration)).isFalse();
+    assertThat(lease.isStillValid(currentTime)).isFalse();
 
     // when/then
     assertThatThrownBy(() -> lease.renew(currentTime, renewalDuration))

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -120,7 +120,11 @@ public class RepositoryNodeIdProviderIT {
     final var expiredLeaseTimestamp = clock.millis();
     final var expiredLease =
         repository.acquire(
-            new Lease(taskId + "old", expiredLeaseTimestamp, new NodeInstance(0)), previousEtag);
+            new Lease(
+                taskId + "old",
+                expiredLeaseTimestamp + EXPIRY_DURATION.toMillis(),
+                new NodeInstance(0)),
+            previousEtag);
     assertThat(expiredLease).isNotNull();
     clock.advance(EXPIRY_DURATION.plusSeconds(1));
 


### PR DESCRIPTION
## Description
The method Lease#isStillValid was comparing the timestamp + leaseDuration with the current timestamp, which was incorrect.

In a followup PR I will rename the field to `expiresAt` to make its purpose more clear.