### PR TITLE
[Backport stable/8.6] ci: speedup MacOS Intel smoke tests

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -37,7 +37,7 @@ jobs:
         arch: [ amd64 ]
         include:
           - os: macos
-            runner: macos-15-intel
+            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
# Description
Backport of #41223 to `stable/8.6`.

relates to 