### PR TITLE
feat: migrate decisions-definitions in operate to v2

### DIFF
--- a/operate/client/e2e-playwright/a11y/decisions.spec.ts
+++ b/operate/client/e2e-playwright/a11y/decisions.spec.ts
@@ -9,7 +9,7 @@
 import {test} from '../visual-fixtures';
 import {
   mockDecisionInstances,
-  mockGroupedDecisions,
+  mockedDecisionDefinitions,
   mockBatchOperations,
   mockResponses,
   mockDecisionXml,
@@ -35,7 +35,7 @@ test.describe('decisions', () => {
     await page.route(
       URL_API_PATTERN,
       mockResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         batchOperations: mockBatchOperations,
         decisionInstances: mockDecisionInstances,
       }),
@@ -58,7 +58,7 @@ test.describe('decisions', () => {
     await page.route(
       URL_API_PATTERN,
       mockResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         batchOperations: mockBatchOperations,
         decisionInstances: mockDecisionInstances,
         decisionXml: mockDecisionXml,

--- a/operate/client/e2e-playwright/docs-screenshots/delete-resource-definitions.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/delete-resource-definitions.spec.ts
@@ -18,7 +18,7 @@ import {
   mockResponses as mockDecisionsResponses,
   mockDeleteDecision,
   mockEmptyDecisionInstances,
-  mockGroupedDecisions,
+  mockedDecisionDefinitions,
 } from '../mocks/decisions.mocks';
 import {openFile} from '@/utils/openFile';
 import {expect} from '@playwright/test';
@@ -123,7 +123,7 @@ test.describe.skip('delete resource definitions', () => {
     await page.route(
       URL_API_PATTERN,
       mockDecisionsResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         batchOperations: {items: [], page: {totalItems: 0}},
         decisionInstances: mockEmptyDecisionInstances,
         decisionXml: mockDecisionXml,

--- a/operate/client/e2e-playwright/mocks/decisions.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/decisions.mocks.ts
@@ -7,25 +7,22 @@
  */
 
 import type {Route} from '@playwright/test';
-import type {
-  DecisionDto,
-  DecisionInstancesDto,
-  BatchOperationDto,
-} from '@/types';
+import type {BatchOperationDto} from '@/types';
 import {
   type QueryBatchOperationsResponseBody,
+  type QueryDecisionDefinitionsResponseBody,
   type QueryDecisionInstancesResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
 function mockResponses({
   batchOperations,
-  groupedDecisions,
+  decisionDefinitions,
   decisionInstances,
   decisionXml,
   deleteDecision,
 }: {
   batchOperations?: QueryBatchOperationsResponseBody;
-  groupedDecisions?: DecisionDto[];
+  decisionDefinitions?: QueryDecisionDefinitionsResponseBody;
   decisionInstances?: QueryDecisionInstancesResponseBody;
   decisionXml?: string;
   deleteDecision?: BatchOperationDto;
@@ -58,10 +55,10 @@ function mockResponses({
       });
     }
 
-    if (route.request().url().includes('/api/decisions/grouped')) {
+    if (route.request().url().includes('/v2/decision-definitions/search')) {
       return route.fulfill({
-        status: groupedDecisions === undefined ? 400 : 200,
-        body: JSON.stringify(groupedDecisions),
+        status: decisionDefinitions === undefined ? 400 : 200,
+        body: JSON.stringify(decisionDefinitions),
         headers: {
           'content-type': 'application/json',
         },
@@ -110,57 +107,56 @@ function mockResponses({
   };
 }
 
-const mockGroupedDecisions: DecisionDto[] = [
-  {
-    decisionId: 'invoiceAssignApprover',
-    tenantId: '<default>',
-    name: 'Assign Approver Group',
-    permissions: [],
-    decisions: [
-      {
-        id: '2251799813687885',
-        version: 2,
-        decisionId: 'invoiceAssignApprover',
-      },
-      {
-        id: '2251799813687195',
-        version: 1,
-        decisionId: 'invoiceAssignApprover',
-      },
-    ],
-  },
-  {
-    decisionId: 'amountToString',
-    tenantId: '<default>',
-    name: 'Convert amount to string',
-    permissions: [],
-    decisions: [
-      {
-        id: '2251799813687887',
-        version: 1,
-        decisionId: 'amountToString',
-      },
-    ],
-  },
-  {
-    decisionId: 'invoiceClassification',
-    tenantId: '<default>',
-    name: 'Invoice Classification',
-    permissions: [],
-    decisions: [
-      {
-        id: '2251799813687886',
-        version: 2,
-        decisionId: 'invoiceClassification',
-      },
-      {
-        id: '2251799813687196',
-        version: 1,
-        decisionId: 'invoiceClassification',
-      },
-    ],
-  },
-];
+const mockedDecisionDefinitions: QueryDecisionDefinitionsResponseBody = {
+  items: [
+    {
+      decisionDefinitionId: 'invoiceClassification',
+      name: 'Invoice Classification',
+      version: 2,
+      decisionRequirementsId: 'invoiceBusinessDecisions',
+      tenantId: '<default>',
+      decisionDefinitionKey: '2251799813687886',
+      decisionRequirementsKey: 'drg-2251799813687886',
+    },
+    {
+      decisionDefinitionId: 'invoiceClassification',
+      name: 'Invoice Classification',
+      version: 1,
+      decisionRequirementsId: 'invoiceBusinessDecisions',
+      tenantId: '<default>',
+      decisionDefinitionKey: '2251799813687196',
+      decisionRequirementsKey: 'drg-2251799813687196',
+    },
+    {
+      decisionDefinitionId: 'invoiceAssignApprover',
+      name: 'Assign Approver Group',
+      version: 2,
+      decisionRequirementsId: 'invoiceBusinessDecisions',
+      tenantId: '<default>',
+      decisionDefinitionKey: '2251799813687885',
+      decisionRequirementsKey: 'drg-2251799813687885',
+    },
+    {
+      decisionDefinitionId: 'invoiceAssignApprover',
+      name: 'Assign Approver Group',
+      version: 1,
+      decisionRequirementsId: 'invoiceBusinessDecisions',
+      tenantId: '<default>',
+      decisionDefinitionKey: '2251799813687195',
+      decisionRequirementsKey: 'drg-2251799813687195',
+    },
+    {
+      decisionDefinitionId: 'amountToString',
+      name: 'Convert amount to string',
+      version: 1,
+      decisionRequirementsId: 'invoiceBusinessDecisions',
+      tenantId: '<default>',
+      decisionDefinitionKey: '2251799813687887',
+      decisionRequirementsKey: 'drg-2251799813687887',
+    },
+  ],
+  page: {totalItems: 5},
+};
 
 const mockBatchOperations: QueryBatchOperationsResponseBody = {
   items: [
@@ -1272,7 +1268,7 @@ const mockDeleteDecision = {
 } as const;
 
 export {
-  mockGroupedDecisions,
+  mockedDecisionDefinitions,
   mockBatchOperations,
   mockEmptyDecisionInstances,
   mockDecisionInstances,

--- a/operate/client/e2e-playwright/visual/decisions.spec.ts
+++ b/operate/client/e2e-playwright/visual/decisions.spec.ts
@@ -12,8 +12,8 @@ import {
   mockBatchOperations,
   mockDecisionInstances,
   mockDecisionXml,
+  mockedDecisionDefinitions,
   mockEmptyDecisionInstances,
-  mockGroupedDecisions,
   mockResponses,
 } from '../mocks/decisions.mocks';
 import {URL_API_PATTERN} from '../constants';
@@ -46,7 +46,7 @@ test.describe('decisions page', () => {
       URL_API_PATTERN,
       mockResponses({
         batchOperations: {items: [], page: {totalItems: 0}},
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         decisionXml: '',
         decisionInstances: mockEmptyDecisionInstances,
       }),
@@ -76,7 +76,7 @@ test.describe('decisions page', () => {
     await page.route(
       URL_API_PATTERN,
       mockResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
       }),
     );
 
@@ -99,7 +99,7 @@ test.describe('decisions page', () => {
     await page.route(
       URL_API_PATTERN,
       mockResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         batchOperations: mockBatchOperations,
         decisionInstances: mockDecisionInstances,
         decisionXml: mockDecisionXml,
@@ -134,7 +134,7 @@ test.describe('decisions page', () => {
     await page.route(
       URL_API_PATTERN,
       mockResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         batchOperations: mockBatchOperations,
         decisionInstances: mockDecisionInstances,
         decisionXml: mockDecisionXml,
@@ -166,7 +166,7 @@ test.describe('decisions page', () => {
     await page.route(
       URL_API_PATTERN,
       mockResponses({
-        groupedDecisions: mockGroupedDecisions,
+        decisionDefinitions: mockedDecisionDefinitions,
         batchOperations: mockBatchOperations,
         decisionInstances: mockDecisionInstances,
         decisionXml: mockDecisionXml,

--- a/operate/client/src/App/Decisions/Decision/DecisionOperations/index.test.tsx
+++ b/operate/client/src/App/Decisions/Decision/DecisionOperations/index.test.tsx
@@ -60,8 +60,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );
@@ -94,8 +94,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );
@@ -128,8 +128,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );
@@ -166,8 +166,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );
@@ -203,8 +203,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );
@@ -255,8 +255,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );
@@ -300,8 +300,8 @@ describe('<DecisionOperations />', () => {
     const {user} = render(
       <DecisionOperations
         decisionName="myDecision"
-        decisionVersion="2"
-        decisionDefinitionId="2251799813687094"
+        decisionVersion={2}
+        decisionDefinitionKey="2251799813687094"
       />,
       {wrapper: Wrapper},
     );

--- a/operate/client/src/App/Decisions/Decision/DecisionOperations/index.tsx
+++ b/operate/client/src/App/Decisions/Decision/DecisionOperations/index.tsx
@@ -22,13 +22,13 @@ import {tracking} from 'modules/tracking';
 import {handleOperationError} from 'modules/utils/notifications';
 
 type Props = {
-  decisionDefinitionId: string;
+  decisionDefinitionKey: string;
   decisionName: string;
-  decisionVersion: string;
+  decisionVersion: number;
 };
 
 const DecisionOperations: React.FC<Props> = ({
-  decisionDefinitionId,
+  decisionDefinitionKey,
   decisionName,
   decisionVersion,
 }) => {
@@ -52,7 +52,7 @@ const DecisionOperations: React.FC<Props> = ({
               tracking.track({
                 eventName: 'definition-deletion-button',
                 resource: 'decision',
-                version: decisionVersion,
+                version: decisionVersion.toString(),
               });
               setIsDeleteModalVisible(true);
             }}
@@ -116,11 +116,11 @@ const DecisionOperations: React.FC<Props> = ({
           tracking.track({
             eventName: 'definition-deletion-confirmation',
             resource: 'decision',
-            version: decisionVersion,
+            version: decisionVersion.toString(),
           });
 
           operationsStore.applyDeleteDecisionDefinitionOperation({
-            decisionDefinitionId,
+            decisionDefinitionId: decisionDefinitionKey,
             onSuccess: () => {
               setIsOperationRunning(false);
               panelStatesStore.expandOperationsPanel();

--- a/operate/client/src/App/Decisions/Decision/tests/decisionOperations.test.tsx
+++ b/operate/client/src/App/Decisions/Decision/tests/decisionOperations.test.tsx
@@ -8,9 +8,9 @@
 
 import {render, screen} from 'modules/testing-library';
 import {mockDmnXml} from 'modules/mocks/mockDmnXml';
-import {groupedDecisions} from 'modules/mocks/groupedDecisions';
-import {mockFetchGroupedDecisions} from 'modules/mocks/api/decisions/fetchGroupedDecisions';
 import {mockFetchDecisionDefinitionXML} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinitionXML';
+import {mockSearchDecisionDefinitions} from 'modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions';
+import {mockDecisionDefinitions} from 'modules/mocks/mockDecisionDefinitions';
 import {Decision} from '..';
 import {createWrapper} from './mocks';
 
@@ -20,9 +20,11 @@ vi.mock('modules/feature-flags', () => ({
 
 describe('<Decision /> - operations', () => {
   beforeEach(() => {
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
-    mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
-    mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
+    const selectedDecisionDefinition = mockDecisionDefinitions.items[5];
+    mockSearchDecisionDefinitions().withSuccess({
+      items: [selectedDecisionDefinition],
+      page: {totalItems: 1},
+    });
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
   });
 
@@ -33,7 +35,7 @@ describe('<Decision /> - operations', () => {
 
     expect(
       await screen.findByRole('button', {
-        name: /^delete decision definition "invoiceClassification - version 1"$/i,
+        name: 'Delete Decision Definition "invoiceClassification - Version 1"',
       }),
     ).toBeInTheDocument();
   });

--- a/operate/client/src/App/Decisions/Decision/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/Decision/tests/index.test.tsx
@@ -6,18 +6,21 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen, waitFor} from 'modules/testing-library';
+import {render, screen} from 'modules/testing-library';
 import {mockDmnXml} from 'modules/mocks/mockDmnXml';
-import {groupedDecisions} from 'modules/mocks/groupedDecisions';
 import {Decision} from '..';
 import {mockFetchDecisionDefinitionXML} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinitionXML';
-import {mockFetchGroupedDecisions} from 'modules/mocks/api/decisions/fetchGroupedDecisions';
 import {createWrapper} from './mocks';
-import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
+import {mockSearchDecisionDefinitions} from 'modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions';
+import {mockDecisionDefinitions} from 'modules/mocks/mockDecisionDefinitions';
 
 describe('<Decision />', () => {
   beforeEach(() => {
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
+    const selectedDecisionDefinition = mockDecisionDefinitions.items[5];
+    mockSearchDecisionDefinitions().withSuccess({
+      items: [selectedDecisionDefinition],
+      page: {totalItems: 1},
+    });
   });
 
   it('should render decision table and panel header', async () => {
@@ -65,10 +68,6 @@ describe('<Decision />', () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Decision'})).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(groupedDecisionsStore.state.status).toBe('fetched'),
-    );
   });
 
   it('should render text when no version is selected', async () => {
@@ -97,6 +96,11 @@ describe('<Decision />', () => {
 
   it('should render text on error', async () => {
     mockFetchDecisionDefinitionXML().withServerError(404);
+    const selectedDecisionDefinition = mockDecisionDefinitions.items[6];
+    mockSearchDecisionDefinitions().withSuccess({
+      items: [selectedDecisionDefinition],
+      page: {totalItems: 1},
+    });
 
     render(<Decision />, {
       wrapper: createWrapper('/decisions?name=calc-key-figures&version=1'),

--- a/operate/client/src/App/Decisions/Decision/tests/mocks.tsx
+++ b/operate/client/src/App/Decisions/Decision/tests/mocks.tsx
@@ -6,25 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
 import {MemoryRouter} from 'react-router-dom';
-import {useEffect} from 'react';
-import {authenticationStore} from 'modules/stores/authentication';
 import {Paths} from 'modules/Routes';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 function createWrapper(initialPath: string = Paths.dashboard()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-    useEffect(() => {
-      groupedDecisionsStore.fetchDecisions();
-
-      return () => {
-        groupedDecisionsStore.reset();
-        authenticationStore.reset();
-      };
-    }, []);
-
     return (
       <QueryClientProvider client={getMockQueryClient()}>
         <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>

--- a/operate/client/src/App/Decisions/Filters/index.tsx
+++ b/operate/client/src/App/Decisions/Filters/index.tsx
@@ -50,7 +50,17 @@ const Filters: React.FC = observer(() => {
   const location = useLocation() as LocationType;
   const navigate = useNavigate();
   const [visibleFilters, setVisibleFilters] = useState<OptionalFilter[]>([]);
-  const filters = parseDecisionInstancesFilter(location.search);
+  const filterValues = parseDecisionInstancesFilter(location.search);
+  if (filterValues.name && filterValues.tenant !== 'all') {
+    filterValues.name = getDefinitionIdentifier(
+      filterValues.name,
+      filterValues.tenant,
+    );
+  }
+  if (filterValues.tenant === 'all') {
+    delete filterValues.name;
+    delete filterValues.version;
+  }
 
   return (
     <Form<DecisionInstanceFilters>
@@ -62,17 +72,7 @@ const Filters: React.FC = observer(() => {
           }),
         });
       }}
-      initialValues={{
-        ...filters,
-        name:
-          filters.name && filters.tenant !== 'all'
-            ? getDefinitionIdentifier(filters.name, filters.tenant)
-            : undefined,
-        version:
-          filters.version && filters.tenant !== 'all'
-            ? filters.version
-            : undefined,
-      }}
+      initialValues={filterValues}
     >
       {({handleSubmit, form, values}) => (
         <StyledForm onSubmit={handleSubmit}>

--- a/operate/client/src/App/Decisions/Filters/index.tsx
+++ b/operate/client/src/App/Decisions/Filters/index.tsx
@@ -32,6 +32,10 @@ import {useState} from 'react';
 import {Locations} from 'modules/Routes';
 import {FiltersPanel} from 'modules/components/FiltersPanel';
 import {TenantField} from 'modules/components/TenantField';
+import {
+  getDefinitionIdentifier,
+  getDefinitionIdFromIdentifier,
+} from 'modules/hooks/decisionDefinition';
 
 const initialValues: DecisionInstanceFilters = {
   evaluated: true,
@@ -46,15 +50,29 @@ const Filters: React.FC = observer(() => {
   const location = useLocation() as LocationType;
   const navigate = useNavigate();
   const [visibleFilters, setVisibleFilters] = useState<OptionalFilter[]>([]);
+  const filters = parseDecisionInstancesFilter(location.search);
 
   return (
     <Form<DecisionInstanceFilters>
       onSubmit={(values) => {
         navigate({
-          search: updateDecisionsFiltersSearchString(location.search, values),
+          search: updateDecisionsFiltersSearchString(location.search, {
+            ...values,
+            name: getDefinitionIdFromIdentifier(values.name),
+          }),
         });
       }}
-      initialValues={parseDecisionInstancesFilter(location.search)}
+      initialValues={{
+        ...filters,
+        name:
+          filters.name && filters.tenant !== 'all'
+            ? getDefinitionIdentifier(filters.name, filters.tenant)
+            : undefined,
+        version:
+          filters.version && filters.tenant !== 'all'
+            ? filters.version
+            : undefined,
+      }}
     >
       {({handleSubmit, form, values}) => (
         <StyledForm onSubmit={handleSubmit}>

--- a/operate/client/src/App/Decisions/Filters/index.tsx
+++ b/operate/client/src/App/Decisions/Filters/index.tsx
@@ -32,7 +32,6 @@ import {useState} from 'react';
 import {Locations} from 'modules/Routes';
 import {FiltersPanel} from 'modules/components/FiltersPanel';
 import {TenantField} from 'modules/components/TenantField';
-import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
 
 const initialValues: DecisionInstanceFilters = {
   evaluated: true,
@@ -47,34 +46,15 @@ const Filters: React.FC = observer(() => {
   const location = useLocation() as LocationType;
   const navigate = useNavigate();
   const [visibleFilters, setVisibleFilters] = useState<OptionalFilter[]>([]);
-  const filtersFromUrl = parseDecisionInstancesFilter(location.search);
+
   return (
     <Form<DecisionInstanceFilters>
       onSubmit={(values) => {
         navigate({
-          search: updateDecisionsFiltersSearchString(location.search, {
-            ...values,
-            ...(values.name !== undefined
-              ? {
-                  name: groupedDecisionsStore.state.decisions.find(
-                    ({key}) => key === values.name,
-                  )?.decisionId,
-                }
-              : {}),
-          }),
+          search: updateDecisionsFiltersSearchString(location.search, values),
         });
       }}
-      initialValues={{
-        ...filtersFromUrl,
-        ...(filtersFromUrl.name !== undefined
-          ? {
-              name: groupedDecisionsStore.getDecision(
-                filtersFromUrl.name,
-                filtersFromUrl.tenant,
-              )?.key,
-            }
-          : {}),
-      }}
+      initialValues={parseDecisionInstancesFilter(location.search)}
     >
       {({handleSubmit, form, values}) => (
         <StyledForm onSubmit={handleSubmit}>
@@ -105,11 +85,9 @@ const Filters: React.FC = observer(() => {
                     <div>
                       <Title>Tenant</Title>
                       <TenantField
-                        onChange={(selectedItem) => {
+                        onChange={() => {
                           form.change('name', undefined);
                           form.change('version', undefined);
-
-                          groupedDecisionsStore.fetchDecisions(selectedItem);
                         }}
                       />
                     </div>

--- a/operate/client/src/App/Decisions/Filters/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/Filters/tests/index.test.tsx
@@ -8,14 +8,11 @@
 
 import {AppHeader} from 'App/Layout/AppHeader';
 import {render, screen, waitFor, within} from 'modules/testing-library';
-import {groupedDecisions} from 'modules/mocks/groupedDecisions';
-import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
 import {LocationLog} from 'modules/utils/LocationLog';
 import {MemoryRouter} from 'react-router-dom';
 import {Filters} from '../';
-import {mockFetchGroupedDecisions} from 'modules/mocks/api/decisions/fetchGroupedDecisions';
 import {pickDateTimeRange} from 'modules/testUtils/dateTimeRange';
-import {act, useEffect} from 'react';
+import {act} from 'react';
 import {
   clearComboBox,
   selectDecision,
@@ -26,13 +23,11 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser} from 'modules/testUtils';
+import {mockSearchDecisionDefinitions} from 'modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions';
+import {mockDecisionDefinitions} from 'modules/mocks/mockDecisionDefinitions';
 
 function getWrapper(initialPath: string = Paths.decisions()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-    useEffect(() => {
-      return groupedDecisionsStore.reset;
-    }, []);
-
     return (
       <QueryClientProvider client={getMockQueryClient()}>
         <MemoryRouter initialEntries={[initialPath]}>
@@ -66,10 +61,9 @@ const MOCK_FILTERS_PARAMS = {
 
 describe('<Filters />', () => {
   beforeEach(async () => {
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
-    await groupedDecisionsStore.fetchDecisions();
     vi.useFakeTimers({shouldAdvanceTime: true});
   });
 
@@ -107,6 +101,12 @@ describe('<Filters />', () => {
   });
 
   it('should write filters to url', async () => {
+    // Note: Reversed call order. Second one for name suggestions, first one for versions.
+    mockSearchDecisionDefinitions().withSuccess({
+      items: mockDecisionDefinitions.items.slice(0, 2),
+      page: {totalItems: 2},
+    });
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     const {user} = render(<Filters />, {
       wrapper: getWrapper(),
     });
@@ -114,6 +114,7 @@ describe('<Filters />', () => {
     expect(screen.getByTestId('pathname')).toHaveTextContent(/^\/decisions$/);
     expect(screen.getByTestId('search')).toBeEmptyDOMElement();
 
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveValue(''));
     await selectDecision({user, option: 'Assign Approver Group'});
     await selectDecisionVersion({user, option: '2'});
 
@@ -203,12 +204,17 @@ describe('<Filters />', () => {
     );
   });
 
-  it('initialise filter values from url', () => {
+  it('initialize filter values from url', async () => {
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     render(<Filters />, {
       wrapper: getWrapper(`/?${new URLSearchParams(MOCK_FILTERS_PARAMS)}`),
     });
 
-    expect(screen.getByLabelText('Name')).toHaveValue('Assign Approver Group');
+    await waitFor(() =>
+      expect(screen.getByLabelText('Name')).toHaveValue(
+        'Assign Approver Group',
+      ),
+    );
     expectVersion('2');
 
     expect(screen.getByLabelText(/evaluated/i)).toBeChecked();
@@ -217,7 +223,7 @@ describe('<Filters />', () => {
     expect(screen.getByDisplayValue(/2251799813689549/i)).toBeInTheDocument();
   });
 
-  it('initialise filter values from url - evaluation date range', async () => {
+  it('initialize filter values from url - evaluation date range', async () => {
     const MOCK_PARAMS = {
       evaluationDateAfter: '2021-02-21 09:00:00',
       evaluationDateBefore: '2021-02-22 10:00:00',
@@ -265,6 +271,7 @@ describe('<Filters />', () => {
 
     unmount();
 
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     render(<Filters />, {
       wrapper: getWrapper(),
     });
@@ -327,6 +334,12 @@ describe('<Filters />', () => {
   });
 
   it('should select decision name and version', async () => {
+    // Note: Reversed call order. Second one for name suggestions, first one for versions.
+    mockSearchDecisionDefinitions().withSuccess({
+      items: mockDecisionDefinitions.items.slice(0, 2),
+      page: {totalItems: 2},
+    });
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     const {user} = render(<Filters />, {
       wrapper: getWrapper(),
     });
@@ -335,9 +348,9 @@ describe('<Filters />', () => {
       screen.getByLabelText('Version', {selector: 'button'}),
     ).toBeDisabled();
 
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveValue(''));
     await selectDecision({user, option: 'Assign Approver Group'});
     await waitFor(() => expectVersion('2'));
-
     expect(
       screen.getByLabelText('Version', {selector: 'button'}),
     ).toBeEnabled();
@@ -514,18 +527,17 @@ describe('<Filters />', () => {
   });
 
   it('should omit all versions option', async () => {
-    const firstDecision = groupedDecisions[0]!;
-    const firstVersion = firstDecision.decisions[1]!;
-
-    mockFetchGroupedDecisions().withSuccess([
-      {...firstDecision, decisions: [firstVersion]},
-    ]);
-
-    await groupedDecisionsStore.fetchDecisions();
+    const firstDecision = mockDecisionDefinitions.items[0]!;
+    // Note: Reversed call order. Second one for name suggestions, first one for versions.
+    mockSearchDecisionDefinitions().withSuccess({
+      items: [firstDecision],
+      page: {totalItems: 1},
+    });
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
 
     const {user} = render(<Filters />, {
       wrapper: getWrapper(
-        `/decisions?name=${firstDecision.decisionId}&version=${firstVersion}`,
+        `/decisions?name=${firstDecision.decisionDefinitionId}&version=${firstDecision.version}`,
       ),
     });
 

--- a/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
@@ -8,13 +8,9 @@
 
 import {AppHeader} from 'App/Layout/AppHeader';
 import {render, screen, waitFor, within} from 'modules/testing-library';
-import {groupedDecisions} from 'modules/mocks/groupedDecisions';
-import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
 import {LocationLog} from 'modules/utils/LocationLog';
 import {MemoryRouter} from 'react-router-dom';
 import {Filters} from '../';
-import {mockFetchGroupedDecisions} from 'modules/mocks/api/decisions/fetchGroupedDecisions';
-import {useEffect} from 'react';
 import {
   selectDecision,
   selectTenant,
@@ -24,13 +20,11 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser} from 'modules/testUtils';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockSearchDecisionDefinitions} from 'modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions';
+import {mockDecisionDefinitions} from 'modules/mocks/mockDecisionDefinitions';
 
 function getWrapper(initialPath: string = Paths.decisions()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-    useEffect(() => {
-      return groupedDecisionsStore.reset;
-    }, []);
-
     return (
       <QueryClientProvider client={getMockQueryClient()}>
         <MemoryRouter initialEntries={[initialPath]}>
@@ -65,7 +59,9 @@ const MOCK_FILTERS_PARAMS = {
 
 describe('<Filters />', () => {
   beforeEach(async () => {
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     mockMe().withSuccess(
       createUser({
         tenants: [
@@ -74,14 +70,10 @@ describe('<Filters />', () => {
         ],
       }),
     );
-
-    await groupedDecisionsStore.fetchDecisions();
   });
 
   it('should write filters to url', async () => {
-    vi.stubGlobal('clientConfig', {
-      multiTenancyEnabled: true,
-    });
+    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
 
     const MOCK_VALUES = {
       name: 'invoice-assign-approver',
@@ -89,15 +81,11 @@ describe('<Filters />', () => {
       tenant: 'tenant-A',
     } as const;
 
-    const {user} = render(<Filters />, {
-      wrapper: getWrapper(),
-    });
+    const {user} = render(<Filters />, {wrapper: getWrapper()});
 
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
     await selectTenant({user, option: 'All tenants'});
 
     await waitFor(() => expect(screen.getByLabelText('Name')).toBeEnabled());
-
     expect(screen.getByRole('combobox', {name: /tenant/i})).toHaveTextContent(
       /all tenants/i,
     );
@@ -109,11 +97,7 @@ describe('<Filters />', () => {
             screen.getByTestId('search').textContent ?? '',
           ).entries(),
         ),
-      ).toEqual(
-        expect.objectContaining({
-          tenant: 'all',
-        }),
-      ),
+      ).toEqual(expect.objectContaining({tenant: 'all'})),
     );
 
     await selectDecision({
@@ -121,8 +105,10 @@ describe('<Filters />', () => {
       option: 'Assign Approver Group for tenant A - Tenant A',
     });
 
-    expect(screen.getByRole('combobox', {name: 'Name'})).toHaveValue(
-      'Assign Approver Group for tenant A',
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', {name: 'Name'})).toHaveValue(
+        'Assign Approver Group for tenant A',
+      ),
     );
 
     expect(screen.getByRole('combobox', {name: /tenant/i})).toHaveTextContent(
@@ -140,17 +126,17 @@ describe('<Filters />', () => {
     );
   });
 
-  it('initialise filter values from url', async () => {
-    vi.stubGlobal('clientConfig', {
-      multiTenancyEnabled: true,
-    });
+  it('initialize filter values from url', async () => {
+    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
 
     render(<Filters />, {
       wrapper: getWrapper(`/?${new URLSearchParams(MOCK_FILTERS_PARAMS)}`),
     });
 
-    expect(screen.getByLabelText('Name')).toHaveValue(
-      'Assign Approver Group for tenant A',
+    await waitFor(() =>
+      expect(screen.getByLabelText('Name')).toHaveValue(
+        'Assign Approver Group for tenant A',
+      ),
     );
     expectVersion('2');
 
@@ -176,36 +162,16 @@ describe('<Filters />', () => {
   });
 
   it('should disable decision name field when tenant is not selected', async () => {
-    window.clientConfig = {
-      multiTenancyEnabled: true,
-    };
+    window.clientConfig = {multiTenancyEnabled: true};
+    render(<Filters />, {wrapper: getWrapper()});
 
-    render(<Filters />, {
-      wrapper: getWrapper(),
-    });
-
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
-
-    await waitFor(() =>
-      expect(groupedDecisionsStore.state.status).toBe('fetched'),
-    );
     expect(screen.getByLabelText('Name')).toBeDisabled();
   });
 
   it('should clear decision name and version field when tenant filter is changed', async () => {
-    vi.stubGlobal('clientConfig', {
-      multiTenancyEnabled: true,
-    });
+    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
+    const {user} = render(<Filters />, {wrapper: getWrapper()});
 
-    const {user} = render(<Filters />, {
-      wrapper: getWrapper(),
-    });
-
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
-
-    await waitFor(() =>
-      expect(groupedDecisionsStore.state.status).toBe('fetched'),
-    );
     expect(screen.getByLabelText('Name')).toBeDisabled();
 
     await selectTenant({user, option: 'All tenants'});
@@ -220,7 +186,11 @@ describe('<Filters />', () => {
       option: 'Assign Approver Group - Default Tenant',
     });
 
-    expect(screen.getByLabelText('Name')).toHaveValue('Assign Approver Group');
+    await waitFor(() =>
+      expect(screen.getByLabelText('Name')).toHaveValue(
+        'Assign Approver Group',
+      ),
+    );
     expect(
       screen.getByLabelText('Version', {selector: 'button'}),
     ).toHaveTextContent('2');
@@ -228,13 +198,10 @@ describe('<Filters />', () => {
       /default tenant/i,
     );
 
-    mockFetchGroupedDecisions().withSuccess(groupedDecisions);
+    mockSearchDecisionDefinitions().withSuccess(mockDecisionDefinitions);
     await selectTenant({user, option: 'Tenant A'});
-    await waitFor(() =>
-      expect(groupedDecisionsStore.state.status).toBe('fetched'),
-    );
 
-    expect(screen.getByLabelText('Name')).toHaveValue('');
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveValue(''));
     expect(
       screen.getByLabelText('Version', {selector: 'button'}),
     ).toHaveTextContent(/select a decision version/i);

--- a/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
@@ -162,7 +162,7 @@ describe('<Filters />', () => {
   });
 
   it('should disable decision name field when tenant is not selected', async () => {
-    window.clientConfig = {multiTenancyEnabled: true};
+    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
     render(<Filters />, {wrapper: getWrapper()});
 
     expect(screen.getByLabelText('Name')).toBeDisabled();

--- a/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
@@ -16,7 +16,6 @@ import {
 import {InstancesTable} from './index';
 import {Routes, Route, MemoryRouter} from 'react-router-dom';
 import {LocationLog} from 'modules/utils/LocationLog';
-import {AppHeader} from 'App/Layout/AppHeader';
 import {Paths} from 'modules/Routes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
@@ -29,8 +28,6 @@ import {
   assignApproverGroup,
   invoiceClassification,
 } from 'modules/mocks/mockDecisionInstance';
-import {mockMe} from 'modules/mocks/api/v2/me';
-import {createUser} from 'modules/testUtils';
 
 const createWrapper = (
   initialPath: string = `${Paths.decisions()}?evaluated=true`,
@@ -273,46 +270,6 @@ describe('<InstancesTable />', () => {
     expect(screen.getByTestId('data-table-loader')).toBeInTheDocument();
 
     await waitForElementToBeRemoved(screen.queryByTestId('data-table-loader'));
-  });
-
-  it('should refetch data when navigated from header', async () => {
-    mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
-    const resolver = vi.fn();
-    mockSearchDecisionInstances().withSuccess(
-      mockDecisionInstancesSearchResult,
-      {mockResolverFn: resolver},
-    );
-    mockSearchDecisionInstances().withSuccess(
-      mockDecisionInstancesSearchResult,
-      {mockResolverFn: resolver},
-    );
-
-    const {user} = render(
-      <>
-        <AppHeader />
-        <InstancesTable />
-      </>,
-      {wrapper: createWrapper()},
-    );
-
-    await waitForElementToBeRemoved(
-      screen.queryByTestId('data-table-skeleton'),
-    );
-
-    await user.click(
-      within(
-        screen.getByRole('navigation', {
-          name: /camunda operate/i,
-        }),
-      ).getByRole('link', {
-        name: /decisions/i,
-      }),
-    );
-
-    expect(screen.getByTestId('data-table-loader')).toBeInTheDocument();
-
-    await waitForElementToBeRemoved(screen.queryByTestId('data-table-loader'));
-    expect(resolver).toHaveBeenCalledTimes(2);
   });
 
   it.each(['all', undefined])(

--- a/operate/client/src/App/Decisions/InstancesTable/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.tsx
@@ -6,8 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect} from 'react';
-import {useLocation, type Location} from 'react-router-dom';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {SortableTable} from 'modules/components/SortableTable';
 import {StateIcon} from 'modules/components/StateIcon';
@@ -29,13 +27,11 @@ const SMOOTH_SCROLL_STEP_SIZE = 5 * ROW_HEIGHT;
 const InstancesTable: React.FC = observer(() => {
   const filter = useDecisionInstancesSearchFilter();
   const sort = useDecisionInstancesSearchSort();
-  const location = useLocation() as Location<{refreshContent?: boolean}>;
 
   const {
     data,
     status,
     isFetching,
-    refetch,
     isFetchingPreviousPage,
     hasPreviousPage,
     fetchPreviousPage,
@@ -59,12 +55,6 @@ const InstancesTable: React.FC = observer(() => {
   });
   const decisionInstances = data?.decisionInstances ?? [];
   const filteredDecisionInstancesCount = data?.totalCount ?? 0;
-
-  useEffect(() => {
-    if (location.state?.refreshContent) {
-      refetch();
-    }
-  }, [location.state, refetch]);
 
   const getTableState = () => {
     switch (true) {

--- a/operate/client/src/App/Decisions/index.tsx
+++ b/operate/client/src/App/Decisions/index.tsx
@@ -13,30 +13,27 @@ import {InstancesList} from '../Layout/InstancesList';
 import {InstancesTable} from './InstancesTable';
 import {VisuallyHiddenH1} from 'modules/components/VisuallyHiddenH1';
 import {Filters} from './Filters';
-import {groupedDecisionsStore} from 'modules/stores/groupedDecisions';
 import {useLocation, type Location} from 'react-router-dom';
 import {OperationsPanel} from 'modules/components/OperationsPanel';
-
-type LocationType = Omit<Location, 'state'> & {
-  state: {refreshContent?: boolean};
-};
+import {useQueryClient} from '@tanstack/react-query';
+import {queryKeys} from 'modules/queries/queryKeys';
 
 const Decisions: React.FC = () => {
-  const location = useLocation() as LocationType;
+  const location = useLocation() as Location<{refreshContent?: boolean}>;
+  const client = useQueryClient();
 
   useEffect(() => {
     document.title = PAGE_TITLE.DECISION_INSTANCES;
-    return groupedDecisionsStore.reset;
   }, []);
 
   useEffect(() => {
-    if (
-      groupedDecisionsStore.state.status === 'initial' ||
-      location.state?.refreshContent
-    ) {
-      groupedDecisionsStore.fetchDecisions();
+    if (location.state?.refreshContent) {
+      client.refetchQueries({
+        queryKey: queryKeys.decisionDefinitions.search(),
+        type: 'active',
+      });
     }
-  }, [location.state]);
+  }, [location.state, client]);
 
   return (
     <>

--- a/operate/client/src/App/Decisions/index.tsx
+++ b/operate/client/src/App/Decisions/index.tsx
@@ -32,6 +32,10 @@ const Decisions: React.FC = () => {
         queryKey: queryKeys.decisionDefinitions.search(),
         type: 'active',
       });
+      client.refetchQueries({
+        queryKey: queryKeys.decisionInstances.searchPaginated(),
+        type: 'active',
+      });
     }
   }, [location.state, client]);
 

--- a/operate/client/src/modules/api/v2/decisionDefinitions/searchDecisionDefinitions.ts
+++ b/operate/client/src/modules/api/v2/decisionDefinitions/searchDecisionDefinitions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type QueryDecisionDefinitionsResponseBody,
+  type QueryDecisionDefinitionsRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {requestWithThrow} from 'modules/request';
+
+const searchDecisionDefinitions = async (
+  payload?: QueryDecisionDefinitionsRequestBody,
+) => {
+  return requestWithThrow<QueryDecisionDefinitionsResponseBody>({
+    url: endpoints.queryDecisionDefinitions.getUrl(),
+    method: endpoints.queryDecisionDefinitions.method,
+    body: payload,
+  });
+};
+
+export {searchDecisionDefinitions};

--- a/operate/client/src/modules/hooks/decisionDefinition.ts
+++ b/operate/client/src/modules/hooks/decisionDefinition.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {DecisionDefinition} from '@camunda/camunda-api-zod-schemas/8.8';
+import {useDecisionInstancesSearchFilter} from './decisionInstancesSearch';
+import {useDecisionDefinitionsSearch} from 'modules/queries/decisionDefinitions/useDecisionDefinitionsSearch';
+
+/**
+ * Returns sorted decision-definitions for an optional `tenantId`.
+ * The definition are deduplicated for their `decisionDefinitionIds` to include
+ * only the latest `version`.
+ */
+function useDecisionDefinitions(tenantId?: string) {
+  return useDecisionDefinitionsSearch({
+    payload: {
+      filter: {tenantId},
+      sort: [
+        {field: 'name', order: 'asc'},
+        {field: 'version', order: 'desc'},
+      ],
+    },
+    select: (definitions) => {
+      const uniquifier = new Map<string, DecisionDefinition>();
+      for (const definition of definitions) {
+        const seenDefinition = uniquifier.get(definition.decisionDefinitionId);
+        if (!seenDefinition || seenDefinition.version < definition.version) {
+          uniquifier.set(definition.decisionDefinitionId, definition);
+        }
+      }
+      return Array.from(uniquifier.values());
+    },
+  });
+}
+
+/**
+ * Returns sorted definition versions for a given `decisionDefinitionId` and `tenantId`.
+ * The query is disabled when no `decisionDefinitionId` is provided. An `'all'` version
+ * is already included when needed.
+ */
+function useDecisionDefinitionVersions(
+  decisionDefinitionId?: string,
+  tenantId?: string,
+) {
+  return useDecisionDefinitionsSearch({
+    enabled: !!decisionDefinitionId,
+    payload: {
+      filter: {decisionDefinitionId, tenantId},
+      sort: [{field: 'version', order: 'desc'}],
+    },
+    select: (definitions) => {
+      const versions = definitions.map((d) => d.version);
+      return versions.length > 1 ? ['all', ...versions] : versions;
+    },
+  });
+}
+
+/**
+ * Returns the decision-definition that matches the selected decisions filters.
+ * The query is disabled when the filter configuration is incomplete.
+ */
+function useSelectedDecisionDefinition() {
+  const filters = useDecisionInstancesSearchFilter();
+  const enabled =
+    !!filters?.decisionDefinitionId && !!filters.decisionDefinitionVersion;
+
+  return useDecisionDefinitionsSearch({
+    enabled,
+    payload: {
+      filter: {
+        decisionDefinitionId: filters?.decisionDefinitionId,
+        version: filters?.decisionDefinitionVersion,
+        tenantId: filters?.tenantId,
+      },
+    },
+    select: (definitions) => definitions.at(0),
+  });
+}
+
+export {
+  useDecisionDefinitionVersions,
+  useDecisionDefinitions,
+  useSelectedDecisionDefinition,
+};

--- a/operate/client/src/modules/hooks/decisionDefinition.ts
+++ b/operate/client/src/modules/hooks/decisionDefinition.ts
@@ -38,7 +38,7 @@ function getDefinitionIdFromIdentifier(
 
 /**
  * Returns sorted decision-definitions for an optional `tenantId`.
- * The definition are deduplicated for their `decisionDefinitionIds` and `tenantIds`
+ * The definitions are deduplicated for their `decisionDefinitionIds` and `tenantIds`
  * to include only the latest `version`.
  */
 function useDecisionDefinitions(tenantId?: string) {

--- a/operate/client/src/modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions.ts
+++ b/operate/client/src/modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  endpoints,
+  type QueryDecisionDefinitionsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockSearchDecisionDefinitions = (contextPath = '') =>
+  mockPostRequest<QueryDecisionDefinitionsResponseBody>(
+    `${contextPath}${endpoints.queryDecisionDefinitions.getUrl()}`,
+  );
+
+export {mockSearchDecisionDefinitions};

--- a/operate/client/src/modules/mocks/mockDecisionDefinitions.ts
+++ b/operate/client/src/modules/mocks/mockDecisionDefinitions.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {QueryDecisionDefinitionsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockDecisionDefinitions: QueryDecisionDefinitionsResponseBody = {
+  items: [
+    {
+      decisionDefinitionId: 'invoice-assign-approver',
+      name: 'Assign Approver Group',
+      version: 2,
+      decisionRequirementsId: 'invoice-assign-approver-requirements',
+      tenantId: '<default>',
+      decisionDefinitionKey: '1',
+      decisionRequirementsKey: '1-requirements',
+    },
+    {
+      decisionDefinitionId: 'invoice-assign-approver',
+      name: 'Assign Approver Group',
+      version: 1,
+      decisionRequirementsId: 'invoice-assign-approver-requirements',
+      tenantId: '<default>',
+      decisionDefinitionKey: '0',
+      decisionRequirementsKey: '0-requirements',
+    },
+    {
+      decisionDefinitionId: 'invoice-assign-approver',
+      name: 'Assign Approver Group for tenant A',
+      version: 3,
+      decisionRequirementsId: 'invoice-assign-approver-tenant-A-requirements',
+      tenantId: 'tenant-A',
+      decisionDefinitionKey: '4',
+      decisionRequirementsKey: '4-requirements',
+    },
+    {
+      decisionDefinitionId: 'invoice-assign-approver',
+      name: 'Assign Approver Group for tenant A',
+      version: 2,
+      decisionRequirementsId: 'invoice-assign-approver-tenant-A-requirements',
+      tenantId: 'tenant-A',
+      decisionDefinitionKey: '3',
+      decisionRequirementsKey: '3-requirements',
+    },
+    {
+      decisionDefinitionId: 'invoice-assign-approver',
+      name: 'Assign Approver Group for tenant A',
+      version: 1,
+      decisionRequirementsId: 'invoice-assign-approver-tenant-A-requirements',
+      tenantId: 'tenant-A',
+      decisionDefinitionKey: '2',
+      decisionRequirementsKey: '2-requirements',
+    },
+    {
+      decisionDefinitionId: 'invoiceClassification',
+      name: 'invoiceClassification',
+      version: 1,
+      decisionRequirementsId: 'invoiceClassification-requirements',
+      tenantId: '<default>',
+      decisionDefinitionKey: '5',
+      decisionRequirementsKey: '5-requirements',
+    },
+    {
+      decisionDefinitionId: 'calc-key-figures',
+      name: 'Calculate Credit History Key Figures',
+      version: 1,
+      decisionRequirementsId: 'calc-key-figures-requirements',
+      tenantId: '<default>',
+      decisionDefinitionKey: '6',
+      decisionRequirementsKey: '6-requirements',
+    },
+  ],
+  page: {totalItems: 7},
+};
+
+export {mockDecisionDefinitions};

--- a/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinitionsSearch.ts
+++ b/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinitionsSearch.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {queryKeys} from '../queryKeys';
+import {searchDecisionDefinitions} from 'modules/api/v2/decisionDefinitions/searchDecisionDefinitions';
+import type {
+  QueryDecisionDefinitionsRequestBody,
+  QueryDecisionDefinitionsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+
+type QueryOptions<T> = {
+  payload?: QueryDecisionDefinitionsRequestBody;
+  enabled?: boolean;
+  select?: (result: QueryDecisionDefinitionsResponseBody['items']) => T;
+};
+
+const useDecisionDefinitionsSearch = <
+  T = QueryDecisionDefinitionsResponseBody['items'],
+>(
+  options?: QueryOptions<T>,
+) => {
+  return useQuery({
+    queryKey: queryKeys.decisionDefinitions.search(options?.payload),
+    enabled: options?.enabled,
+    select: options?.select,
+    queryFn: async () => {
+      const {error, response} = await searchDecisionDefinitions(
+        options?.payload,
+      );
+      if (error) {
+        throw error;
+      }
+
+      if (response.page.totalItems <= response.items.length) {
+        return response.items;
+      }
+
+      const {response: remaining, error: remainingError} =
+        await searchDecisionDefinitions({
+          ...options?.payload,
+          page: {
+            from: response.items.length,
+            limit: response.page.totalItems,
+          },
+        });
+      if (remainingError) {
+        throw remainingError;
+      }
+
+      return response.items.concat(remaining.items);
+    },
+  });
+};
+
+export {useDecisionDefinitionsSearch};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -50,6 +50,10 @@ const queryKeys = {
       'decisionDefinition',
       decisionDefinitionKey,
     ],
+    search: (payload?: object) =>
+      payload
+        ? ['decisionDefinitionsSearch', payload]
+        : ['decisionDefinitionsSearch'],
   },
   processDefinitionXml: {
     get: (processDefinitionKey?: string) => [

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -40,10 +40,10 @@ const queryKeys = {
       'decisionInstancesSearch',
       payload,
     ],
-    searchPaginated: (payload?: QueryDecisionInstancesRequestBody) => [
-      'decisionInstancesSearchPaginated',
-      payload,
-    ],
+    searchPaginated: (payload?: QueryDecisionInstancesRequestBody) =>
+      payload
+        ? ['decisionInstancesSearchPaginated', payload]
+        : ['decisionInstancesSearchPaginated'],
   },
   decisionDefinitions: {
     get: (decisionDefinitionKey: string) => [

--- a/operate/client/src/modules/utils/filter/decisionInstancesSearch.test.ts
+++ b/operate/client/src/modules/utils/filter/decisionInstancesSearch.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  parseDecisionDefinitionsSearchFilter,
   parseDecisionInstancesSearchFilter,
   parseDecisionInstancesSearchSort,
 } from './decisionInstancesSearch';
@@ -72,6 +73,56 @@ describe('parseDecisionInstancesSearchFilter', () => {
     const filter = parseDecisionInstancesSearchFilter(searchParams);
 
     expect(filter).toEqual({state: {$in: ['EVALUATED']}});
+  });
+});
+
+describe('parseDecisionDefinitionsSearchFilter', () => {
+  it('should parse decision definitions search filter from search params', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('name', 'testName');
+    searchParams.append('version', '3');
+    searchParams.append('tenant', 'tenant-A');
+
+    const filter = parseDecisionDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({
+      decisionDefinitionId: 'testName',
+      version: 3,
+      tenantId: 'tenant-A',
+    });
+  });
+
+  it('should return empty filters when no relevant param is set', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('someParam', 'someValue');
+
+    const filter = parseDecisionDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({});
+  });
+
+  it('should not include a version in the filter when its value is all', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('name', 'testName');
+    searchParams.append('version', 'all');
+
+    const filter = parseDecisionDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({
+      decisionDefinitionId: 'testName',
+    });
+  });
+
+  it('should not include a tenantId in the filter when its value is all', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('name', 'testName');
+    searchParams.append('tenant', 'all');
+
+    const filter = parseDecisionDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({
+      decisionDefinitionId: 'testName',
+    });
   });
 });
 

--- a/operate/client/src/modules/utils/filter/decisionInstancesSearch.ts
+++ b/operate/client/src/modules/utils/filter/decisionInstancesSearch.ts
@@ -9,6 +9,7 @@
 import {
   queryDecisionInstancesRequestBodySchema,
   type DecisionInstanceState,
+  type QueryDecisionDefinitionsRequestBody,
   type QueryDecisionInstancesRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import z from 'zod';
@@ -17,6 +18,10 @@ import {parseIds, parseSortParamsV2, updateFiltersSearchString} from '.';
 
 type DecisionInstancesSearchFilter = NonNullable<
   QueryDecisionInstancesRequestBody['filter']
+>;
+
+type DecisionDefinitionsSearchFilter = NonNullable<
+  QueryDecisionDefinitionsRequestBody['filter']
 >;
 
 type DecisionInstanceFiltersField = keyof DecisionInstanceFilters;
@@ -56,6 +61,21 @@ function parseDecisionInstancesSearchFilter(
     processInstanceKey: filter.processInstanceId,
     tenantId: filter.tenant === 'all' ? undefined : filter.tenant,
     evaluationDate: mapEvaluationDateFilter(filter),
+  };
+}
+
+/**
+ * Parses filter arguments for a decision-definitions search from the given {@linkcode URLSearchParams}.
+ */
+function parseDecisionDefinitionsSearchFilter(
+  search: URLSearchParams,
+): DecisionDefinitionsSearchFilter {
+  const filter = parseDecisionInstancesFilter(search);
+
+  return {
+    decisionDefinitionId: filter.name,
+    version: mapDecisionDefinitionVersionFilter(filter),
+    tenantId: filter.tenant === 'all' ? undefined : filter.tenant,
   };
 }
 
@@ -151,6 +171,7 @@ function updateDecisionsFiltersSearchString(
 
 export {
   parseDecisionInstancesSearchFilter,
+  parseDecisionDefinitionsSearchFilter,
   parseDecisionInstancesFilter,
   parseDecisionInstancesSearchSort,
   updateDecisionsFiltersSearchString,


### PR DESCRIPTION
## Description

Migrated the use of the `decisionGroupStore` and API endpoints to the decisions-definitions search endpoint and TanStack Query hooks. The commits can help to bring some structure to the PR:

1. Established methods and query hook for the new endpoint
2. Migrated the decisions UI to use the new endpoint
3. I intended to streamline the filter logic a bit, which went south. This commits addresses it by re-introducing a computed decision identifier.
4. Inconsistencies didn't stop... Viewing a decision did not behave the same around edge-cases as the current UI. This commit adds further complexity to bring align the UI behavior with the existing implementation.
5. Adjusts all unit tests.
6. Adjusts the Playwright tests, and tackled an inconsistency around the disabled state of the "reset filters" button.

> [!NOTE]
> I left some PR comments that hopefully provide some further insights into some of my decisions in this PR.
>
> Cleanup will happen in a follow-up PR. Furthermore, The naming of the `decisionInstanceSearch` filter file and its functions got a bit overloaded. I intent to rename them, so they better align across "decision filter (UI state)", "decision-definitions-search filter", and "decision-instances-search filter".

## Checklist

- [x] Notice that this PR is stacked on #41050

## Related issues

relates #27343
