### PR TITLE
test: add process instance key filter to stabilise flaky compensation test

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -3435,6 +3435,7 @@ public class CompensationEventExecutionTest {
         .contains(tuple(CompensationSubscriptionIntent.TRIGGERED, "adhoc-subprocess"));
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId())
         .containsSubsequence(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR updates CompensationEventExecutionTest.shouldTriggerCompensationWithAdHocSubprocessesHandler to include a process instance key filter in the engine query.
The filter ensures the assertion only inspects events from the test’s own process instance, removing the source of flakiness.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41276
