### PR TITLE
ci: restore add-to-project behavior for bug issues

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -137,10 +137,13 @@ jobs:
           labeled: component/clients, component/spring-boot-starter, component/camunda-process-test, component/c8-api
 
       - id: add-bug-to-quality-board
-        if: github.event.action != 'labeled' || github.event.label.name == 'kind/bug'
+        # Attention: This step uses a custom action maintained by the QA Engineering Team
+        # It adds all issues labeled with "kind/bug" to the Quality Board project,
+        # extracts the labels for component and severity and sets them in the project accordingly.
+        # The action must be triggered for any label change to keep the project data up to date.
         name: Add issue to Quality Board
         uses: camunda/infra-global-github-actions/add-bug-to-quality-board@main
         with:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           project-number: "187"
-          labeled: kind/bug
+        if: contains(github.event.issue.labels.*.name, 'kind/bug')


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->
This commit partially reverst changes done by https://github.com/camunda/camunda/pull/38925
    
To keep Bug Issues in sync with the Quality Board every label change needs to trigger the respective action.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41314
