### PR TITLE
Re-add ref input for Camunda Load Test workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -22,6 +22,10 @@ on:
         type: string
         default: ""
         required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'stable/8.7'
+        required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
@@ -58,6 +62,11 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'main'
+        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
@@ -107,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref }}
       - name: Get image tag
         id: image-tag
         run: |
@@ -134,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -177,7 +186,7 @@ jobs:
         name: Build Camunda Docker Image
         with:
           repository: 'gcr.io/zeebe-io/zeebe'
-          revision: ${{ github.ref }}
+          revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
@@ -204,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref }}
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         id: auth
@@ -345,7 +354,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -9,6 +9,11 @@ name: Camunda load test
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Specifies the ref (e.g. branch name, commit sha or tag) from which the docker image is build and used to run the load test against'
+        default: 'stable/8.6'
+        type: string
+        required: false
       name:
         description: 'Specifies the name of the load test'
         required: true
@@ -21,10 +26,6 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
-        required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'stable/8.7'
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
@@ -49,6 +50,11 @@ on:
         default: false
   workflow_call:
     inputs:
+      ref:
+        description: 'Specifies the ref (e.g. branch name, commit sha or tag) from which the docker image is build and used to run the load test against'
+        default: 'stable/8.6'
+        type: string
+        required: false
       name:
         description: 'Specifies the name of the load test'
         type: string
@@ -62,11 +68,6 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
-        required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'main'
-        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -19,6 +19,7 @@ jobs:
       name: ${{github.event.pull_request.head.ref}}-benchmark
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
+      ref: ${{ github.event.pull_request.head.ref }}
 
   delete-benchmark:
     name: Benchmark Cleanup

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -26,6 +26,7 @@ jobs:
       name: release-rolling
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
+      ref: refs/tags/${{ needs.fetch-release.outputs.release-tag }}
       load-test-load: >
         --set starter.rate=5
         --set worker.replicas=1


### PR DESCRIPTION
## Description

When re-creating the release load tests, we realized that the `ref` input is quite useful, as we might want to pick the latest state of the GitHub workflow from the stable branch and the version from a tag for the docker image.

Ideally in the long-term we should also support to reference existing docker image tags from releases. Right now we only support gcr.io docker images we have build and pushed previously to our registry. When set up load tests for releases we should be able to support the released versions as well. But this is needs to be support by our load test helm chart, and needs some more involvement, so we are going the pragmatic approach here for now.

related to https://github.com/camunda/camunda/issues/38829

## Details

* Reverts the commit which removed the ref input
* Improvement of the input param, move it up for better visibility and documentation for clarity

## Usage

This change was used [when recreating](https://camunda.slack.com/archives/C013MEVQ4M9/p1763654022883029?thread_ts=1763648223.069159&cid=C013MEVQ4M9) the `release-8-6-x` load test.

<img width="2504" height="821" alt="2025-11-20_16-53" src="https://github.com/user-attachments/assets/9e89a156-b405-4624-836d-1c9aca76d436" />
<img width="1313" height="881" alt="2025-11-20_15-50" src="https://github.com/user-attachments/assets/0e6a6df9-4eae-4459-892c-084df052c6ee" />
