### PR TITLE
feat: fix issues when cluster variables are tenant scoped without tenant

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -44,7 +44,6 @@ public class ClusterVariableCreateProcessor
   @Override
   public void processNewCommand(final TypedRecord<ClusterVariableRecord> command) {
     final ClusterVariableRecord clusterVariableRecord = command.getValue();
-
     clusterVariableRecordValidator
         .validateName(clusterVariableRecord)
         .flatMap(clusterVariableRecordValidator::ensureValidScope)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
+import org.apache.commons.lang3.StringUtils;
 
 public class ClusterVariableRecordValidator {
 
@@ -85,7 +86,13 @@ public class ClusterVariableRecordValidator {
 
   public Either<Rejection, ClusterVariableRecord> ensureValidScope(
       final ClusterVariableRecord clusterVariableRecord) {
-    if (clusterVariableRecord.isTenantScoped() || clusterVariableRecord.isGloballyScoped()) {
+    if (clusterVariableRecord.isTenantScoped()
+        && StringUtils.isBlank(clusterVariableRecord.getTenantId())) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Invalid cluster variable scope. Tenant-scoped variables must have a non-blank tenant ID."));
+    } else if (clusterVariableRecord.isTenantScoped() || clusterVariableRecord.isGloballyScoped()) {
       return Either.right(clusterVariableRecord);
     } else {
       return Either.left(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -114,6 +114,25 @@ public final class CreateClusterVariableTest {
   }
 
   @Test
+  public void createTenantScopedClusterVariableWithoutTenant() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_3")
+            .setTenantScope()
+            .withValue("\"VALUE\"")
+            .expectRejection()
+            .create();
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Invalid cluster variable scope. Tenant-scoped variables must have a non-blank tenant ID.");
+  }
+
+  @Test
   public void globalScopedAndTenantScopedClusterVariableDoNotOverlap() {
     // given
     final var recordGlobal =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
@@ -100,6 +100,7 @@ public final class DeleteClusterVariableTest {
         .clusterVariables()
         .withName("KEY_TO_DELETE_2")
         .setTenantScope()
+        .withTenantId("tenant_1")
         .withValue("\"VALUE\"")
         .create();
 
@@ -131,6 +132,24 @@ public final class DeleteClusterVariableTest {
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
             "Invalid cluster variable name: 'KEY_3'. The variable does not exist in the scope 'GLOBAL'");
+  }
+
+  @Test
+  public void deleteTenantScopedClusterVariableWithoutTenantId() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_3")
+            .setTenantScope()
+            .expectRejection()
+            .delete();
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Invalid cluster variable scope. Tenant-scoped variables must have a non-blank tenant ID.");
   }
 
   @Test


### PR DESCRIPTION
## Description

While doing integration tests, I noticed we could create a tenant scoped cluster variable without tenant. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
