### PR TITLE
feat: Expose databaseType via Tasklist client config

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
@@ -19,6 +19,7 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.security.TasklistProfileService;
+import io.camunda.tasklist.webapp.service.EnvironmentService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,7 @@ import org.springframework.web.context.WebApplicationContext;
     classes = {
       TestApplicationWithNoBeans.class,
       TasklistProfileService.class,
+      EnvironmentService.class,
       ClientConfig.class,
       ClientConfigRestService.class,
       SecurityConfiguration.class,
@@ -90,6 +92,7 @@ public class ClientConfigRestServiceIT {
                 + "\"contextPath\":\"\","
                 + "\"baseName\":\"/tasklist\","
                 + "\"clientMode\":\"v2\","
+                + "\"databaseType\":\"document-store\","
                 + "\"organizationId\":\"organizationId\","
                 + "\"clusterId\":null,"
                 + "\"stage\":\"stage\","

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/rest/ClientConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/rest/ClientConfig.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.webapp.rest;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.security.TasklistProfileService;
+import io.camunda.tasklist.webapp.service.EnvironmentService;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ public class ClientConfig {
   public String contextPath;
   public String baseName;
   public String clientMode;
+  public String databaseType;
 
   // Cloud related properties for mixpanel events
   @Value("${CAMUNDA_TASKLIST_CLOUD_ORGANIZATIONID:#{null}}")
@@ -59,6 +61,7 @@ public class ClientConfig {
   private boolean isV2ModeEnabled;
 
   @Autowired private TasklistProfileService profileService;
+  @Autowired private EnvironmentService environmentService;
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private ServletContext context;
@@ -73,5 +76,6 @@ public class ClientConfig {
     isLoginDelegated = profileService.isLoginDelegated();
     maxRequestSize = maxRequestSizeConfigValue.toBytes();
     clientMode = isV2ModeEnabled ? "v2" : "v1";
+    databaseType = environmentService.getDatabaseType();
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/EnvironmentService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/EnvironmentService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.service;
+
+import io.camunda.spring.utils.DatabaseTypeUtils;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnvironmentService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentService.class);
+
+  private final Environment environment;
+  private final Map<String, String> databaseTypes =
+      Map.of(
+          "elasticsearch", "document-store",
+          "opensearch", "document-store",
+          "rdbms", "rdbms",
+          "none", "none");
+
+  public EnvironmentService(final Environment environment) {
+    this.environment = environment;
+  }
+
+  public String getDatabaseType() {
+    final var dbType = DatabaseTypeUtils.getDatabaseTypeOrDefault(environment);
+    if (!databaseTypes.containsKey(dbType)) {
+      LOGGER.warn("Could not identify database type: {}", dbType);
+      return "unknown";
+    }
+    return databaseTypes.get(dbType);
+  }
+}

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/EnvironmentServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/EnvironmentServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.service;
+
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.core.env.Environment;
+
+public class EnvironmentServiceTest {
+
+  private EnvironmentService environmentService;
+  private Environment mockEnvironment;
+
+  @BeforeEach
+  public void setup() {
+    mockEnvironment = mock(Environment.class);
+    environmentService = new EnvironmentService(mockEnvironment);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "elasticsearch, document-store",
+    "opensearch, document-store",
+    "rdbms, rdbms",
+    "none, none",
+    "invalid, unknown"
+  })
+  void testGetDatabaseType(final String environmentValue, final String expectedOutput) {
+    // given
+    when(mockEnvironment.getProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE))
+        .thenReturn(environmentValue);
+
+    // when
+    final String result = environmentService.getDatabaseType();
+
+    // then
+    assertThat(result).isEqualTo(expectedOutput);
+  }
+}


### PR DESCRIPTION
## Description

In https://github.com/camunda/camunda/issues/39306 there was part of the ACs that was missed

> A simple flag indicating the storage type ... is exposed through ClientConfig for both Operate **and Tasklist**

This PR aims to satisfy this for Tasklist.

For ES/OS

```
GET http://localhost:8080/tasklist/client-config.js

Response
----------
window.clientConfig = { "isEnterprise": false, "isMultiTenancyEnabled": false, "canLogout": true, "isLoginDelegated": false, "contextPath": "", "baseName": "/tasklist", "clientMode": "v2", "databaseType": "document-store", "organizationId": null, "clusterId": null, "stage": null, "mixpanelToken": null, "mixpanelAPIHost": null, "isResourcePermissionsEnabled": false, "isUserAccessRestrictionsEnabled": true, "maxRequestSize": 10485760 };
```

For RDBMS

```
GET http://localhost:8080/tasklist/client-config.js

Response
----------
window.clientConfig = { "isEnterprise": false, "isMultiTenancyEnabled": false, "canLogout": true, "isLoginDelegated": false, "contextPath": "", "baseName": "/tasklist", "clientMode": "v2", "databaseType": "rdbms", "organizationId": null, "clusterId": null, "stage": null, "mixpanelToken": null, "mixpanelAPIHost": null, "isResourcePermissionsEnabled": false, "isUserAccessRestrictionsEnabled": true, "maxRequestSize": 10485760 };
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39306
