### PR TITLE
[Backport main]:  41056 to main

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -287,9 +287,9 @@ jobs:
           --set orchestration.image.registry=gcr.io
           --set orchestration.image.repository=zeebe-io/zeebe
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
+          -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
-          ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
+          ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/load-tests/setup/default/values-stable.yaml', github.ref) || '' }}
       - name: Label namespace with creator
         run: >
             kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -317,7 +317,7 @@ jobs:
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.4
+      - uses: google-github-actions/get-gke-credentials@v2.3.5
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -1,10 +1,10 @@
 # description: This workflow deploys a load test with a camunda cluster under test.
-# We use this worklow to start weekly medic load tests.
+# We use this workflow to start ad-hoc load tests or weekly medic load tests.
 # The health of the cluster and results of the load tests are monitored by Core team's regularly.
 # https://grafana.dev.zeebe.io/login
 # called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
 # type: CI
-# owner: @camunda/core-features
+# owner: camunda/orchestration-cluster-team
 name: Camunda load test
 on:
   workflow_dispatch:
@@ -102,6 +102,8 @@ jobs:
   calculate-image-tag:
     name: Calculate Image Tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: { }
     outputs:
       image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
     steps:
@@ -177,6 +179,15 @@ jobs:
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   build-load-test-images:
     name: Build Starter and Worker
@@ -215,6 +226,15 @@ jobs:
         run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Build Worker Image
         run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   deploy-cluster-under-test:
     name: Deploy cluster under test
@@ -289,6 +309,15 @@ jobs:
             $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
             \`\`\`
           EOF
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   deploy-load-test:
     name: Deploy load test
@@ -361,3 +390,12 @@ jobs:
             $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
             \`\`\`
           EOF
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -22,10 +22,6 @@ on:
         type: string
         default: ""
         required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'main'
-        required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
@@ -62,11 +58,6 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
-        required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'main'
-        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
@@ -116,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
       - name: Get image tag
         id: image-tag
         run: |
@@ -134,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -181,7 +172,7 @@ jobs:
         name: Build Camunda Docker Image
         with:
           repository: 'gcr.io/zeebe-io/zeebe'
-          revision: ${{ inputs.ref }}
+          revision: ${{ github.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
@@ -199,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         id: auth
@@ -321,7 +312,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -276,9 +276,9 @@ jobs:
           --set orchestration.image.registry=gcr.io
           --set orchestration.image.repository=zeebe-io/zeebe
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          -f https://raw.githubusercontent.com/camunda/camunda/${{ inputs.ref }}/load-tests/camunda-platform-values.yaml
+          -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
-          ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
+          ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
       - name: Label namespace with creator
         run: >
             kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -19,7 +19,6 @@ jobs:
     name: Collect benchmark data
     runs-on: ubuntu-latest
     outputs:
-      full-ref: ${{ steps.data.outputs.full-ref }}
       benchmark: ${{ steps.data.outputs.benchmark }}
       operate: ${{ steps.data.outputs.operate }}
     steps:
@@ -56,8 +55,6 @@ jobs:
       ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
-      ref: ${{ needs.benchmark-data.outputs.full-ref }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
       publish: "slack"
   setup-mixed-benchmark:
     name: Mixed Benchmark
@@ -70,9 +67,7 @@ jobs:
       ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
-      ref: ${{ needs.benchmark-data.outputs.full-ref }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
-      realistic: true
+      realistic: 'true'
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/camunda-load-test.yml
@@ -84,8 +79,6 @@ jobs:
       ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
-      ref: ${{ needs.benchmark-data.outputs.full-ref }}
-      reuse-tag: ${{ inputs.reuse-tag || '' }}
       load-test-load: >
         --set starter.rate=1
         --set workers.worker.replicas=1

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -22,7 +22,6 @@ jobs:
       name: ${{github.event.pull_request.head.ref}}-benchmark
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
-      ref: ${{ github.event.pull_request.head.ref }}
 
   delete-benchmark:
     name: Benchmark Cleanup

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -29,7 +29,6 @@ jobs:
       name: release-rolling
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
-      ref: refs/tags/${{ needs.fetch-release.outputs.release-tag }}
       load-test-load: >
         --set starter.rate=5
         --set worker.replicas=1


### PR DESCRIPTION
## Description

Backporting https://github.com/camunda/camunda/pull/41056 to main

Had to do it manual as it was not possible without merge conflicts, see https://github.com/camunda/camunda/pull/41224


## Details


## Description

> 
> Several changes and improvements have been done recently, when bringing the load test workflow to 8.7 and 8.6.
> 
>  * https://github.com/camunda/camunda/pull/40991
>  * https://github.com/camunda/camunda/pull/40865
> 
> This is the attempt to bring this to 8.8 (and forward this to main as well).
> 
> ### This PR includes
> 
>  * Removing the confusing duplicate `ref` input. See discussion [here](https://github.com/camunda/camunda/pull/40865#discussion_r2523736601)
>  * Bump version of github action
>  * Remove [remove maven.test.skip=true](https://github.com/camunda/camunda/commit/c68809ddfb8c8cf178b85b34c3e0cd294e946e06) to avoid failing when test snapshot dependency doesnt exist. See [thread](https://camunda.slack.com/archives/C013MEVQ4M9/p1763381532908289?thread_ts=1760674300.805349&cid=C013MEVQ4M9) 
>  * [apply CI guidelines to workflow](https://github.com/camunda/camunda/commit/79e6fb4a7f160929928ca0abcc39f0819cba235f) 
>      * Several issues have been reported on 8.7/8.6, but not before. I guess because they have been recently introduced.
>      * adding owner (without at)
>      * fixing typos
>      * configuring default shell
>      * add observing build status on every job
>      * add permission and timeout on all jobs
> 
