### PR TITLE
Add version in NodeInstance and add VersionMappings

### DIFF
--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -20,22 +20,19 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 public record Lease(
-    String taskId,
-    long timestamp,
-    NodeInstance nodeInstance,
-    VersionMappings versionMappings) {
+    String taskId, long timestamp, NodeInstance nodeInstance, VersionMappings versionMappings) {
 
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   /**
-   * Wrapper for mappings from NodeId -> Version
-   * A sorted map is used to the order of the keys is stable
+   * Wrapper for mappings from NodeId -> Version A sorted map is used to the order of the keys is
+   * stable
+   *
    * @param mappingsByNodeId
    */
-  public record VersionMappings (
-      SortedMap<Integer, Version> mappingsByNodeId) {
+  public record VersionMappings(SortedMap<Integer, Version> mappingsByNodeId) {
 
-    public static VersionMappings of(NodeInstance ...nodeInstance) {
+    public static VersionMappings of(NodeInstance... nodeInstance) {
       var map = new TreeMap<Integer, Version>();
       for (var node : nodeInstance) {
         map.put(node.id(), node.version());
@@ -43,7 +40,7 @@ public record Lease(
       return new VersionMappings(Collections.unmodifiableSortedMap(map));
     }
 
-    public VersionMappings(Map<Integer,Version> mappingsByNodeId){
+    public VersionMappings(Map<Integer, Version> mappingsByNodeId) {
       this(Collections.unmodifiableSortedMap(new TreeMap<>(mappingsByNodeId)));
     }
 
@@ -57,17 +54,14 @@ public record Lease(
   public static Lease fromMetadata(Metadata metadata, int nodeId) {
     Objects.requireNonNull(metadata, "metadata cannot be null");
     var nodeInstance = new NodeInstance(nodeId, metadata.version());
-    return new Lease(metadata.task(), metadata.expiry(), nodeInstance, VersionMappings.of(nodeInstance));
-  }
-  public static Lease from(String taskId, long expiry, NodeInstance currentNodeInstance){
-    var nodeInstance = currentNodeInstance.nextVersion();
     return new Lease(
-        taskId,
-        expiry,
-        nodeInstance,
-        VersionMappings.of(nodeInstance));
+        metadata.task(), metadata.expiry(), nodeInstance, VersionMappings.of(nodeInstance));
   }
 
+  public static Lease from(String taskId, long expiry, NodeInstance currentNodeInstance) {
+    var nodeInstance = currentNodeInstance.nextVersion();
+    return new Lease(taskId, expiry, nodeInstance, VersionMappings.of(nodeInstance));
+  }
 
   public Lease {
     Objects.requireNonNull(taskId, "taskId cannot be null");

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -9,11 +9,75 @@ package io.camunda.zeebe.dynamic.nodeid;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
-public record Lease(String taskId, long timestamp, NodeInstance nodeInstance) {
+public record Lease(
+    String taskId,
+    long timestamp,
+    NodeInstance nodeInstance,
+    VersionMappings versionMappings) {
+
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /**
+   * Wrapper for mappings from NodeId -> Version
+   * A sorted map is used to the order of the keys is stable
+   * @param mappingsByNodeId
+   */
+  public record VersionMappings (
+      SortedMap<Integer, Version> mappingsByNodeId) {
+
+    public static VersionMappings of(NodeInstance ...nodeInstance) {
+      var map = new TreeMap<Integer, Version>();
+      for (var node : nodeInstance) {
+        map.put(node.id(), node.version());
+      }
+      return new VersionMappings(Collections.unmodifiableSortedMap(map));
+    }
+
+    public VersionMappings(Map<Integer,Version> mappingsByNodeId){
+      this(Collections.unmodifiableSortedMap(new TreeMap<>(mappingsByNodeId)));
+    }
+
+    private static final VersionMappings EMPTY = new VersionMappings(Collections.emptySortedMap());
+
+    public static VersionMappings empty() {
+      return EMPTY;
+    }
+  }
+
+  public static Lease fromMetadata(Metadata metadata, int nodeId) {
+    Objects.requireNonNull(metadata, "metadata cannot be null");
+    var nodeInstance = new NodeInstance(nodeId, metadata.version());
+    return new Lease(metadata.task(), metadata.expiry(), nodeInstance, VersionMappings.of(nodeInstance));
+  }
+  public static Lease from(String taskId, long expiry, NodeInstance currentNodeInstance){
+    var nodeInstance = currentNodeInstance.nextVersion();
+    return new Lease(
+        taskId,
+        expiry,
+        nodeInstance,
+        VersionMappings.of(nodeInstance));
+  }
+
+
+  public Lease {
+    Objects.requireNonNull(taskId, "taskId cannot be null");
+    if (taskId.isEmpty()) {
+      throw new IllegalArgumentException("taskId cannot be empty");
+    }
+    Objects.requireNonNull(nodeInstance, "nodeInstance cannot be null");
+    Objects.requireNonNull(versionMappings, "versionMappings cannot be null");
+  }
+
   public String toJson(final ObjectMapper objectMapper) {
     try {
       return objectMapper.writeValueAsString(this);
@@ -56,6 +120,6 @@ public record Lease(String taskId, long timestamp, NodeInstance nodeInstance) {
               + Instant.ofEpochMilli(timestamp));
     }
     final var millis = leaseDuration.toMillis();
-    return new Lease(taskId, now + millis, nodeInstance);
+    return new Lease(taskId, now + millis, nodeInstance, versionMappings);
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -20,7 +20,10 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 public record Lease(
-    String taskId, long timestamp, NodeInstance nodeInstance, VersionMappings versionMappings) {
+    String taskId,
+    long timestamp,
+    NodeInstance nodeInstance,
+    VersionMappings knownVersionMappings) {
 
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -30,7 +33,7 @@ public record Lease(
       throw new IllegalArgumentException("taskId cannot be empty");
     }
     Objects.requireNonNull(nodeInstance, "nodeInstance cannot be null");
-    Objects.requireNonNull(versionMappings, "versionMappings cannot be null");
+    Objects.requireNonNull(knownVersionMappings, "knownVersionMappings cannot be null");
   }
 
   public static Lease fromMetadata(final Metadata metadata, final long expireAt, final int nodeId) {
@@ -91,7 +94,7 @@ public record Lease(
               + Instant.ofEpochMilli(timestamp));
     }
     final var millis = leaseDuration.toMillis();
-    return new Lease(taskId, now + millis, nodeInstance, versionMappings);
+    return new Lease(taskId, now + millis, nodeInstance, knownVersionMappings);
   }
 
   /**

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -19,6 +19,13 @@ import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+/**
+ * @param taskId the taskId that acquired this lease
+ * @param timestamp the timestamp at which the lease expires
+ * @param nodeInstance the nodeInstance this lease refers to
+ * @param knownVersionMappings contains the versions of the other nodes that the node holding the
+ *     lease is aware of.
+ */
 public record Lease(
     String taskId,
     long timestamp,

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -33,11 +33,14 @@ public record Lease(
     Objects.requireNonNull(versionMappings, "versionMappings cannot be null");
   }
 
-  public static Lease fromMetadata(final Metadata metadata, final int nodeId) {
+  public static Lease fromMetadata(final Metadata metadata, final long expireAt, final int nodeId) {
     Objects.requireNonNull(metadata, "metadata cannot be null");
+    if (metadata.task().isEmpty()) {
+      throw new IllegalArgumentException("task cannot be empty");
+    }
     final var nodeInstance = new NodeInstance(nodeId, metadata.version());
     return new Lease(
-        metadata.task(), metadata.expiry(), nodeInstance, VersionMappings.of(nodeInstance));
+        metadata.task().get(), expireAt, nodeInstance, VersionMappings.of(nodeInstance));
   }
 
   public static Lease from(

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -72,7 +72,6 @@ public record Lease(
     return new Lease(taskId, expiry, nodeInstance, VersionMappings.of(nodeInstance));
   }
 
-
   public String toJson(final ObjectMapper objectMapper) {
     try {
       return objectMapper.writeValueAsString(this);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -22,6 +22,15 @@ import java.util.TreeMap;
 public record Lease(
     String taskId, long timestamp, NodeInstance nodeInstance, VersionMappings versionMappings) {
 
+  public Lease {
+    Objects.requireNonNull(taskId, "taskId cannot be null");
+    if (taskId.isEmpty()) {
+      throw new IllegalArgumentException("taskId cannot be empty");
+    }
+    Objects.requireNonNull(nodeInstance, "nodeInstance cannot be null");
+    Objects.requireNonNull(versionMappings, "versionMappings cannot be null");
+  }
+
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   /**
@@ -63,14 +72,6 @@ public record Lease(
     return new Lease(taskId, expiry, nodeInstance, VersionMappings.of(nodeInstance));
   }
 
-  public Lease {
-    Objects.requireNonNull(taskId, "taskId cannot be null");
-    if (taskId.isEmpty()) {
-      throw new IllegalArgumentException("taskId cannot be empty");
-    }
-    Objects.requireNonNull(nodeInstance, "nodeInstance cannot be null");
-    Objects.requireNonNull(versionMappings, "versionMappings cannot be null");
-  }
 
   public String toJson(final ObjectMapper objectMapper) {
     try {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -92,7 +92,7 @@ public record Lease(
   }
 
   /**
-   * Wrapper for mappings from NodeId -> Version A sorted map is used to the order of the keys is
+   * Wrapper for mappings from NodeId -> Version. A sorted map is used so the order of the keys is
    * stable
    *
    * @param mappingsByNodeId

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -48,7 +48,7 @@ public interface NodeIdProvider extends AutoCloseable {
 
       @Override
       public NodeInstance currentNodeInstance() {
-        return new NodeInstance(nodeId);
+        return new NodeInstance(nodeId, Version.zero());
       }
 
       @Override

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
@@ -7,11 +7,18 @@
  */
 package io.camunda.zeebe.dynamic.nodeid;
 
+import java.util.Objects;
+
 // id ~ integer from 0 to clusterSize
-public record NodeInstance(int id /*, int version*/) {
+public record NodeInstance(int id , Version version) {
   public NodeInstance {
     if (id < 0) {
       throw new IllegalArgumentException("id cannot be negative, was " + id);
     }
+    Objects.requireNonNull(version, "version cannot be null");
+  }
+
+  public NodeInstance nextVersion(){
+    return new NodeInstance(id, version.next());
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.dynamic.nodeid;
 import java.util.Objects;
 
 // id ~ integer from 0 to clusterSize
-public record NodeInstance(int id , Version version) {
+public record NodeInstance(int id, Version version) {
   public NodeInstance {
     if (id < 0) {
       throw new IllegalArgumentException("id cannot be negative, was " + id);
@@ -18,7 +18,7 @@ public record NodeInstance(int id , Version version) {
     Objects.requireNonNull(version, "version cannot be null");
   }
 
-  public NodeInstance nextVersion(){
+  public NodeInstance nextVersion() {
     return new NodeInstance(id, version.next());
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -157,7 +157,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   private StoredLease.Initialized tryAcquireInitialLease(final StoredLease lease) {
     try {
       var newLease = lease.acquireInitialLease(taskId, clock, leaseDuration);
-      return nodeIdRepository.acquire(newLease, lease.eTag());
+      return newLease.map(value -> nodeIdRepository.acquire(value, lease.eTag())).orElse(null);
     } catch (final Exception e) {
       LOG.warn("Failed to acquire the lease {}", lease, e);
       return null;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -156,7 +156,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
 
   private StoredLease.Initialized tryAcquireInitialLease(final StoredLease lease) {
     try {
-      var newLease = lease.acquireInitialLease(taskId, clock, leaseDuration);
+      final var newLease = lease.acquireInitialLease(taskId, clock, leaseDuration);
       return newLease.map(value -> nodeIdRepository.acquire(value, lease.eTag())).orElse(null);
     } catch (final Exception e) {
       LOG.warn("Failed to acquire the lease {}", lease, e);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+public record Version(long version) {
+  private  static final Version ZERO = new Version(0L);
+
+  public static Version zero(){
+    return ZERO;
+  }
+  public static Version of(long version) {
+    return new Version(version);
+  }
+  public Version{
+    if (version < 0) {
+      throw new IllegalArgumentException("version must be positive");
+    }
+  }
+
+  public Version next(){
+    return new Version(version + 1);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.nodeid;
 
-public record Version(long version) {
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public record Version(@JsonValue long version) {
   private static final Version ZERO = new Version(0L);
 
   public static Version zero() {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
@@ -8,21 +8,23 @@
 package io.camunda.zeebe.dynamic.nodeid;
 
 public record Version(long version) {
-  private  static final Version ZERO = new Version(0L);
+  private static final Version ZERO = new Version(0L);
 
-  public static Version zero(){
+  public static Version zero() {
     return ZERO;
   }
+
   public static Version of(long version) {
     return new Version(version);
   }
-  public Version{
+
+  public Version {
     if (version < 0) {
       throw new IllegalArgumentException("version must be positive");
     }
   }
 
-  public Version next(){
+  public Version next() {
     return new Version(version + 1);
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
@@ -12,18 +12,18 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public record Version(@JsonValue long version) {
   private static final Version ZERO = new Version(0L);
 
+  public Version {
+    if (version < 0) {
+      throw new IllegalArgumentException("version must be positive");
+    }
+  }
+
   public static Version zero() {
     return ZERO;
   }
 
   public static Version of(long version) {
     return new Version(version);
-  }
-
-  public Version {
-    if (version < 0) {
-      throw new IllegalArgumentException("version must be positive");
-    }
   }
 
   public Version next() {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Version.java
@@ -14,7 +14,7 @@ public record Version(@JsonValue long version) {
 
   public Version {
     if (version < 0) {
-      throw new IllegalArgumentException("version must be positive");
+      throw new IllegalArgumentException("version must be non-negative");
     }
   }
 
@@ -22,7 +22,7 @@ public record Version(@JsonValue long version) {
     return ZERO;
   }
 
-  public static Version of(long version) {
+  public static Version of(final long version) {
     return new Version(version);
   }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -20,7 +20,7 @@ public record Metadata(String task, long expiry, Version version) {
 
   public Metadata {
     Objects.requireNonNull(task, "task cannot be null");
-    Objects.requireNonNull(task, "version cannot be null");
+    Objects.requireNonNull(version, "version cannot be null");
     if (expiry <= 0) {
       throw new IllegalArgumentException("expiry must be greater than zero");
     }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -13,6 +13,11 @@ import java.util.Map;
 import java.util.Objects;
 
 public record Metadata(String task, long expiry, Version version) {
+  // KEYS MUST BE LOWERCASE
+  private static final String TASK_ID_KEY = "taskid";
+  private static final String EXPIRY_KEY = "expiry";
+  private static final String VERSION_KEY = "version";
+
   public Metadata {
     Objects.requireNonNull(task, "task cannot be null");
     Objects.requireNonNull(task, "version cannot be null");
@@ -20,11 +25,6 @@ public record Metadata(String task, long expiry, Version version) {
       throw new IllegalArgumentException("expiry must be greater than zero");
     }
   }
-
-  // KEYS MUST BE LOWERCASE
-  private static final String TASK_ID_KEY = "taskid";
-  private static final String EXPIRY_KEY = "expiry";
-  private static final String VERSION_KEY = "version";
 
   public static Metadata fromLease(final Lease lease) {
     return new Metadata(lease.taskId(), lease.timestamp(), lease.nodeInstance().version());
@@ -45,11 +45,11 @@ public record Metadata(String task, long expiry, Version version) {
       return null;
     }
     try {
-      var taskId = map.get(TASK_ID_KEY);
-      var expiry = Long.parseLong(map.get(EXPIRY_KEY));
-      var version = new Version(Long.parseLong(map.get(VERSION_KEY)));
+      final var taskId = map.get(TASK_ID_KEY);
+      final var expiry = Long.parseLong(map.get(EXPIRY_KEY));
+      final var version = new Version(Long.parseLong(map.get(VERSION_KEY)));
       return new Metadata(taskId, expiry, version);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new IllegalArgumentException("Failed to deserialize metadata, map is " + map, e);
     }
   }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.nodeid.Lease;
 import io.camunda.zeebe.dynamic.nodeid.Version;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public record Metadata(Optional<String> task, Version version) {
   // KEYS MUST BE LOWERCASE
@@ -23,6 +24,10 @@ public record Metadata(Optional<String> task, Version version) {
       throw new IllegalArgumentException("task cannot be empty");
     }
     Objects.requireNonNull(version, "version cannot be null");
+  }
+
+  public Metadata forRelease() {
+    return new Metadata(Optional.empty(), version);
   }
 
   public static Metadata fromLease(final Lease lease) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public record Metadata(String task, long expiry, Version version) {
-  public Metadata{
+  public Metadata {
     Objects.requireNonNull(task, "task cannot be null");
     Objects.requireNonNull(task, "version cannot be null");
     if (expiry <= 0) {
@@ -31,18 +31,24 @@ public record Metadata(String task, long expiry, Version version) {
   }
 
   public Map<String, String> asMap() {
-    return Map.of(TASK_ID_KEY, task, EXPIRY_KEY, String.valueOf(expiry),  VERSION_KEY, Long.toString(version.version()));
+    return Map.of(
+        TASK_ID_KEY,
+        task,
+        EXPIRY_KEY,
+        String.valueOf(expiry),
+        VERSION_KEY,
+        Long.toString(version.version()));
   }
 
   public static Metadata fromMap(final Map<String, String> map) {
     if (map.isEmpty()) {
       return null;
     }
-    try{
-    var taskId = map.get(TASK_ID_KEY);
-    var expiry = Long.parseLong(map.get(EXPIRY_KEY));
-    var version = new Version(Long.parseLong(map.get(VERSION_KEY)));
-    return new Metadata(taskId, expiry, version);
+    try {
+      var taskId = map.get(TASK_ID_KEY);
+      var expiry = Long.parseLong(map.get(EXPIRY_KEY));
+      var version = new Version(Long.parseLong(map.get(VERSION_KEY)));
+      return new Metadata(taskId, expiry, version);
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to deserialize metadata, map is " + map, e);
     }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -89,7 +89,8 @@ public interface NodeIdRepository extends AutoCloseable {
     }
 
     /** Acquire the initial lease * */
-    default Optional<Lease> acquireInitialLease(String taskId, InstantSource clock, Duration leaseDuration) {
+    default Optional<Lease> acquireInitialLease(
+        String taskId, InstantSource clock, Duration leaseDuration) {
       if (isStillValid(clock.millis())) {
         return Optional.empty();
       } else {
@@ -134,14 +135,23 @@ public interface NodeIdRepository extends AutoCloseable {
           throw new IllegalArgumentException("eTag cannot be empty");
         }
         Objects.requireNonNull(lease, "Lease cannot be null");
-        if (!Objects.equals(metadata.task(),lease.taskId())) {
-          throw new IllegalStateException(String.format("TaskId in metadata(%s) and in lease(%s) do not match!", metadata.task(), lease.taskId()));
+        if (!Objects.equals(metadata.task(), lease.taskId())) {
+          throw new IllegalStateException(
+              String.format(
+                  "TaskId in metadata(%s) and in lease(%s) do not match!",
+                  metadata.task(), lease.taskId()));
         }
-        if (!Objects.equals(metadata.version(),lease.nodeInstance().version())) {
-          throw new IllegalStateException(String.format("Version in metadata(%s) and in lease(%s) do not match!", metadata.version(), lease.nodeInstance().version()));
+        if (!Objects.equals(metadata.version(), lease.nodeInstance().version())) {
+          throw new IllegalStateException(
+              String.format(
+                  "Version in metadata(%s) and in lease(%s) do not match!",
+                  metadata.version(), lease.nodeInstance().version()));
         }
-        if (metadata.expiry() !=lease.timestamp()) {
-          throw new IllegalStateException(String.format("Expire timestamp in metadata(%s) and in lease(%s) do not match!", metadata.expiry(), lease.timestamp()));
+        if (metadata.expiry() != lease.timestamp()) {
+          throw new IllegalStateException(
+              String.format(
+                  "Expire timestamp in metadata(%s) and in lease(%s) do not match!",
+                  metadata.expiry(), lease.timestamp()));
         }
       }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -110,7 +110,7 @@ public interface NodeIdRepository extends AutoCloseable {
       }
       if (lease == null) {
         final var version =
-            Optional.ofNullable(metadata).map(Metadata::version).orElse(new Version(0));
+            Optional.ofNullable(metadata).map(Metadata::version).orElse(Version.zero());
         return new StoredLease.Uninitialized(new NodeInstance(nodeId, version), eTag);
       } else {
         return new StoredLease.Initialized(metadata, lease, eTag);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -89,11 +89,11 @@ public interface NodeIdRepository extends AutoCloseable {
     }
 
     /** Acquire the initial lease * */
-    default Lease acquireInitialLease(String taskId, InstantSource clock, Duration leaseDuration) {
+    default Optional<Lease> acquireInitialLease(String taskId, InstantSource clock, Duration leaseDuration) {
       if (isStillValid(clock.millis())) {
-        return null;
+        return Optional.empty();
       } else {
-        return Lease.from(taskId, clock.millis() + leaseDuration.toMillis(), node());
+        return Optional.of(Lease.from(taskId, clock.millis() + leaseDuration.toMillis(), node()));
       }
     }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -81,7 +81,7 @@ public interface NodeIdRepository extends AutoCloseable {
       };
     }
 
-    default boolean isStillValid(long now) {
+    default boolean isStillValid(final long now) {
       return switch (this) {
         case final Uninitialized u -> false;
         case final Initialized i -> i.lease().isStillValid(now);
@@ -90,7 +90,7 @@ public interface NodeIdRepository extends AutoCloseable {
 
     /** Acquire the initial lease * */
     default Optional<Lease> acquireInitialLease(
-        String taskId, InstantSource clock, Duration leaseDuration) {
+        final String taskId, final InstantSource clock, final Duration leaseDuration) {
       if (isStillValid(clock.millis())) {
         return Optional.empty();
       } else {
@@ -104,7 +104,8 @@ public interface NodeIdRepository extends AutoCloseable {
         throw new IllegalArgumentException("eTag cannot be null or empty:" + eTag);
       }
       if (lease == null) {
-        var version = Optional.ofNullable(metadata).map(Metadata::version).orElse(new Version(0));
+        final var version =
+            Optional.ofNullable(metadata).map(Metadata::version).orElse(new Version(0));
         return new StoredLease.Uninitialized(new NodeInstance(nodeId, version), eTag);
       } else {
         return new StoredLease.Initialized(metadata, lease, eTag);
@@ -123,7 +124,7 @@ public interface NodeIdRepository extends AutoCloseable {
 
     record Initialized(Metadata metadata, Lease lease, String eTag) implements StoredLease {
 
-      public Initialized(Metadata metadata, int nodeId, String eTag) {
+      public Initialized(final Metadata metadata, final int nodeId, final String eTag) {
         this(metadata, Lease.fromMetadata(metadata, nodeId), eTag);
       }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -88,7 +88,12 @@ public interface NodeIdRepository extends AutoCloseable {
       };
     }
 
-    /** Acquire the initial lease * */
+    /**
+     * Acquire the initial lease
+     *
+     * @return {@link Optional#empty()} if the lease should not be acquired, or the lease to acquire
+     *     *
+     */
     default Optional<Lease> acquireInitialLease(
         final String taskId, final InstantSource clock, final Duration leaseDuration) {
       if (isStillValid(clock.millis())) {
@@ -129,13 +134,12 @@ public interface NodeIdRepository extends AutoCloseable {
       }
 
       public Initialized {
+        Objects.requireNonNull(lease, "Lease cannot be null");
         Objects.requireNonNull(metadata, "metadata cannot be null");
-        Objects.requireNonNull(lease.nodeInstance(), "node cannot be null");
         Objects.requireNonNull(eTag, "eTag cannot be null");
         if (eTag.isEmpty()) {
           throw new IllegalArgumentException("eTag cannot be empty");
         }
-        Objects.requireNonNull(lease, "Lease cannot be null");
         if (!Objects.equals(metadata.task(), lease.taskId())) {
           throw new IllegalStateException(
               String.format(

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -134,6 +134,15 @@ public interface NodeIdRepository extends AutoCloseable {
           throw new IllegalArgumentException("eTag cannot be empty");
         }
         Objects.requireNonNull(lease, "Lease cannot be null");
+        if (!Objects.equals(metadata.task(),lease.taskId())) {
+          throw new IllegalStateException(String.format("TaskId in metadata(%s) and in lease(%s) do not match!", metadata.task(), lease.taskId()));
+        }
+        if (!Objects.equals(metadata.version(),lease.nodeInstance().version())) {
+          throw new IllegalStateException(String.format("Version in metadata(%s) and in lease(%s) do not match!", metadata.version(), lease.nodeInstance().version()));
+        }
+        if (metadata.expiry() !=lease.timestamp()) {
+          throw new IllegalStateException(String.format("Expire timestamp in metadata(%s) and in lease(%s) do not match!", metadata.expiry(), lease.timestamp()));
+        }
       }
 
       @Override

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -129,8 +129,9 @@ public interface NodeIdRepository extends AutoCloseable {
 
     record Initialized(Metadata metadata, Lease lease, String eTag) implements StoredLease {
 
-      public Initialized(final Metadata metadata, final int nodeId, final String eTag) {
-        this(metadata, Lease.fromMetadata(metadata, nodeId), eTag);
+      public Initialized(
+          final Metadata metadata, final long expireAt, final int nodeId, final String eTag) {
+        this(metadata, Lease.fromMetadata(metadata, expireAt, nodeId), eTag);
       }
 
       public Initialized {
@@ -140,7 +141,7 @@ public interface NodeIdRepository extends AutoCloseable {
         if (eTag.isEmpty()) {
           throw new IllegalArgumentException("eTag cannot be empty");
         }
-        if (!Objects.equals(metadata.task(), lease.taskId())) {
+        if (!Objects.equals(metadata.task(), Optional.of(lease.taskId()))) {
           throw new IllegalStateException(
               String.format(
                   "TaskId in metadata(%s) and in lease(%s) do not match!",
@@ -151,12 +152,6 @@ public interface NodeIdRepository extends AutoCloseable {
               String.format(
                   "Version in metadata(%s) and in lease(%s) do not match!",
                   metadata.version(), lease.nodeInstance().version()));
-        }
-        if (metadata.expiry() != lease.timestamp()) {
-          throw new IllegalStateException(
-              String.format(
-                  "Expire timestamp in metadata(%s) and in lease(%s) do not match!",
-                  metadata.expiry(), lease.timestamp()));
         }
       }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.dynamic.nodeid.repository;
 
 import io.camunda.zeebe.dynamic.nodeid.Lease;
-import io.camunda.zeebe.dynamic.nodeid.Version;
 import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
+import io.camunda.zeebe.dynamic.nodeid.Version;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Objects;
@@ -81,7 +81,7 @@ public interface NodeIdRepository extends AutoCloseable {
       };
     }
 
-    default boolean isStillValid(long now){
+    default boolean isStillValid(long now) {
       return switch (this) {
         case final Uninitialized u -> false;
         case final Initialized i -> i.lease().isStillValid(now);
@@ -90,7 +90,7 @@ public interface NodeIdRepository extends AutoCloseable {
 
     /** Acquire the initial lease * */
     default Lease acquireInitialLease(String taskId, InstantSource clock, Duration leaseDuration) {
-      if (isStillValid(clock.millis())){
+      if (isStillValid(clock.millis())) {
         return null;
       } else {
         return Lease.from(taskId, clock.millis() + leaseDuration.toMillis(), node());

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.nodeid.repository.s3;
 
+import static io.camunda.zeebe.dynamic.nodeid.Lease.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.dynamic.nodeid.Lease;
 import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
@@ -33,7 +35,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 public class S3NodeIdRepository implements NodeIdRepository {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final Logger LOG = LoggerFactory.getLogger(S3NodeIdRepository.class);
   private final S3Client client;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.InstantSource;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
@@ -89,7 +88,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
 
   @Override
   public StoredLease.Initialized acquire(final Lease lease, final String previousETag) {
-    if (lease == null){
+    if (lease == null) {
       throw new IllegalArgumentException("lease is null");
     }
     final var nodeId = lease.nodeInstance().id();

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -115,7 +115,9 @@ public class S3NodeIdRepository implements NodeIdRepository {
   public void release(final StoredLease.Initialized lease) {
     final var nodeId = lease.lease().nodeInstance().id();
     final PutObjectRequest putRequest =
-        createPutObjectRequest(nodeId, Optional.empty(), Optional.of(lease.eTag())).build();
+        createPutObjectRequest(
+                nodeId, Optional.of(lease.metadata().forRelease()), Optional.of(lease.eTag()))
+            .build();
     try {
       LOG.info("Release lease {}", lease);
       client.putObject(putRequest, RequestBody.empty());

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
@@ -88,6 +89,9 @@ public class S3NodeIdRepository implements NodeIdRepository {
 
   @Override
   public StoredLease.Initialized acquire(final Lease lease, final String previousETag) {
+    if (lease == null){
+      throw new IllegalArgumentException("lease is null");
+    }
     final var nodeId = lease.nodeInstance().id();
     final var metadata = Metadata.fromLease(lease);
     final PutObjectRequest putRequest =

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.dynamic.nodeid.repository.s3;
 
 import static io.camunda.zeebe.dynamic.nodeid.Lease.OBJECT_MAPPER;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.dynamic.nodeid.Lease;
 import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
@@ -26,6 +26,7 @@ public class ControlledInstantSource implements InstantSource {
   public void advance(final Duration duration) {
     instant = instant.plus(duration);
   }
+
   public void advance(final long millis) {
     instant = instant.plusMillis(millis);
   }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
@@ -26,6 +26,9 @@ public class ControlledInstantSource implements InstantSource {
   public void advance(final Duration duration) {
     instant = instant.plus(duration);
   }
+  public void advance(final long millis) {
+    instant = instant.plusMillis(millis);
+  }
 
   @Override
   public Instant instant() {

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.nodeid;
 
+import static io.camunda.zeebe.dynamic.nodeid.Lease.OBJECT_MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -18,7 +19,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class LeaseTest {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   final NodeInstance nodeInstance = new NodeInstance(1, new Version(117L));
   final long originalTimestamp = 1000L;
   final Lease lease =
@@ -76,7 +76,7 @@ public class LeaseTest {
     // then
     var expectedJson =
         """
-        {"taskId":"task1","timestamp":1000,"nodeInstance":{"id":1,"version":{"version":117}},"versionMappings":{"mappingsByNodeId":{"1":{"version":117},"2":{"version":119},"3":{"version":3}}}}""";
+        {"taskId":"task1","timestamp":1000,"nodeInstance":{"id":1,"version":117},"versionMappings":{"mappingsByNodeId":{"1":117,"2":119,"3":3}}}""";
     assertThat(serialized).isEqualTo(expectedJson);
     final var deserialized = Lease.fromJson(OBJECT_MAPPER, serialized);
     assertThat(deserialized).isEqualTo(lease);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -62,8 +62,7 @@ public class LeaseTest {
     var expectedMessage =
         String.format(
             "Lease is not valid anymore(%s), it expired at %s",
-            Instant.ofEpochMilli(currentTime),
-            Instant.ofEpochMilli(lease.timestamp()));
+            Instant.ofEpochMilli(currentTime), Instant.ofEpochMilli(lease.timestamp()));
     assertThatThrownBy(() -> lease.renew(currentTime, renewalDuration))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(expectedMessage);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.dynamic.nodeid.Lease.OBJECT_MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.dynamic.nodeid.Lease.VersionMappings;
 import java.time.Duration;
 import java.time.Instant;

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -58,7 +58,7 @@ public class LeaseTest {
     assertThat(lease.isStillValid(currentTime)).isFalse();
 
     // when/then
-    var expectedMessage =
+    final var expectedMessage =
         String.format(
             "Lease is not valid anymore(%s), it expired at %s",
             Instant.ofEpochMilli(currentTime), Instant.ofEpochMilli(lease.timestamp()));
@@ -73,7 +73,7 @@ public class LeaseTest {
     final var serialized = lease.toJson(OBJECT_MAPPER);
 
     // then
-    var expectedJson =
+    final var expectedJson =
         """
         {"taskId":"task1","timestamp":1000,"nodeInstance":{"id":1,"version":117},"versionMappings":{"mappingsByNodeId":{"1":117,"2":119,"3":3}}}""";
     assertThat(serialized).isEqualTo(expectedJson);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -75,7 +75,7 @@ public class LeaseTest {
     // then
     final var expectedJson =
         """
-        {"taskId":"task1","timestamp":1000,"nodeInstance":{"id":1,"version":117},"versionMappings":{"mappingsByNodeId":{"1":117,"2":119,"3":3}}}""";
+        {"taskId":"task1","timestamp":1000,"nodeInstance":{"id":1,"version":117},"knownVersionMappings":{"mappingsByNodeId":{"1":117,"2":119,"3":3}}}""";
     assertThat(serialized).isEqualTo(expectedJson);
     final var deserialized = Lease.fromJson(OBJECT_MAPPER, serialized);
     assertThat(deserialized).isEqualTo(lease);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -11,14 +11,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.dynamic.nodeid.Lease.VersionMappings;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class LeaseTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  final NodeInstance nodeInstance = new NodeInstance(1);
+  final NodeInstance nodeInstance = new NodeInstance(1, new Version(117L));
   final long originalTimestamp = 1000L;
-  final Lease lease = new Lease("task1", originalTimestamp, nodeInstance);
+  final Lease lease =
+      new Lease(
+          "task1",
+          originalTimestamp,
+          nodeInstance,
+          new VersionMappings(Map.of(1, Version.of(117L), 2, Version.of(119L), 3, Version.of(3L))));
 
   @Test
   public void shouldReturnIfValid() {
@@ -46,14 +54,19 @@ public class LeaseTest {
   @Test
   public void shouldNotRenewLeaseWhenExpired() {
     // given
-    final var currentTime = 10000L;
+    final var currentTime = 1120830000L;
     final var renewalDuration = Duration.ofSeconds(5);
     assertThat(lease.isStillValid(currentTime)).isFalse();
 
     // when/then
+    var expectedMessage =
+        String.format(
+            "Lease is not valid anymore(%s), it expired at %s",
+            Instant.ofEpochMilli(currentTime),
+            Instant.ofEpochMilli(lease.timestamp()));
     assertThatThrownBy(() -> lease.renew(currentTime, renewalDuration))
         .isInstanceOf(IllegalStateException.class)
-        .withFailMessage("Lease is not valid anymore, it expired at");
+        .hasMessageContaining(expectedMessage);
   }
 
   @Test
@@ -62,6 +75,10 @@ public class LeaseTest {
     final var serialized = lease.toJson(OBJECT_MAPPER);
 
     // then
+    var expectedJson =
+        """
+        {"taskId":"task1","timestamp":1000,"nodeInstance":{"id":1,"version":{"version":117}},"versionMappings":{"mappingsByNodeId":{"1":{"version":117},"2":{"version":119},"3":{"version":3}}}}""";
+    assertThat(serialized).isEqualTo(expectedJson);
     final var deserialized = Lease.fromJson(OBJECT_MAPPER, serialized);
     assertThat(deserialized).isEqualTo(lease);
   }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdBasedDataDirectoryProviderTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdBasedDataDirectoryProviderTest.java
@@ -26,7 +26,7 @@ class NodeIdBasedDataDirectoryProviderTest {
     // given
     final int nodeId = 5;
     final NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
-    when(nodeIdProvider.currentNodeInstance()).thenReturn(new NodeInstance(nodeId));
+    when(nodeIdProvider.currentNodeInstance()).thenReturn(new NodeInstance(nodeId, Version.of(3L)));
 
     final Path baseDirectory = tempDir.resolve("base");
     final DataDirectoryProvider initializer = new NodeIdBasedDataDirectoryProvider(nodeIdProvider);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -104,8 +104,8 @@ public class RepositoryNodeIdProviderIT {
     final var acquiredLease = nodeIdProvider.getCurrentLease();
     final var nodeId = acquiredLease.lease().nodeInstance().id();
     assertThat(nodeId).isEqualTo(0);
-    assertThat(acquiredLease.metadata().task()).isEqualTo(taskId);
-    assertThat(acquiredLease.metadata().expiry())
+    assertThat(acquiredLease.metadata().task()).isEqualTo(Optional.of(taskId));
+    assertThat(acquiredLease.lease().timestamp())
         .isEqualTo(clock.instant().plus(EXPIRY_DURATION).toEpochMilli());
     assertThat(repository.getLease(nodeId)).isEqualTo(acquiredLease);
   }
@@ -144,8 +144,7 @@ public class RepositoryNodeIdProviderIT {
     assertThat(currentLease)
         .asInstanceOf(type(StoredLease.Initialized.class))
         .isEqualTo(acquiredLease)
-        .isNotEqualTo(expiredLease)
-        .satisfies(l -> assertThat(l.metadata().expiry()).isGreaterThan(expiredLeaseTimestamp));
+        .isNotEqualTo(expiredLease);
   }
 
   @Test

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -125,7 +125,8 @@ public class RepositoryNodeIdProviderIT {
             new Lease(
                 taskId + "old",
                 expiredLeaseTimestamp + EXPIRY_DURATION.toMillis(),
-                 new NodeInstance(0, lease.version().next()), VersionMappings.empty()),
+                new NodeInstance(0, lease.version().next()),
+                VersionMappings.empty()),
             previousEtag);
     assertThat(expiredLease).isNotNull();
     clock.advance(EXPIRY_DURATION.plusSeconds(1));
@@ -160,7 +161,12 @@ public class RepositoryNodeIdProviderIT {
                 i -> {
                   final var lease = repository.getLease(i);
                   return repository.acquire(
-                      new Lease(taskId, clock.millis() + 2000L,  new NodeInstance(i, lease.version().next()), VersionMappings.empty()), lease.eTag());
+                      new Lease(
+                          taskId,
+                          clock.millis() + 2000L,
+                          new NodeInstance(i, lease.version().next()),
+                          VersionMappings.empty()),
+                      lease.eTag());
                 })
             .toList();
     assertThat(acquiredLeases)

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -117,7 +117,7 @@ public class RepositoryNodeIdProviderIT {
     clusterSize = 3;
     repository.initialize(clusterSize);
     // acquire a lease in the past
-    var lease = repository.getLease(0);
+    final var lease = repository.getLease(0);
     final var previousEtag = lease.eTag();
     final var expiredLeaseTimestamp = clock.millis();
     final var expiredLease =

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -208,6 +208,7 @@ public class RepositoryNodeIdProviderIT {
     final var renewedLease = nodeIdProvider.getCurrentLease();
     assertThat(renewedLease).isNotEqualTo(firstLease);
     assertThat(renewedLease.lease().timestamp()).isGreaterThan(firstLease.lease().timestamp());
+    assertThat(renewedLease.node()).isEqualTo(firstLease.node());
   }
 
   @Test
@@ -247,10 +248,11 @@ public class RepositoryNodeIdProviderIT {
     // clock is not moved, so the lease can only be acquired if released
     final var releasedLease = repository.getLease(lease.lease().nodeInstance().id());
     assertThat(releasedLease).isInstanceOf(StoredLease.Uninitialized.class);
+    assertThat(releasedLease.node()).isEqualTo(lease.node());
     nodeIdProvider = ofSize(clusterSize);
     assertLeaseIsReady();
-    assertThat(nodeIdProvider.getCurrentLease().lease().nodeInstance().id())
-        .isEqualTo(lease.lease().nodeInstance().id());
+    assertThat(nodeIdProvider.getCurrentLease().lease().nodeInstance())
+        .isEqualTo(lease.lease().nodeInstance().nextVersion());
   }
 
   public void assertLeaseIsReady() {

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.dynamic.nodeid.Lease.VersionMappings;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.Config;
@@ -116,14 +117,15 @@ public class RepositoryNodeIdProviderIT {
     clusterSize = 3;
     repository.initialize(clusterSize);
     // acquire a lease in the past
-    final var previousEtag = repository.getLease(0).eTag();
+    var lease = repository.getLease(0);
+    final var previousEtag = lease.eTag();
     final var expiredLeaseTimestamp = clock.millis();
     final var expiredLease =
         repository.acquire(
             new Lease(
                 taskId + "old",
                 expiredLeaseTimestamp + EXPIRY_DURATION.toMillis(),
-                new NodeInstance(0)),
+                 new NodeInstance(0, lease.version().next()), VersionMappings.empty()),
             previousEtag);
     assertThat(expiredLease).isNotNull();
     clock.advance(EXPIRY_DURATION.plusSeconds(1));
@@ -158,7 +160,7 @@ public class RepositoryNodeIdProviderIT {
                 i -> {
                   final var lease = repository.getLease(i);
                   return repository.acquire(
-                      new Lease(taskId, clock.millis() + 2000L, new NodeInstance(i)), lease.eTag());
+                      new Lease(taskId, clock.millis() + 2000L,  new NodeInstance(i, lease.version().next()), VersionMappings.empty()), lease.eTag());
                 })
             .toList();
     assertThat(acquiredLeases)

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -25,6 +25,10 @@ public class StoredLeaseTest {
   private final String taskId = "newTaskId";
   private final Duration expiryDuration = Duration.ofSeconds(15);
 
+  long expiryFromNow() {
+    return clock.millis() + expiryDuration.toMillis();
+  }
+
   @Nested
   class Uninitialized {
     @Test
@@ -46,10 +50,10 @@ public class StoredLeaseTest {
     @Test
     void canBeAcquired() {
       // given
-      var stored = new StoredLease.Uninitialized(nodeInstance, "eTagExample");
+      final var stored = new StoredLease.Uninitialized(nodeInstance, "eTagExample");
 
       // when
-      var toAcquire = stored.acquireInitialLease(taskId, clock, expiryDuration);
+      final var toAcquire = stored.acquireInitialLease(taskId, clock, expiryDuration);
 
       // then
       assertThat(toAcquire)
@@ -95,14 +99,14 @@ public class StoredLeaseTest {
     @Test
     void shouldNotAcquireAValidLease() {
       // given
-      var stored =
+      final var stored =
           new StoredLease.Initialized(
               new Metadata(taskId, expiryFromNow(), nodeInstance.version()),
               nodeInstance.id(),
               "eTagExample");
 
-      var newTaskId = "newTaskId";
-      var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
+      final var newTaskId = "newTaskId";
+      final var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
 
       // then
       assertThat(acquired).isEmpty();
@@ -111,7 +115,7 @@ public class StoredLeaseTest {
     @Test
     void shouldAcquireWithANewVersionWhenExpired() {
       // given
-      var stored =
+      final var stored =
           new StoredLease.Initialized(
               new Metadata(taskId, expiryFromNow(), nodeInstance.version()),
               nodeInstance.id(),
@@ -119,8 +123,8 @@ public class StoredLeaseTest {
 
       // when
       clock.advance(expiryDuration.plusMillis(1));
-      var newTaskId = "newTaskId";
-      var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
+      final var newTaskId = "newTaskId";
+      final var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
 
       // then
       assertThat(acquired)
@@ -134,9 +138,5 @@ public class StoredLeaseTest {
                           VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
                       .returns(expiryFromNow(), Lease::timestamp));
     }
-  }
-
-  long expiryFromNow() {
-    return clock.millis() + expiryDuration.toMillis();
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -65,7 +65,8 @@ public class StoredLeaseTest {
                       .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
                       .returns(taskId, Lease::taskId)
                       .returns(
-                          VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
+                          VersionMappings.of(nodeInstance.nextVersion()),
+                          Lease::knownVersionMappings)
                       .returns(expiryFromNow(), Lease::timestamp));
     }
   }
@@ -140,7 +141,8 @@ public class StoredLeaseTest {
                       .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
                       .returns(newTaskId, Lease::taskId)
                       .returns(
-                          VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
+                          VersionMappings.of(nodeInstance.nextVersion()),
+                          Lease::knownVersionMappings)
                       .returns(expiryFromNow(), Lease::timestamp));
     }
   }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -53,10 +53,15 @@ public class StoredLeaseTest {
 
       // then
       assertThat(toAcquire)
-          .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
-          .returns(taskId, Lease::taskId)
-          .returns(VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
-          .returns(expiryFromNow(), Lease::timestamp);
+          .isPresent()
+          .hasValueSatisfying(
+              lease ->
+                  assertThat(lease)
+                      .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
+                      .returns(taskId, Lease::taskId)
+                      .returns(
+                          VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
+                      .returns(expiryFromNow(), Lease::timestamp));
     }
   }
 
@@ -100,7 +105,7 @@ public class StoredLeaseTest {
       var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
 
       // then
-      assertThat(acquired).isNull();
+      assertThat(acquired).isEmpty();
     }
 
     @Test
@@ -119,10 +124,15 @@ public class StoredLeaseTest {
 
       // then
       assertThat(acquired)
-          .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
-          .returns(newTaskId, Lease::taskId)
-          .returns(VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
-          .returns(expiryFromNow(), Lease::timestamp);
+          .isPresent()
+          .hasValueSatisfying(
+              lease ->
+                  assertThat(lease)
+                      .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
+                      .returns(newTaskId, Lease::taskId)
+                      .returns(
+                          VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
+                      .returns(expiryFromNow(), Lease::timestamp));
     }
   }
 

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.dynamic.nodeid.Lease.VersionMappings;
+import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StoredLeaseTest {
+
+  private final NodeInstance nodeInstance = new NodeInstance(2, Version.of(2L));
+  private final ControlledInstantSource clock = new ControlledInstantSource(Instant.now());
+  private final String taskId = "newTaskId";
+  private final Duration expiryDuration = Duration.ofSeconds(15);
+
+  @Nested
+  class Uninitialized{
+    @Test
+    void shouldAlwaysContainNodeId(){
+      assertThatThrownBy(() -> new StoredLease.Uninitialized(null, "asdasd")).hasMessageContaining("node cannot be null");
+    }
+
+    @Test
+    void shouldAlwaysContainETag(){
+      assertThatThrownBy(() -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), "")).hasMessageContaining("eTag cannot be empty");
+      assertThatThrownBy(() -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), null))
+          .hasMessageContaining("eTag cannot be null");
+    }
+
+    @Test
+    void canBeAcquired(){
+      //given
+      var stored = new StoredLease.Uninitialized(nodeInstance, "eTagExample");
+
+      //when
+      var toAcquire = stored.acquireInitialLease(taskId, clock, expiryDuration);
+
+      // then
+      assertThat(toAcquire)
+          .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
+          .returns(taskId, Lease::taskId)
+          .returns(VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
+          .returns(expiryFromNow(), Lease::timestamp);
+    }
+  }
+
+
+  @Nested
+  class Initialized{
+
+    @Test
+    void shouldAlwaysContainMetadata(){
+      assertThatThrownBy(() -> new StoredLease.Initialized(null,0, "asd")).hasMessageContaining("metadata cannot be null");
+      assertThatThrownBy(
+              () ->
+                  new StoredLease.Initialized(
+                      null, new Lease("asdasd", 123, new NodeInstance(0, Version.of(1)), VersionMappings.empty()), "asd"))
+          .hasMessageContaining("metadata cannot be null");
+    }
+
+    @Test
+    void shouldAlwaysContainETag(){
+      assertThatThrownBy(() -> new StoredLease.Initialized(new Metadata("asd", 123, Version.of(1)), 0, null))
+          .hasMessageContaining("eTag cannot be null");
+    }
+    @Test
+    void shouldNotAcquireAValidLease(){
+    //given
+    var stored = new StoredLease.Initialized(new Metadata(taskId, expiryFromNow(), nodeInstance.version()), nodeInstance.id(), "eTagExample");
+
+      var newTaskId = "newTaskId";
+      var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
+
+      //then
+      assertThat(acquired).isNull();
+    }
+    @Test
+    void shouldAcquireWithANewVersionWhenExpired(){
+      //given
+      var stored = new StoredLease.Initialized(new Metadata(taskId, expiryFromNow(), nodeInstance.version()), nodeInstance.id(), "eTagExample");
+
+      //when
+      clock.advance(expiryDuration.plusMillis(1));
+      var newTaskId = "newTaskId";
+      var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
+
+      //then
+      assertThat(acquired)
+          .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
+          .returns(newTaskId, Lease::taskId)
+          .returns(VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
+          .returns(expiryFromNow(), Lease::timestamp);
+
+    }
+  }
+
+  long expiryFromNow(){return clock.millis() + expiryDuration.toMillis();}
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +75,7 @@ public class StoredLeaseTest {
 
     @Test
     void shouldAlwaysContainMetadata() {
-      assertThatThrownBy(() -> new StoredLease.Initialized(null, 0, "asd"))
+      assertThatThrownBy(() -> new StoredLease.Initialized(null, 0L, 0, "asd"))
           .hasMessageContaining("metadata cannot be null");
       assertThatThrownBy(
               () ->
@@ -92,7 +93,9 @@ public class StoredLeaseTest {
     @Test
     void shouldAlwaysContainETag() {
       assertThatThrownBy(
-              () -> new StoredLease.Initialized(new Metadata("asd", 123, Version.of(1)), 0, null))
+              () ->
+                  new StoredLease.Initialized(
+                      new Metadata(Optional.of("asd"), Version.of(1)), 1L, 0, null))
           .hasMessageContaining("eTag cannot be null");
     }
 
@@ -101,7 +104,8 @@ public class StoredLeaseTest {
       // given
       final var stored =
           new StoredLease.Initialized(
-              new Metadata(taskId, expiryFromNow(), nodeInstance.version()),
+              new Metadata(Optional.of(taskId), nodeInstance.version()),
+              expiryFromNow(),
               nodeInstance.id(),
               "eTagExample");
 
@@ -117,7 +121,8 @@ public class StoredLeaseTest {
       // given
       final var stored =
           new StoredLease.Initialized(
-              new Metadata(taskId, expiryFromNow(), nodeInstance.version()),
+              new Metadata(Optional.of(taskId), nodeInstance.version()),
+              expiryFromNow(),
               nodeInstance.id(),
               "eTagExample");
 

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -40,11 +40,9 @@ public class StoredLeaseTest {
 
     @Test
     void shouldAlwaysContainETag() {
-      assertThatThrownBy(
-              () -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), ""))
+      assertThatThrownBy(() -> new StoredLease.Uninitialized(nodeInstance, ""))
           .hasMessageContaining("eTag cannot be empty");
-      assertThatThrownBy(
-              () -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), null))
+      assertThatThrownBy(() -> new StoredLease.Uninitialized(nodeInstance, null))
           .hasMessageContaining("eTag cannot be null");
     }
 
@@ -62,7 +60,7 @@ public class StoredLeaseTest {
           .hasValueSatisfying(
               lease ->
                   assertThat(lease)
-                      .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
+                      .returns(new NodeInstance(2, Version.of(3L)), Lease::nodeInstance)
                       .returns(taskId, Lease::taskId)
                       .returns(
                           VersionMappings.of(nodeInstance.nextVersion()),

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -26,25 +26,29 @@ public class StoredLeaseTest {
   private final Duration expiryDuration = Duration.ofSeconds(15);
 
   @Nested
-  class Uninitialized{
+  class Uninitialized {
     @Test
-    void shouldAlwaysContainNodeId(){
-      assertThatThrownBy(() -> new StoredLease.Uninitialized(null, "asdasd")).hasMessageContaining("node cannot be null");
+    void shouldAlwaysContainNodeId() {
+      assertThatThrownBy(() -> new StoredLease.Uninitialized(null, "asdasd"))
+          .hasMessageContaining("node cannot be null");
     }
 
     @Test
-    void shouldAlwaysContainETag(){
-      assertThatThrownBy(() -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), "")).hasMessageContaining("eTag cannot be empty");
-      assertThatThrownBy(() -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), null))
+    void shouldAlwaysContainETag() {
+      assertThatThrownBy(
+              () -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), ""))
+          .hasMessageContaining("eTag cannot be empty");
+      assertThatThrownBy(
+              () -> new StoredLease.Uninitialized(new NodeInstance(2, Version.of(2L)), null))
           .hasMessageContaining("eTag cannot be null");
     }
 
     @Test
-    void canBeAcquired(){
-      //given
+    void canBeAcquired() {
+      // given
       var stored = new StoredLease.Uninitialized(nodeInstance, "eTagExample");
 
-      //when
+      // when
       var toAcquire = stored.acquireInitialLease(taskId, clock, expiryDuration);
 
       // then
@@ -56,55 +60,73 @@ public class StoredLeaseTest {
     }
   }
 
-
   @Nested
-  class Initialized{
+  class Initialized {
 
     @Test
-    void shouldAlwaysContainMetadata(){
-      assertThatThrownBy(() -> new StoredLease.Initialized(null,0, "asd")).hasMessageContaining("metadata cannot be null");
+    void shouldAlwaysContainMetadata() {
+      assertThatThrownBy(() -> new StoredLease.Initialized(null, 0, "asd"))
+          .hasMessageContaining("metadata cannot be null");
       assertThatThrownBy(
               () ->
                   new StoredLease.Initialized(
-                      null, new Lease("asdasd", 123, new NodeInstance(0, Version.of(1)), VersionMappings.empty()), "asd"))
+                      null,
+                      new Lease(
+                          "asdasd",
+                          123,
+                          new NodeInstance(0, Version.of(1)),
+                          VersionMappings.empty()),
+                      "asd"))
           .hasMessageContaining("metadata cannot be null");
     }
 
     @Test
-    void shouldAlwaysContainETag(){
-      assertThatThrownBy(() -> new StoredLease.Initialized(new Metadata("asd", 123, Version.of(1)), 0, null))
+    void shouldAlwaysContainETag() {
+      assertThatThrownBy(
+              () -> new StoredLease.Initialized(new Metadata("asd", 123, Version.of(1)), 0, null))
           .hasMessageContaining("eTag cannot be null");
     }
+
     @Test
-    void shouldNotAcquireAValidLease(){
-    //given
-    var stored = new StoredLease.Initialized(new Metadata(taskId, expiryFromNow(), nodeInstance.version()), nodeInstance.id(), "eTagExample");
+    void shouldNotAcquireAValidLease() {
+      // given
+      var stored =
+          new StoredLease.Initialized(
+              new Metadata(taskId, expiryFromNow(), nodeInstance.version()),
+              nodeInstance.id(),
+              "eTagExample");
 
       var newTaskId = "newTaskId";
       var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
 
-      //then
+      // then
       assertThat(acquired).isNull();
     }
-    @Test
-    void shouldAcquireWithANewVersionWhenExpired(){
-      //given
-      var stored = new StoredLease.Initialized(new Metadata(taskId, expiryFromNow(), nodeInstance.version()), nodeInstance.id(), "eTagExample");
 
-      //when
+    @Test
+    void shouldAcquireWithANewVersionWhenExpired() {
+      // given
+      var stored =
+          new StoredLease.Initialized(
+              new Metadata(taskId, expiryFromNow(), nodeInstance.version()),
+              nodeInstance.id(),
+              "eTagExample");
+
+      // when
       clock.advance(expiryDuration.plusMillis(1));
       var newTaskId = "newTaskId";
       var acquired = stored.acquireInitialLease(newTaskId, clock, expiryDuration);
 
-      //then
+      // then
       assertThat(acquired)
           .returns(nodeInstance.nextVersion(), Lease::nodeInstance)
           .returns(newTaskId, Lease::taskId)
           .returns(VersionMappings.of(nodeInstance.nextVersion()), Lease::versionMappings)
           .returns(expiryFromNow(), Lease::timestamp);
-
     }
   }
 
-  long expiryFromNow(){return clock.millis() + expiryDuration.toMillis();}
+  long expiryFromNow() {
+    return clock.millis() + expiryDuration.toMillis();
+  }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -137,8 +137,9 @@ public class S3NodeIdRepositoryIT {
     assertThat(acquired.eTag()).isNotEmpty();
     final var metadata = acquired.metadata();
     assertThat(metadata.asMap()).isNotEmpty();
-    assertThat(metadata.expiry()).isEqualTo(toAcquire.timestamp());
-    assertThat(metadata.task()).isEqualTo(taskId);
+    assertThat(metadata.task())
+        .isPresent()
+        .hasValueSatisfying(t -> assertThat(t).isEqualTo(taskId));
   }
 
   @Test

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -99,9 +99,9 @@ public class S3NodeIdRepositoryIT {
     repository = fixed(millis);
     repository.initialize(clusterSize);
     final var initial = repository.getLease(0);
-    final var acquired =
-        repository.acquire(
-            initial.acquireInitialLease(taskId, clock, EXPIRY_DURATION), initial.eTag());
+    var firstAcquired = initial.acquireInitialLease(taskId, clock, EXPIRY_DURATION);
+    assertThat(firstAcquired).isPresent();
+    final var acquired = repository.acquire(firstAcquired.get(), initial.eTag());
     assertThat(acquired).isInstanceOf(StoredLease.Initialized.class);
 
     // when
@@ -127,7 +127,7 @@ public class S3NodeIdRepositoryIT {
     // when
     final var lease = repository.getLease(id);
 
-    final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION);
+    final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION).get();
     final var acquired = repository.acquire(toAcquire, lease.eTag());
     final var fromGet = repository.getLease(id);
 
@@ -170,7 +170,7 @@ public class S3NodeIdRepositoryIT {
     // when
     final var lease = repository.getLease(id);
 
-    final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION);
+    final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION).get();
 
     // then
     assertThatThrownBy(() -> repository.acquire(toAcquire, "10298301928309128"))
@@ -186,7 +186,7 @@ public class S3NodeIdRepositoryIT {
     repository.initialize(3);
     var id = 2;
     final var lease = repository.getLease(id);
-    final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION);
+    final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION).get();
     final var acquired = repository.acquire(toAcquire, lease.eTag());
 
     // when

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -101,11 +101,7 @@ public class S3NodeIdRepositoryIT {
     final var initial = repository.getLease(0);
     final var acquired =
         repository.acquire(
-            initial.acquireInitialLease(
-                taskId,
-                clock,
-            EXPIRY_DURATION),
-            initial.eTag());
+            initial.acquireInitialLease(taskId, clock, EXPIRY_DURATION), initial.eTag());
     assertThat(acquired).isInstanceOf(StoredLease.Initialized.class);
 
     // when
@@ -156,7 +152,9 @@ public class S3NodeIdRepositoryIT {
     // when
     final var lease = repository.getLease(id);
 
-    final var toAcquire = new Lease(taskId, now - 10000L, new NodeInstance(id, Version.of(1)), VersionMappings.empty());
+    final var toAcquire =
+        new Lease(
+            taskId, now - 10000L, new NodeInstance(id, Version.of(1)), VersionMappings.empty());
     assertThatThrownBy(() -> repository.acquire(toAcquire, lease.eTag()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("not valid anymore");

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -99,7 +99,7 @@ public class S3NodeIdRepositoryIT {
     repository = fixed(millis);
     repository.initialize(clusterSize);
     final var initial = repository.getLease(0);
-    var firstAcquired = initial.acquireInitialLease(taskId, clock, EXPIRY_DURATION);
+    final var firstAcquired = initial.acquireInitialLease(taskId, clock, EXPIRY_DURATION);
     assertThat(firstAcquired).isPresent();
     final var acquired = repository.acquire(firstAcquired.get(), initial.eTag());
     assertThat(acquired).isInstanceOf(StoredLease.Initialized.class);
@@ -184,7 +184,7 @@ public class S3NodeIdRepositoryIT {
     final var now = Clock.systemUTC().millis();
     repository = fixed(now);
     repository.initialize(3);
-    var id = 2;
+    final var id = 2;
     final var lease = repository.getLease(id);
     final var toAcquire = lease.acquireInitialLease(taskId, clock, EXPIRY_DURATION).get();
     final var acquired = repository.acquire(toAcquire, lease.eTag());

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -195,7 +195,9 @@ public class S3NodeIdRepositoryIT {
 
     // then
     final var afterRelease = repository.getLease(id);
-    assertThat(afterRelease).isInstanceOf(StoredLease.Uninitialized.class);
+    assertThat(afterRelease)
+        .isInstanceOf(StoredLease.Uninitialized.class)
+        .returns(acquired.node(), StoredLease::node);
   }
 
   @Test

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -133,7 +133,7 @@ public class S3NodeIdRepositoryIT {
     // then
     assertThat(fromGet).isEqualTo(acquired);
     assertThat(acquired.lease()).isEqualTo(toAcquire);
-    final var expectedNodeInstance = new NodeInstance(0, Version.of(1));
+    final var expectedNodeInstance = new NodeInstance(id, Version.of(1));
     assertThat(acquired.node()).isEqualTo(expectedNodeInstance);
     assertThat(acquired.lease())
         .isEqualTo(


### PR DESCRIPTION
## Description
The node version has been added in `NodeInstance`.
The `Version` is a wrapper for some added type safety since it's not in the hot path.

`VersionMappings` has been added to the `Lease` to track the registered version by the other nodes from SWIM.
The class is completely immutable and it's using a `Collections.unmodifiableSortedMap`, so it's effectively immutable.
I didn't use `SortedImmutableMap` from `guava` because it requires adding a new dependency (to the entire monorepo) for serializing it with jackson.
I used a `SortedMap` so the keys are always in order, which makes the tests easier to write and it's easier to compare different leases from S3.

## Related issues

closes #41173 
