### PR TITLE
feat: enable ahsp migration from operate UI

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -15,6 +15,8 @@ import {
   mockOrderProcessInstances,
   mockOrderProcessV2Instances,
   mockMigrationOperation,
+  mockAhspGroupedProcesses,
+  mockAhspProcessInstances,
 } from '../mocks/processes.mocks';
 import {openFile} from '@/utils/openFile';
 import {expect} from '@playwright/test';
@@ -255,5 +257,216 @@ test.describe('process instance migration', () => {
     await page.screenshot({
       path: path.join(baseDirectory, 'operations-panel.png'),
     });
+  });
+
+  test('migrate ad hoc subprocess process instances', async ({
+    page,
+    processesPage,
+    migrationView,
+  }) => {
+    await page.route(
+      URL_API_PATTERN,
+      mockProcessesResponses({
+        groupedProcesses: mockAhspGroupedProcesses,
+        batchOperations: {items: [], page: {totalItems: 0}},
+        processInstances: mockAhspProcessInstances,
+        statisticsV2: {
+          items: [
+            {
+              elementId: 'AD_HOC_SUBPROCESS',
+              active: 3,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+            {
+              elementId: 'A',
+              active: 3,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+          ],
+        },
+        processXml: openFile(
+          './e2e-playwright/mocks/resources/migration-ahsp-process_v1.bpmn',
+        ),
+      }),
+    );
+
+    await processesPage.gotoProcessesPage({
+      searchParams: {
+        active: 'true',
+        incidents: 'false',
+        canceled: 'false',
+        completed: 'false',
+      },
+    });
+
+    await processesPage.gotoProcessesPage({
+      searchParams: {
+        process: 'migration-ahsp-process_v1',
+        version: '1',
+        active: 'true',
+      },
+    });
+
+    // Select first instance for migration
+    await processesPage.getNthProcessInstanceCheckbox(0).click();
+    await processesPage.getNthProcessInstanceCheckbox(1).click();
+    await processesPage.getNthProcessInstanceCheckbox(2).click();
+
+    await processesPage.migrateButton.click();
+    await processesPage.migrationModal.confirmButton.click();
+
+    // Load target process v2 with statistics
+    await page.route(
+      URL_API_PATTERN,
+      mockProcessesResponses({
+        statisticsV2: {
+          items: [
+            {
+              elementId: 'AD_HOC_SUBPROCESS',
+              active: 3,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+            {
+              elementId: 'D',
+              active: 3,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+          ],
+        },
+        groupedProcesses: mockAhspGroupedProcesses,
+        processXml: openFile(
+          './e2e-playwright/mocks/resources/migration-ahsp-process_v2.bpmn',
+        ),
+      }),
+    );
+
+    await migrationView.selectTargetProcess('Ad Hoc Subprocess Target');
+    await migrationView.selectTargetVersion('2');
+
+    // Verify ad hoc subprocess element is shown
+    await expect(
+      page.getByText('Ad Hoc Subprocess', {exact: true}),
+    ).toHaveCount(4);
+
+    // Verify user task element is shown
+    await expect(
+      page.getByText('A', {exact: true}),
+    ).toHaveCount(2);
+
+    // Map the ad hoc subprocess
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Ad Hoc Subprocess',
+      targetFlowNodeName: 'Ad Hoc Subprocess',
+    });
+
+    // Map user task
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'A',
+      targetFlowNodeName: 'D',
+    });
+
+    await migrationView.nextButton.click();
+
+    // Wait for overlays to appear
+    await expect(page.getByTestId('state-overlay-active').first()).toBeVisible();
+    await expect(page.getByTestId('modifications-overlay').first()).toBeVisible();
+
+    // Mock the migration operation
+    await page.route(
+      URL_API_PATTERN,
+      mockProcessesResponses({
+        groupedProcesses: mockAhspGroupedProcesses,
+        batchOperations: {
+          items: [mockMigrationOperation],
+          page: {totalItems: 1},
+        },
+      }),
+    );
+
+    // Confirm migration
+    await migrationView.confirmButton.click();
+
+    await migrationView.migrationConfirmationModal.getByRole('textbox').fill('MIGRATE');
+
+    await migrationView.migrationConfirmationModal
+      .getByRole('button', {name: /confirm/i})
+      .click()
+
+    // Mock the migrated process instances
+    await page.route(
+      URL_API_PATTERN,
+      mockProcessesResponses({
+        groupedProcesses: mockAhspGroupedProcesses,
+        batchOperations: {
+          items: [
+            {
+              ...mockMigrationOperation,
+              endDate: '2023-10-10T09:00:00.000+0000',
+              operationsCompletedCount: 3,
+            },
+          ],
+          page: {totalItems: 1},
+        },
+        processInstances: {
+          totalCount: 3,
+          processInstances: mockAhspProcessInstances.processInstances.map(
+            (instance) => ({
+              ...instance,
+              processId: '2251799813685250',
+              processVersion: 2,
+              bpmnProcessId: 'migration-ahsp-process_v2',
+              processName: 'Ad Hoc Subprocess Target',
+            }),
+          ),
+        },
+        statisticsV2: {
+          items: [
+            {
+              elementId: 'AD_HOC_SUBPROCESS',
+              active: 3,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+            {
+              elementId: 'D',
+              active: 3,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+          ],
+        },
+        processXml: openFile(
+          './e2e-playwright/mocks/resources/migration-ahsp-process_v2.bpmn',
+        ),
+      }),
+    );
+
+    await processesPage.gotoProcessesPage({
+      searchParams: {
+        process: 'migration-ahsp-process_v2',
+        version: '2',
+        active: 'true',
+      },
+    });
+
+    // Wait for process instances table to have data
+    await expect(processesPage.processInstancesTable.getByRole('row')).not.toHaveCount(0);
+
+    await processesPage.diagram.moveCanvasHorizontally(-200);
+
+    // Verify success message
+    await expect(
+      page.getByText(mockMigrationOperation.batchOperationKey),
+    ).toHaveCount(1);
   });
 });

