### PR TITLE
Convert bulk request processing in operate to use ES java client

### DIFF
--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -116,6 +116,11 @@
       <artifactId>elasticsearch</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-java</artifactId>
+    </dependency>
+
     <!-- Opensearch -->
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -11,7 +11,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.cluster.HealthResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.ElasticsearchProperties;
@@ -52,6 +52,8 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -61,6 +63,10 @@ import org.springframework.context.annotation.Configuration;
 public class ElasticsearchConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchConnector.class);
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   private PluginRepository esClientRepository = new PluginRepository();
   private final OperateProperties operateProperties;
@@ -134,11 +140,8 @@ public class ElasticsearchConnector {
           configCallback -> setTimeouts(configCallback, elsConfig));
     }
 
-    final var mapper = new JacksonJsonpMapper();
-    mapper.objectMapper().registerModule(new JavaTimeModule());
-
     final RestClientTransport transport =
-        new RestClientTransport(restClientBuilder.build(), mapper);
+        new RestClientTransport(restClientBuilder.build(), new JacksonJsonpMapper(objectMapper));
 
     final var client = new ElasticsearchClient(transport);
 

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.operate.connect;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.ElasticsearchProperties;
@@ -105,6 +109,45 @@ public class ElasticsearchConnector {
       LOGGER.warn("Elasticsearch cluster health check is disabled.");
     }
     return esClient;
