### PR TITLE
[Backport stable/8.8] test: add process instance key filter to stabilise flaky compensation test

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -3435,6 +3435,7 @@ public class CompensationEventExecutionTest {
         .contains(tuple(CompensationSubscriptionIntent.TRIGGERED, "adhoc-subprocess"));
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId())
         .containsSubsequence(


### PR DESCRIPTION
# Description
Backport of #41277 to `stable/8.8`.

relates to #41276