### PR TITLE
test: force a default admin role for old routes redirection IT

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -24,7 +24,10 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
 
   @LocalServerPort private int port;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -9,8 +9,13 @@ package io.camunda.tasklist.webapp.controllers;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +30,7 @@ public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
   @LocalServerPort private int port;
 
   @Autowired private TestRestTemplate restTemplate;
+  @Autowired private CamundaSecurityProperties securityConfig;
 
   private String baseUrl() {
     return "http://localhost:" + port;
@@ -33,6 +39,17 @@ public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
   static Stream<String> redirectionTestDataProvider() {
     return Stream.of(
         "", "/processes", "/login", "/123456", "/processes/order/start", "/new/process_id");
+  }
+
+  @BeforeEach
+  public void setup() {
+    // force a default admin role so that AdminUserCheckFilter does not interfere and redirect to
+    // /identity/setup as otherwise we try to search in secondary storage for the roles and then
+    // things may or may not work depending on what else ran before
+    securityConfig
+        .getInitialization()
+        .getDefaultRoles()
+        .put("admin", Map.of("users", List.of(InitializationConfiguration.DEFAULT_USER_USERNAME)));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Otherwise it seems these tests sometimes fail if other tests running before have updated roles in secondary storage.

This test seemed to be failing quite regularly when I was working on #41204 

When running locally I realised that it was only passing due to it it catching the exception:
```
co.elastic.clients.elasticsearch._types.ElasticsearchException: [es/search] failed: [index_not_found_exception] no such index [camunda-role-8.8.0_alias]
	at co.elastic.clients.transport.ElasticsearchTransportBase.getApiResponse(ElasticsearchTransportBase.java:349) ~[elasticsearch-java-8.16.6.jar:?]
	at co.elastic.clients.transport.ElasticsearchTransportBase.performRequest(ElasticsearchTransportBase.java:148) ~[elasticsearch-java-8.16.6.jar:?]
	at co.elastic.clients.elasticsearch.ElasticsearchClient.search(ElasticsearchClient.java:2398) ~[elasticsearch-java-8.16.6.jar:?]
	at io.camunda.search.es.clients.ElasticsearchSearchClient.search(ElasticsearchSearchClient.java:79) ~[classes/:?]
	at io.camunda.search.clients.SearchClientBasedQueryExecutor.lambda$executePaginatedSearch$5(SearchClientBasedQueryExecutor.java:169) ~[classes/:?]
	at io.camunda.search.clients.SearchClientBasedQueryExecutor.executeSearch(SearchClientBasedQueryExecutor.java:186) ~[classes/:?]
	at io.camunda.search.clients.SearchClientBasedQueryExecutor.executePaginatedSearch(SearchClientBasedQueryExecutor.java:169) ~[classes/:?]
	at io.camunda.search.clients.SearchClientBasedQueryExecutor.search(SearchClientBasedQueryExecutor.java:62) ~[classes/:?]
```

then logging:

```
2025-11-20 17:21:06.101 ERROR 54741 --- [0-auto-1-exec-2] i.c.a.f.AdminUserCheckFilter             : Error while searching for admin role members. This might indicate that secondary storage is down.
```

and then carrying on without issuing a `/identity/setup` redirect.

My assumption is that some other tests were setting up `camunda-role-8.8.0_alias` in the shared Elasticsearch instance and then no admin roles were found, so the redirect was being sent.

