### PR TITLE
[stable/8.7] build: library parent for version management across client artifacts

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -5,9 +5,9 @@
 
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-library-parent</artifactId>
     <version>8.7.21-SNAPSHOT</version>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>zeebe-client-java</artifactId>

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-library-parent</artifactId>
     <version>8.7.21-SNAPSHOT</version>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>spring-boot-starter-camunda-sdk</artifactId>
@@ -217,12 +217,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>spring-boot-3.5</id>
-      <properties>
-        <version.spring-boot>3.5.7</version.spring-boot>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.7.21-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-library-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Camunda SDK Library Parent</name>
+  <description>A parent pom for all SDK related artifacts such as clients as test tooling.</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <!-- The Spring Boot version is managed explicitly here to avoid inheriting
+    Spring Boot version from the parent pom.xml, which is the reference for internal modules.
+    This allows decoupled control of the Spring Boot version for this user facing artifact. -->
+    <version.spring-boot>3.4.12</version.spring-boot>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>spring-boot-3.5</id>
+      <properties>
+        <!-- For testing Spring Boot 3.5 compatibility -->
+        <version.spring-boot>3.5.8</version.spring-boot>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   <modules>
     <module>bom</module>
     <module>parent</module>
+    <module>library-parent</module>
     <module>dist</module>
     <module>build-tools</module>
     <module>zeebe</module>

--- a/testing/camunda-process-test-example/pom.xml
+++ b/testing/camunda-process-test-example/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-library-parent</artifactId>
     <version>8.7.21-SNAPSHOT</version>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>camunda-process-test-example</artifactId>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-library-parent</artifactId>
     <version>8.7.21-SNAPSHOT</version>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>camunda-process-test-java</artifactId>

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-library-parent</artifactId>
     <version>8.7.21-SNAPSHOT</version>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <relativePath>../../library-parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>camunda-process-test-spring</artifactId>
@@ -178,12 +178,4 @@
 
   </build>
 
-  <profiles>
-    <profile>
-      <id>spring-boot-3.5</id>
-      <properties>
-        <version.spring-boot>3.5.7</version.spring-boot>
-      </properties>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
## Description

This addressed the following Acceptance Criteria of the linked issue.
>The spring-boot version of the relevant client modules is decoupled from the central version in the parent pom of camunda/camunda - to avoid that updates of the version used for internal components causes client facing libraries to raise the spring version as well

This is a solution based on a new `camunda-library-parent` module to be used as base for all user facing library artifacts such as clients, spring-boot integrations or test libraries. This allows to manage any dependency version different from the one used by internal components, e.g. for now the Spring Boot version used, when it's used.

The benefits of this approach are:
* no duplication across spring modules to manage the version as well as compatibility profiles for CI
* by default versions managed via the zeebe-parent are inherited, unless overwritten explicitly
* central place to override certain dependency version for user facing modules only

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #37112
