### PR TITLE
test: adopt unified configuration to Test* applications

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -158,6 +158,12 @@ public class Cluster implements Cloneable {
     this.initialContactPoints = initialContactPoints;
   }
 
+  // TODO KPO fix
+  public int nodeId() {
+    // return node id without backwards compatibility check; useful for internal testing
+    return nodeId;
+  }
+
   public Integer getNodeId() {
     return nodeIdProvider.fixed().getNodeId();
   }

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -158,12 +158,6 @@ public class Cluster implements Cloneable {
     this.initialContactPoints = initialContactPoints;
   }
 
-  // TODO KPO fix
-  public int nodeId() {
-    // return node id without backwards compatibility check; useful for internal testing
-    return nodeId;
-  }
-
   public Integer getNodeId() {
     return nodeIdProvider.fixed().getNodeId();
   }

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -65,6 +65,16 @@ public class UnifiedConfigurationHelper {
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<String> legacyProperties) {
 
+    // If the environment is not set, it is assumed that the helper is used
+    // in a non-Spring context, and the validation of backward compatibility
+    // is not necessary.
+    // This is the case when running the test applications
+    // (e.g., TestCluster, TestStandaloneBroker, TestStandaloneGateway).
+    // These applications are configured using only the unified configuration.
+    if (environment == null) {
+      return newValue;
+    }
+
     if (backwardsCompatibilityMode == null) {
       throw new UnifiedConfigurationException("backwardsCompatibilityMode cannot be null");
     }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -58,7 +58,7 @@ public class SearchEngineDatabaseConfiguration {
 
     // Override schema creation if database type is "none"
     final DatabaseType databaseType = searchEngineConnectProperties.getTypeEnum();
-    if (DatabaseConfig.NONE.equals(databaseType.name())) {
+    if (DatabaseConfig.NONE.equalsIgnoreCase(databaseType.name())) {
       searchEngineSchemaManagerProperties.setCreateSchema(false);
     }
 

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -491,18 +491,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-atomix-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
@@ -59,13 +59,9 @@ public class UsageMetricAuthorizationIT {
           .withBasicAuth()
           .withMultiTenancyEnabled()
           .withAuthorizationsEnabled()
-          .withBrokerConfig(
-              brokerBasedProperties ->
-                  brokerBasedProperties
-                      .getExperimental()
-                      .getEngine()
-                      .getUsageMetrics()
-                      .setExportInterval(EXPORT_INTERVAL));
+          // set exportInterval via properties because it is not yet supported in unified config
+          .withProperty(
+              "zeebe.broker.experimental.engine.usageMetrics.exportInterval", EXPORT_INTERVAL);
 
   private static final String TENANT_A = "tenantA";
   private static final String TENANT_B = "tenantB";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -11,9 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import feign.FeignException.NotFound;
+import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.configuration.Backup;
+import io.camunda.configuration.Backup.BackupStoreType;
 import io.camunda.configuration.Camunda;
 import io.camunda.it.document.DocumentClient;
 import io.camunda.management.backups.StateCode;
@@ -29,8 +31,7 @@ import io.camunda.webapps.backup.Metadata;
 import io.camunda.webapps.backup.repository.SnapshotNameProvider;
 import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
 import io.camunda.zeebe.backup.azure.AzureBackupStore;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
@@ -113,6 +114,7 @@ public class BackupRestoreIT {
   private DataGenerator generator;
   private HistoryBackupClient historyBackupClient;
   private MultiDbConfigurator configurator;
+  private WorkingDirectory workingDirectory;
 
   @AfterEach
   public void tearDown() {
@@ -125,7 +127,7 @@ public class BackupRestoreIT {
             .withAuthenticationMethod(AuthenticationMethod.BASIC)
             .withUnauthenticatedAccess();
     configurator = new MultiDbConfigurator(testStandaloneApplication);
-    testStandaloneApplication.withBrokerConfig(this::configureZeebeBackupStore);
+    testStandaloneApplication.withUnifiedConfig(this::configureZeebeBackupStore);
     final String dbUrl;
     searchContainer =
         switch (config.databaseType) {
@@ -160,8 +162,6 @@ public class BackupRestoreIT {
                   "Unsupported database type: " + config.databaseType);
         };
 
-    testStandaloneApplication.withProperty("camunda.data.backup.repository-name", REPOSITORY_NAME);
-
     testStandaloneApplication.start().awaitCompleteTopology();
 
     camundaClient =
@@ -176,6 +176,7 @@ public class BackupRestoreIT {
     webappsDBClient = DocumentClient.create(dbUrl, config.databaseType, EXECUTOR);
     webappsDBClient.createRepository(REPOSITORY_NAME);
     generator = new DataGenerator(camundaClient, PROCESS_ID, TIMEOUT);
+    workingDirectory = testStandaloneApplication.bean(WorkingDirectory.class);
   }
 
   public static Stream<BackupRestoreTestConfig> sources() {
@@ -222,6 +223,11 @@ public class BackupRestoreIT {
     webappsDBClient.restore(REPOSITORY_NAME, snapshots);
     restoreZeebe();
 
+    // Since the unified configuration does not contain the full data directory path, we set the
+    // working directory so that the path can be properly constructed during application startup.
+    testStandaloneApplication.withBean(
+        "workingDirectory", workingDirectory, WorkingDirectory.class);
+
     testStandaloneApplication.start();
 
     generator.verifyAllExported(ProcessInstanceState.ACTIVE);
@@ -232,13 +238,15 @@ public class BackupRestoreIT {
     generator.verifyAllExported(ProcessInstanceState.COMPLETED);
   }
 
-  private void configureZeebeBackupStore(final BrokerCfg cfg) {
+  private void configureZeebeBackupStore(final Camunda cfg) {
     final var backup = cfg.getData().getBackup();
     final var azure = backup.getAzure();
 
     backup.setStore(BackupStoreType.AZURE);
     azure.setBasePath(containerName);
     azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
+
+    cfg.getData().getBackup().setRepositoryName(REPOSITORY_NAME);
   }
 
   private void restoreZeebe() {
@@ -249,16 +257,19 @@ public class BackupRestoreIT {
     backup.getAzure().setBasePath(containerName);
     backup.getAzure().setConnectionString(AZURITE_CONTAINER.getConnectString());
 
-    final var brokerCfg = testStandaloneApplication.brokerConfig();
+    final var brokerCfg = testStandaloneApplication.unifiedConfig();
     unifiedRestoreConfig.getCluster().setNodeId(brokerCfg.getCluster().getNodeId());
-    unifiedRestoreConfig
-        .getCluster()
-        .setPartitionCount(brokerCfg.getCluster().getPartitionsCount());
+    unifiedRestoreConfig.getCluster().setPartitionCount(brokerCfg.getCluster().getPartitionCount());
+    // The directory is constructed using the broker’s working directory because the unified
+    // configuration does not contain the full path
     unifiedRestoreConfig
         .getData()
         .getPrimaryStorage()
-        .setDirectory(brokerCfg.getData().getDirectory());
-    unifiedRestoreConfig.getCluster().setSize(brokerCfg.getCluster().getClusterSize());
+        .setDirectory(
+            ConfigurationUtil.toAbsolutePath(
+                brokerCfg.getData().getPrimaryStorage().getDirectory(),
+                workingDirectory.path().toString()));
+    unifiedRestoreConfig.getCluster().setSize(brokerCfg.getCluster().getSize());
 
     try (final var restoreApp = new TestRestoreApp(unifiedRestoreConfig).withBackupId(BACKUP_ID)) {
       assertThatNoException().isThrownBy(restoreApp::start);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -93,8 +93,12 @@ final class StandaloneBackupManagerIT {
           .withUnauthenticatedAccess()
           .withProperty("camunda.operate.elasticsearch.health-check-enabled", "false")
           .withProperty("camunda.tasklist.elasticsearch.health-check-enabled", "false")
-          .withProperty("camunda.data.secondary-storage.elasticsearch.username", APP_USER)
-          .withProperty("camunda.data.secondary-storage.elasticsearch.password", APP_PASSWORD)
+          .withUnifiedConfig(
+              cfg -> {
+                cfg.getData().getSecondaryStorage().getElasticsearch().setUsername(APP_USER);
+                cfg.getData().getSecondaryStorage().getElasticsearch().setPassword(APP_PASSWORD);
+                cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
+              })
           .withExporter(
               CamundaExporter.class.getSimpleName(),
               cfg -> {
@@ -161,7 +165,8 @@ final class StandaloneBackupManagerIT {
 
     // Connect to ES in Camunda
     camunda
-        .withProperty("camunda.data.secondary-storage.elasticsearch.url", esUrl)
+        .withUnifiedConfig(
+            cfg -> cfg.getData().getSecondaryStorage().getElasticsearch().setUrl(esUrl))
         .updateExporterArgs(
             CamundaExporter.class.getSimpleName(),
             args -> ((Map) args.get("connect")).put("url", esUrl));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
@@ -48,13 +48,10 @@ public class BatchOperationLifecycleManagementTest {
   private static final TestStandaloneApplication<?> APPLICATION =
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
-          .withBrokerConfig(
-              b -> {
-                b.getExperimental()
-                    .getEngine()
-                    .getBatchOperations()
-                    .setSchedulerInterval(Duration.ofDays(1));
-              });
+          // set schedulerInterval via properties because it is not yet supported in unified config
+          .withProperty(
+              "zeebe.broker.experimental.engine.batchOperations.schedulerInterval",
+              Duration.ofDays(1));
 
   String testScopeId;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsTest.java
@@ -48,13 +48,9 @@ public class UsageMetricsTest {
           .withBasicAuth()
           .withMultiTenancyEnabled()
           .withAuthenticatedAccess()
-          .withBrokerConfig(
-              brokerBasedProperties ->
-                  brokerBasedProperties
-                      .getExperimental()
-                      .getEngine()
-                      .getUsageMetrics()
-                      .setExportInterval(EXPORT_INTERVAL));
+          // set exportInterval via properties because it is not yet supported in unified config
+          .withProperty(
+              "zeebe.broker.experimental.engine.usageMetrics.exportInterval", EXPORT_INTERVAL);
 
   private static final String ADMIN = "admin";
   private static final String ASSIGNEE = "bar2";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
@@ -51,10 +51,10 @@ public class ClusterMultiplePartitionsBatchOperationIT {
   private static final TestStandaloneApplication<?> APPLICATION =
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
-          .withBrokerConfig(
+          .withUnifiedConfig(
               b -> {
                 final var cluster = b.getCluster();
-                cluster.setPartitionsCount(3);
+                cluster.setPartitionCount(3);
                 b.setCluster(cluster);
               });
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import eu.rekawek.toxiproxy.model.ToxicDirection;
+import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
 import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
@@ -23,7 +24,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.awaitility.Awaitility;
@@ -59,37 +59,27 @@ public class HealthCheckIT {
   @AutoClose private static S3Client s3Client;
   private static final String BUCKET_NAME = UUID.randomUUID().toString();
   private static final Duration LEASE_DURATION = Duration.ofSeconds(5);
-  private static final String TASK_ID_PROPERTY = "camunda.cluster.node-id-provider.s3.taskId";
   private static final ProxyRegistry PROXY_REGISTRY = new ProxyRegistry(TOXIPROXY);
   private static URI toxiproxyS3Endpoint;
   private static ContainerProxy proxy;
   private static final String LATENCY_TOXIC = "latency";
 
   @TestZeebe
-  private TestStandaloneBroker broker =
+  private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
-          .withAdditionalProperties(
-              Map.of(
-                  "camunda.data.secondary-storage.type",
-                  "none",
-                  "camunda.cluster.node-id-provider.type",
-                  "s3",
-                  TASK_ID_PROPERTY,
-                  UUID.randomUUID().toString(),
-                  "camunda.cluster.node-id-provider.s3.bucketName",
-                  BUCKET_NAME,
-                  "camunda.cluster.node-id-provider.s3.leaseDuration",
-                  LEASE_DURATION,
-                  "camunda.cluster.node-id-provider.s3.endpoint",
-                  toxiproxyS3Endpoint,
-                  "camunda.cluster.node-id-provider.s3.region",
-                  S3.getRegion(),
-                  "camunda.cluster.node-id-provider.s3.accessKey",
-                  S3.getAccessKey(),
-                  "camunda.cluster.node-id-provider.s3.secretKey",
-                  S3.getSecretKey(),
-                  "camunda.cluster.node-id-provider.s3.apiCallTimeout",
-                  LEASE_DURATION.dividedBy(2).toString()));
+          .withUnifiedConfig(
+              cfg -> {
+                cfg.getCluster().getNodeIdProvider().setType(Type.S3);
+                final var s3 = cfg.getCluster().getNodeIdProvider().s3();
+                s3.setTaskId(UUID.randomUUID().toString());
+                s3.setBucketName(BUCKET_NAME);
+                s3.setLeaseDuration(LEASE_DURATION);
+                s3.setEndpoint(toxiproxyS3Endpoint.toString());
+                s3.setRegion(S3.getRegion());
+                s3.setAccessKey(S3.getAccessKey());
+                s3.setSecretKey(S3.getSecretKey());
+                s3.setApiCallTimeout(LEASE_DURATION.dividedBy(2));
+              });
 
   @BeforeAll
   public static void setupAll() throws URISyntaxException {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -10,11 +10,8 @@ package io.camunda.it.network;
 import static io.camunda.application.commons.security.CamundaSecurityConfiguration.UNPROTECTED_API_ENV_VAR;
 import static io.camunda.zeebe.test.util.asserts.TopologyAssert.assertThat;
 
-import io.atomix.utils.net.Address;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.Topology;
-import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
-import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
@@ -215,13 +212,6 @@ final class SecuredClusteredMessagingIT {
             container.getMappedPort(ZeebePort.INTERNAL.getPort()));
 
     assertAddressIsSecured(container.getNetworkAliases(), internalApiAddress);
-  }
-
-  private InetSocketAddress getGatewayAddress(final TestCluster cluster) {
-    final ClusterCfg clusterConfig = cluster.availableGateway().gatewayConfig().getCluster();
-    final var address =
-        Address.from(clusterConfig.getAdvertisedHost(), clusterConfig.getAdvertisedPort());
-    return address.socketAddress();
   }
 
   private void assertAddressIsSecured(final Object nodeId, final SocketAddress address) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoAuthNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/NoAuthNoSecondaryStorageTest.java
@@ -8,7 +8,6 @@
 package io.camunda.it.nodb;
 
 import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
-import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,7 +35,6 @@ public class NoAuthNoSecondaryStorageTest {
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
           .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "none")
-          .withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, "none")
           .withProperty("spring.profiles.active", "broker");
 
   @AutoClose private CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.it.nodb;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
-import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
@@ -68,7 +66,6 @@ public class OidcNoSecondaryStorageTest {
       new TestStandaloneBroker()
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
-          .withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE)
           .withProperty("camunda.security.authentication.method", "oidc")
           .withSecurityConfig(
               c -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
@@ -81,9 +81,10 @@ public class IncidentNotifierIT {
     final var camundaExporter = CamundaExporter.class.getSimpleName().toLowerCase();
 
     // configure exporter to point to WireMock
-    STANDALONE_CAMUNDA.withBrokerConfig(
+    STANDALONE_CAMUNDA.withUnifiedConfig(
         c -> {
-          final var newArgs = new HashMap<>(c.getExporters().get(camundaExporter).getArgs());
+          final var newArgs =
+              new HashMap<>(c.getData().getExporters().get(camundaExporter).getArgs());
           final var baseUrl = wireMockServer.baseUrl();
           newArgs.put(
               "notifier",
@@ -95,7 +96,7 @@ public class IncidentNotifierIT {
                   "auth0Protocol",
                   "http"));
 
-          c.getExporters().get(camundaExporter).setArgs(newArgs);
+          c.getData().getExporters().get(camundaExporter).setArgs(newArgs);
         });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -10,9 +10,11 @@ package io.camunda.it.rdbms.db.util;
 import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.configuration.Camunda;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,6 +117,12 @@ public final class CamundaRdbmsTestApplication
   @Override
   public boolean isGateway() {
     return false;
+  }
+
+  @Override
+  public CamundaRdbmsTestApplication withUnifiedConfig(final Consumer<Camunda> modifier) {
+    throw new UnsupportedOperationException(
+        "CamundaRdbmsTestApplication does not support unified configuration");
   }
 
   public RdbmsService getRdbmsService() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARC
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.application.Profile;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
@@ -123,13 +124,14 @@ public final class ElasticsearchBackendStrategy implements SearchBackendStrategy
         .withProperty(CREATE_SCHEMA_PROPERTY, "false")
         .withProperty("camunda.operate.elasticsearch.health-check-enabled", "false")
         .withProperty("camunda.tasklist.elasticsearch.health-check-enabled", "false")
-        .withProperty(
-            "zeebe.broker.exporters.elasticsearch.class-name",
-            ElasticsearchExporter.class.getName())
-        .withProperty("camunda.data.secondary-storage.type", "elasticsearch")
-        .withProperty("camunda.data.secondary-storage.elasticsearch.url", url)
-        .withProperty("camunda.data.secondary-storage.elasticsearch.username", APP_USER)
-        .withProperty("camunda.data.secondary-storage.elasticsearch.password", APP_PASSWORD)
+        .withSecondaryStorageType(SecondaryStorageType.elasticsearch)
+        .withUnifiedConfig(
+            cfg -> {
+              cfg.getData().getSecondaryStorage().getElasticsearch().setUrl(url);
+              cfg.getData().getSecondaryStorage().getElasticsearch().setUsername(APP_USER);
+              cfg.getData().getSecondaryStorage().getElasticsearch().setPassword(APP_PASSWORD);
+              cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
+            })
         .withExporter(
             CamundaExporter.class.getSimpleName(),
             cfg -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
@@ -10,6 +10,7 @@ package io.camunda.it.schema.strategy;
 import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_OPENSEARCH_VERSION;
 
 import io.camunda.application.Profile;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
@@ -89,8 +90,12 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
         .withUnauthenticatedAccess()
         .withProperty("camunda.database.url", url)
         .withProperty("camunda.database.type", "opensearch")
-        .withProperty("camunda.data.secondary-storage.type", "opensearch")
-        .withProperty("camunda.data.secondary-storage.opensearch.url", url)
+        .withSecondaryStorageType(SecondaryStorageType.opensearch)
+        .withUnifiedConfig(
+            cfg -> {
+              cfg.getData().getSecondaryStorage().getOpensearch().setUrl(url);
+              cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
+            })
         .withExporter(
             CamundaExporter.class.getSimpleName(),
             cfg -> {

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -36,10 +36,6 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>elasticsearch</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -18,8 +18,11 @@ import io.camunda.application.commons.security.CamundaSecurityConfiguration.Camu
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.client.CredentialsProvider;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
@@ -67,8 +70,9 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         TestStandaloneApplication<TestCamundaApplication> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestCamundaApplication.class);
-  private final BrokerBasedProperties brokerProperties;
+  private final Camunda unifiedConfig;
   private final CamundaSecurityProperties securityConfig;
+  private final boolean isGatewayEnabled = true;
 
   public TestCamundaApplication() {
     super(
@@ -81,6 +85,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         SearchEngineIndexPropertiesOverride.class,
         SearchEngineRetentionPropertiesOverride.class,
         GatewayRestPropertiesOverride.class,
+        BrokerBasedPropertiesOverride.class,
         // ---
         CommonsModuleConfiguration.class,
         OperateModuleConfiguration.class,
@@ -90,20 +95,41 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         BrokerModuleConfiguration.class,
         IndexTemplateDescriptorsConfigurator.class);
 
-    brokerProperties = new BrokerBasedProperties();
+    unifiedConfig = new Camunda();
 
-    brokerProperties.getNetwork().getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
-    brokerProperties.getNetwork().getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
-    brokerProperties.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
+    unifiedConfig
+        .getCluster()
+        .getNetwork()
+        .getCommandApi()
+        .setPort(SocketUtil.getNextAddress().getPort());
+    unifiedConfig
+        .getCluster()
+        .getNetwork()
+        .getInternalApi()
+        .setPort(SocketUtil.getNextAddress().getPort());
+    unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
 
     // set a smaller default log segment size since we pre-allocate, which might be a lot in tests
     // for local development; also lower the watermarks for local testing
-    brokerProperties.getData().setLogSegmentSize(DataSize.ofMegabytes(16));
-    brokerProperties.getData().getDisk().getFreeSpace().setProcessing(DataSize.ofMegabytes(128));
-    brokerProperties.getData().getDisk().getFreeSpace().setReplication(DataSize.ofMegabytes(64));
-
-    brokerProperties.getExperimental().getConsistencyChecks().setEnableForeignKeyChecks(true);
-    brokerProperties.getExperimental().getConsistencyChecks().setEnablePreconditions(true);
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getLogStream()
+        .setLogSegmentSize(DataSize.ofMegabytes(16));
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getDisk()
+        .getFreeSpace()
+        .setProcessing(DataSize.ofMegabytes(128));
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getDisk()
+        .getFreeSpace()
+        .setReplication(DataSize.ofMegabytes(64));
+    unifiedConfig.getProcessing().setEnableForeignKeyChecks(true);
+    unifiedConfig.getProcessing().setEnablePreconditionsCheck(true);
 
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthorizations().setEnabled(false);
@@ -137,7 +163,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
                 List.of(DEFAULT_MAPPING_RULE_ID)));
 
     //noinspection resource
-    withBean("config", brokerProperties, BrokerBasedProperties.class)
+    withBean("camunda", unifiedConfig, Camunda.class)
         .withBean("security-config", securityConfig, CamundaSecurityProperties.class)
         .withProperty(
             AuthenticationProperties.API_UNPROTECTED,
@@ -162,9 +188,9 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   @Override
   public int mappedPort(final TestZeebePort port) {
     return switch (port) {
-      case COMMAND -> brokerProperties.getNetwork().getCommandApi().getPort();
-      case GATEWAY -> brokerProperties.getGateway().getNetwork().getPort();
-      case CLUSTER -> brokerProperties.getNetwork().getInternalApi().getPort();
+      case COMMAND -> unifiedConfig.getCluster().getNetwork().getCommandApi().getPort();
+      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
+      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
       default -> super.mappedPort(port);
     };
   }
@@ -182,7 +208,10 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     // because @ConditionalOnRestGatewayEnabled relies on the zeebe.broker.gateway.enable property,
     // we need to hook in at the last minute and set the property as it won't resolve from the
     // config bean
-    withProperty("zeebe.broker.gateway.enable", brokerProperties.getGateway().isEnable());
+    // Gateway enable flag is set via property since gateway config isn't fully in unified config
+    withProperty(
+        "zeebe.broker.gateway.enable",
+        property("zeebe.broker.gateway.enable", Boolean.class, isGatewayEnabled));
     return super.createSpringBuilder();
   }
 
@@ -217,12 +246,14 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   @Override
   public MemberId nodeId() {
-    return MemberId.from(String.valueOf(brokerProperties.getCluster().getNodeId()));
+    return MemberId.from(String.valueOf(unifiedConfig.getCluster().getNodeId()));
   }
 
   @Override
   public String host() {
-    return brokerProperties.getNetwork().getHost();
+    return unifiedConfig.getCluster().getNetwork().getHost() != null
+        ? unifiedConfig.getCluster().getNetwork().getHost()
+        : "0.0.0.0";
   }
 
   @Override
@@ -230,9 +261,10 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     return BrokerHealthActuator.of(monitoringUri().toString());
   }
 
+  // TODO KPO add gateway enabled to unified configuration?
   @Override
   public boolean isGateway() {
-    return brokerProperties.getGateway().isEnable();
+    return isGatewayEnabled;
   }
 
   @Override
@@ -252,39 +284,78 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   @Override
   public TestCamundaApplication withGatewayConfig(final Consumer<GatewayCfg> modifier) {
-    modifier.accept(brokerProperties.getGateway());
+    throw new UnsupportedOperationException(
+        "Gateway configuration via withGatewayConfig is not supported. "
+            + "Gateway is not yet fully migrated to unified configuration. "
+            + "Use withProperty() to set zeebe.broker.gateway.* properties instead.");
+  }
+
+  @Override
+  public TestCamundaApplication withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(unifiedConfig);
     return this;
   }
 
   @Override
   public GatewayCfg gatewayConfig() {
-    return brokerProperties.getGateway();
+    throw new UnsupportedOperationException(
+        "Gateway configuration access via gatewayConfig() is not supported. "
+            + "Gateway is not yet fully migrated to unified configuration.");
   }
 
   /**
-   * Registers or replaces a new exporter with the given ID. If it was already registered, the
-   * existing configuration is passed to the modifier.
+   * Returns the unified configuration object. This provides access to the camunda.* configuration
+   * structure and is the primary way to read/configure the test broker.
+   *
+   * @return the Camunda unified configuration object
+   */
+  @Override
+  public Camunda unifiedConfig() {
+    return unifiedConfig;
+  }
+
+  /**
+   * Adds or replaces a new exporter with the given ID using unified configuration.
+   *
+   * <p>Note: This method accepts ExporterCfg for backward compatibility but configures the unified
+   * config exporter. ExporterCfg will be converted to the unified Exporter format.
    *
    * @param id the ID of the exporter
-   * @param modifier a configuration function
+   * @param modifier a configuration function that accepts ExporterCfg
    * @return itself for chaining
    */
   @Override
   public TestCamundaApplication withExporter(
       final String id, final Consumer<ExporterCfg> modifier) {
-    final var cfg = new ExporterCfg();
-    modifier.accept(cfg);
-    brokerProperties.getExporters().put(id, cfg);
-    return this;
+    // Create a temporary ExporterCfg to accept the configuration
+    final var tempExporterCfg = new ExporterCfg();
+    modifier.accept(tempExporterCfg);
+
+    // Transfer to unified config exporter
+    return withDataConfig(
+        data -> {
+          final var unifiedExporter =
+              data.getExporters()
+                  .computeIfAbsent(id, ignored -> new io.camunda.configuration.Exporter());
+          unifiedExporter.setClassName(tempExporterCfg.getClassName());
+          unifiedExporter.setJarPath(tempExporterCfg.getJarPath());
+          unifiedExporter.setArgs(tempExporterCfg.getArgs());
+        });
   }
 
-  /**
-   * Modifies the broker configuration. Will still mutate the configuration if the broker is
-   * started, but likely has no effect until it's restarted.
-   */
+  @Deprecated
   @Override
   public TestCamundaApplication withBrokerConfig(final Consumer<BrokerBasedProperties> modifier) {
-    modifier.accept(brokerProperties);
+    throw new UnsupportedOperationException(
+        "withBrokerConfig() is no longer supported. "
+            + "Use withUnifiedConfig() or convenience methods like withClusterConfig(), withDataConfig(), etc. "
+            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
+  }
+
+  @Override
+  public TestCamundaApplication withSecondaryStorageType(final SecondaryStorageType type) {
+    unifiedConfig.getData().getSecondaryStorage().setType(type);
+    withProperty("camunda.data.secondary-storage.type", type.name());
     return this;
   }
 
@@ -299,9 +370,13 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     return this;
   }
 
+  @Deprecated
   @Override
   public BrokerBasedProperties brokerConfig() {
-    return brokerProperties;
+    throw new UnsupportedOperationException(
+        "brokerConfig() is no longer supported. "
+            + "Use unifiedConfig() instead. "
+            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
   }
 
   @Override
@@ -311,10 +386,10 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   public TestCamundaApplication updateExporterArgs(
       final String id, final Consumer<Map<String, Object>> modifier) {
-    final var exporterCfg = brokerProperties.getExporters().get(id);
-    final var argsCopy = deepCopy(exporterCfg.getArgs());
+    final var exporter = unifiedConfig.getData().getExporters().get(id);
+    final var argsCopy = deepCopy(exporter.getArgs());
     modifier.accept(argsCopy);
-    exporterCfg.setArgs(argsCopy);
+    exporter.setArgs(argsCopy);
     return this;
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -29,7 +29,6 @@ import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverr
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
-import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.security.configuration.ConfiguredMappingRule;
@@ -40,7 +39,6 @@ import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
@@ -261,10 +259,15 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     return BrokerHealthActuator.of(monitoringUri().toString());
   }
 
-  // TODO KPO add gateway enabled to unified configuration?
   @Override
   public boolean isGateway() {
     return isGatewayEnabled;
+  }
+
+  @Override
+  public TestCamundaApplication withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(unifiedConfig);
+    return this;
   }
 
   @Override
@@ -280,27 +283,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   @Override
   public GatewayHealthActuator gatewayHealth() {
     throw new UnsupportedOperationException("Brokers do not support the gateway health indicators");
-  }
-
-  @Override
-  public TestCamundaApplication withGatewayConfig(final Consumer<GatewayCfg> modifier) {
-    throw new UnsupportedOperationException(
-        "Gateway configuration via withGatewayConfig is not supported. "
-            + "Gateway is not yet fully migrated to unified configuration. "
-            + "Use withProperty() to set zeebe.broker.gateway.* properties instead.");
-  }
-
-  @Override
-  public TestCamundaApplication withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
-  }
-
-  @Override
-  public GatewayCfg gatewayConfig() {
-    throw new UnsupportedOperationException(
-        "Gateway configuration access via gatewayConfig() is not supported. "
-            + "Gateway is not yet fully migrated to unified configuration.");
   }
 
   /**
@@ -343,15 +325,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         });
   }
 
-  @Deprecated
-  @Override
-  public TestCamundaApplication withBrokerConfig(final Consumer<BrokerBasedProperties> modifier) {
-    throw new UnsupportedOperationException(
-        "withBrokerConfig() is no longer supported. "
-            + "Use withUnifiedConfig() or convenience methods like withClusterConfig(), withDataConfig(), etc. "
-            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
-  }
-
   @Override
   public TestCamundaApplication withSecondaryStorageType(final SecondaryStorageType type) {
     unifiedConfig.getData().getSecondaryStorage().setType(type);
@@ -368,15 +341,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
       final Consumer<CamundaSecurityProperties> modifier) {
     modifier.accept(securityConfig);
     return this;
-  }
-
-  @Deprecated
-  @Override
-  public BrokerBasedProperties brokerConfig() {
-    throw new UnsupportedOperationException(
-        "brokerConfig() is no longer supported. "
-            + "Use unifiedConfig() instead. "
-            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -10,6 +10,7 @@ package io.camunda.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandaloneBackupManager;
 import io.camunda.application.StandaloneBackupManager.BackupManagerConfiguration;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
@@ -18,6 +19,7 @@ import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOve
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import java.util.function.Consumer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
@@ -57,6 +59,12 @@ public class TestStandaloneBackupManager
   @Override
   public boolean isGateway() {
     return false;
+  }
+
+  @Override
+  public TestStandaloneBackupManager withUnifiedConfig(final Consumer<Camunda> modifier) {
+    throw new UnsupportedOperationException(
+        "TestStandaloneBackupManager does not support unified configuration");
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
@@ -9,9 +9,11 @@ package io.camunda.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandaloneSchemaManager;
+import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import java.util.function.Consumer;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
@@ -39,6 +41,12 @@ public class TestStandaloneSchemaManager
   @Override
   public boolean isGateway() {
     return false;
+  }
+
+  @Override
+  public TestStandaloneSchemaManager withUnifiedConfig(final Consumer<Camunda> modifier) {
+    throw new UnsupportedOperationException(
+        "TestStandaloneSchemaManager does not support unified configuration");
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -270,8 +270,10 @@ public class CamundaMultiDBExtension
     final var application = applicationUnderTest.application();
     multiDbConfigurator = new MultiDbConfigurator(application);
     application
-        .withBrokerConfig(cfg -> cfg.getData().setDirectory(DataCfg.DEFAULT_DIRECTORY))
-        .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))
+        .withUnifiedConfig(
+            cfg -> {
+              cfg.getData().getPrimaryStorage().setDirectory(DataCfg.DEFAULT_DIRECTORY);
+            })
         .withExporter(
             "recordingExporter", cfg -> cfg.setClassName(RecordingExporter.class.getName()));
   }
@@ -477,7 +479,7 @@ public class CamundaMultiDBExtension
     closeables.add(application);
     application.start();
     application.awaitCompleteTopology(
-        application.brokerConfig(), authenticatedClientFactory.getAdminCamundaClient());
+        application.unifiedConfig(), authenticatedClientFactory.getAdminCamundaClient());
 
     Awaitility.await("Await exporter readiness")
         .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -546,12 +546,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureBackupAcceptanceIT.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
+import io.camunda.configuration.Backup;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.azure.AzureBackupConfig;
 import io.camunda.zeebe.backup.azure.AzureBackupStore;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -87,12 +87,12 @@ final class AzureBackupAcceptanceIT implements BackupAcceptance {
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
           final var backup = cfg.getData().getBackup();
           final var azure = backup.getAzure();
 
-          backup.setStore(BackupStoreType.AZURE);
+          backup.setStore(Backup.BackupStoreType.AZURE);
           azure.setBasePath(CONTAINER_NAME);
           azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
         });

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -183,7 +183,6 @@ class BackupMultiPartitionTest {
     waitUntilBackupIsCompleted(backupId);
   }
 
-  // TODO KPO check test
   @Test
   @Timeout(value = 120)
   void shouldTriggerBackupViaInterPartitionMessageCorrelationCommands() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
@@ -67,7 +67,7 @@ public class ClusteredBackupRestoreTest {
             .withBrokersCount(3)
             .withPartitionsCount(3)
             .withReplicationFactor(1)
-            .withBrokerConfig(broker -> configureBackupStore(broker.brokerConfig()))
+            .withBrokerConfig(broker -> configureBackupStore(broker.unifiedConfig()))
             .build()
             .start()
             .awaitCompleteTopology()) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
@@ -102,7 +102,7 @@ public class ClusteredBackupRestoreTest {
     // then -- restoring with one broker is successful
     try (final var restoreApp =
         new TestRestoreApp()
-            .withConfig(
+            .withUnifiedConfig(
                 config -> {
                   configureBackupStore(config);
                   config.getCluster().setSize(1);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ConcurrentBackupScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ConcurrentBackupScalingIT.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import feign.FeignException;
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.configuration.Backup;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
@@ -48,14 +48,16 @@ final class ConcurrentBackupScalingIT {
           .withPartitionsCount(1)
           .withEmbeddedGateway(false)
           .withBrokerConfig(
-              b ->
-                  b.withBrokerConfig(
-                      bb -> {
-                        bb.getCluster()
-                            .getMembership()
-                            .setSyncInterval(Duration.ofSeconds(1))
-                            .setGossipInterval(Duration.ofMillis(500));
-                      }))
+              b -> {
+                b.unifiedConfig()
+                    .getCluster()
+                    .getMembership()
+                    .setSyncInterval(Duration.ofSeconds(1));
+                b.unifiedConfig()
+                    .getCluster()
+                    .getMembership()
+                    .setGossipInterval(Duration.ofMillis(500));
+              })
           .withNodeConfig(this::configureNode)
           .build();
 
@@ -113,12 +115,13 @@ final class ConcurrentBackupScalingIT {
   }
 
   private void configureBackup(final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
-          final var backup = cfg.getData().getBackup();
-          backup.setStore(BackupStoreType.FILESYSTEM);
-          final var fileSystem = backup.getFilesystem();
-          fileSystem.setBasePath(backupBasePath.toAbsolutePath().toString());
+          cfg.getData().getBackup().setStore(Backup.BackupStoreType.FILESYSTEM);
+          cfg.getData()
+              .getBackup()
+              .getFilesystem()
+              .setBasePath(backupBasePath.toAbsolutePath().toString());
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
@@ -134,7 +134,7 @@ final class ContinuousBackupIT {
     FileUtil.ensureDirectoryExists(workingDirectory);
     final var restore =
         new TestRestoreApp()
-            .withConfig(this::configureRestoreApp)
+            .withUnifiedConfig(this::configureRestoreApp)
             .withWorkingDirectory(workingDirectory)
             .withBackupId(1, 2, 3)
             .start();
@@ -176,7 +176,7 @@ final class ContinuousBackupIT {
     FileUtil.ensureDirectoryExists(workingDirectory);
     final var restore =
         new TestRestoreApp()
-            .withConfig(this::configureRestoreApp)
+            .withUnifiedConfig(this::configureRestoreApp)
             .withWorkingDirectory(workingDirectory)
             .withBackupId(1, 3);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupAcceptanceIT.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.it.cluster.backup;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
-import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
+import io.camunda.configuration.Backup;
+import io.camunda.configuration.Filesystem;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -53,14 +53,13 @@ final class FilesystemBackupAcceptanceIT implements BackupAcceptance {
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
-          final var backup = cfg.getData().getBackup();
-          backup.setStore(BackupStoreType.FILESYSTEM);
+          cfg.getData().getBackup().setStore(Backup.BackupStoreType.FILESYSTEM);
 
-          final var config = new FilesystemBackupStoreConfig();
+          final var config = new Filesystem();
           config.setBasePath(basePath.toAbsolutePath().toString());
-          backup.setFilesystem(config);
+          cfg.getData().getBackup().setFilesystem(config);
         });
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupAcceptanceIT.java
@@ -9,11 +9,10 @@ package io.camunda.zeebe.it.cluster.backup;
 
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.client.CamundaClient;
+import io.camunda.configuration.Backup;
+import io.camunda.configuration.Gcs;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
-import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -87,17 +86,16 @@ final class GcsBackupAcceptanceIT implements BackupAcceptance {
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
-          final var backup = cfg.getData().getBackup();
-          backup.setStore(BackupStoreType.GCS);
+          cfg.getData().getBackup().setStore(Backup.BackupStoreType.GCS);
 
-          final var config = new GcsBackupStoreConfig();
-          config.setAuth(GcsBackupStoreAuth.NONE);
+          final var config = new Gcs();
+          config.setAuth(Gcs.GcsBackupStoreAuth.NONE);
           config.setBasePath(basePath);
           config.setBucketName(BUCKET_NAME);
           config.setHost(GCS.externalEndpoint());
-          backup.setGcs(config);
+          cfg.getData().getBackup().setGcs(config);
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RestoreAcceptance.java
@@ -49,7 +49,7 @@ public interface RestoreAcceptance {
   private void takeBackup(final long backupId) {
     try (final var zeebe =
         new TestStandaloneBroker()
-            .withBrokerConfig(this::configureBackupStore)
+            .withUnifiedConfig(this::configureBackupStore)
             .start()
             .awaitCompleteTopology()) {
       final var actuator = BackupActuator.of(zeebe);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RestoreAcceptance.java
@@ -81,7 +81,10 @@ public interface RestoreAcceptance {
 
   private void restoreBackup(final long backupId) {
     final var restore =
-        new TestRestoreApp().withConfig(this::configureBackupStore).withBackupId(backupId).start();
+        new TestRestoreApp()
+            .withUnifiedConfig(this::configureBackupStore)
+            .withBackupId(backupId)
+            .start();
     restore.close();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupAcceptanceIT.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
+import io.camunda.configuration.Backup;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -106,12 +106,12 @@ final class S3BackupAcceptanceIT implements BackupAcceptance {
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
           final var backup = cfg.getData().getBackup();
           final var s3 = backup.getS3();
 
-          backup.setStore(BackupStoreType.S3);
+          backup.setStore(Backup.BackupStoreType.S3);
           s3.setBucketName(bucketName);
           s3.setEndpoint(minio.externalEndpoint());
           s3.setRegion(minio.region());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FixedPartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FixedPartitionDistributionIT.java
@@ -10,13 +10,10 @@ package io.camunda.zeebe.it.cluster.clustering;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
-import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
@@ -59,32 +56,20 @@ final class FixedPartitionDistributionIT {
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
-          cfg.getCluster().getRaft().setEnablePriorityElection(false);
-
-          final var partitioning = cfg.getExperimental().getPartitioning();
-          partitioning.setScheme(Scheme.FIXED);
-          partitioning.setFixed(
-              List.of(
-                  createPartitionCfg(1, 1, 2),
-                  createPartitionCfg(2, 0, 2),
-                  createPartitionCfg(3, 0, 1)));
+          cfg.getCluster().getRaft().setPriorityElectionEnabled(false);
         });
-  }
-
-  private FixedPartitionCfg createPartitionCfg(final int partitionId, final int... nodeIds) {
-    final var config = new FixedPartitionCfg();
-    final var nodes = new ArrayList<NodeCfg>();
-    config.setPartitionId(partitionId);
-    config.setNodes(nodes);
-
-    for (final var nodeId : nodeIds) {
-      final var node = new NodeCfg();
-      node.setNodeId(nodeId);
-      nodes.add(node);
-    }
-
-    return config;
+    // set partitioning via properties because it is not yet supported in unified config
+    broker.withProperty("zeebe.broker.experimental.partitioning.scheme", Scheme.FIXED);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[0].partitionId", 1);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[0].nodes.[0].nodeId", 1);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[0].nodes.[1].nodeId", 2);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[1].partitionId", 2);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[1].nodes.[0].nodeId", 0);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[1].nodes.[1].nodeId", 2);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[2].partitionId", 3);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[2].nodes.[0].nodeId", 0);
+    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[2].nodes.[1].nodeId", 1);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/GossipClusteringIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/GossipClusteringIT.java
@@ -25,7 +25,7 @@ final class GossipClusteringIT {
   @TestZeebe
   private final TestCluster cluster =
       new TestClusterBuilder()
-          .withUnifiedBrokerConfig(
+          .withBrokerConfig(
               broker -> {
                 final var membership = broker.unifiedConfig().getCluster().getMembership();
                 membership.setFailureTimeout(Duration.ofMillis(2000));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/GossipClusteringIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/GossipClusteringIT.java
@@ -25,17 +25,13 @@ final class GossipClusteringIT {
   @TestZeebe
   private final TestCluster cluster =
       new TestClusterBuilder()
-          .withBrokerConfig(
-              broker ->
-                  broker.withBrokerConfig(
-                      config ->
-                          config
-                              .getCluster()
-                              .getMembership()
-                              .setFailureTimeout(Duration.ofMillis(2000))
-                              .setGossipInterval(Duration.ofMillis(150))
-                              .setProbeInterval(Duration.ofMillis(250))
-                              .setProbeInterval(Duration.ofMillis(250))))
+          .withUnifiedBrokerConfig(
+              broker -> {
+                final var membership = broker.unifiedConfig().getCluster().getMembership();
+                membership.setFailureTimeout(Duration.ofMillis(2000));
+                membership.setGossipInterval(Duration.ofMillis(150));
+                membership.setProbeInterval(Duration.ofMillis(250));
+              })
           .withBrokersCount(3)
           .withReplicationFactor(3)
           .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/LongPollingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/LongPollingIT.java
@@ -104,6 +104,6 @@ final class LongPollingIT {
   }
 
   private void configureGateway(final TestGateway<?> gateway) {
-    gateway.withGatewayConfig(cfg -> cfg.getLongPolling().setEnabled(true));
+    gateway.withUnifiedConfig(cfg -> cfg.getApi().getLongPolling().setEnabled(true));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -27,10 +27,8 @@ final class ClusterEndpointResponseIT {
   static void initTestStandaloneBroker() {
     broker =
         new TestStandaloneBroker()
-            .withBrokerConfig(
-                cfg -> {
-                  cfg.getCluster().setClusterId("cluster-id");
-                });
+            // set clusterId via properties because it is not yet supported in unified config
+            .withProperty("zeebe.broker.cluster.clusterId", "cluster-id");
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/DynamicClusterConfigurationServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/DynamicClusterConfigurationServiceTest.java
@@ -30,13 +30,12 @@ final class DynamicClusterConfigurationServiceTest {
       TestCluster.builder()
           .withGatewaysCount(1)
           .withGatewayConfig(
-              g ->
-                  g.gatewayConfig()
-                      .getCluster()
-                      .getMembership()
-                      // Reduce timeouts so that the test is faster
-                      .setProbeInterval(Duration.ofMillis(100))
-                      .setFailureTimeout(Duration.ofSeconds(2)))
+              g -> {
+                final var membership = g.unifiedConfig().getCluster().getMembership();
+                // Reduce timeouts so that the test is faster
+                membership.setProbeInterval(Duration.ofMillis(100));
+                membership.setFailureTimeout(Duration.ofSeconds(2));
+              })
           .withEmbeddedGateway(false)
           .withBrokersCount(3)
           .withPartitionsCount(PARTITIONS_COUNT)
@@ -100,14 +99,14 @@ final class DynamicClusterConfigurationServiceTest {
 
   private void configureDynamicClusterTopology(
       final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         b -> {
           if (!memberId.id().equals("0")) {
             // not coordinator. Give wrong configuration to verify that it is overwritten by dynamic
             // cluster topology. Note that this would not work in production because the engine
             // still reads the partition count from the static configuration, so message correlation
             // would not work.
-            b.getCluster().setPartitionsCount(1);
+            b.getCluster().setPartitionCount(1);
           }
         });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ForceScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ForceScaleDownBrokersTest.java
@@ -64,7 +64,7 @@ class ForceScaleDownBrokersTest {
       brokersToShutdown.forEach(
           brokerId ->
               ClusterActuatorAssert.assertThat(cluster)
-                  .doesNotHaveBroker(brokerId.brokerConfig().getCluster().getNodeId()));
+                  .doesNotHaveBroker(brokerId.unifiedConfig().getCluster().getNodeId()));
 
       // Changes are reflected in the topology returned by grpc query
       cluster.awaitCompleteTopology(
@@ -87,16 +87,15 @@ class ForceScaleDownBrokersTest {
             .withPartitionsCount(PARTITIONS_COUNT)
             .withReplicationFactor(replicationFactor)
             .withGatewayConfig(
-                g ->
-                    g.withCreateSchema(false)
-                        .gatewayConfig()
-                        .getCluster()
-                        .getMembership()
-                        // Decrease the timeouts for fast convergence of gateway topology. When the
-                        // broker is shutdown, the topology update takes at least 10 seconds with
-                        // the default values.
-                        .setSyncInterval(Duration.ofSeconds(1))
-                        .setFailureTimeout(Duration.ofSeconds(2)))
+                g -> {
+                  g.withCreateSchema(false);
+                  // Decrease the timeouts for fast convergence of gateway topology. When the
+                  // broker is shutdown, the topology update takes at least 10 seconds with
+                  // the default values.
+                  final var membership = g.unifiedConfig().getCluster().getMembership();
+                  membership.setSyncInterval(Duration.ofSeconds(1));
+                  membership.setFailureTimeout(Duration.ofSeconds(2));
+                })
             .build()
             .start();
     cluster.awaitCompleteTopology();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PersistedClusterTopologyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PersistedClusterTopologyTest.java
@@ -41,17 +41,16 @@ public class PersistedClusterTopologyTest {
           .withPartitionsCount(PARTITION_COUNT)
           .withReplicationFactor(REPLICATION_FACTOR)
           .withGatewayConfig(
-              g ->
-                  g.gatewayConfig()
-                      .getCluster()
-                      .getMembership()
-                      .setGossipInterval(Duration.ofMillis(100))
-                      // Decrease the timeouts for fast convergence of gateway topology. When the
-                      // broker is shutdown, the topology update takes at least 10 seconds with
-                      // the
-                      // default values.
-                      .setSyncInterval(Duration.ofMillis(100))
-                      .setFailureTimeout(Duration.ofSeconds(5)))
+              g -> {
+                final var membership = g.unifiedConfig().getCluster().getMembership();
+                membership.setGossipInterval(Duration.ofMillis(100));
+                // Decrease the timeouts for fast convergence of gateway topology. When the
+                // broker is shutdown, the topology update takes at least 10 seconds with
+                // the
+                // default values.
+                membership.setSyncInterval(Duration.ofMillis(100));
+                membership.setFailureTimeout(Duration.ofSeconds(5));
+              })
           .build();
 
   @Test
@@ -100,7 +99,7 @@ public class PersistedClusterTopologyTest {
     cluster.shutdown();
 
     // when
-    cluster.brokers().forEach((id, b) -> b.brokerConfig().getCluster().setPartitionsCount(1));
+    cluster.brokers().forEach((id, b) -> b.unifiedConfig().getCluster().setPartitionCount(1));
     cluster.start();
     cluster.awaitCompleteTopology(
         CLUSTER_SIZE, PARTITION_COUNT, REPLICATION_FACTOR, Duration.ofSeconds(10));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleDownBrokersTest.java
@@ -44,23 +44,27 @@ final class ScaleDownBrokersTest {
           .withBrokersCount(CLUSTER_SIZE)
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
-          .withBrokerConfig(
-              b ->
-                  b.brokerConfig()
-                      .getCluster()
-                      .getMembership()
-                      // Decrease the timeouts for fast convergence of broker topology.
-                      .setSyncInterval(Duration.ofSeconds(1)))
-          .withGatewayConfig(
-              g ->
-                  g.gatewayConfig()
-                      .getCluster()
-                      .getMembership()
-                      // Decrease the timeouts for fast convergence of gateway topology. When the
-                      // broker is shutdown, the topology update takes at least 10 seconds with the
-                      // default values.
-                      .setSyncInterval(Duration.ofSeconds(1))
-                      .setFailureTimeout(Duration.ofSeconds(2)))
+          .withUnifiedBrokerConfig(
+              b -> {
+                b.unifiedConfig()
+                    .getCluster()
+                    .getMembership()
+                    .setSyncInterval(Duration.ofSeconds(1));
+              })
+          .withUnifiedGatewayConfig(
+              g -> {
+                // Decrease the timeouts for fast convergence of gateway topology. When the
+                // broker is shutdown, the topology update takes at least 10 seconds with the
+                // default values.
+                g.unifiedConfig()
+                    .getCluster()
+                    .getMembership()
+                    .setSyncInterval(Duration.ofSeconds(1));
+                g.unifiedConfig()
+                    .getCluster()
+                    .getMembership()
+                    .setFailureTimeout(Duration.ofSeconds(2));
+              })
           .build();
 
   @BeforeEach

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleDownBrokersTest.java
@@ -44,14 +44,15 @@ final class ScaleDownBrokersTest {
           .withBrokersCount(CLUSTER_SIZE)
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
-          .withUnifiedBrokerConfig(
+          .withBrokerConfig(
               b -> {
+                // Decrease the timeouts for fast convergence of broker topology.
                 b.unifiedConfig()
                     .getCluster()
                     .getMembership()
                     .setSyncInterval(Duration.ofSeconds(1));
               })
-          .withUnifiedGatewayConfig(
+          .withGatewayConfig(
               g -> {
                 // Decrease the timeouts for fast convergence of gateway topology. When the
                 // broker is shutdown, the topology update takes at least 10 seconds with the

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpBrokersTest.java
@@ -231,9 +231,9 @@ final class ScaleUpBrokersTest {
       final int newClusterSize, final int newBrokerId, final Optional<Path> dataDirectory) {
     final var newBroker =
         new TestStandaloneBroker()
-            .withBrokerConfig(
+            .withUnifiedConfig(
                 b -> {
-                  b.getCluster().setClusterSize(newClusterSize);
+                  b.getCluster().setSize(newClusterSize);
                   b.getCluster().setNodeId(newBrokerId);
                   b.getCluster()
                       .setInitialContactPoints(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -22,9 +22,7 @@ import io.camunda.configuration.Backup;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Filesystem;
 import io.camunda.management.backups.StateCode;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
-import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
@@ -93,24 +91,24 @@ public class ScaleUpPartitionsTest {
             .withReplicationFactor(3)
             .withBrokerConfig(
                 b ->
-                    b.withBrokerConfig(
-                        cfg -> {
-                          final var backup = cfg.getData().getBackup();
-                          backup.setStore(BackupStoreType.FILESYSTEM);
-                          final var fs = new FilesystemBackupStoreConfig();
-                          fs.setBasePath(backupPath.toString());
-                          backup.setFilesystem(fs);
+                    b.withUnifiedConfig(
+                            cfg -> {
+                              final var backup = cfg.getData().getBackup();
+                              backup.setStore(Backup.BackupStoreType.FILESYSTEM);
+                              backup.getFilesystem().setBasePath(backupPath.toString());
 
-                          cfg.getCluster()
-                              .getMembership()
-                              .setSyncInterval(Duration.ofSeconds(1))
-                              .setGossipInterval(Duration.ofMillis(500));
-
-                          final var engineDistribution =
-                              cfg.getExperimental().getEngine().getDistribution();
-                          engineDistribution.setMaxBackoffDuration(Duration.ofSeconds(1));
-                          engineDistribution.setRedistributionInterval(Duration.ofMillis(200));
-                        }))
+                              final var membership = cfg.getCluster().getMembership();
+                              membership.setSyncInterval(Duration.ofSeconds(1));
+                              membership.setGossipInterval(Duration.ofMillis(500));
+                            })
+                        // set distribution via properties because it is not yet supported in
+                        // unified config
+                        .withProperty(
+                            "zeebe.broker.experimental.engine.distribution.maxBackoffDuration",
+                            "1s")
+                        .withProperty(
+                            "zeebe.broker.experimental.engine.distribution.redistributionInterval",
+                            "200ms"))
             .build();
   }
 
@@ -121,20 +119,19 @@ public class ScaleUpPartitionsTest {
     backupActuator = BackupActuator.of(cluster.availableGateway());
   }
 
-  private Camunda getRestoreConfig(final BrokerCfg brokerCfg) {
+  private Camunda getRestoreConfig(final Camunda brokerCfg, final Path workingDirectory) {
     final var unifiedRestoreConfig = new Camunda();
     unifiedRestoreConfig.getCluster().setNodeId(brokerCfg.getCluster().getNodeId());
-    unifiedRestoreConfig
-        .getCluster()
-        .setPartitionCount(brokerCfg.getCluster().getPartitionsCount());
-    unifiedRestoreConfig
-        .getData()
-        .getPrimaryStorage()
-        .setDirectory(brokerCfg.getData().getDirectory());
+    unifiedRestoreConfig.getCluster().setPartitionCount(brokerCfg.getCluster().getPartitionCount());
+
+    final var dataDirectory =
+        ConfigurationUtil.toAbsolutePath(
+            brokerCfg.getData().getPrimaryStorage().getDirectory(), workingDirectory.toString());
+    unifiedRestoreConfig.getData().getPrimaryStorage().setDirectory(dataDirectory);
     unifiedRestoreConfig
         .getCluster()
         .setReplicationFactor(brokerCfg.getCluster().getReplicationFactor());
-    unifiedRestoreConfig.getCluster().setSize(brokerCfg.getCluster().getClusterSize());
+    unifiedRestoreConfig.getCluster().setSize(brokerCfg.getCluster().getSize());
 
     final var backupConfig = unifiedRestoreConfig.getData().getBackup();
     backupConfig.setStore(Backup.BackupStoreType.FILESYSTEM);
@@ -299,7 +296,11 @@ public class ScaleUpPartitionsTest {
 
     final var partition1Leader = cluster.leaderForPartition(1);
 
-    final var directory = Path.of(partition1Leader.brokerConfig().getData().getDirectory());
+    final var directory =
+        Path.of(
+            ConfigurationUtil.toAbsolutePath(
+                partition1Leader.unifiedConfig().getData().getPrimaryStorage().getDirectory(),
+                partition1Leader.getWorkingDirectory().toString()));
     final var bootstrapSnapshotDirectory =
         directory.resolve("raft-partition/partitions/1/bootstrap-snapshots/1-1-0-0-0");
     scaleToPartitions(targetPartitionCount);
@@ -579,13 +580,19 @@ public class ScaleUpPartitionsTest {
       throws IOException {
     for (final var broker : cluster.brokers().values()) {
       LOG.debug("Restoring broker: {}", broker.nodeId());
-      final var dataFolder = Path.of(broker.brokerConfig().getData().getDirectory());
+      final var workingDirectory = broker.getWorkingDirectory();
+      final var dataFolder =
+          Path.of(
+              ConfigurationUtil.toAbsolutePath(
+                  broker.unifiedConfig().getData().getPrimaryStorage().getDirectory(),
+                  workingDirectory.toString()));
       FileUtil.deleteFolderIfExists(dataFolder);
 
       Files.createDirectories(dataFolder);
-      broker.brokerConfig().getCluster().setPartitionsCount(desiredPartitionCount);
+      broker.unifiedConfig().getCluster().setPartitionCount(desiredPartitionCount);
       try (final var restoreApp =
-          new TestRestoreApp(getRestoreConfig(broker.brokerConfig())).withBackupId(backupId)) {
+          new TestRestoreApp(getRestoreConfig(broker.unifiedConfig(), workingDirectory))
+              .withBackupId(backupId)) {
         assertThatNoException().isThrownBy(restoreApp::start);
       }
       FileUtil.flushDirectory(dataFolder);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/TopologyCoordinatorTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/TopologyCoordinatorTest.java
@@ -39,15 +39,14 @@ final class TopologyCoordinatorTest {
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
           .withGatewayConfig(
-              g ->
-                  g.gatewayConfig()
-                      .getCluster()
-                      .getMembership()
-                      // Decrease the timeouts for fast convergence of gateway topology. When the
-                      // broker is shutdown, the topology update takes at least 10 seconds with the
-                      // default values.
-                      .setSyncInterval(Duration.ofSeconds(1))
-                      .setFailureTimeout(Duration.ofSeconds(2)))
+              g -> {
+                final var membership = g.unifiedConfig().getCluster().getMembership();
+                // Decrease the timeouts for fast convergence of gateway topology. When the
+                // broker is shutdown, the topology update takes at least 10 seconds with the
+                // default values.
+                membership.setSyncInterval(Duration.ofSeconds(1));
+                membership.setFailureTimeout(Duration.ofSeconds(2));
+              })
           .build();
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/config/IdleStrategyConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/config/IdleStrategyConfigIT.java
@@ -42,11 +42,13 @@ final class IdleStrategyConfigIT {
   void shouldConfigureIdleStrategyWithUnifiedConfig() {
     // given
     try (final var gateway = new TestStandaloneGateway()) {
-      gateway
-          .withProperty("camunda.system.actor.idle.max-spins", 50L)
-          .withProperty("camunda.system.actor.idle.max-yields", 62L)
-          .withProperty("camunda.system.actor.idle.min-park-period", Duration.ofNanos(100))
-          .withProperty("camunda.system.actor.idle.max-park-period", Duration.ofNanos(500));
+      gateway.withUnifiedConfig(
+          cfg -> {
+            cfg.getSystem().getActor().getIdle().setMaxSpins(50L);
+            cfg.getSystem().getActor().getIdle().setMaxYields(62L);
+            cfg.getSystem().getActor().getIdle().setMinParkPeriod(Duration.ofNanos(100));
+            cfg.getSystem().getActor().getIdle().setMaxParkPeriod(Duration.ofNanos(500));
+          });
 
       // when
       gateway.start();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ActorClockEndpointIT.java
@@ -33,9 +33,7 @@ public class ActorClockEndpointIT {
             .withBrokersCount(1)
             .withPartitionsCount(1)
             .withReplicationFactor(1)
-            .withBrokerConfig(
-                testStandaloneBroker ->
-                    testStandaloneBroker.withProperty("zeebe.clock.controlled", true))
+            .withBrokerConfig(broker -> broker.unifiedConfig().getSystem().setClockControlled(true))
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/AdvertisedAddressTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/AdvertisedAddressTest.java
@@ -70,13 +70,14 @@ final class AdvertisedAddressTest {
         .values()
         .forEach(
             b ->
-                b.withBrokerConfig(cfg -> cfg.getCluster().setInitialContactPoints(contactPoints)));
+                b.withUnifiedConfig(
+                    cfg -> cfg.getCluster().setInitialContactPoints(contactPoints)));
     cluster
         .gateways()
         .values()
         .forEach(
             g ->
-                g.withGatewayConfig(
+                g.withUnifiedConfig(
                     cfg -> cfg.getCluster().setInitialContactPoints(contactPoints)));
   }
 
@@ -135,9 +136,9 @@ final class AdvertisedAddressTest {
     final var internalApiProxy =
         PROXY_REGISTRY.getOrCreateHostProxy(broker.mappedPort(TestZeebePort.CLUSTER));
 
-    broker.withBrokerConfig(
+    broker.withUnifiedConfig(
         cfg -> {
-          final var network = cfg.getNetwork();
+          final var network = cfg.getCluster().getNetwork();
           network.getInternalApi().setAdvertisedHost(TOXIPROXY.getHost());
           network
               .getInternalApi()
@@ -157,11 +158,12 @@ final class AdvertisedAddressTest {
     final var gatewayClusterProxy =
         PROXY_REGISTRY.getOrCreateHostProxy(gateway.mappedPort(TestZeebePort.CLUSTER));
 
-    gateway.withGatewayConfig(
+    gateway.withUnifiedConfig(
         cfg -> {
-          cfg.getCluster()
-              .setAdvertisedHost(TOXIPROXY.getHost())
-              .setAdvertisedPort(TOXIPROXY.getMappedPort(gatewayClusterProxy.internalPort()));
+          final var internalApi = cfg.getCluster().getNetwork().getInternalApi();
+          internalApi.setAdvertisedHost(TOXIPROXY.getHost());
+          internalApi.setAdvertisedPort(
+              TOXIPROXY.getMappedPort(gatewayClusterProxy.internalPort()));
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/startup/IdentitySetupOnStartupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/startup/IdentitySetupOnStartupTest.java
@@ -38,8 +38,11 @@ final class IdentitySetupOnStartupTest {
                 .withReplicationFactor(3)
                 .withBrokerConfig(
                     cfg -> {
-                      cfg.brokerConfig().getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
-                      cfg.brokerConfig().getProcessing().setMaxCommandsInBatch(100);
+                      cfg.unifiedConfig()
+                          .getCluster()
+                          .getNetwork()
+                          .setMaxMessageSize(DataSize.ofKilobytes(32));
+                      cfg.unifiedConfig().getProcessing().setMaxCommandsInBatch(100);
                     })
                 .build()
                 .start()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceTest.java
@@ -43,7 +43,8 @@ public class BrokerAdminServiceTest {
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withBrokerConfig(cfg -> cfg.getData().setLogIndexDensity(1));
+          .withUnifiedConfig(
+              cfg -> cfg.getData().getPrimaryStorage().getLogStream().setLogIndexDensity(1));
 
   @AutoClose private ZeebeResourcesHelper resourcesHelper;
   private PartitionsActuator partitions;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverGrpcIT.java
@@ -16,6 +16,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
@@ -48,15 +49,19 @@ public class BasicAuthOverGrpcIT {
       new TestStandaloneBroker()
           .withRecordingExporter(true)
           .withAuthorizationsEnabled()
-          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+          .withAuthenticationMethod(AuthenticationMethod.BASIC)
+          .withSecondaryStorageType(SecondaryStorageType.elasticsearch);
 
   @BeforeEach
   void beforeEach() {
     broker
         .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-        .withProperty(
-            "camunda.data.secondary-storage.elasticsearch.url",
-            "http://" + CONTAINER.getHttpHostAddress());
+        .withUnifiedConfig(
+            cfg ->
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setUrl("http://" + CONTAINER.getHttpHostAddress()));
     broker.start();
 
     final var defaultUsername = "demo";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverRestIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
@@ -47,15 +48,19 @@ final class BasicAuthOverRestIT {
       new TestStandaloneBroker()
           .withRecordingExporter(true)
           .withAuthorizationsEnabled()
-          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+          .withAuthenticationMethod(AuthenticationMethod.BASIC)
+          .withSecondaryStorageType(SecondaryStorageType.elasticsearch);
 
   @BeforeEach
   void beforeEach() {
     broker
         .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-        .withProperty(
-            "camunda.data.secondary-storage.elasticsearch.url",
-            "http://" + CONTAINER.getHttpHostAddress());
+        .withUnifiedConfig(
+            cfg ->
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setUrl("http://" + CONTAINER.getHttpHostAddress()));
     broker.start();
 
     final var defaultUsername = "demo";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/SecurityTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/SecurityTest.java
@@ -114,12 +114,10 @@ public final class SecurityTest {
     final String privateKeyPath = getResource("security/test-server.key.pem").getFile();
 
     // configure the gRPC server for TLS/SSL
-    gateway
-        .gatewayConfig()
-        .getSecurity()
-        .setEnabled(true)
-        .setCertificateChainPath(new File(certificatePath))
-        .setPrivateKeyPath(new File(privateKeyPath));
+    final var ssl = gateway.unifiedConfig().getApi().getGrpc().getSsl();
+    ssl.setEnabled(true);
+    ssl.setCertificate(new File(certificatePath));
+    ssl.setCertificatePrivateKey(new File(privateKeyPath));
 
     // configure the REST API server for TLS/SSL
     gateway

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ActivateJobsTest.java
@@ -33,7 +33,7 @@ class ActivateJobsTest {
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withGatewayConfig(c -> c.getLongPolling().setEnabled(true));
+          .withUnifiedConfig(c -> c.getApi().getLongPolling().setEnabled(true));
 
   ZeebeResourcesHelper resourcesHelper;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
@@ -42,7 +42,8 @@ public final class CreateDeploymentTest {
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withBrokerConfig(b -> b.getNetwork().setMaxMessageSize(DataSize.ofMegabytes(1)));
+          .withUnifiedConfig(
+              b -> b.getCluster().getNetwork().setMaxMessageSize(DataSize.ofMegabytes(1)));
 
   ZeebeResourcesHelper resourcesHelper;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateLargeDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateLargeDeploymentTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 
-// TODO KPO check test
 @ZeebeIntegration
 public final class CreateLargeDeploymentTest {
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/LongPollingActivateJobsTest.java
@@ -35,7 +35,7 @@ public class LongPollingActivateJobsTest {
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withGatewayConfig(c -> c.getLongPolling().setEnabled(true));
+          .withUnifiedConfig(c -> c.getApi().getLongPolling().setEnabled(true));
 
   ZeebeResourcesHelper resourcesHelper;
 
@@ -70,7 +70,8 @@ public class LongPollingActivateJobsTest {
     // given
     final int availableJobs = 10;
 
-    final int maxMessageSize = (int) zeebe.brokerConfig().getNetwork().getMaxMessageSizeInBytes();
+    final int maxMessageSize =
+        (int) zeebe.unifiedConfig().getCluster().getNetwork().getMaxMessageSize().toBytes();
     final var largeVariableValue = "x".repeat(maxMessageSize / 4);
     final String variablesJson = String.format("{\"variablesJson\":\"%s\"}", largeVariableValue);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
@@ -32,6 +32,7 @@ import io.camunda.client.api.response.UnassignUserTaskResponse;
 import io.camunda.client.api.response.UpdateTimeoutJobResponse;
 import io.camunda.client.api.response.UpdateUserTaskResponse;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
@@ -89,6 +90,7 @@ public class MultiTenancyIT {
           .withBasicAuth()
           .withMultiTenancyEnabled()
           .withAuthenticatedAccess()
+          .withSecondaryStorageType(SecondaryStorageType.elasticsearch)
           .withSecurityConfig(
               cfg ->
                   cfg.getInitialization()
@@ -122,9 +124,12 @@ public class MultiTenancyIT {
   static void init() {
     BROKER
         .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-        .withProperty(
-            "camunda.data.secondary-storage.elasticsearch.url",
-            "http://" + CONTAINER.getHttpHostAddress())
+        .withUnifiedConfig(
+            cfg ->
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setUrl("http://" + CONTAINER.getHttpHostAddress()))
         .start();
 
     // We can do the setup with any user. We pick user A for convenience.

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
@@ -225,8 +225,6 @@ final class IdentitySetupInitializerIT {
             .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(authorizationsEnabled))
             .withSecurityConfig(securityCfg)
             .withClusterConfig(cluster -> cluster.setPartitionCount(partitionCount))
-            .withUnifiedConfig(
-                uc -> uc.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false))
             .withRecordingExporter(true);
 
     if (tempDir != null) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
@@ -224,7 +224,9 @@ final class IdentitySetupInitializerIT {
         new TestStandaloneBroker()
             .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(authorizationsEnabled))
             .withSecurityConfig(securityCfg)
-            .withBrokerConfig(cfg -> cfg.getCluster().setPartitionsCount(partitionCount))
+            .withClusterConfig(cluster -> cluster.setPartitionCount(partitionCount))
+            .withUnifiedConfig(
+                uc -> uc.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false))
             .withRecordingExporter(true);
 
     if (tempDir != null) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/MultipleInvalidResourceDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/MultipleInvalidResourceDeletionTest.java
@@ -28,7 +28,7 @@ public class MultipleInvalidResourceDeletionTest {
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           // disable long polling to increase the load in streamprocessor
-          .withGatewayConfig(cfg -> cfg.getLongPolling().setEnabled(false))
+          .withUnifiedConfig(cfg -> cfg.getApi().getLongPolling().setEnabled(false))
           .withRecordingExporter(true);
 
   private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/queryapi/QueryApiIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/queryapi/QueryApiIT.java
@@ -15,7 +15,7 @@ import io.camunda.client.api.response.CancelProcessInstanceResponse;
 import io.camunda.client.api.response.CompleteJobResponse;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.worker.JobHandler;
-import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
+import io.camunda.configuration.Interceptor;
 import io.camunda.zeebe.it.engine.queryapi.util.TestAuthorizationClientInterceptor;
 import io.camunda.zeebe.it.engine.queryapi.util.TestAuthorizationListener;
 import io.camunda.zeebe.it.engine.queryapi.util.TestAuthorizationServerInterceptor;
@@ -58,14 +58,15 @@ final class QueryApiIT {
   static void initTestStandaloneBroker() {
     broker =
         new TestStandaloneBroker()
-            .withBrokerConfig(cfg -> cfg.getExperimental().getQueryApi().setEnabled(true))
-            .withBrokerConfig(
+            // set queryApi via properties because it is not yet supported in unified config
+            .withProperty("zeebe.broker.experimental.queryApi.enabled", true)
+            .withUnifiedConfig(
                 cfg -> {
-                  final var config = new InterceptorCfg();
+                  final var config = new Interceptor();
                   config.setId("auth");
                   config.setClassName(TestAuthorizationServerInterceptor.class.getName());
                   config.setJarPath(createInterceptorJar().getAbsolutePath());
-                  cfg.getGateway().getInterceptors().add(config);
+                  cfg.getApi().getGrpc().getInterceptors().add(config);
                 });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
@@ -17,6 +17,7 @@ import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.command.CommandWithCommunicationApiStep;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.response.Topology;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -126,7 +127,8 @@ public class GatewayAuthenticationNoneIT {
           .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
           .withProperty("zeebe.broker.gateway.security.authentication.mode", "none")
           .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
-          .withProperty("camunda.identity.audience", ORCHESTRATION_CLIENT_AUDIENCE);
+          .withProperty("camunda.identity.audience", ORCHESTRATION_CLIENT_AUDIENCE)
+          .withSecondaryStorageType(SecondaryStorageType.elasticsearch);
 
   @BeforeEach
   void beforeEach() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/rest/FilterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/rest/FilterIT.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
+import io.camunda.configuration.Filter;
 import io.camunda.zeebe.it.shared.gateway.rest.util.DisableTopologyFilter;
 import io.camunda.zeebe.it.shared.gateway.rest.util.DisableUserTasksTestFilter;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -34,15 +34,19 @@ public class FilterIT {
           .withBrokersCount(1)
           .withGatewayConfig(
               (memberId, testGateway) -> {
-                final var firstFilterCfg = new FilterCfg();
-                firstFilterCfg.setId("firstFilter");
-                firstFilterCfg.setClassName(DisableTopologyFilter.class.getName());
+                final var firstFilter = new Filter();
+                firstFilter.setId("firstFilter");
+                firstFilter.setClassName(DisableTopologyFilter.class.getName());
 
-                final var secondFilterCfg = new FilterCfg();
-                secondFilterCfg.setId("secondFilter");
-                secondFilterCfg.setClassName(DisableUserTasksTestFilter.class.getName());
+                final var secondFilter = new Filter();
+                secondFilter.setId("secondFilter");
+                secondFilter.setClassName(DisableUserTasksTestFilter.class.getName());
 
-                testGateway.gatewayConfig().setFilters(List.of(firstFilterCfg, secondFilterCfg));
+                testGateway
+                    .unifiedConfig()
+                    .getApi()
+                    .getRest()
+                    .setFilters(List.of(firstFilter, secondFilter));
               })
           .build();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBasicAuthIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBasicAuthIT.java
@@ -23,6 +23,7 @@ import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.configuration.headers.ContentSecurityPolicyConfig;
 import io.camunda.security.configuration.headers.PermissionsPolicyConfig;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -49,18 +50,23 @@ public class SecurityHeadersBasicAuthIT extends SecurityHeadersBaseIT {
   @AutoClose private static CamundaClient camundaClient;
 
   @TestZeebe(autoStart = false)
-  private TestStandaloneBroker broker =
+  private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
           .withAuthorizationsEnabled()
-          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+          .withAuthenticationMethod(AuthenticationMethod.BASIC)
+          .withSecondaryStorageType(SecondaryStorageType.elasticsearch);
 
   @BeforeEach
   void beforeEach() {
     broker
         .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-        .withProperty(
-            "camunda.data.secondary-storage.elasticsearch.url", CONTAINER.getHttpHostAddress());
+        .withUnifiedConfig(
+            cfg ->
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setUrl(CONTAINER.getHttpHostAddress()));
     broker.start();
 
     camundaClient = createClient(broker, USERNAME, PASSWORD);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.headers.ContentSecurityPolicyConfig;
 import io.camunda.security.configuration.headers.PermissionsPolicyConfig;
@@ -95,9 +96,13 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
           .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
-          .withProperty(
-              "camunda.data.secondary-storage.elasticsearch.url",
-              "http://" + CONTAINER.getHttpHostAddress())
+          .withSecondaryStorageType(SecondaryStorageType.elasticsearch)
+          .withUnifiedConfig(
+              cfg ->
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getElasticsearch()
+                      .setUrl("http://" + CONTAINER.getHttpHostAddress()))
           .withSecurityConfig(
               c -> {
                 c.getAuthorizations().setEnabled(true);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/smoke/NoSecondaryStorageSmokeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/smoke/NoSecondaryStorageSmokeIT.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.it.shared.smoke;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
-import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -39,10 +37,7 @@ final class NoSecondaryStorageSmokeIT {
 
   @TestZeebe
   private final TestStandaloneBroker broker =
-      new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
-          .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, "none")
-          .withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, "none");
+      new TestStandaloneBroker().withUnauthenticatedAccess();
 
   @AutoClose private CamundaClient client;
 

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -161,11 +161,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.google.common.collect.ObjectArrays;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
+import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.SequencedCollection;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -266,4 +268,12 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
   default T withAdditionalProfile(final Profile profile) {
     return withAdditionalProfile(profile.getId());
   }
+
+  /**
+   * Modifies the unified configuration (camunda.* properties).
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  T withUnifiedConfig(final Consumer<Camunda> modifier);
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -33,21 +33,9 @@ public final class TestClusterBuilder {
 
   private Consumer<TestApplication<?>> nodeConfig = node -> {};
   private BiConsumer<MemberId, TestStandaloneBroker> brokerConfig =
-      (id, broker) -> {
-        broker.withUnauthenticatedAccess();
-      };
-  private BiConsumer<MemberId, TestStandaloneBroker> unifiedBrokerConfig =
-      (id, broker) -> {
-        broker.withUnauthenticatedAccess();
-      };
+      (id, broker) -> broker.withUnauthenticatedAccess();
   private BiConsumer<MemberId, TestStandaloneGateway> gatewayConfig =
-      (id, gateway) -> {
-        gateway.withUnauthenticatedAccess();
-      };
-  private BiConsumer<MemberId, TestStandaloneGateway> unifiedGatewayConfig =
-      (id, gateway) -> {
-        gateway.withUnauthenticatedAccess();
-      };
+      (id, gateway) -> gateway.withUnauthenticatedAccess();
 
   private final Map<MemberId, TestStandaloneGateway> gateways = new HashMap<>();
   private final Map<MemberId, TestStandaloneBroker> brokers = new HashMap<>();
@@ -222,12 +210,6 @@ public final class TestClusterBuilder {
     return this;
   }
 
-  public TestClusterBuilder withUnifiedGatewayConfig(
-      final Consumer<TestStandaloneGateway> modifier) {
-    unifiedGatewayConfig = (memberId, gateway) -> modifier.accept(gateway);
-    return this;
-  }
-
   /**
    * Sets the configuration function that will be executed in the {@link #build()} method on each
    * broker. The first argument is the broker ID, and the second argument is the broker itself.
@@ -251,16 +233,10 @@ public final class TestClusterBuilder {
    * <p>NOTE: in case of conflicts with {@link #nodeConfig} or {@link #gatewayConfig} this
    * configuration will override them.
    *
-   * @param modifier the function that will be applied on all cluster brokers
    * @return this builder instance for chaining
    */
   public TestClusterBuilder withBrokerConfig(final Consumer<TestStandaloneBroker> modifier) {
     brokerConfig = (id, broker) -> modifier.accept(broker);
-    return this;
-  }
-
-  public TestClusterBuilder withUnifiedBrokerConfig(final Consumer<TestStandaloneBroker> modifier) {
-    unifiedBrokerConfig = (id, broker) -> modifier.accept(broker);
     return this;
   }
 
@@ -385,6 +361,7 @@ public final class TestClusterBuilder {
                   uc.getSystem().setIoThreadCount(replicas);
                   uc.getSystem().setCpuThreadCount(replicas);
                 })
+            // TODO KPO can we remove setAutoconfigureCamundaExporter?
             .withUnifiedConfig(
                 uc -> uc.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false))
             .withGatewayEnabled(useEmbeddedGateway)

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -349,7 +349,7 @@ public final class TestClusterBuilder {
                   final var cluster = uc.getCluster();
                   if (setNodeId) {
                     cluster.setNodeId(index);
-                    }
+                  }
                   cluster.setPartitionCount(partitionsCount);
                   cluster.setReplicationFactor(replicationFactor);
                   cluster.setSize(brokersCount);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -361,7 +361,6 @@ public final class TestClusterBuilder {
                   uc.getSystem().setIoThreadCount(replicas);
                   uc.getSystem().setCpuThreadCount(replicas);
                 })
-            // TODO KPO can we remove setAutoconfigureCamundaExporter?
             .withUnifiedConfig(
                 uc -> uc.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false))
             .withGatewayEnabled(useEmbeddedGateway)
@@ -389,7 +388,6 @@ public final class TestClusterBuilder {
                   cluster.setName(name);
                   cluster.setInitialContactPoints(getInitialContactPoints());
                 })
-            // TODO KPO not available in UC
             .withProperty("zeebe.gateway.cluster.memberId", id);
     return gateway;
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -95,6 +95,15 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
    */
   T withGatewayConfig(final Consumer<GatewayCfg> modifier);
 
+  /**
+   * Modifies the unified configuration (camunda.* properties). This is the recommended way to
+   * configure test gateways going forward.
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  T withUnifiedConfig(final Consumer<Camunda> modifier);
+
   /** Returns the gateway configuration for this node. */
   GatewayCfg gatewayConfig();
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -102,6 +102,7 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
    * @param modifier a configuration function that accepts the Camunda configuration object
    * @return itself for chaining
    */
+  @Override
   T withUnifiedConfig(final Consumer<Camunda> modifier);
 
   /** Returns the gateway configuration for this node. */

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.qa.util.cluster;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.configuration.Camunda;
-import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
@@ -90,12 +88,6 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
   }
 
   /**
-   * Allows modifying the gateway configuration. Changes will not take effect until the node is
-   * restarted.
-   */
-  T withGatewayConfig(final Consumer<GatewayCfg> modifier);
-
-  /**
    * Modifies the unified configuration (camunda.* properties). This is the recommended way to
    * configure test gateways going forward.
    *
@@ -105,9 +97,7 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
   @Override
   T withUnifiedConfig(final Consumer<Camunda> modifier);
 
-  /** Returns the gateway configuration for this node. */
-  GatewayCfg gatewayConfig();
-
+  /** Returns the unified configuration for this node */
   Camunda unifiedConfig();
 
   /** Returns a new pre-configured client builder for this gateway */
@@ -175,42 +165,6 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
    */
   default T awaitCompleteTopology() {
     return awaitCompleteTopology(1, 1, 1, Duration.ofSeconds(30));
-  }
-
-  /**
-   * Method to await the complete topology of a cluster with the given configuration.
-   *
-   * @return itself for chaining
-   * @deprecated Use {@link #awaitCompleteTopology(Camunda)} instead. BrokerBasedProperties is
-   *     deprecated in favor of unified configuration.
-   */
-  @Deprecated
-  default T awaitCompleteTopology(final BrokerBasedProperties brokerBasedProperties) {
-    final var clusterCfg = brokerBasedProperties.getCluster();
-    return awaitCompleteTopology(
-        clusterCfg.getClusterSize(),
-        clusterCfg.getPartitionsCount(),
-        clusterCfg.getReplicationFactor(),
-        Duration.ofSeconds(30));
-  }
-
-  /**
-   * Method to await the complete topology of a cluster with the given configuration.
-   *
-   * @return itself for chaining
-   * @deprecated Use {@link #awaitCompleteTopology(Camunda, CamundaClient)} instead.
-   *     BrokerBasedProperties is deprecated in favor of unified configuration.
-   */
-  @Deprecated
-  default T awaitCompleteTopology(
-      final BrokerBasedProperties brokerBasedProperties, final CamundaClient camundaClient) {
-    final var clusterCfg = brokerBasedProperties.getCluster();
-    return awaitCompleteTopology(
-        clusterCfg.getClusterSize(),
-        clusterCfg.getPartitionsCount(),
-        clusterCfg.getReplicationFactor(),
-        Duration.ofSeconds(30),
-        camundaClient);
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -56,6 +56,12 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   }
 
   @Override
+  public TestRestoreApp withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(config);
+    return this;
+  }
+
+  @Override
   protected String[] commandLineArgs() {
     return backupId == null
         ? super.commandLineArgs()
@@ -68,11 +74,6 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
     return super.createSpringBuilder().web(WebApplicationType.NONE);
-  }
-
-  public TestRestoreApp withConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(config);
-    return this;
   }
 
   public TestRestoreApp withBackupId(final long... backupId) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
@@ -13,6 +13,12 @@ import static io.camunda.security.configuration.InitializationConfiguration.DEFA
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.configuration.Api;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Cluster;
+import io.camunda.configuration.Data;
+import io.camunda.configuration.Monitoring;
+import io.camunda.configuration.Processing;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -44,12 +50,86 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
   T withBrokerConfig(final Consumer<BrokerBasedProperties> modifier);
 
   /**
+   * Modifies the unified configuration (camunda.* properties). This is the recommended way to
+   * configure test brokers going forward.
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  default T withUnifiedConfig(final Consumer<Camunda> modifier) {
+    throw new UnsupportedOperationException(
+        "Unified configuration is not supported by this implementation");
+  }
+
+  /**
+   * Convenience method to modify cluster configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for cluster settings
+   * @return itself for chaining
+   */
+  default T withClusterConfig(final Consumer<Cluster> modifier) {
+    return withUnifiedConfig(c -> modifier.accept(c.getCluster()));
+  }
+
+  /**
+   * Convenience method to modify data configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for data settings
+   * @return itself for chaining
+   */
+  default T withDataConfig(final Consumer<Data> modifier) {
+    return withUnifiedConfig(c -> modifier.accept(c.getData()));
+  }
+
+  /**
+   * Convenience method to modify API configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for API settings
+   * @return itself for chaining
+   */
+  default T withApiConfig(final Consumer<Api> modifier) {
+    return withUnifiedConfig(c -> modifier.accept(c.getApi()));
+  }
+
+  /**
+   * Convenience method to modify processing configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for processing settings
+   * @return itself for chaining
+   */
+  default T withProcessingConfig(final Consumer<Processing> modifier) {
+    return withUnifiedConfig(c -> modifier.accept(c.getProcessing()));
+  }
+
+  /**
+   * Convenience method to modify monitoring configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for monitoring settings
+   * @return itself for chaining
+   */
+  default T withMonitoringConfig(final Consumer<Monitoring> modifier) {
+    return withUnifiedConfig(c -> modifier.accept(c.getMonitoring()));
+  }
+
+  /**
    * Modifies the security configuration. Will still mutate the configuration if the broker is
    * started, but likely has no effect until it's restarted.
    */
   T withSecurityConfig(final Consumer<CamundaSecurityProperties> modifier);
 
   BrokerBasedProperties brokerConfig();
+
+  /**
+   * Returns the unified configuration object. This provides access to the camunda.* configuration
+   * structure.
+   *
+   * @return the Camunda unified configuration object
+   */
+  @Override
+  default Camunda unifiedConfig() {
+    throw new UnsupportedOperationException(
+        "Unified configuration is not supported by this implementation");
+  }
 
   default Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return Optional.empty();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
@@ -56,6 +56,7 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
    * @param modifier a configuration function that accepts the Camunda configuration object
    * @return itself for chaining
    */
+  @Override
   default T withUnifiedConfig(final Consumer<Camunda> modifier) {
     throw new UnsupportedOperationException(
         "Unified configuration is not supported by this implementation");

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
@@ -20,7 +20,6 @@ import io.camunda.configuration.Data;
 import io.camunda.configuration.Monitoring;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import java.util.Optional;
@@ -43,12 +42,6 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
    * @return itself for chaining
    */
   T withExporter(final String id, final Consumer<ExporterCfg> modifier);
-
-  /**
-   * Modifies the broker configuration. Will still mutate the configuration if the broker is
-   * started, but likely has no effect until it's restarted.
-   */
-  T withBrokerConfig(final Consumer<BrokerBasedProperties> modifier);
 
   /**
    * Sets the secondary storage type to use.
@@ -162,8 +155,6 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
    * started, but likely has no effect until it's restarted.
    */
   T withSecurityConfig(final Consumer<CamundaSecurityProperties> modifier);
-
-  BrokerBasedProperties brokerConfig();
 
   default Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return Optional.empty();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -199,9 +199,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
   @Override
   public String host() {
-    return unifiedConfig.getCluster().getNetwork().getHost() != null
-        ? unifiedConfig.getCluster().getNetwork().getHost()
-        : "0.0.0.0";
+    final var host = unifiedConfig.getCluster().getNetwork().getHost();
+    return host != null ? host : "0.0.0.0";
   }
 
   @Override

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -15,8 +15,11 @@ import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.authentication.config.AuthenticationProperties;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
@@ -32,7 +35,6 @@ import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.broker.NodeIdProviderConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
@@ -59,8 +61,9 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public static final String DEFAULT_MAPPING_RULE_CLAIM_NAME = "client_id";
   public static final String DEFAULT_MAPPING_RULE_CLAIM_VALUE = "default";
   public static final String RECORDING_EXPORTER_ID = "recordingExporter";
-  private final BrokerBasedProperties config;
+  private final Camunda unifiedConfig;
   private final CamundaSecurityProperties securityConfig;
+  private boolean isGatewayEnabled = true;
 
   public TestStandaloneBroker() {
     super(
@@ -69,35 +72,20 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         UnifiedConfigurationHelper.class,
         UnifiedConfiguration.class,
         NodeIdProviderConfiguration.class,
+        BrokerBasedPropertiesOverride.class,
+        GatewayBasedPropertiesOverride.class,
         GatewayRestPropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
         SearchEngineRetentionPropertiesOverride.class);
 
-    config = new BrokerBasedProperties();
+    unifiedConfig = new Camunda();
 
-    config.getNetwork().getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
-    config.getNetwork().getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
-    config.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
-
-    // set a smaller default log segment size since we pre-allocate, which might be a lot in tests
-    // for local development; also lower the watermarks for local testing
-    config.getData().setLogSegmentSize(DataSize.ofMegabytes(16));
-    config.getData().getDisk().getFreeSpace().setProcessing(DataSize.ofMegabytes(128));
-    config.getData().getDisk().getFreeSpace().setReplication(DataSize.ofMegabytes(64));
-    // Disable pre-allocation of segment files - many tests won't even fill up their first segment
-    config.getExperimental().getRaft().setPreallocateSegmentFiles(false);
-    // Disable flushes to reduce test runtime - we don't need perfect durability in tests, if the
-    // machine crashes the test fails anyway.
-    config.getCluster().getRaft().setFlush(new FlushConfig(false, Duration.ZERO));
-    config.getCluster().getMembership().setFailureTimeout(Duration.ofSeconds(5));
-    config.getCluster().getMembership().setProbeInterval(Duration.ofMillis(100));
-    config.getCluster().getMembership().setSyncInterval(Duration.ofMillis(500));
-    config.getExperimental().getConsistencyChecks().setEnableForeignKeyChecks(true);
-    config.getExperimental().getConsistencyChecks().setEnablePreconditions(true);
+    // Initialize unified config with test-friendly defaults
+    initializeUnifiedConfigDefaults();
 
     //noinspection resource
-    withBean("config", config, BrokerBasedProperties.class).withAdditionalProfile(Profile.BROKER);
+    withBean("camunda", unifiedConfig, Camunda.class).withAdditionalProfile(Profile.BROKER);
 
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthorizations().setEnabled(false);
@@ -144,9 +132,9 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   @Override
   public int mappedPort(final TestZeebePort port) {
     return switch (port) {
-      case COMMAND -> config.getNetwork().getCommandApi().getPort();
-      case GATEWAY -> config.getGateway().getNetwork().getPort();
-      case CLUSTER -> config.getNetwork().getInternalApi().getPort();
+      case COMMAND -> unifiedConfig.getCluster().getNetwork().getCommandApi().getPort();
+      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
+      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
       default -> super.mappedPort(port);
     };
   }
@@ -174,9 +162,11 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
     // because @ConditionalOnRestGatewayEnabled relies on the zeebe.broker.gateway.enable property,
-    // we need to hook in at the last minute and set the property as it won't resolve from the
-    // config bean
-    withProperty("zeebe.broker.gateway.enable", config.getGateway().isEnable());
+    // we need to hook in at the last minute and set the property
+    // Gateway enable flag is set via property since gateway config isn't fully in unified config
+    withProperty(
+        "zeebe.broker.gateway.enable",
+        property("zeebe.broker.gateway.enable", Boolean.class, isGatewayEnabled));
     return super.createSpringBuilder();
   }
 
@@ -199,12 +189,12 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
   @Override
   public MemberId nodeId() {
-    return MemberId.from(String.valueOf(config.getCluster().getNodeId()));
+    return MemberId.from(String.valueOf(unifiedConfig.getCluster().getNodeId()));
   }
 
   @Override
   public String host() {
-    return config.getNetwork().getHost();
+    return unifiedConfig.getCluster().getNetwork().getHost();
   }
 
   @Override
@@ -212,9 +202,17 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     return brokerHealth();
   }
 
+  // TODO KPO add gateway enabled to unified configuration?
   @Override
   public boolean isGateway() {
-    return config.getGateway().isEnable();
+    // Gateway enable flag is set via property (not fully in unified config yet)
+    return isGatewayEnabled;
+  }
+
+  public TestStandaloneBroker withGatewayEnabled(final boolean enabled) {
+    // Gateway enable flag is set via property (not fully in unified config yet)
+    isGatewayEnabled = enabled;
+    return this;
   }
 
   @Override
@@ -224,7 +222,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
           "Expected to get the gateway address for this broker, but the embedded gateway is not enabled");
     }
 
-    return TestStandaloneApplication.super.grpcAddress();
+    final var scheme = unifiedConfig.getApi().getGrpc().getSsl().isEnabled() ? "https" : "http";
+    return uri(scheme, TestZeebePort.GATEWAY);
   }
 
   @Override
@@ -234,13 +233,28 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
   @Override
   public TestStandaloneBroker withGatewayConfig(final Consumer<GatewayCfg> modifier) {
-    modifier.accept(config.getGateway());
-    return this;
+    throw new UnsupportedOperationException(
+        "Gateway configuration via withGatewayConfig is not supported. "
+            + "Gateway is not yet fully migrated to unified configuration. "
+            + "Use withProperty() to set zeebe.broker.gateway.* properties instead.");
   }
 
   @Override
   public GatewayCfg gatewayConfig() {
-    return config.getGateway();
+    throw new UnsupportedOperationException(
+        "Gateway configuration access via gatewayConfig() is not supported. "
+            + "Gateway is not yet fully migrated to unified configuration.");
+  }
+
+  /**
+   * Returns the unified configuration object. This provides access to the camunda.* configuration
+   * structure and is the primary way to read/configure the test broker.
+   *
+   * @return the Camunda unified configuration object
+   */
+  @Override
+  public Camunda unifiedConfig() {
+    return unifiedConfig;
   }
 
   /** Enables multi-tenancy in the security configuration. */
@@ -267,38 +281,142 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
    */
   public TestStandaloneBroker withRecordingExporter(final boolean useRecordingExporter) {
     if (!useRecordingExporter) {
-      config.getExporters().remove(RECORDING_EXPORTER_ID);
+      unifiedConfig.getData().getExporters().remove(RECORDING_EXPORTER_ID);
       return this;
     }
 
-    return withExporter(
-        RECORDING_EXPORTER_ID, cfg -> cfg.setClassName(RecordingExporter.class.getName()));
+    return withDataConfig(
+        data -> {
+          final var exporter =
+              data.getExporters()
+                  .computeIfAbsent(
+                      RECORDING_EXPORTER_ID, ignored -> new io.camunda.configuration.Exporter());
+          exporter.setClassName(RecordingExporter.class.getName());
+        });
   }
 
   /**
-   * Adds or replaces a new exporter with the given ID. If it was already existing, the existing
-   * configuration is passed to the modifier. If it's new, a blank configuration is passed.
+   * Adds or replaces a new exporter with the given ID using unified configuration.
+   *
+   * <p>Note: This method accepts ExporterCfg for backward compatibility but configures the unified
+   * config exporter. ExporterCfg will be converted to the unified Exporter format.
    *
    * @param id the ID of the exporter
-   * @param modifier a configuration function
+   * @param modifier a configuration function that accepts ExporterCfg
    * @return itself for chaining
    */
   @Override
   public TestStandaloneBroker withExporter(final String id, final Consumer<ExporterCfg> modifier) {
-    final var exporterConfig =
-        config.getExporters().computeIfAbsent(id, ignored -> new ExporterCfg());
-    modifier.accept(exporterConfig);
+    // Create a temporary ExporterCfg to accept the configuration
+    final var tempExporterCfg = new ExporterCfg();
+    modifier.accept(tempExporterCfg);
 
+    // Transfer to unified config exporter
+    return withDataConfig(
+        data -> {
+          final var unifiedExporter =
+              data.getExporters()
+                  .computeIfAbsent(id, ignored -> new io.camunda.configuration.Exporter());
+          unifiedExporter.setClassName(tempExporterCfg.getClassName());
+          unifiedExporter.setJarPath(tempExporterCfg.getJarPath());
+          unifiedExporter.setArgs(tempExporterCfg.getArgs());
+        });
+  }
+
+  /**
+   * Modifies the broker configuration.
+   *
+   * @deprecated BrokerBasedProperties is no longer the primary configuration object. Use {@link
+   *     #withUnifiedConfig(Consumer)} or convenience methods like {@link
+   *     #withClusterConfig(Consumer)}, {@link #withDataConfig(Consumer)}, etc. instead.
+   *     BrokerBasedProperties will be created from UnifiedConfiguration at Spring startup.
+   */
+  @Deprecated
+  @Override
+  public TestStandaloneBroker withBrokerConfig(final Consumer<BrokerBasedProperties> modifier) {
+    throw new UnsupportedOperationException(
+        "withBrokerConfig() is no longer supported. "
+            + "Use withUnifiedConfig() or convenience methods like withClusterConfig(), withDataConfig(), etc. "
+            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
+  }
+
+  /**
+   * Modifies the unified configuration (camunda.* properties). This is the recommended way to
+   * configure test brokers going forward.
+   *
+   * <p>The unified configuration will be merged into BrokerBasedProperties at Spring application
+   * startup via BrokerBasedPropertiesOverride, with unified config taking precedence.
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  @Override
+  public TestStandaloneBroker withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(unifiedConfig);
     return this;
   }
 
   /**
-   * Modifies the broker configuration. Will still mutate the configuration if the broker is
-   * started, but likely has no effect until it's restarted.
+   * Convenience method to modify cluster configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for cluster settings (membership, raft, network, etc.)
+   * @return itself for chaining
    */
   @Override
-  public TestStandaloneBroker withBrokerConfig(final Consumer<BrokerBasedProperties> modifier) {
-    modifier.accept(config);
+  public TestStandaloneBroker withClusterConfig(
+      final Consumer<io.camunda.configuration.Cluster> modifier) {
+    modifier.accept(unifiedConfig.getCluster());
+    return this;
+  }
+
+  /**
+   * Convenience method to modify data configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for data settings (storage, backup, exporters, etc.)
+   * @return itself for chaining
+   */
+  @Override
+  public TestStandaloneBroker withDataConfig(
+      final Consumer<io.camunda.configuration.Data> modifier) {
+    modifier.accept(unifiedConfig.getData());
+    return this;
+  }
+
+  /**
+   * Convenience method to modify API configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for API settings (gRPC, REST, long-polling, etc.)
+   * @return itself for chaining
+   */
+  @Override
+  public TestStandaloneBroker withApiConfig(final Consumer<io.camunda.configuration.Api> modifier) {
+    modifier.accept(unifiedConfig.getApi());
+    return this;
+  }
+
+  /**
+   * Convenience method to modify processing configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for processing settings (batches, async tasks, etc.)
+   * @return itself for chaining
+   */
+  @Override
+  public TestStandaloneBroker withProcessingConfig(
+      final Consumer<io.camunda.configuration.Processing> modifier) {
+    modifier.accept(unifiedConfig.getProcessing());
+    return this;
+  }
+
+  /**
+   * Convenience method to modify monitoring configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for monitoring settings (metrics, tracing, etc.)
+   * @return itself for chaining
+   */
+  @Override
+  public TestStandaloneBroker withMonitoringConfig(
+      final Consumer<io.camunda.configuration.Monitoring> modifier) {
+    modifier.accept(unifiedConfig.getMonitoring());
     return this;
   }
 
@@ -313,15 +431,87 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     return this;
   }
 
-  /** Returns the broker configuration */
+  /**
+   * Returns the broker configuration.
+   *
+   * @deprecated BrokerBasedProperties is no longer maintained in TestStandaloneBroker. Use {@link
+   *     #unifiedConfig()} instead. BrokerBasedProperties will be created from UnifiedConfiguration
+   *     at Spring startup.
+   */
+  @Deprecated
   @Override
   public BrokerBasedProperties brokerConfig() {
-    return config;
+    throw new UnsupportedOperationException(
+        "brokerConfig() is no longer supported. "
+            + "Use unifiedConfig() instead. "
+            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
   }
 
   @Override
   public Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return apiAuthenticationMethod();
+  }
+
+  /**
+   * Initialize unified configuration with test-friendly defaults that match the legacy
+   * configuration behavior.
+   */
+  private void initializeUnifiedConfigDefaults() {
+    // Set cluster defaults
+    unifiedConfig.getCluster().setSize(1);
+    unifiedConfig.getCluster().setPartitionCount(1);
+    unifiedConfig.getCluster().setReplicationFactor(1);
+    unifiedConfig
+        .getCluster()
+        .setCompressionAlgorithm(io.camunda.configuration.Cluster.CompressionAlgorithm.NONE);
+
+    // Set membership defaults for fast test execution
+    unifiedConfig.getCluster().getMembership().setFailureTimeout(Duration.ofSeconds(5));
+    unifiedConfig.getCluster().getMembership().setProbeInterval(Duration.ofMillis(100));
+    unifiedConfig.getCluster().getMembership().setSyncInterval(Duration.ofMillis(500));
+
+    // Set raft defaults - disable flushing for faster tests
+    unifiedConfig.getCluster().getRaft().setFlushEnabled(false);
+    unifiedConfig.getCluster().getRaft().setFlushDelay(Duration.ZERO);
+
+    // Set data defaults - smaller segments for tests
+    unifiedConfig.getData().setSnapshotPeriod(Duration.ofMinutes(5));
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getLogStream()
+        .setLogSegmentSize(DataSize.ofMegabytes(16));
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getDisk()
+        .getFreeSpace()
+        .setProcessing(DataSize.ofMegabytes(128));
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getDisk()
+        .getFreeSpace()
+        .setReplication(DataSize.ofMegabytes(64));
+
+    // Set processing defaults - enable consistency checks
+    unifiedConfig.getProcessing().setEnablePreconditionsCheck(true);
+    unifiedConfig.getProcessing().setEnableForeignKeyChecks(true);
+
+    // Set dynamic ports via properties (these aren't in unified config yet)
+    unifiedConfig
+        .getCluster()
+        .getNetwork()
+        .getCommandApi()
+        .setPort(SocketUtil.getNextAddress().getPort());
+    unifiedConfig
+        .getCluster()
+        .getNetwork()
+        .getInternalApi()
+        .setPort(SocketUtil.getNextAddress().getPort());
+    unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
+
+    unifiedConfig.getCluster().getNetwork().setHost("0.0.0.0");
   }
 
   public TestStandaloneBroker withCamundaExporter(final String elasticSearchUrl) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -37,7 +37,6 @@ import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.broker.NodeIdProviderConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
@@ -215,7 +214,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     return brokerHealth();
   }
 
-  // TODO KPO add gateway enabled to unified configuration?
   @Override
   public boolean isGateway() {
     // Gateway enable flag is set via property (not fully in unified config yet)
@@ -258,21 +256,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   @Override
   public GatewayHealthActuator gatewayHealth() {
     throw new UnsupportedOperationException("Brokers do not support the gateway health indicators");
-  }
-
-  @Override
-  public TestStandaloneBroker withGatewayConfig(final Consumer<GatewayCfg> modifier) {
-    throw new UnsupportedOperationException(
-        "Gateway configuration via withGatewayConfig is not supported. "
-            + "Gateway is not yet fully migrated to unified configuration. "
-            + "Use withProperty() to set zeebe.broker.gateway.* properties instead.");
-  }
-
-  @Override
-  public GatewayCfg gatewayConfig() {
-    throw new UnsupportedOperationException(
-        "Gateway configuration access via gatewayConfig() is not supported. "
-            + "Gateway is not yet fully migrated to unified configuration.");
   }
 
   /**
@@ -350,23 +333,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
           unifiedExporter.setJarPath(tempExporterCfg.getJarPath());
           unifiedExporter.setArgs(tempExporterCfg.getArgs());
         });
-  }
-
-  /**
-   * Modifies the broker configuration.
-   *
-   * @deprecated BrokerBasedProperties is no longer the primary configuration object. Use {@link
-   *     #withUnifiedConfig(Consumer)} or convenience methods like {@link
-   *     #withClusterConfig(Consumer)}, {@link #withDataConfig(Consumer)}, etc. instead.
-   *     BrokerBasedProperties will be created from UnifiedConfiguration at Spring startup.
-   */
-  @Deprecated
-  @Override
-  public TestStandaloneBroker withBrokerConfig(final Consumer<BrokerBasedProperties> modifier) {
-    throw new UnsupportedOperationException(
-        "withBrokerConfig() is no longer supported. "
-            + "Use withUnifiedConfig() or convenience methods like withClusterConfig(), withDataConfig(), etc. "
-            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
   }
 
   /**
@@ -457,22 +423,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
       final Consumer<CamundaSecurityProperties> modifier) {
     modifier.accept(securityConfig);
     return this;
-  }
-
-  /**
-   * Returns the broker configuration.
-   *
-   * @deprecated BrokerBasedProperties is no longer maintained in TestStandaloneBroker. Use {@link
-   *     #unifiedConfig()} instead. BrokerBasedProperties will be created from UnifiedConfiguration
-   *     at Spring startup.
-   */
-  @Deprecated
-  @Override
-  public BrokerBasedProperties brokerConfig() {
-    throw new UnsupportedOperationException(
-        "brokerConfig() is no longer supported. "
-            + "Use unifiedConfig() instead. "
-            + "BrokerBasedProperties is created from UnifiedConfiguration at Spring startup.");
   }
 
   @Override

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -58,7 +58,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
 
     unifiedConfig.getApi().getGrpc().setAddress("0.0.0.0");
     unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
-    // unifiedConfig.getCluster().getNetwork().setHost("0.0.0.0");
     unifiedConfig
         .getCluster()
         .getNetwork()
@@ -117,6 +116,18 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
             + "Use withProperty() to set zeebe.gateway.* properties instead.");
   }
 
+  /**
+   * Modifies the unified configuration (camunda.* properties).
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  @Override
+  public TestStandaloneGateway withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(unifiedConfig);
+    return this;
+  }
+
   @Override
   public GatewayCfg gatewayConfig() {
     throw new UnsupportedOperationException(
@@ -133,18 +144,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
   @Override
   public Camunda unifiedConfig() {
     return unifiedConfig;
-  }
-
-  /**
-   * Modifies the unified configuration (camunda.* properties).
-   *
-   * @param modifier a configuration function that accepts the Camunda configuration object
-   * @return itself for chaining
-   */
-  @Override
-  public TestStandaloneGateway withUnifiedConfig(final Consumer<Camunda> modifier) {
-    modifier.accept(unifiedConfig);
-    return this;
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -141,6 +141,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
    * @param modifier a configuration function that accepts the Camunda configuration object
    * @return itself for chaining
    */
+  @Override
   public TestStandaloneGateway withUnifiedConfig(final Consumer<Camunda> modifier) {
     modifier.accept(unifiedConfig);
     return this;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -11,10 +11,12 @@ import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOverride;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
@@ -22,7 +24,6 @@ import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverr
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
-import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
@@ -31,7 +32,7 @@ import java.util.function.Consumer;
 /** Encapsulates an instance of the {@link GatewayModuleConfiguration} Spring application. */
 public final class TestStandaloneGateway extends TestSpringApplication<TestStandaloneGateway>
     implements TestGateway<TestStandaloneGateway> {
-  private final GatewayBasedProperties config;
+  private final Camunda unifiedConfig;
   private final CamundaSecurityProperties securityConfig;
 
   public TestStandaloneGateway() {
@@ -42,6 +43,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         TasklistPropertiesOverride.class,
         OperatePropertiesOverride.class,
         BrokerBasedPropertiesOverride.class,
+        GatewayBasedPropertiesOverride.class,
         ActorClockControlledPropertiesOverride.class,
         GatewayRestPropertiesOverride.class,
         IdleStrategyPropertiesOverride.class,
@@ -51,14 +53,19 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         // ---
         GatewayModuleConfiguration.class,
         CommonsModuleConfiguration.class);
-    config = new GatewayBasedProperties();
 
-    config.getNetwork().setHost("0.0.0.0");
-    config.getNetwork().setPort(SocketUtil.getNextAddress().getPort());
-    config.getCluster().setPort(SocketUtil.getNextAddress().getPort());
+    unifiedConfig = new Camunda();
 
+    unifiedConfig.getApi().getGrpc().setAddress("0.0.0.0");
+    unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
+    // unifiedConfig.getCluster().getNetwork().setHost("0.0.0.0");
+    unifiedConfig
+        .getCluster()
+        .getNetwork()
+        .getInternalApi()
+        .setPort(SocketUtil.getNextAddress().getPort());
     //noinspection resource
-    withBean("config", config, GatewayBasedProperties.class).withAdditionalProfile(Profile.GATEWAY);
+    withBean("camunda", unifiedConfig, Camunda.class).withAdditionalProfile(Profile.GATEWAY);
 
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthentication().setUnprotectedApi(true);
@@ -76,14 +83,16 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
     return this;
   }
 
+  // TODO KPO memeberId does not exist in UC, add?
   @Override
   public MemberId nodeId() {
-    return MemberId.from(config.getCluster().getMemberId());
+    // Gateway member ID via property
+    return MemberId.from(property("zeebe.gateway.cluster.memberId", String.class, "gateway"));
   }
 
   @Override
   public String host() {
-    return config.getNetwork().getHost();
+    return unifiedConfig.getApi().getGrpc().getAddress();
   }
 
   @Override
@@ -94,20 +103,58 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
   @Override
   public int mappedPort(final TestZeebePort port) {
     return switch (port) {
-      case GATEWAY -> config.getNetwork().getPort();
-      case CLUSTER -> config.getCluster().getPort();
+      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
+      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
       default -> super.mappedPort(port);
     };
   }
 
   @Override
   public TestStandaloneGateway withGatewayConfig(final Consumer<GatewayCfg> modifier) {
-    modifier.accept(config);
-    return self();
+    throw new UnsupportedOperationException(
+        "Gateway configuration via withGatewayConfig is not supported. "
+            + "Gateway is not yet fully migrated to unified configuration. "
+            + "Use withProperty() to set zeebe.gateway.* properties instead.");
   }
 
   @Override
   public GatewayCfg gatewayConfig() {
-    return config;
+    throw new UnsupportedOperationException(
+        "Gateway configuration access via gatewayConfig() is not supported. "
+            + "Gateway is not yet fully migrated to unified configuration.");
+  }
+
+  /**
+   * Returns the unified configuration object. This provides access to the camunda.* configuration
+   * structure.
+   *
+   * @return the Camunda unified configuration object
+   */
+  @Override
+  public Camunda unifiedConfig() {
+    return unifiedConfig;
+  }
+
+  /**
+   * Modifies the unified configuration (camunda.* properties).
+   *
+   * @param modifier a configuration function that accepts the Camunda configuration object
+   * @return itself for chaining
+   */
+  public TestStandaloneGateway withUnifiedConfig(final Consumer<Camunda> modifier) {
+    modifier.accept(unifiedConfig);
+    return this;
+  }
+
+  /**
+   * Convenience method to modify cluster configuration using the unified configuration API.
+   *
+   * @param modifier a configuration function for cluster settings
+   * @return itself for chaining
+   */
+  public TestStandaloneGateway withClusterConfig(
+      final Consumer<io.camunda.configuration.Cluster> modifier) {
+    modifier.accept(unifiedConfig.getCluster());
+    return this;
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -25,7 +25,6 @@ import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverrid
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.util.function.Consumer;
 
@@ -82,7 +81,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
     return this;
   }
 
-  // TODO KPO memeberId does not exist in UC, add?
   @Override
   public MemberId nodeId() {
     // Gateway member ID via property
@@ -99,23 +97,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
     return true;
   }
 
-  @Override
-  public int mappedPort(final TestZeebePort port) {
-    return switch (port) {
-      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
-      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
-      default -> super.mappedPort(port);
-    };
-  }
-
-  @Override
-  public TestStandaloneGateway withGatewayConfig(final Consumer<GatewayCfg> modifier) {
-    throw new UnsupportedOperationException(
-        "Gateway configuration via withGatewayConfig is not supported. "
-            + "Gateway is not yet fully migrated to unified configuration. "
-            + "Use withProperty() to set zeebe.gateway.* properties instead.");
-  }
-
   /**
    * Modifies the unified configuration (camunda.* properties).
    *
@@ -129,10 +110,12 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
   }
 
   @Override
-  public GatewayCfg gatewayConfig() {
-    throw new UnsupportedOperationException(
-        "Gateway configuration access via gatewayConfig() is not supported. "
-            + "Gateway is not yet fully migrated to unified configuration.");
+  public int mappedPort(final TestZeebePort port) {
+    return switch (port) {
+      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
+      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
+      default -> super.mappedPort(port);
+    };
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -243,7 +243,11 @@ final class ZeebeIntegrationExtension
       throw new UncheckedIOException(e);
     }
 
-    broker.withWorkingDirectory(workingDirectory);
+    broker
+        .withWorkingDirectory(workingDirectory)
+        .withUnifiedConfig(
+            camunda ->
+                camunda.getData().getPrimaryStorage().setDirectory(workingDirectory.toString()));
   }
 
   private Path createManagedDirectory(final Store store, final String prefix) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -243,11 +243,7 @@ final class ZeebeIntegrationExtension
       throw new UncheckedIOException(e);
     }
 
-    broker
-        .withWorkingDirectory(workingDirectory)
-        .withUnifiedConfig(
-            camunda ->
-                camunda.getData().getPrimaryStorage().setDirectory(workingDirectory.toString()));
+    broker.withWorkingDirectory(workingDirectory);
   }
 
   private Path createManagedDirectory(final Store store, final String prefix) {

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
@@ -30,8 +30,7 @@ final class TestClusterBuilderTest {
 
     // then
     assertThat(cluster.brokers())
-        .allSatisfy(
-            haveProperty("cluster size", b -> b.brokerConfig().getCluster().getClusterSize(), 2));
+        .allSatisfy(haveProperty("cluster size", b -> b.unifiedConfig().getCluster().getSize(), 2));
   }
 
   @Test
@@ -48,7 +47,7 @@ final class TestClusterBuilderTest {
     assertThat(brokers)
         .allSatisfy(
             haveProperty(
-                "partition count", b -> b.brokerConfig().getCluster().getPartitionsCount(), 2));
+                "partition count", b -> b.unifiedConfig().getCluster().getPartitionCount(), 2));
   }
 
   @Test
@@ -66,7 +65,7 @@ final class TestClusterBuilderTest {
         .allSatisfy(
             haveProperty(
                 "replication factor",
-                b -> b.brokerConfig().getCluster().getReplicationFactor(),
+                b -> b.unifiedConfig().getCluster().getReplicationFactor(),
                 2));
   }
 
@@ -87,15 +86,11 @@ final class TestClusterBuilderTest {
     assertThat(cluster.brokers())
         .allSatisfy(
             haveProperty(
-                "cluster name",
-                b -> b.brokerConfig().getCluster().getClusterName(),
-                "test-cluster"));
+                "cluster name", b -> b.unifiedConfig().getCluster().getName(), "test-cluster"));
     assertThat(cluster.gateways())
         .allSatisfy(
             haveProperty(
-                "cluster name",
-                g -> g.gatewayConfig().getCluster().getClusterName(),
-                "test-cluster"));
+                "cluster name", g -> g.unifiedConfig().getCluster().getName(), "test-cluster"));
   }
 
   @Test
@@ -152,13 +147,13 @@ final class TestClusterBuilderTest {
         .allSatisfy(
             haveProperty(
                 "initial contact points",
-                b -> b.brokerConfig().getCluster().getInitialContactPoints(),
+                b -> b.unifiedConfig().getCluster().getInitialContactPoints(),
                 expectedValue));
     assertThat(cluster.gateways())
         .allSatisfy(
             haveProperty(
                 "initial contact points",
-                g -> g.gatewayConfig().getCluster().getInitialContactPoints(),
+                g -> g.unifiedConfig().getCluster().getInitialContactPoints(),
                 expectedValue));
   }
 
@@ -177,7 +172,7 @@ final class TestClusterBuilderTest {
         .has(
             hasProperty(
                 "initial contact point",
-                g -> g.gatewayConfig().getCluster().getInitialContactPoints(),
+                g -> g.unifiedConfig().getCluster().getInitialContactPoints(),
                 Collections.emptyList()));
   }
 
@@ -194,9 +189,7 @@ final class TestClusterBuilderTest {
     final var brokerId = MemberId.from("0");
     final var broker = cluster.brokers().get(brokerId);
     assertThat(broker)
-        .has(
-            hasProperty(
-                "embedded gateway enabled", b -> b.brokerConfig().getGateway().isEnable(), true));
+        .has(hasProperty("embedded gateway enabled", TestStandaloneBroker::isGateway, true));
     assertThat(broker.isGateway()).isTrue();
   }
 
@@ -213,11 +206,7 @@ final class TestClusterBuilderTest {
     final var brokerId = MemberId.from("0");
     final var broker = cluster.brokers().get(brokerId);
     assertThat(broker)
-        .has(
-            hasProperty(
-                "embedded gateway not enabled",
-                b -> b.brokerConfig().getGateway().isEnable(),
-                false));
+        .has(hasProperty("embedded gateway not enabled", TestStandaloneBroker::isGateway, false));
     assertThat(broker.isGateway()).isFalse();
   }
 


### PR DESCRIPTION
## Description

This PR migrates the test applications `TestClusterBuilder`, `TestStandaloneBroker`, `TestStandaloneGateway`, and `TestRestoreApp` to the unified configuration, along with the tests that consume these applications.

Commit Structure

- Replace legacy configuration with the unified configuration in the test applications and establish the baseline for the consuming tests.
- Migrate consuming tests per test application, with adjustments to the test applications where necessary to ensure the tests pass.
- Adjust tests related to the new DynamicNodeId.
- Include two cleanup commits.

Note
- Some tests (e.g. SecureClusteredMessagingIT) still access `BrokerBasedProperties` to assert the behavior, since this class contains initialization logic that is not available in the unified configuration, and the resulting values may differ. 

## Related issues

relates to #36058