### PR TITLE
[Backport stable/8.8] ci: speedup MacOS Intel smoke tests

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -46,7 +46,7 @@ jobs:
         arch: [ amd64 ]
         include:
           - os: macos
-            runner: macos-15-intel
+            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
# Description
Backport of #41223 to `stable/8.8`.

relates to 