### PR TITLE
ci: re-add tzdata to all Docker images for TLS

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,13 +12,13 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21-dev",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:21-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",
   "org.opencontainers.image.url": "https://camunda.com/platform/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/openjre",
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
   "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/operate-docker-labels.golden.json
+++ b/.ci/docker/test/operate-docker-labels.golden.json
@@ -18,6 +18,6 @@
   "org.opencontainers.image.url": "https://camunda.com/platform/operate/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/openjre",
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
   "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/tasklist-docker-labels.golden.json
+++ b/.ci/docker/test/tasklist-docker-labels.golden.json
@@ -18,6 +18,6 @@
   "org.opencontainers.image.url": "https://camunda.com/platform/tasklist/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/openjre",
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
   "io.minimus.images.line": "21"
 }

--- a/.ci/docker/test/zeebe-docker-labels.golden.json
+++ b/.ci/docker/test/zeebe-docker-labels.golden.json
@@ -11,13 +11,13 @@
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/zeebe-deployment/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/openjre:21-dev",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:21-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Zeebe",
   "org.opencontainers.image.url": "https://zeebe.io",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/openjre",
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
   "io.minimus.images.line": "21"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # renovate: datasource=github-releases depName=rhysd/actionlint
       ACTIONLINT_VERSION: '1.7.8'
       # renovate: datasource=github-tags depName=open-policy-agent/conftest
-      CONFTEST_VERSION: '0.62.0'
+      CONFTEST_VERSION: '0.64.0'
     steps:
       - uses: actions/checkout@v4
       - uses: camunda/infra-global-github-actions/actionlint@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
-ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+ARG BASE_DIGEST="sha256:1374fb954464843a022aa8087e5b21c7ea5c130371b6555e8d63e46b1c52e214"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -3,8 +3,8 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
-ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+ARG BASE_DIGEST="sha256:1374fb954464843a022aa8087e5b21c7ea5c130371b6555e8d63e46b1c52e214"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
-ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+ARG BASE_DIGEST="sha256:1374fb954464843a022aa8087e5b21c7ea5c130371b6555e8d63e46b1c52e214"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
-ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+ARG BASE_DIGEST="sha256:1374fb954464843a022aa8087e5b21c7ea5c130371b6555e8d63e46b1c52e214"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/openjre:21-dev"
-ARG BASE_DIGEST="sha256:5a15ae56ac90e5ed64653236c9feeadbad9ebde5b483dd11fdb93760fc22c2ce"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+ARG BASE_DIGEST="sha256:1374fb954464843a022aa8087e5b21c7ea5c130371b6555e8d63e46b1c52e214"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:


### PR DESCRIPTION
## Description

This PR re-adds `tzdata` information to all C8 component Docker images, that were lost when migrating to `reg.mini.dev/openjre:21-dev` by changing to a custom hardened base image. This is relevant for eventual backporting of our changes to 8.8-8.6, and for TLS connections.

The custom hardened base image `reg.mini.dev/1212/openjre-base:21-dev` is derived from `reg.mini.dev/openjre:21-dev` and additionally includes `tzdata` package. Minimus takes care of automatically keeping our custom image up2date.

`eclipse-temurin:21-jdk-noble` previously used by `camunda/camunda` and `camunda/zeebe` included that info.

[Operate](https://github.com/camunda/camunda/blob/8.8.0/operate.Dockerfile#L63), Tasklist and [Optimize](https://github.com/camunda/camunda/blob/8.8.0/optimize.Dockerfile#L68) Docker images installed that dependency explicitly.

Note: I'm also updating the `conftest` dependency just to have to most up2date checks in place, not directly related to this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) -- out of scope https://github.com/camunda/camunda/blob/8.8.0/operate.Dockerfile#L63

## Related issues

Related to #40739 
