### PR TITLE
Refactor/rework stable values for 8.6

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -27,10 +27,6 @@ on:
         type: string
         default: ""
         required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'stable/8.7'
-        required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
@@ -72,11 +68,6 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
-        required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'main'
-        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -27,6 +27,10 @@ on:
         type: string
         default: ""
         required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'stable/8.7'
+        required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
@@ -68,6 +72,11 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'main'
+        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -1,67 +1,33 @@
 # Additional values file to run Zeebe on stable VMs
-camunda-platform:
-  core:
-    # Require n2-standard-2 to ensure the broker is the only application running on its node
-    nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-2-stable
+zeebe:
+  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-2-stable
 
-    # Ignore the stable VM node taints
-    tolerations:
-      - key: cloud.google.com/gke-spot
-        operator: Equal
-        effect: NoSchedule
-        value: 'false'
+  # Ignore the stable VM node taints
+  tolerations:
+    - key: cloud.google.com/gke-spot
+      operator: Equal
+      effect: NoSchedule
+      value: 'false'
 
-  zeebe:
-    # Require n2-standard-2 to ensure the broker is the only application running on its node
-    nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-2-stable
+# Support of 10.x camunda platform
+zeebeGateway:
+  # Prefer scheduling on any non-spot VM
+  # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
+  # not a spot VM, that node label simply is not present. When it is a spot VM, then the value is
+  # set to true.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: cloud.google.com/gke-spot
+                operator: DoesNotExist
 
-    # Ignore the stable VM node taints
-    tolerations:
-      - key: cloud.google.com/gke-spot
-        operator: Equal
-        effect: NoSchedule
-        value: 'false'
-
-  # Support of -9.x camunda platform
-  zeebe-gateway:
-    # Prefer scheduling on any non-spot VM
-    # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
-    # not a spot VM, that node label simply is not present. When it is a spot VM, then the value is
-    # set to true.
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: cloud.google.com/gke-spot
-                  operator: DoesNotExist
-
-    # Ignore the stable VM node taints
-    tolerations:
-      - key: cloud.google.com/gke-spot
-        operator: Equal
-        effect: NoSchedule
-        value: 'false'
-
-  # Support of 10.x camunda platform
-  zeebeGateway:
-    # Prefer scheduling on any non-spot VM
-    # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
-    # not a spot VM, that node label simply is not present. When it is a spot VM, then the value is
-    # set to true.
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: cloud.google.com/gke-spot
-                  operator: DoesNotExist
-
-    # Ignore the stable VM node taints
-    tolerations:
-      - key: cloud.google.com/gke-spot
-        operator: Equal
-        effect: NoSchedule
-        value: 'false'
+  # Ignore the stable VM node taints
+  tolerations:
+    - key: cloud.google.com/gke-spot
+      operator: Equal
+      effect: NoSchedule
+      value: 'false'


### PR DESCRIPTION
## Description

 * The stable values didn't work for 8.6 and decoupled load tests, as they were referencing the old keys/objects with the dependency chart
 * Removed obsolete keys and settings

related to https://github.com/camunda/camunda/issues/38829