### PR TITLE
feat: add reusable workflow job to execute secondary database ITs #36365

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -1,0 +1,100 @@
+# description: This is a reusable workflow used to run Database tests for the secondary database layer
+# test location: qa/acceptance-tests
+# type: CI
+# owner: @camunda/data-layer
+---
+name: Database integration tests reusable
+
+on:
+  workflow_call:
+    inputs:
+      it-database-type:
+        required: true
+        type: string
+        description: The database type to be used during the integration tests. This is the enum value of DatabaseType in the MultiDbTest extension
+      database-type:
+        required: true
+        type: string
+        description: The name/type of the database. Should have a corresponding entry in the db/docker-compose.yml. Will be used in output descriptions.
+      database-image-version:
+        required: false
+        type: string
+        description: The database docker image version to be used during the tests. Will be set as env variable IMAGE_VERSION. If not set, the default value from the docker-compose file will be used.
+defaults:
+  run:
+    shell: bash
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  integration-tests:
+    name: "${{inputs.database-type}}"
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    timeout-minutes: 15
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+      IMAGE_VERSION: ${{inputs.database-image-version}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-database-${{inputs.database-type}}
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # start the required database service
+      - name: Start Database service
+        if: ${{ inputs.database-type != 'h2' }}
+        run: docker-compose -f db/docker-compose.yml up -d ${{inputs.database-type}}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      # To communicate to the IT what database to expect and run against:
+      # -Dcamunda.it.database.type=rdbms
+      #
+      - name: Run database integration test with ${{inputs.database-type}}
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=6
+          -D maven.javadoc.skip=true
+          -D skipUTs
+          -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3
+          -D flaky.test.reportDir=failsafe-reports
+          -D test.integration.camunda.database.type=${{inputs.it-database-type}}
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -pl 'qa/acceptance-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Stop Database service
+        if: always()
+        run: docker-compose -f db/docker-compose.yml down
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] Database - ${{inputs.database-type}}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 services:
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:${IMAGE_VERSION:-18-alpine}
     restart: always
     # set shared memory limit when using docker-compose
     shm_size: 128mb
@@ -23,7 +23,7 @@ services:
       - "5432:5432"
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/mssql/server:${IMAGE_VERSION:-2019-latest}
     restart: always
     environment:
       ACCEPT_EULA: y
@@ -32,7 +32,7 @@ services:
       - "1433:1433"
 
   mariadb:
-    image: mariadb:11.8
+    image: mariadb:${IMAGE_VERSION:-12.0}
     restart: always
     environment:
       MARIADB_ROOT_PASSWORD: example
@@ -43,7 +43,7 @@ services:
       - "3306:3306"
 
   mysql:
-    image: mysql:8.4
+    image: mysql:${IMAGE_VERSION:-9.4}
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
@@ -56,7 +56,7 @@ services:
       # Name of the Docker Compose service
   oracle:
     # Docker Hub image (feel free to change the tag "latest" to any other available one)
-    image: gvenzl/oracle-free:latest
+    image: gvenzl/oracle-free:${IMAGE_VERSION:-23-slim-faststart}
     # Forward Oracle port to localhost
     ports:
       - "1521:1521"
@@ -74,7 +74,7 @@ services:
       start_period: 5s
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.18.4}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -98,7 +98,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.3}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster


### PR DESCRIPTION
## Description

Adds a reusable workflow job to execute integration tests agains supported secondary databases.

## Related issues

relates to #36365
