### PR TITLE
Use correct values for setting zeebe image

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -297,9 +297,10 @@ jobs:
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set orchestration.image.registry=gcr.io
-          --set orchestration.image.repository=zeebe-io/zeebe
-          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set zeebe.image.repository=gcr.io/zeebe-io/zeebe
+          --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
+          --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -27,10 +27,6 @@ on:
         type: string
         default: ""
         required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'stable/8.7'
-        required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
@@ -72,11 +68,6 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
-        required: false
-      ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
-        default: 'main'
-        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -27,6 +27,10 @@ on:
         type: string
         default: ""
         required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'stable/8.7'
+        required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
@@ -68,6 +72,11 @@ on:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'main'
+        type: string
         required: false
       cluster:
         description: 'Specifies which cluster to deploy the load test on'


### PR DESCRIPTION
## Description

During migrating the release load tests, I realized that we are not correctly set the docker image https://camunda.slack.com/archives/C013MEVQ4M9/p1763658733549259?thread_ts=1763648223.069159&cid=C013MEVQ4M9

 * We were using values from 8.8 release orchestration instead of the old zeebe and zeebeGateway

related to https://github.com/camunda/camunda/issues/38829

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
