### PR TITLE
fix: fix permission checks for process instance creation

### DIFF
--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:25.0.6
+    image: bitnamilegacy/keycloak:25.0.6
     ports:
       - "18080:8080"
     environment:

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/external/ProcessExternalControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/external/ProcessExternalControllerIT.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.webapp.api.rest.v1.controllers.external;
 
 import static io.camunda.tasklist.util.TestCheck.PROCESS_IS_DEPLOYED_CHECK;
 import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
@@ -22,6 +23,7 @@ import io.camunda.tasklist.webapp.api.rest.v1.entities.StartProcessRequest;
 import io.camunda.tasklist.webapp.graphql.entity.ProcessInstanceDTO;
 import io.camunda.tasklist.webapp.graphql.entity.VariableInputDTO;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
+import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +35,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -45,6 +48,8 @@ public class ProcessExternalControllerIT extends TasklistZeebeIntegrationTest {
   @Autowired private WebApplicationContext context;
 
   @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private IdentityAuthorizationService identityAuthorizationService;
 
   private MockMvcHelper mockMvcHelper;
 
@@ -176,6 +181,8 @@ public class ProcessExternalControllerIT extends TasklistZeebeIntegrationTest {
             processInstanceDTO -> {
               Assertions.assertThat(processInstanceDTO.getId()).isNotNull();
             });
+
+    verifyNoInteractions(identityAuthorizationService);
   }
 
   @Test

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
@@ -84,7 +84,7 @@ public class ProcessService {
       final String tenantId,
       final boolean executeWithAuthentication) {
 
-    if (!executeWithAuthentication
+    if (executeWithAuthentication
         && !identityAuthorizationService.isAllowedToStartProcess(processDefinitionKey)) {
       throw new ForbiddenActionException(
           "User does not have the permission to start this process.");


### PR DESCRIPTION
## Description

With the changes in this PR we see that now trying to start a process instance through the API when the user is not authorized to start returns an error

```
PATCH http://localhost:8082/v1/internal/processes/pid1/start
{"variables":[]}
-----------
{
    "status": 403,
    "message": "User does not have the permission to start this process.",
    "instance": "0d0ae86a-e1be-4b0a-800b-c1eea59a9ea8"
}
```

instead of

```
PATCH http://localhost:8082/v1/internal/processes/pid1/start
{"variables":[]}
-----------
{
    "id": 6755399441056104
}
```

The change in `tasklist/config/docker-compose.yml`
```
-    image: bitnami/keycloak:25.0.6
+    image: bitnamilegacy/keycloak:25.0.6
```

Is because `bitnami/keycloak:25.0.6` is not valid anymore

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/40441
