### PR TITLE
refactor: use only bpmn type for rendering element icon

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -346,7 +346,6 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer((props) => {
         elementId={elementId}
         renderIcon={() => (
           <ElementInstanceIcon
-            elementInstanceType={elementType}
             diagramBusinessObject={businessObjects[elementId]}
             $hasLeftMargin={false}
           />
@@ -363,7 +362,6 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer((props) => {
       elementId={elementId}
       renderIcon={() => (
         <ElementInstanceIcon
-          elementInstanceType={elementType}
           diagramBusinessObject={businessObjects[elementId]}
           $hasLeftMargin
         />

--- a/operate/client/src/modules/bpmn-js/utils/isAdHocSubProcessInnerInstance.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isAdHocSubProcessInnerInstance.ts
@@ -10,13 +10,21 @@ import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import {hasType} from './hasType';
 
 function isAdHocSubProcessInnerInstance(businessObject?: BusinessObject) {
-  return (
-    businessObject !== undefined &&
-    hasType({businessObject, types: ['bpmn:AdHocSubProcess']}) &&
-    businessObject.extensionElements?.values?.find(
-      (value) => value?.type === 'io.camunda.agenticai:aiagent-job-worker',
-    )
+  if (businessObject === undefined) {
+    return false;
+  }
+
+  if (!hasType({businessObject, types: ['bpmn:AdHocSubProcess']})) {
+    return false;
+  }
+
+  const extensionElement = businessObject.extensionElements?.values.find(
+    (value) =>
+      value?.$type === 'zeebe:taskDefinition' &&
+      value?.type?.startsWith('io.camunda.agenticai:aiagent-job-worker'),
   );
+
+  return extensionElement !== undefined;
 }
 
 export {isAdHocSubProcessInnerInstance};

--- a/operate/client/src/modules/bpmn-js/utils/isAdHocSubProcessInnerInstance.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isAdHocSubProcessInnerInstance.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
+
+function isAdHocSubProcessInnerInstance(businessObject?: BusinessObject) {
+  return (
+    businessObject !== undefined &&
+    hasType({businessObject, types: ['bpmn:AdHocSubProcess']}) &&
+    businessObject.extensionElements?.values?.find(
+      (value) => value?.type === 'io.camunda.agenticai:aiagent-job-worker',
+    )
+  );
+}
+
+export {isAdHocSubProcessInnerInstance};

--- a/operate/client/src/modules/components/ElementInstanceIcon/index.test.tsx
+++ b/operate/client/src/modules/components/ElementInstanceIcon/index.test.tsx
@@ -13,7 +13,6 @@ describe('ElementInstanceIcon', () => {
   it('should render default icon', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="UNSPECIFIED"
         diagramBusinessObject={{
           id: 'unknown',
           name: 'Unknown',
@@ -26,12 +25,7 @@ describe('ElementInstanceIcon', () => {
   });
 
   it('should render default icon for deleted element', () => {
-    render(
-      <ElementInstanceIcon
-        elementInstanceType="UNSPECIFIED"
-        diagramBusinessObject={undefined}
-      />,
-    );
+    render(<ElementInstanceIcon diagramBusinessObject={undefined} />);
 
     expect(screen.getByTestId('element-instance-icon')).toBeInTheDocument();
   });
@@ -39,7 +33,6 @@ describe('ElementInstanceIcon', () => {
   it('should render parallel multi instance body', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="MULTI_INSTANCE_BODY"
         diagramBusinessObject={{
           id: 'subProcess',
           name: 'Sub Process',
@@ -58,7 +51,6 @@ describe('ElementInstanceIcon', () => {
   it('should render sequential multi instance body', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="MULTI_INSTANCE_BODY"
         diagramBusinessObject={{
           id: 'subProcess',
           name: 'Sub Process',
@@ -77,7 +69,6 @@ describe('ElementInstanceIcon', () => {
   it('should render intermediate timer event', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="INTERMEDIATE_CATCH_EVENT"
         diagramBusinessObject={{
           id: 'event1',
           name: 'Event',
@@ -97,7 +88,6 @@ describe('ElementInstanceIcon', () => {
   it('should render message boundary event', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="BOUNDARY_EVENT"
         diagramBusinessObject={{
           id: 'event1',
           name: 'Event',
@@ -118,7 +108,6 @@ describe('ElementInstanceIcon', () => {
   it('should render event sub process', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="EVENT_SUB_PROCESS"
         diagramBusinessObject={{
           id: 'eventSubProcess1',
           name: 'Event Sub Process 1',
@@ -134,7 +123,6 @@ describe('ElementInstanceIcon', () => {
   it('should render compensation end event', () => {
     render(
       <ElementInstanceIcon
-        elementInstanceType="END_EVENT"
         diagramBusinessObject={{
           id: 'compensationEndEvent',
           name: 'Compensation End Event',

--- a/operate/client/src/modules/types/bpmn-js.d.ts
+++ b/operate/client/src/modules/types/bpmn-js.d.ts
@@ -79,6 +79,7 @@ declare module 'bpmn-js/lib/NavigatedViewer' {
     extensionElements?: {
       values: {
         $type: string;
+        type?: string;
         $children?: {
           $type: string;
           source: string;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I'm changing this icon again logic again. I changed it to only use the `bpmn-js` types instead of the element instance type since it's easier to infer the icon types for modification nodes in the history

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#27330](https://github.com/camunda/camunda/issues/27330)