+  }
+
+  @Bean
+  public ElasticsearchClient es8Client() {
+    System.setProperty("es.set.netty.runtime.available.processors", "false");
+    esClientRepository.load(operateProperties.getElasticsearch().getInterceptorPlugins());
+    return createEs8Client(operateProperties.getElasticsearch(), esClientRepository);
+  }
+
+  public ElasticsearchClient createEs8Client(
+      final ElasticsearchProperties elsConfig, final PluginRepository pluginRepository) {
+    LOGGER.debug("Creating Elasticsearch connection...");
+
+    final RestClientBuilder restClientBuilder =
+        RestClient.builder(getHttpHost(elsConfig))
+            .setHttpClientConfigCallback(
+                httpClientBuilder ->
+                    configureHttpClient(
+                        httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()));
+    if (elsConfig.getConnectTimeout() != null || elsConfig.getSocketTimeout() != null) {
+      restClientBuilder.setRequestConfigCallback(
+          configCallback -> setTimeouts(configCallback, elsConfig));
+    }
+
+    final RestClientTransport transport =
+        new RestClientTransport(restClientBuilder.build(), new JacksonJsonpMapper());
+
+    final var client = new ElasticsearchClient(transport);
+
+    if (operateProperties.getElasticsearch().isHealthCheckEnabled()) {
+      if (!checkHealth(client)) {
+        LOGGER.warn("Elasticsearch cluster is not accessible");
+      } else {
+        LOGGER.debug("Elasticsearch connection was successfully created.");
+      }
+    } else {
+      LOGGER.warn("Elasticsearch cluster health check is disabled.");
+    }
+    return client;
   }
 
   protected HttpAsyncClientBuilder configureHttpClient(
@@ -248,6 +291,30 @@ public class ElasticsearchConnector {
                 final ClusterHealthResponse clusterHealthResponse =
                     esClient.cluster().health(new ClusterHealthRequest(), RequestOptions.DEFAULT);
                 return clusterHealthResponse.getClusterName().equals(elsConfig.getClusterName());
+              })
+          .build()
+          .retry();
+    } catch (final Exception e) {
+      throw new OperateRuntimeException("Couldn't connect to Elasticsearch. Abort.", e);
+    }
+  }
+
+  @VisibleForTesting
+  boolean checkHealth(final ElasticsearchClient esClient) {
+    final ElasticsearchProperties elsConfig = operateProperties.getElasticsearch();
+    try {
+      return RetryOperation.<Boolean>newBuilder()
+          .noOfRetry(50)
+          .retryOn(IOException.class, ElasticsearchException.class)
+          .delayInterval(3, TimeUnit.SECONDS)
+          .message(
+              String.format(
+                  "Connect to Elasticsearch cluster [%s] at %s",
+                  elsConfig.getClusterName(), elsConfig.getUrl()))
+          .retryConsumer(
+              () -> {
+                final HealthResponse clusterHealthResponse = esClient.cluster().health();
+                return clusterHealthResponse.clusterName().equals(elsConfig.getClusterName());
               })
           .build()
           .retry();

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.cluster.HealthResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.ElasticsearchProperties;
@@ -133,8 +134,11 @@ public class ElasticsearchConnector {
           configCallback -> setTimeouts(configCallback, elsConfig));
     }
 
+    final var mapper = new JacksonJsonpMapper();
+    mapper.objectMapper().registerModule(new JavaTimeModule());
+
     final RestClientTransport transport =
-        new RestClientTransport(restClientBuilder.build(), new JacksonJsonpMapper());
+        new RestClientTransport(restClientBuilder.build(), mapper);
 
     final var client = new ElasticsearchClient(transport);
 

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -120,7 +120,6 @@ public class ElasticsearchConnector {
 
   @Bean
   public ElasticsearchClient es8Client() {
-    System.setProperty("es.set.netty.runtime.available.processors", "false");
     esClientRepository.load(operateProperties.getElasticsearch().getInterceptorPlugins());
     return createEs8Client(operateProperties.getElasticsearch(), esClientRepository);
   }

--- a/operate/common/src/main/java/io/camunda/operate/tenant/TenantAwareElasticsearchClient.java
+++ b/operate/common/src/main/java/io/camunda/operate/tenant/TenantAwareElasticsearchClient.java
@@ -33,7 +33,7 @@ public class TenantAwareElasticsearchClient
   private TenantCheckApplier<SearchRequest> tenantCheckApplier;
 
   @Override
-  public SearchResponse search(SearchRequest searchRequest) throws IOException {
+  public SearchResponse search(final SearchRequest searchRequest) throws IOException {
     return search(
         searchRequest,
         () -> {
@@ -42,15 +42,16 @@ public class TenantAwareElasticsearchClient
   }
 
   @Override
-  public <C> C search(SearchRequest searchRequest, Callable<C> searchExecutor) throws IOException {
+  public <C> C search(final SearchRequest searchRequest, final Callable<C> searchExecutor)
+      throws IOException {
     applyTenantCheckIfPresent(searchRequest);
     try {
       return searchExecutor.call();
-    } catch (IOException ioe) {
+    } catch (final IOException ioe) {
       throw ioe;
-    } catch (RuntimeException re) {
+    } catch (final RuntimeException re) {
       throw re;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final var message =
           String.format("Unexpectedly failed to execute search request with %s", e.getMessage());
       throw new OperateRuntimeException(message, e);

--- a/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.connect;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -16,22 +15,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.camunda.operate.property.ElasticsearchProperties;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.operate.property.OperateElasticsearchProperties;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.plugin.search.header.CustomHeader;
-import io.camunda.plugin.search.header.DatabaseCustomHeaderSupplier;
-import io.camunda.search.connect.plugin.PluginConfiguration;
-import io.camunda.search.connect.plugin.PluginRepository;
-import java.util.List;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestWrapper;
-import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.nio.client.HttpAsyncClient;
-import org.apache.http.protocol.BasicHttpContext;
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +33,7 @@ class ElasticsearchConnectorTest {
 
     connector.createEsClient(esProperties, mock());
 
-    verify(connector, never()).checkHealth(any(RestHighLevelClient.class));
+    verify(connector, never()).checkHealth(any(ElasticsearchClient.class));
   }
 
   @Test
@@ -61,57 +47,5 @@ class ElasticsearchConnectorTest {
     connector.createEsClient(esProperties, mock());
 
     verify(connector, times(1)).checkHealth(any(RestHighLevelClient.class));
-  }
-
-  // TODO: this test will may be removed once RestHighLevelClient is gone
-  @Test
-  void shouldApplyRequestInterceptorsInOrderForES7RestClient() throws Exception {
-    final var context = new BasicHttpContext();
-    final var esProperties = new ElasticsearchProperties();
-    final var operateProperties = new OperateProperties();
-    final PluginRepository pluginRepository = new PluginRepository();
-    pluginRepository.load(
-        List.of(new PluginConfiguration("plg1", TestPlugin.class.getName(), null)));
-    final var connector = spy(new ElasticsearchConnector(operateProperties));
-    doReturn(true).when(connector).checkHealth(any(RestHighLevelClient.class));
-    final var client = connector.createEsClient(esProperties, pluginRepository);
-
-    // when
-    getRestHighLevelClient(client)
-        .execute(HttpHost.create("localhost:9200"), new HttpGet(), context, NoopCallback.INSTANCE);
-
-    // then
-    final HttpRequestWrapper reqWrapper = (HttpRequestWrapper) context.getAttribute("http.request");
-
-    assertThat(reqWrapper.getFirstHeader("foo").getValue()).isEqualTo("bar");
-  }
-
-  private static HttpAsyncClient getRestHighLevelClient(final RestHighLevelClient client)
-      throws Exception {
-    final var field = client.getClass().getDeclaredField("client");
-    field.setAccessible(true);
-    final RestClient restClient = (RestClient) field.get(client);
-    return restClient.getHttpClient();
-  }
-
-  public static final class TestPlugin implements DatabaseCustomHeaderSupplier {
-
-    @Override
-    public CustomHeader getSearchDatabaseCustomHeader() {
-      return new CustomHeader("foo", "bar");
-    }
-  }
-
-  private static final class NoopCallback implements FutureCallback<HttpResponse> {
-    private static final NoopCallback INSTANCE = new NoopCallback();
-
-    @Override
-    public void completed(final HttpResponse result) {}
-
-    @Override
-    public void failed(final Exception ex) {}
-
-    @Override
-    public void cancelled() {}
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
@@ -14,8 +14,10 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.TestPlugin;
 import io.camunda.search.connect.plugin.PluginConfiguration;
@@ -47,7 +49,9 @@ import org.testcontainers.utility.DockerImageName;
       DatabaseInfo.class,
       OperatePropertiesOverride.class,
       UnifiedConfigurationHelper.class,
-      UnifiedConfiguration.class
+      UnifiedConfiguration.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
     })
 public class ElasticsearchConnectorIT {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
@@ -224,7 +224,7 @@ public class ElasticsearchTestRuleProvider implements SearchTestRuleProvider {
 
       ElasticsearchUtil.processBulkRequest(
           es8Client,
-          bulkRequest.build(),
+          bulkRequest,
           true,
           operateProperties.getElasticsearch().getBulkRequestMaxSizeInBytes());
     } catch (final Exception ex) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchBatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchBatchRequest.java
@@ -258,11 +258,9 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   @Override
   public void execute() throws PersistenceException {
     try {
-      final var builtBulkRequest = bulkRequest.build();
-      LOGGER.debug("Execute batchRequest with {} requests", builtBulkRequest.operations().size());
       ElasticsearchUtil.processBulkRequest(
           es8Client,
-          builtBulkRequest,
+          bulkRequest,
           operateProperties.getElasticsearch().getBulkRequestMaxSizeInBytes());
     } catch (final MissingRequiredPropertyException ignored) {
       // empty bulk request
@@ -272,13 +270,9 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   @Override
   public void executeWithRefresh() {
     try {
-      final var builtBulkRequest = bulkRequest.build();
-      LOGGER.debug(
-          "Execute batchRequest with {} requests and refresh",
-          builtBulkRequest.operations().size());
       ElasticsearchUtil.processBulkRequest(
           es8Client,
-          builtBulkRequest,
+          bulkRequest,
           true,
           operateProperties.getElasticsearch().getBulkRequestMaxSizeInBytes());
     } catch (final MissingRequiredPropertyException ignored) {

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -171,10 +171,10 @@ public abstract class ElasticsearchUtil {
       final var bulkRequest = bulkRequestBuilder.build();
       LOGGER.debug("Execute batchRequest with {} requests", bulkRequest.operations().size());
 
-      final var bulkIngester =
-          createBulkIngester(esClient, maxBulkRequestSizeInBytes, refreshImmediately);
-      bulkRequest.operations().forEach(bulkIngester::add);
-      bulkIngester.close();
+      try (final var bulkIngester =
+          createBulkIngester(esClient, maxBulkRequestSizeInBytes, refreshImmediately)) {
+        bulkRequest.operations().forEach(bulkIngester::add);
+      }
     } catch (final MissingRequiredPropertyException ignored) {
       // if bulk request has no operations calling .build() will throw an exception, we suppress
       // this as it is a no op.

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -9,18 +9,17 @@ package io.camunda.operate.util;
 
 import static io.camunda.operate.util.CollectionUtil.map;
 import static io.camunda.operate.util.CollectionUtil.throwAwayNullElements;
-import static java.util.Arrays.asList;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.entities.HitEntity;
 import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
-import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -28,26 +27,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.*;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -162,145 +152,41 @@ public abstract class ElasticsearchUtil {
   }
 
   public static void processBulkRequest(
-      final RestHighLevelClient esClient,
-      final BulkRequest bulkRequest,
-      final long maxBulkRequestSizeInBytes)
-      throws PersistenceException {
+      final ElasticsearchClient esClient,
+      final co.elastic.clients.elasticsearch.core.BulkRequest bulkRequest,
+      final long maxBulkRequestSizeInBytes) {
     processBulkRequest(esClient, bulkRequest, false, maxBulkRequestSizeInBytes);
   }
 
   /* EXECUTE QUERY */
 
   public static void processBulkRequest(
-      final RestHighLevelClient esClient,
-      final BulkRequest bulkRequest,
+      final ElasticsearchClient esClient,
+      final co.elastic.clients.elasticsearch.core.BulkRequest bulkRequest,
       final boolean refreshImmediately,
-      final long maxBulkRequestSizeInBytes)
-      throws PersistenceException {
-    if (bulkRequest.estimatedSizeInBytes() > maxBulkRequestSizeInBytes) {
-      divideLargeBulkRequestAndProcess(
-          esClient, bulkRequest, refreshImmediately, maxBulkRequestSizeInBytes);
+      final long maxBulkRequestSizeInBytes) {
+    final var bulkIngester =
+        createBulkIngester(esClient, maxBulkRequestSizeInBytes, refreshImmediately);
+    bulkRequest.operations().forEach(bulkIngester::add);
+    bulkIngester.close();
+  }
+
+  private static BulkIngester<Void> createBulkIngester(
+      final ElasticsearchClient esClient,
+      final long maxBulkRequestSizeInBytes,
+      final boolean refreshImmediately) {
+    final Refresh refreshVal;
+    if (refreshImmediately) {
+      refreshVal = Refresh.True;
     } else {
-      processLimitedBulkRequest(esClient, bulkRequest, refreshImmediately);
+      refreshVal = Refresh.False;
     }
-  }
-
-  private static void divideLargeBulkRequestAndProcess(
-      final RestHighLevelClient esClient,
-      final BulkRequest bulkRequest,
-      final boolean refreshImmediately,
-      final long maxBulkRequestSizeInBytes)
-      throws PersistenceException {
-    LOGGER.debug(
-        "Bulk request has {} bytes > {} max bytes ({} requests). Will divide it into smaller bulk requests.",
-        bulkRequest.estimatedSizeInBytes(),
-        maxBulkRequestSizeInBytes,
-        bulkRequest.requests().size());
-
-    int requestCount = 0;
-    final List<DocWriteRequest<?>> requests = bulkRequest.requests();
-
-    BulkRequest limitedBulkRequest = new BulkRequest();
-    while (requestCount < requests.size()) {
-      final DocWriteRequest<?> nextRequest = requests.get(requestCount);
-      if (nextRequest.ramBytesUsed() > maxBulkRequestSizeInBytes) {
-        throw new PersistenceException(
-            String.format(
-                "One of the request with size of %d bytes is greater than max allowed %d bytes",
-                nextRequest.ramBytesUsed(), maxBulkRequestSizeInBytes));
-      }
-
-      final long wholeSize = limitedBulkRequest.estimatedSizeInBytes() + nextRequest.ramBytesUsed();
-      if (wholeSize < maxBulkRequestSizeInBytes) {
-        limitedBulkRequest.add(nextRequest);
-      } else {
-        LOGGER.debug(
-            "Submit bulk of {} requests, size {} bytes.",
-            limitedBulkRequest.requests().size(),
-            limitedBulkRequest.estimatedSizeInBytes());
-        processLimitedBulkRequest(esClient, limitedBulkRequest, refreshImmediately);
-        limitedBulkRequest = new BulkRequest();
-        limitedBulkRequest.add(nextRequest);
-      }
-      requestCount++;
-    }
-    if (!limitedBulkRequest.requests().isEmpty()) {
-      LOGGER.debug(
-          "Submit bulk of {} requests, size {} bytes.",
-          limitedBulkRequest.requests().size(),
-          limitedBulkRequest.estimatedSizeInBytes());
-      processLimitedBulkRequest(esClient, limitedBulkRequest, refreshImmediately);
-    }
-  }
-
-  @SuppressWarnings("checkstyle:NestedIfDepth")
-  private static void processLimitedBulkRequest(
-      final RestHighLevelClient esClient, BulkRequest bulkRequest, final boolean refreshImmediately)
-      throws PersistenceException {
-    if (bulkRequest.requests().size() > 0) {
-      try {
-        LOGGER.debug("************* FLUSH BULK START *************");
-        if (refreshImmediately) {
-          bulkRequest = bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        }
-        final BulkResponse bulkItemResponses = esClient.bulk(bulkRequest, RequestOptions.DEFAULT);
-        final BulkItemResponse[] items = bulkItemResponses.getItems();
-        for (int i = 0; i < items.length; i++) {
-          final BulkItemResponse responseItem = items[i];
-          if (responseItem.isFailed() && !isEventConflictError(responseItem)) {
-
-            if (isMissingIncident(responseItem)) {
-              // the case when incident was already archived to dated index, but must be updated
-              final DocWriteRequest<?> request = bulkRequest.requests().get(i);
-              final String incidentId = extractIncidentId(responseItem.getFailure().getMessage());
-              final String indexName =
-                  getIndexNames(request.index() + "alias", asList(incidentId), esClient)
-                      .get(incidentId);
-              request.index(indexName);
-              if (indexName == null) {
-                LOGGER.warn("Index is not known for incident: " + incidentId);
-              } else {
-                esClient.update((UpdateRequest) request, RequestOptions.DEFAULT);
-              }
-            } else {
-              LOGGER.error(
-                  String.format(
-                      "%s failed for type [%s] and id [%s]: %s",
-                      responseItem.getOpType(),
-                      responseItem.getIndex(),
-                      responseItem.getId(),
-                      responseItem.getFailureMessage()),
-                  responseItem.getFailure().getCause());
-              throw new PersistenceException(
-                  "Operation failed: " + responseItem.getFailureMessage(),
-                  responseItem.getFailure().getCause(),
-                  responseItem.getItemId());
-            }
-          }
-        }
-        LOGGER.debug("************* FLUSH BULK FINISH *************");
-      } catch (final IOException ex) {
-        throw new PersistenceException(
-            "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
-      }
-    }
-  }
-
-  private static String extractIncidentId(final String errorMessage) {
-    final Pattern fniPattern = Pattern.compile(".*\\[_doc\\]\\[(\\d*)\\].*");
-    final Matcher matcher = fniPattern.matcher(errorMessage);
-    matcher.matches();
-    return matcher.group(1);
-  }
-
-  private static boolean isMissingIncident(final BulkItemResponse responseItem) {
-    return responseItem.getIndex().contains(IncidentTemplate.INDEX_NAME)
-        && responseItem.getFailure().getStatus().equals(RestStatus.NOT_FOUND);
-  }
-
-  private static boolean isEventConflictError(final BulkItemResponse responseItem) {
-    return responseItem.getIndex().contains(MessageSubscriptionTemplate.INDEX_NAME)
-        && responseItem.getFailure().getStatus().equals(RestStatus.CONFLICT);
+    return BulkIngester.of(
+        b ->
+            b.client(esClient)
+                .maxOperations(100)
+                .maxSize(maxBulkRequestSizeInBytes)
+                .globalSettings(s -> s.refresh(refreshVal)));
   }
 
   /* MAP QUERY RESULTS */

--- a/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
@@ -54,6 +55,8 @@ public class ElasticsearchProcessStoreTest {
 
   @Mock private RestHighLevelClient esClient;
 
+  @Mock private ElasticsearchClient es8Client;
+
   @Mock private TenantAwareElasticsearchClient tenantAwareClient;
 
   @Mock private OperateProperties operateProperties;
@@ -70,6 +73,7 @@ public class ElasticsearchProcessStoreTest {
             objectMapper,
             operateProperties,
             esClient,
+            es8Client,
             tenantAwareClient);
   }
 


### PR DESCRIPTION
## Description

- this only applies to operate for now will do tasklist after it is approved
- added es8 client bean
- added health check using es8 client
- in `ElasticsearchBatchRequest.java` the bulk request became a bulk request builder as completed objects like search requests or bulk requests are now immutable with the es8 java client objects, then used this and converted all bulk requests to es8 java client syntax.
- the aim was to completely convert `processBulkRequest` over to java client syntax.
- there is no need to manually divide up bulk requests in case they are too big with `divideLargeBulkRequestAndProcess` instead the java client provides us with a bulk ingester that does this for us where we can pass in the max size of requests, max operations and refresh values

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/40523