--- a/operate/client/e2e-playwright/mocks/processes.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processes.mocks.ts
@@ -3059,6 +3059,99 @@ const mockOrderProcessV2Instances: ProcessInstancesDto = {
     }),
 };
 
+const mockAhspGroupedProcesses = [
+  {
+    bpmnProcessId: 'migration-ahsp-process_v1',
+    name: 'Ad Hoc Subprocess Source',
+    tenantId: '<default>',
+    permissions: [],
+    processes: [
+      {
+        id: '2251799813685249',
+        name: 'Ad Hoc Subprocess Source',
+        version: 1,
+        bpmnProcessId: 'migration-ahsp-process_v1',
+        versionTag: null,
+      },
+    ],
+  },
+  {
+    bpmnProcessId: 'migration-ahsp-process_v2',
+    name: 'Ad Hoc Subprocess Target',
+    tenantId: '<default>',
+    permissions: [],
+    processes: [
+      {
+        id: '2251799813685250',
+        name: 'Ad Hoc Subprocess Target',
+        version: 2,
+        bpmnProcessId: 'migration-ahsp-process_v2',
+        versionTag: null,
+      },
+    ],
+  },
+];
+
+const mockAhspProcessInstances: ProcessInstancesDto = {
+  totalCount: 3,
+  processInstances: [
+    {
+      id: '2251799813685251',
+      processId: '2251799813685249',
+      processName: 'Ad Hoc Subprocess Source',
+      processVersion: 1,
+      startDate: '2023-10-10T08:30:00.000+0000',
+      endDate: null,
+      state: 'ACTIVE' as InstanceEntityState,
+      bpmnProcessId: 'migration-ahsp-process_v1',
+      hasActiveOperation: false,
+      operations: [],
+      parentInstanceId: null,
+      rootInstanceId: null,
+      callHierarchy: [],
+      sortValues: ['', ''],
+      permissions: [],
+      tenantId: '<default>',
+    },
+    {
+      id: '2251799813685252',
+      processId: '2251799813685249',
+      processName: 'Ad Hoc Subprocess Source',
+      processVersion: 1,
+      startDate: '2023-10-10T08:31:00.000+0000',
+      endDate: null,
+      state: 'ACTIVE' as InstanceEntityState,
+      bpmnProcessId: 'migration-ahsp-process_v1',
+      hasActiveOperation: false,
+      operations: [],
+      parentInstanceId: null,
+      rootInstanceId: null,
+      callHierarchy: [],
+      sortValues: ['', ''],
+      permissions: [],
+      tenantId: '<default>',
+    },
+    {
+      id: '2251799813685253',
+      processId: '2251799813685249',
+      processName: 'Ad Hoc Subprocess Source',
+      processVersion: 1,
+      startDate: '2023-10-10T08:32:00.000+0000',
+      endDate: null,
+      state: 'ACTIVE' as InstanceEntityState,
+      bpmnProcessId: 'migration-ahsp-process_v1',
+      hasActiveOperation: false,
+      operations: [],
+      parentInstanceId: null,
+      rootInstanceId: null,
+      callHierarchy: [],
+      sortValues: ['', ''],
+      permissions: [],
+      tenantId: '<default>',
+    },
+  ],
+};
+
 const mockStatistics = [
   {
     activityId: 'eventSubprocess',
@@ -3345,4 +3438,6 @@ export {
   mockOrderProcessInstancesWithFailedOperations,
   mockOrderProcessV2Instances,
   mockMigrationOperation,
+  mockAhspGroupedProcesses,
+  mockAhspProcessInstances,
 };

--- a/operate/client/e2e-playwright/mocks/resources/migration-ahsp-process_v1.bpmn
+++ b/operate/client/e2e-playwright/mocks/resources/migration-ahsp-process_v1.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0n9iif1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="migration-ahsp-process_v1" name="Ad Hoc Subprocess Source" isExecutable="true">
+    <bpmn:extensionElements />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0jbaiqk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:adHocSubProcess id="AD_HOC_SUBPROCESS" name="Ad Hoc Subprocess">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;A&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jbaiqk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mc17bj</bpmn:outgoing>
+      <bpmn:userTask id="A" name="A">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0jbaiqk" sourceRef="StartEvent_1" targetRef="AD_HOC_SUBPROCESS" />
+    <bpmn:endEvent id="Event_0a2lx2v">
+      <bpmn:incoming>Flow_0mc17bj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mc17bj" sourceRef="AD_HOC_SUBPROCESS" targetRef="Event_0a2lx2v" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="migration-ahsp-process_v1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a2lx2v_di" bpmnElement="Event_0a2lx2v">
+        <dc:Bounds x="692" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rnrumn_di" bpmnElement="AD_HOC_SUBPROCESS" isExpanded="true">
+        <dc:Bounds x="280" y="80" width="320" height="220" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03ygwar_di" bpmnElement="A">
+        <dc:Bounds x="390" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jbaiqk_di" bpmnElement="Flow_0jbaiqk">
+        <di:waypoint x="188" y="190" />
+        <di:waypoint x="280" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mc17bj_di" bpmnElement="Flow_0mc17bj">
+        <di:waypoint x="600" y="190" />
+        <di:waypoint x="692" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/e2e-playwright/mocks/resources/migration-ahsp-process_v2.bpmn
+++ b/operate/client/e2e-playwright/mocks/resources/migration-ahsp-process_v2.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0n9iif1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="migration-ahsp-process_v2" name="Ad Hoc Subprocess Target" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0jbaiqk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:adHocSubProcess id="AD_HOC_SUBPROCESS" name="Ad Hoc Subprocess">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;D&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jbaiqk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mc17bj</bpmn:outgoing>
+      <bpmn:userTask id="D" name="D">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0jbaiqk" sourceRef="StartEvent_1" targetRef="AD_HOC_SUBPROCESS" />
+    <bpmn:endEvent id="Event_0a2lx2v">
+      <bpmn:incoming>Flow_0mc17bj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mc17bj" sourceRef="AD_HOC_SUBPROCESS" targetRef="Event_0a2lx2v" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="migration-ahsp-process_v2">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a2lx2v_di" bpmnElement="Event_0a2lx2v">
+        <dc:Bounds x="742" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rnrumn_di" bpmnElement="AD_HOC_SUBPROCESS" isExpanded="true">
+        <dc:Bounds x="280" y="80" width="360" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1vs9vyx" bpmnElement="D">
+        <dc:Bounds x="410" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jbaiqk_di" bpmnElement="Flow_0jbaiqk">
+        <di:waypoint x="188" y="210" />
+        <di:waypoint x="280" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mc17bj_di" bpmnElement="Flow_0mc17bj">
+        <di:waypoint x="640" y="210" />
+        <di:waypoint x="742" y="210" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/src/modules/bpmn-js/utils/isMigratableFlowNode.test.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMigratableFlowNode.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {isMigratableFlowNode} from './isMigratableFlowNode';
+
+describe('isMigratableFlowNode', () => {
+  it('should return true for ad hoc sub process', () => {
+    const businessObject = {
+      id: 'adHocSubProcess',
+      $type: 'bpmn:AdHocSubProcess',
+    } as BusinessObject;
+
+    expect(isMigratableFlowNode(businessObject)).toBe(true);
+  });
+});

--- a/operate/client/src/modules/bpmn-js/utils/isMigratableFlowNode.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMigratableFlowNode.ts
@@ -117,6 +117,7 @@ const isMigratableFlowNode = (businessObject: BusinessObject) => {
       'bpmn:ServiceTask',
       'bpmn:UserTask',
       'bpmn:SubProcess',
+      'bpmn:AdHocSubProcess',
       'bpmn:CallActivity',
       'bpmn:ReceiveTask',
       'bpmn:BusinessRuleTask',


### PR DESCRIPTION
## Description

On process instance migration, enable AHSP type migration from operate UI.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40421 
