### PR TITLE
Fix inconsistency in authorization DB state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -69,6 +69,7 @@ public class AuthorizationUpdateProcessor
                     record.getResourceType(),
                     "Expected to update authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"))
         .flatMap(record -> authorizationEntityChecker.validateResourceMatcher(record, "update"))
+        .flatMap(permissionsBehavior::permissionsAlreadyExistForUpdate)
         .flatMap(record -> authorizationEntityChecker.ownerAndResourceExists(command))
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, authorizationRecord),
@@ -83,6 +84,7 @@ public class AuthorizationUpdateProcessor
     permissionsBehavior
         .authorizationExists(command.getValue(), AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE)
         .flatMap(s -> authorizationEntityChecker.ownerAndResourceExists(command))
+        .flatMap(permissionsBehavior::permissionsAlreadyExistForUpdate)
         .ifRightOrLeft(
             ignored -> {
               stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.HashSet;
 import java.util.Set;
-import org.jetbrains.annotations.NotNull;
 
 public class PermissionsBehavior {
 
@@ -84,7 +83,7 @@ public class PermissionsBehavior {
     return verifyPermissionsDontExist(record, permissionsToAdd);
   }
 
-  private @NotNull Either<Rejection, AuthorizationRecord> verifyPermissionsDontExist(
+  private Either<Rejection, AuthorizationRecord> verifyPermissionsDontExist(
       final AuthorizationRecord record, final Set<PermissionType> permissionsToAdd) {
     for (final PermissionType permission : permissionsToAdd) {
       final var addedAuthorizationScope = AuthorizationScope.of(record.getResourceId());


### PR DESCRIPTION
## Description
Currently, we allow to create duplicate authorizations permissions and this leads to problems with updating and deleting authorizations later on. This problem seems to be resource-independent.

## Root cause
The root cause of this problem is that we allow to create duplicate authorizations, for example:
1. We have authorization for Group `test` with User `READ` for resource `resourceID` and authorization for Group `test` with User `UPDATE` for resource `resourceID`
2. We allow authorization for Group `test` with User `UPDATE` for resource `resourceID` to be updated to Group `test` with User `UPDATE` and `READ` for resource `resourceID`

**What's happening in the bug under the hood example:**
1. When we add authorization 1: `GROUP "testGroup", USER *, READ`
   in `permissionsColumnFamily` we get: key(GROUP "testGroup", USER) mapped to (READ -> USER *)
   
2. When we add authorization 2: `GROUP "testGroup", USER *, UPDATE`
  in `permissionsColumnFamily` we get : key(GROUP "testGroup", USER) mapped to (READ -> USER *, UPDATE -> USER *)
  
3. When we update authorization 2 to be: `GROUP "testGroup", USER *, READ UPDATE`, then:
  we first delete authorization: `permissionsColumnFamily` we have left: key(GROUP "testGroup", USER) -> value(READ -> USER *)
  and then we create authorization and in `permissionsColumnFamily` we get: key(GROUP "testGroup", USER) -> value(READ -> USER *, UPDATE -> USER *)
  
4. Then, if we try to delete authorization 2: in `permissionsColumnFamily` the entry is deleted.

5. Then, if we try to delete authorization 1: `removePermission() `loads from `permissionsColumnFamily`, gets `null` (as the entry was deleted) and fails with NPE

_Please reach out if this is confusing_ (it is still confusing for me)

**Solution**
Don't allow several authorizations use the same permission.

**After the issue is fixed the below test case should succeed:**
1. Create authorization for Group `test` with User `READ` for resource `resourceID`
4. Create authorization for Group `test` with User `UPDATE` for resource `resourceID`
5. Try to update authorization from the second step to be: Group `test` with User `UPDATE` and `READ` for resource `resourceID`
Update should fail as we've already created `READ` authorization before and should not allow to duplicate it.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40276
