### PR TITLE
remove usage of ZeebeContainer on tasklist ITs

### DIFF
--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -335,14 +335,6 @@ jobs:
           dockerfile: tasklist.Dockerfile
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
-      - uses: ./.github/actions/build-platform-docker
-        id: build-zeebe-docker
-        with:
-          repository: localhost:5000/camunda/zeebe
-          version: ${{ env.DOCKER_IMAGE_TAG }}
-          dockerfile: Dockerfile
-          push: true
-          distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Tasklist backup restore Tests
         shell: bash
         run: ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ matrix.database }} -DskipTests=false verify | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -212,6 +212,7 @@
           <systemPropertyVariables>
             <spring.profiles.active>test</spring.profiles.active>
             <camunda.tasklist.database>${tasklistDatabase}</camunda.tasklist.database>
+            <camunda.data.secondary-storage.type>${tasklistDatabase}</camunda.data.secondary-storage.type>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -74,8 +74,8 @@
     </dependency>
 
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -139,7 +139,7 @@ public class BackupRestoreTest {
                 new HttpHost(testContext.getExternalElsHost(), testContext.getExternalElsPort()))));
     createElsSnapshotRepository(testContext);
 
-    testContainerUtil.startZeebe(IMAGE_REPO, VERSION, testContext);
+    testContainerUtil.startStandaloneBroker(testContext);
     createCamundaClient(testContext.getZeebeGrpcAddress());
   }
 
@@ -163,7 +163,7 @@ public class BackupRestoreTest {
     testContext.setOsClient(osClient);
     createOsSnapshotRepository(testContext);
 
-    testContainerUtil.startZeebe(IMAGE_REPO, VERSION, testContext);
+    testContainerUtil.startStandaloneBroker(testContext);
     createCamundaClient(testContext.getZeebeGrpcAddress());
   }
 

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -75,11 +75,6 @@
 
     <!-- TEST CONTAINERS -->
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-elasticsearch</artifactId>
       <scope>test</scope>
@@ -446,6 +441,26 @@
       <artifactId>configuration</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -469,6 +484,7 @@
             <camunda.tasklist.database>${camunda.tasklist.database}</camunda.tasklist.database>
             <camunda.database.type>${camunda.tasklist.database}</camunda.database.type>
             <camunda.database.url>${camunda.database.url:http://localhost:9200}</camunda.database.url>
+            <testForkNumber>$${surefire.forkNumber}</testForkNumber>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -484,6 +500,7 @@
             <camunda.tasklist.database>${camunda.tasklist.database}</camunda.tasklist.database>
             <camunda.database.type>${camunda.tasklist.database}</camunda.database.type>
             <camunda.database.url>${camunda.database.url:http://localhost:9200}</camunda.database.url>
+            <testForkNumber>$${surefire.forkNumber}</testForkNumber>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -456,11 +456,6 @@
       <artifactId>zeebe-broker</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-gateway</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -484,6 +479,9 @@
             <camunda.tasklist.database>${camunda.tasklist.database}</camunda.tasklist.database>
             <camunda.database.type>${camunda.tasklist.database}</camunda.database.type>
             <camunda.database.url>${camunda.database.url:http://localhost:9200}</camunda.database.url>
+            <camunda.data.secondary-storage.type>${camunda.tasklist.database}</camunda.data.secondary-storage.type>
+            <camunda.data.secondary-storage.elasticsearch.url>${camunda.database.url:http://localhost:9200}</camunda.data.secondary-storage.elasticsearch.url>
+            <camunda.data.secondary-storage.opensearch.url>${camunda.database.url:http://localhost:9200}</camunda.data.secondary-storage.opensearch.url>
             <testForkNumber>$${surefire.forkNumber}</testForkNumber>
           </systemPropertyVariables>
         </configuration>
@@ -500,6 +498,9 @@
             <camunda.tasklist.database>${camunda.tasklist.database}</camunda.tasklist.database>
             <camunda.database.type>${camunda.tasklist.database}</camunda.database.type>
             <camunda.database.url>${camunda.database.url:http://localhost:9200}</camunda.database.url>
+            <camunda.data.secondary-storage.type>${camunda.tasklist.database}</camunda.data.secondary-storage.type>
+            <camunda.data.secondary-storage.elasticsearch.url>${camunda.database.url:http://localhost:9200}</camunda.data.secondary-storage.elasticsearch.url>
+            <camunda.data.secondary-storage.opensearch.url>${camunda.database.url:http://localhost:9200}</camunda.data.secondary-storage.opensearch.url>
             <testForkNumber>$${surefire.forkNumber}</testForkNumber>
           </systemPropertyVariables>
         </configuration>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
@@ -10,9 +10,9 @@ package io.camunda.tasklist;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
-import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.qa.util.TestContainerUtil;
 import io.camunda.tasklist.qa.util.TestContext;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -36,7 +36,7 @@ public class StartupIT {
   //  values for local test:
   // private static final String TASKLIST_TEST_DOCKER_IMAGE = "camunda/tasklist:SNAPSHOT";
   //  public static final String VERSION = "8.1.2";
-  private static final String TASKLIST_TEST_DOCKER_IMAGE = "localhost:5000/camunda/tasklist";
+  private static final String TASKLIST_TEST_DOCKER_IMAGE = "camunda/tasklist";
   private static final String VERSION = "current-test";
   public TestRestTemplate restTemplate = new TestRestTemplate();
   private final TestContainerUtil testContainerUtil = new TestContainerUtil();
@@ -48,14 +48,15 @@ public class StartupIT {
     testContext = new TestContext();
     testContainerUtil.startElasticsearch(testContext);
 
-    testContainerUtil.startZeebe(
-        ContainerVersionsUtil.readProperty(
-            ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME),
-        testContext);
+    new TestStandaloneBroker()
+        .withCreateSchema(false)
+        .withProperty("management.endpoint.health.group.readiness.include", "readinessState")
+        .start();
 
     tasklistContainer =
         testContainerUtil
             .createTasklistContainer(TASKLIST_TEST_DOCKER_IMAGE, VERSION, testContext)
+            .withAccessToHost(true)
             .withCreateContainerCmdModifier(
                 cmd -> ((CreateContainerCmd) cmd).withUser("1000620000:0"))
             .withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import io.camunda.tasklist.qa.util.TestContainerUtil;
 import io.camunda.tasklist.qa.util.TestContext;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -36,7 +35,7 @@ public class StartupIT {
   //  values for local test:
   // private static final String TASKLIST_TEST_DOCKER_IMAGE = "camunda/tasklist:SNAPSHOT";
   //  public static final String VERSION = "8.1.2";
-  private static final String TASKLIST_TEST_DOCKER_IMAGE = "camunda/tasklist";
+  private static final String TASKLIST_TEST_DOCKER_IMAGE = "localhost:5000/camunda/tasklist";
   private static final String VERSION = "current-test";
   public TestRestTemplate restTemplate = new TestRestTemplate();
   private final TestContainerUtil testContainerUtil = new TestContainerUtil();
@@ -48,15 +47,13 @@ public class StartupIT {
     testContext = new TestContext();
     testContainerUtil.startElasticsearch(testContext);
 
-    new TestStandaloneBroker()
-        .withCreateSchema(false)
-        .withProperty("management.endpoint.health.group.readiness.include", "readinessState")
-        .start();
+    testContainerUtil.startStandaloneBroker(testContext);
 
     tasklistContainer =
         testContainerUtil
             .createTasklistContainer(TASKLIST_TEST_DOCKER_IMAGE, VERSION, testContext)
             .withAccessToHost(true)
+            .withExtraHost("host.testcontainers.internal", "host-gateway")
             .withCreateContainerCmdModifier(
                 cmd -> ((CreateContainerCmd) cmd).withUser("1000620000:0"))
             .withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorIT.java
@@ -19,6 +19,8 @@ import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TasklistZeebeExtension;
 import io.camunda.tasklist.util.TestApplication;
 import io.camunda.tasklist.zeebe.ZeebeConnector;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.time.Duration;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -73,9 +75,12 @@ public class ZeebeConnectorIT extends TasklistIntegrationTest {
     startZeebe();
 
     camundaClient =
-        zeebeConnector.newCamundaClient(
-            new ZeebeProperties()
-                .setGatewayAddress(zeebeExtension.getZeebeContainer().getExternalGatewayAddress()));
+        CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
+            .grpcAddress(zeebeExtension.getZeebeBroker().grpcAddress())
+            .restAddress(zeebeExtension.getZeebeBroker().restAddress())
+            .defaultRequestTimeout(Duration.ofSeconds(15))
+            .build();
 
     // then 2
     assertThat(camundaClient.newTopologyRequest().send().join().getBrokers()).isNotEmpty();
@@ -100,7 +105,7 @@ public class ZeebeConnectorIT extends TasklistIntegrationTest {
     camundaClient =
         zeebeConnector.newCamundaClient(
             new ZeebeProperties()
-                .setGatewayAddress(zeebeExtension.getZeebeContainer().getExternalGatewayAddress()));
+                .setGatewayAddress(zeebeExtension.getZeebeBroker().address(TestZeebePort.GATEWAY)));
 
     // then 1
     assertThat(camundaClient.newTopologyRequest().send().join().getBrokers()).isNotEmpty();
@@ -113,9 +118,12 @@ public class ZeebeConnectorIT extends TasklistIntegrationTest {
     zeebeExtension.beforeEach(null);
 
     camundaClient =
-        zeebeConnector.newCamundaClient(
-            new ZeebeProperties()
-                .setGatewayAddress(zeebeExtension.getZeebeContainer().getExternalGatewayAddress()));
+        CamundaClient.newClientBuilder()
+            .preferRestOverGrpc(false)
+            .grpcAddress(zeebeExtension.getZeebeBroker().grpcAddress())
+            .restAddress(zeebeExtension.getZeebeBroker().restAddress())
+            .defaultRequestTimeout(Duration.ofSeconds(15))
+            .build();
 
     // then 2
     assertThat(camundaClient.newTopologyRequest().send().join().getBrokers()).isNotEmpty();

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -64,7 +64,6 @@ public class ZeebeConnectorSecureIT {
                       .setPrivateKeyPath(privateKeyFile)
                       .setEnabled(true);
                 })
-            .withProperty("management.endpoint.health.group.readiness.include", "readinessState")
             .withSecurityConfig(cfg -> cfg.getAuthentication().setUnprotectedApi(true));
     broker.start();
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -64,6 +64,7 @@ public class ZeebeConnectorSecureIT {
                       .setPrivateKeyPath(privateKeyFile)
                       .setEnabled(true);
                 })
+            .withProperty("management.endpoint.health.group.readiness.include", "readinessState")
             .withSecurityConfig(cfg -> cfg.getAuthentication().setUnprotectedApi(true));
     broker.start();
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -44,6 +45,7 @@ public class ZeebeConnectorSecureIT {
   private static final String CERTIFICATE_FILE = "zeebe-test-chain.cert.pem";
   private static final String PRIVATE_KEY_FILE = "zeebe-test-server.key.pem";
   @Autowired ZeebeConnector zeebeConnector;
+  @Autowired TasklistProperties tasklistProperties;
   private TestStandaloneBroker broker;
   private CamundaClient camundaClient;
 
@@ -56,13 +58,18 @@ public class ZeebeConnectorSecureIT {
     broker =
         new TestStandaloneBroker()
             .withCreateSchema(false)
-            .withBrokerConfig(
+            .withGatewayEnabled(true)
+            .withUnifiedConfig(
                 cfg -> {
-                  cfg.getGateway()
-                      .getSecurity()
-                      .setCertificateChainPath(certFile)
-                      .setPrivateKeyPath(privateKeyFile)
-                      .setEnabled(true);
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .setType(
+                          tasklistProperties.isElasticsearchDB()
+                              ? SecondaryStorageType.elasticsearch
+                              : SecondaryStorageType.opensearch);
+                  cfg.getApi().getGrpc().getSsl().setEnabled(true);
+                  cfg.getApi().getGrpc().getSsl().setCertificatePrivateKey(privateKeyFile);
+                  cfg.getApi().getGrpc().getSsl().setCertificate(certFile);
                 })
             .withSecurityConfig(cfg -> cfg.getAuthentication().setUnprotectedApi(true));
     broker.start();

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.it;
 
-import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_ENV_VAR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
@@ -17,14 +16,12 @@ import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.property.ZeebeProperties;
-import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.util.CertificateUtil;
 import io.camunda.tasklist.zeebe.ZeebeConnector;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import java.io.File;
-import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,9 +29,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.MountableFile;
 
 @SpringBootTest(
     classes = {
@@ -49,15 +43,8 @@ public class ZeebeConnectorSecureIT {
 
   private static final String CERTIFICATE_FILE = "zeebe-test-chain.cert.pem";
   private static final String PRIVATE_KEY_FILE = "zeebe-test-server.key.pem";
-  private static final DockerImageName ZEEBE_DOCKER_IMAGE =
-      DockerImageName.parse(
-              ContainerVersionsUtil.readProperty(
-                  ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME))
-          .withTag(
-              ContainerVersionsUtil.readProperty(
-                  ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME));
   @Autowired ZeebeConnector zeebeConnector;
-  private ZeebeContainer zeebeContainer;
+  private TestStandaloneBroker broker;
   private CamundaClient camundaClient;
 
   @Test
@@ -66,32 +53,29 @@ public class ZeebeConnectorSecureIT {
     final File certFile = new File(tempDir, CERTIFICATE_FILE);
     final File privateKeyFile = new File(tempDir, PRIVATE_KEY_FILE);
     CertificateUtil.generateRSACertificate(certFile, privateKeyFile);
-    zeebeContainer =
-        new ZeebeContainer(ZEEBE_DOCKER_IMAGE)
-            .withCopyFileToContainer(
-                MountableFile.forHostPath(tempDir.toPath(), 0755), "/usr/local/zeebe/certs")
-            .withEnv(
-                Map.of(
-                    "ZEEBE_BROKER_GATEWAY_SECURITY_CERTIFICATECHAINPATH",
-                    "/usr/local/zeebe/certs/" + CERTIFICATE_FILE,
-                    "ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH",
-                    "/usr/local/zeebe/certs/" + PRIVATE_KEY_FILE,
-                    "ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED",
-                    "true",
-                    CREATE_SCHEMA_ENV_VAR,
-                    "false",
-                    "CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI",
-                    "true"))
-            // Can't use connection wait strategy because of TLS
-            .waitingFor(
-                new LogMessageWaitStrategy()
-                    .withRegEx(".*Broker is ready!.*")
-                    .withStartupTimeout(Duration.ofSeconds(101)));
-    zeebeContainer.start();
+    broker =
+        new TestStandaloneBroker()
+            .withCreateSchema(false)
+            .withBrokerConfig(
+                cfg -> {
+                  cfg.getGateway()
+                      .getSecurity()
+                      .setCertificateChainPath(certFile)
+                      .setPrivateKeyPath(privateKeyFile)
+                      .setEnabled(true);
+                })
+            .withProperty("management.endpoint.health.group.readiness.include", "readinessState")
+            .withSecurityConfig(cfg -> cfg.getAuthentication().setUnprotectedApi(true));
+    broker.start();
+
+    // replace loopback address with localhost for certificate match
+    final String gatewayAddress =
+        broker.address(TestZeebePort.GATEWAY).replace("0.0.0.0", "localhost");
+
     camundaClient =
         zeebeConnector.newCamundaClient(
             new ZeebeProperties()
-                .setGatewayAddress(zeebeContainer.getExternalGatewayAddress())
+                .setGatewayAddress(gatewayAddress)
                 .setSecure(true)
                 .setCertificatePath(tempDir.getCanonicalPath() + "/" + CERTIFICATE_FILE));
     // when
@@ -106,8 +90,8 @@ public class ZeebeConnectorSecureIT {
     if (camundaClient != null) {
       camundaClient.close();
     }
-    if (zeebeContainer != null) {
-      zeebeContainer.stop();
+    if (broker != null) {
+      broker.close();
     }
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
@@ -46,6 +46,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },
+    properties = {
+      "management.endpoint.health.group.readiness.include: readinessState,searchEngineCheck"
+    },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"tasklist", "test", "standalone"})
 public class HealthCheckIT {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/SessionlessTasklistZeebeIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/SessionlessTasklistZeebeIntegrationTest.java
@@ -18,9 +18,10 @@ import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.webapp.es.cache.ProcessCache;
 import io.camunda.tasklist.webapp.service.CamundaClientBasedAdapter;
 import io.camunda.tasklist.webapp.service.OrganizationService;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.zeebe.containers.ZeebeContainer;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -52,7 +53,7 @@ public abstract class SessionlessTasklistZeebeIntegrationTest extends TasklistIn
   @Order(2)
   public TasklistZeebeExtension zeebeExtension;
 
-  public ZeebeContainer zeebeContainer;
+  public TestStandaloneBroker zeebeBroker;
 
   @MockitoBean protected OrganizationService organizationService;
   @MockitoBean protected CamundaClient mockedCamundaClient;
@@ -75,8 +76,8 @@ public abstract class SessionlessTasklistZeebeIntegrationTest extends TasklistIn
   public void before() {
     super.before();
 
-    zeebeContainer = zeebeExtension.getZeebeContainer();
-    assertThat(zeebeContainer).as("zeebeContainer is not null").isNotNull();
+    zeebeBroker = zeebeExtension.getZeebeBroker();
+    assertThat(zeebeBroker).as("zeebeBroker is not null").isNotNull();
 
     camundaClient = getClient();
     workerName = TestUtil.createRandomString(10);
@@ -145,7 +146,7 @@ public abstract class SessionlessTasklistZeebeIntegrationTest extends TasklistIn
       throws IOException, InterruptedException {
     final var fullEndpoint =
         URI.create(
-            String.format("http://%s/%s", zeebeContainer.getExternalAddress(9600), endpoint));
+            String.format("http://%s/%s", zeebeBroker.address(TestZeebePort.MONITORING), endpoint));
     final var httpRequest =
         HttpRequest.newBuilder(fullEndpoint)
             .method(method, bodyPublisher)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -75,7 +75,8 @@ public abstract class TasklistZeebeExtension
                     "zeebe.log.level", "ERROR",
                     "atomix.log.level", "ERROR",
                     "zeebe.clock.controlled", "true",
-                    "zeebe.broker.gateway.enable", "true"))
+                    "zeebe.broker.gateway.enable", "true",
+                    "management.endpoint.health.group.readiness.include", "readinessState"))
             .withExporter(
                 CamundaExporter.class.getSimpleName().toLowerCase(),
                 cfg -> {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -8,13 +8,12 @@
 package io.camunda.tasklist.util;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
-import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.qa.util.TasklistIndexPrefixHolder;
-import io.zeebe.containers.ZeebeContainer;
-import java.net.URI;
-import java.net.URISyntaxException;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -27,8 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.utility.DockerImageName;
 
 public abstract class TasklistZeebeExtension
     implements BeforeEachCallback, AfterEachCallback, TestExecutionExceptionHandler {
@@ -39,7 +36,7 @@ public abstract class TasklistZeebeExtension
   @Autowired protected TasklistProperties tasklistProperties;
   @Autowired protected SecurityConfiguration securityConfiguration;
   @Autowired protected TasklistIndexPrefixHolder indexPrefixHolder;
-  protected ZeebeContainer zeebeContainer;
+  protected TestStandaloneBroker zeebeBroker;
   protected boolean failed = false;
 
   private CamundaClient client;
@@ -67,72 +64,65 @@ public abstract class TasklistZeebeExtension
   }
 
   private void startZeebe() {
+
+    final String indexPrefix = indexPrefixHolder.getIndexPrefix();
+    prefix = indexPrefix;
+
+    final var app =
+        new TestStandaloneBroker()
+            .withAdditionalProperties(
+                Map.of(
+                    "zeebe.log.level", "ERROR",
+                    "atomix.log.level", "ERROR",
+                    "zeebe.clock.controlled", "true",
+                    "zeebe.broker.gateway.enable", "true",
+                    "management.endpoint.health.group.readiness.include", "readinessState"))
+            .withExporter(
+                CamundaExporter.class.getSimpleName().toLowerCase(),
+                cfg -> {
+                  cfg.setClassName(CamundaExporter.class.getName());
+                  cfg.setArgs(
+                      Map.of(
+                          "connect",
+                          Map.of(
+                              "url",
+                              "http://localhost:9200",
+                              "indexPrefix",
+                              indexPrefix,
+                              "type",
+                              getDatabaseType().toString(),
+                              "index",
+                              Map.of("prefix", indexPrefix),
+                              "bulk",
+                              Map.of("size", 1))));
+                })
+            .withBrokerConfig(cfg -> cfg.getCluster().setPartitionsCount(2))
+            .withUnauthenticatedAccess()
+            .withAuthorizationsDisabled();
+
+    getDatabaseEnvironmentVariables(indexPrefix).forEach(app::withProperty);
+
+    zeebeBroker = app.start();
     Testcontainers.exposeHostPorts(getDatabasePort());
-    zeebeContainer = createZeebeContainer();
-    zeebeContainer.start();
-    prefix = zeebeContainer.getEnvMap().get(getZeebeExporterIndexPrefixConfigParameterName());
-    LOGGER.info("Using Zeebe container with indexPrefix={}", prefix);
-    final Integer zeebeRestPort = zeebeContainer.getMappedPort(8080);
+
+    LOGGER.info("Using StandaloneBroker with indexPrefix={}", prefix);
 
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .grpcAddress(zeebeContainer.getGrpcAddress())
-            .restAddress(
-                getURIFromString(
-                    String.format("http://%s:%s", zeebeContainer.getExternalHost(), zeebeRestPort)))
+            .grpcAddress(app.grpcAddress())
+            .restAddress(app.restAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
   }
 
-  protected abstract String getZeebeExporterIndexPrefixConfigParameterName();
-
-  private ZeebeContainer createZeebeContainer() {
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(
-            ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    final String zeebeRepo =
-        ContainerVersionsUtil.readProperty(
-            ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME);
-    final String indexPrefix = indexPrefixHolder.getIndexPrefix();
-    LOGGER.info(
-        "************ Starting Zeebe - {}:{}, indexPrefix={} ************",
-        zeebeRepo,
-        zeebeVersion,
-        indexPrefix);
-    final ZeebeContainer zContainer =
-        new ZeebeContainer(DockerImageName.parse(zeebeRepo).withTag(zeebeVersion))
-            .withEnv(getDatabaseEnvironmentVariables(indexPrefix))
-            .withEnv("JAVA_OPTS", "-Xss256k -XX:+TieredCompilation -XX:TieredStopAtLevel=1")
-            .withEnv("ZEEBE_LOG_LEVEL", "ERROR")
-            .withEnv("ATOMIX_LOG_LEVEL", "ERROR")
-            .withEnv("ZEEBE_CLOCK_CONTROLLED", "true")
-            .withEnv("ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT", "2")
-            .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
-            .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
-            .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
-            .withEnv(
-                "JAVA_OPTS",
-                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005");
-    zContainer.withLogConsumer(new Slf4jLogConsumer(LOGGER));
-    zContainer.addExposedPort(8080);
-    zContainer.addExposedPort(5005);
-    return zContainer;
-  }
-
-  private static URI getURIFromString(final String uri) {
-    try {
-      return new URI(uri);
-    } catch (final URISyntaxException e) {
-      throw new IllegalArgumentException("Failed to parse URI string", e);
-    }
-  }
+  protected abstract DatabaseType getDatabaseType();
 
   protected abstract Map<String, String> getDatabaseEnvironmentVariables(String indexPrefix);
 
   /** Stops the broker and destroys the client. Does nothing if not started yet. */
   public void stop() {
-    CompletableFuture.runAsync(() -> zeebeContainer.stop());
+    CompletableFuture.runAsync(() -> zeebeBroker.stop());
 
     if (client != null) {
       client.close();
@@ -148,8 +138,8 @@ public abstract class TasklistZeebeExtension
     this.prefix = prefix;
   }
 
-  public ZeebeContainer getZeebeContainer() {
-    return zeebeContainer;
+  public TestStandaloneBroker getZeebeBroker() {
+    return zeebeBroker;
   }
 
   public CamundaClient getClient() {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -75,8 +75,7 @@ public abstract class TasklistZeebeExtension
                     "zeebe.log.level", "ERROR",
                     "atomix.log.level", "ERROR",
                     "zeebe.clock.controlled", "true",
-                    "zeebe.broker.gateway.enable", "true",
-                    "management.endpoint.health.group.readiness.include", "readinessState"))
+                    "zeebe.broker.gateway.enable", "true"))
             .withExporter(
                 CamundaExporter.class.getSimpleName().toLowerCase(),
                 cfg -> {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -9,6 +9,8 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.util.Map;
@@ -46,23 +48,31 @@ public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension 
   }
 
   @Override
-  protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
+  protected void setSecondaryStorageConfig(final Camunda camunda, final String indexPrefix) {
     final String dbUrl = "http://host.testcontainers.internal:9200";
 
-    return Map.ofEntries(
-        // Unified Configuration: DB URL + compatibility
-        Map.entry("camunda.data.secondary-storage.elasticsearch.url", dbUrl),
-        Map.entry("camunda.database.url", dbUrl),
-        Map.entry("camunda.tasklist.elasticsearch.url", dbUrl),
-        Map.entry("camunda.operate.elasticsearch.url", dbUrl),
-        // Unified Configuration: DB type + compatibility
-        Map.entry("camunda.data.secondary-storage.type", getDatabaseType().toString()),
-        Map.entry("camunda.operate.database", getDatabaseType().toString()),
-        Map.entry("camunda.tasklist.database", getDatabaseType().toString()),
-        Map.entry("camunda.database.type", getDatabaseType().toString()),
-        Map.entry("camunda.data.secondary-storage.elasticsearch.index-prefix", indexPrefix),
-        // ---
-        Map.entry("camunda.database.index-prefix", indexPrefix));
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+    camunda.getData().getSecondaryStorage().getElasticsearch().setUrl(dbUrl);
+    camunda.getData().getSecondaryStorage().getElasticsearch().setIndexPrefix(indexPrefix);
+  }
+
+  @Override
+  protected Map<String, String> getLegacyConfiguration(final String indexPrefix) {
+    final String dbUrl = "http://host.testcontainers.internal:9200";
+
+    return Map.of(
+        "camunda.database.type",
+        getDatabaseType().name(),
+        "camunda.database.url",
+        dbUrl,
+        "camunda.tasklist.database",
+        getDatabaseType().name(),
+        "camunda.operate.database",
+        getDatabaseType().name(),
+        "camunda.tasklist.elasticsearch.url",
+        dbUrl,
+        "camunda.operate.elasticsearch.url",
+        dbUrl);
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.util.Map;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -40,35 +41,28 @@ public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension 
   }
 
   @Override
-  protected String getZeebeExporterIndexPrefixConfigParameterName() {
-    return "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX";
+  protected DatabaseType getDatabaseType() {
+    return DatabaseType.ELASTICSEARCH;
   }
 
   @Override
   protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
     final String dbUrl = "http://host.testcontainers.internal:9200";
-    final String dbType = "elasticsearch";
-    final String exporterClassName = "io.camunda.exporter.CamundaExporter";
 
     return Map.ofEntries(
         // Unified Configuration: DB URL + compatibility
-        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", dbUrl),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", dbUrl),
-        Map.entry("CAMUNDA_DATABASE_URL", dbUrl),
-        Map.entry("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", dbUrl),
-        Map.entry("CAMUNDA_OPERATE_ELASTICSEARCH_URL", dbUrl),
+        Map.entry("camunda.data.secondary-storage.elasticsearch.url", dbUrl),
+        Map.entry("camunda.database.url", dbUrl),
+        Map.entry("camunda.tasklist.elasticsearch.url", dbUrl),
+        Map.entry("camunda.operate.elasticsearch.url", dbUrl),
         // Unified Configuration: DB type + compatibility
-        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE", dbType),
-        Map.entry("CAMUNDA_OPERATE_DATABASE", dbType),
-        Map.entry("CAMUNDA_TASKLIST_DATABASE", dbType),
-        Map.entry("CAMUNDA_DATABASE_TYPE", dbType),
-        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX", indexPrefix),
+        Map.entry("camunda.data.secondary-storage.type", getDatabaseType().toString()),
+        Map.entry("camunda.operate.database", getDatabaseType().toString()),
+        Map.entry("camunda.tasklist.database", getDatabaseType().toString()),
+        Map.entry("camunda.database.type", getDatabaseType().toString()),
+        Map.entry("camunda.data.secondary-storage.elasticsearch.index-prefix", indexPrefix),
         // ---
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1"),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX", indexPrefix),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME", exporterClassName),
-        Map.entry("CAMUNDA_DATABASE_INDEXPREFIX", indexPrefix));
+        Map.entry("camunda.database.index-prefix", indexPrefix));
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -66,9 +66,9 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
         getDatabaseType().name(),
         "camunda.operate.database",
         getDatabaseType().name(),
-        "camunda.tasklist.elasticsearch.url",
+        "camunda.tasklist.opensearch.url",
         dbUrl,
-        "camunda.operate.elasticsearch.url",
+        "camunda.operate.opensearch.url",
         dbUrl);
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -9,6 +9,8 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.util.Map;
@@ -43,23 +45,31 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
   }
 
   @Override
-  protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
+  protected void setSecondaryStorageConfig(final Camunda camunda, final String indexPrefix) {
     final String dbUrl = "http://host.testcontainers.internal:9200";
 
-    return Map.ofEntries(
-        // Unified Configuration: DB URL + compatibility
-        Map.entry("camunda.data.secondary-storage.opensearch.url", dbUrl),
-        Map.entry("camunda.database.url", dbUrl),
-        Map.entry("camunda.tasklist.opensearch.url", dbUrl),
-        Map.entry("camunda.operate.opensearch.url", dbUrl),
-        // Unified Configuration: DB type + compatibility
-        Map.entry("camunda.data.secondary-storage.type", getDatabaseType().toString()),
-        Map.entry("camunda.operate.database", getDatabaseType().toString()),
-        Map.entry("camunda.tasklist.database", getDatabaseType().toString()),
-        Map.entry("camunda.database.type", getDatabaseType().toString()),
-        Map.entry("camunda.data.secondary-storage.opensearch.index-prefix", indexPrefix),
-        // ---
-        Map.entry("camunda.database.index-prefix", indexPrefix));
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.opensearch);
+    camunda.getData().getSecondaryStorage().getOpensearch().setUrl(dbUrl);
+    camunda.getData().getSecondaryStorage().getOpensearch().setIndexPrefix(indexPrefix);
+  }
+
+  @Override
+  protected Map<String, String> getLegacyConfiguration(final String indexPrefix) {
+    final String dbUrl = "http://host.testcontainers.internal:9200";
+
+    return Map.of(
+        "camunda.database.type",
+        getDatabaseType().name(),
+        "camunda.database.url",
+        dbUrl,
+        "camunda.tasklist.database",
+        getDatabaseType().name(),
+        "camunda.operate.database",
+        getDatabaseType().name(),
+        "camunda.tasklist.elasticsearch.url",
+        dbUrl,
+        "camunda.operate.elasticsearch.url",
+        dbUrl);
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.util.Map;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -37,36 +38,28 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
   }
 
   @Override
-  protected String getZeebeExporterIndexPrefixConfigParameterName() {
-    return "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX";
+  protected DatabaseType getDatabaseType() {
+    return DatabaseType.OPENSEARCH;
   }
 
   @Override
   protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
     final String dbUrl = "http://host.testcontainers.internal:9200";
-    final String dbType = "opensearch";
 
     return Map.ofEntries(
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1"),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX", indexPrefix),
-        Map.entry(
-            "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-            "io.camunda.exporter.CamundaExporter"),
-        // Unified Config: db type + compatibility vars
-        Map.entry("CAMUNDA_DATABASE_TYPE", dbType),
-        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType),
-        Map.entry("CAMUNDA_OPERATE_DATABASE", dbType),
-        Map.entry("CAMUNDA_TASKLIST_DATABASE", dbType),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE", dbType),
-        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX", indexPrefix),
-        // Unified Config: db url + compatibility vars
-        Map.entry("CAMUNDA_DATABASE_URL", dbUrl),
-        Map.entry("CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_URL", dbUrl),
-        Map.entry("CAMUNDA_OPERATE_OPENSEARCH_URL", dbUrl),
-        Map.entry("CAMUNDA_TASKLIST_OPENSEARCH_URL", dbUrl),
-        Map.entry("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", dbUrl),
+        // Unified Configuration: DB URL + compatibility
+        Map.entry("camunda.data.secondary-storage.opensearch.url", dbUrl),
+        Map.entry("camunda.database.url", dbUrl),
+        Map.entry("camunda.tasklist.opensearch.url", dbUrl),
+        Map.entry("camunda.operate.opensearch.url", dbUrl),
+        // Unified Configuration: DB type + compatibility
+        Map.entry("camunda.data.secondary-storage.type", getDatabaseType().toString()),
+        Map.entry("camunda.operate.database", getDatabaseType().toString()),
+        Map.entry("camunda.tasklist.database", getDatabaseType().toString()),
+        Map.entry("camunda.database.type", getDatabaseType().toString()),
+        Map.entry("camunda.data.secondary-storage.opensearch.index-prefix", indexPrefix),
         // ---
-        Map.entry("CAMUNDA_DATABASE_INDEXPREFIX", indexPrefix));
+        Map.entry("camunda.database.index-prefix", indexPrefix));
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -37,7 +37,7 @@ server.error.include-message: always
 management.health.defaults.enabled: false
 management.endpoint.health.probes.enabled: true
 management.endpoints.web.exposure.include: health,prometheus,loggers,usage-metrics,backups
-management.endpoint.health.group.readiness.include: readinessState,searchEngineCheck
+management.endpoint.health.group.readiness.include: readinessState
 ---
 spring.config.activate.on-profile: sso-auth
 camunda.webapps.login-delegated: true

--- a/tasklist/qa/util/pom.xml
+++ b/tasklist/qa/util/pom.xml
@@ -204,17 +204,17 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>configuration</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-zeebe</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
     </dependency>
 
   </dependencies>

--- a/tasklist/qa/util/pom.xml
+++ b/tasklist/qa/util/pom.xml
@@ -65,12 +65,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- TEST CONTAINERS -->
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-    </dependency>
-
     <!-- Necessary for zeebe-test-container -->
     <dependency>
       <groupId>io.camunda</groupId>
@@ -106,11 +100,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java-api</artifactId>
     </dependency>
 
     <dependency>
@@ -196,6 +185,36 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-zeebe</artifactId>
     </dependency>
 
   </dependencies>

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -481,8 +481,7 @@ public class TestContainerUtil {
           .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
     }
 
-    final String zeebeContactPoint =
-        String.format("host.testcontainers.internal:%d", broker.mappedPort(TestZeebePort.GATEWAY));
+    final String zeebeContactPoint = testContext.getInternalZeebeContactPoint();
     if (zeebeContactPoint != null) {
       tasklistContainer.withEnv("CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS", zeebeContactPoint);
     }
@@ -505,7 +504,9 @@ public class TestContainerUtil {
       broker.start();
       LOGGER.info("************ StandaloneBroker started  ************");
 
-      testContext.setInternalZeebeContactPoint(broker.address(TestZeebePort.GATEWAY));
+      testContext.setInternalZeebeContactPoint(
+          String.format(
+              "host.testcontainers.internal:%d", broker.mappedPort(TestZeebePort.GATEWAY)));
       testContext.setZeebeGrpcAddress(broker.grpcAddress());
     } else {
       throw new IllegalStateException("Broker is already started. Call stopZeebe first.");
@@ -561,29 +562,6 @@ public class TestContainerUtil {
       zeebeBroker.withProperty(
           "camunda.data.secondary-storage." + type + ".index-prefix", testContext.getIndexPrefix());
     }
-
-    /*    zeebeBroker
-        // Unified Configuration: DB URL + compatibility
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_" + type.toUpperCase() + "_URL", url)
-        .withEnv("CAMUNDA_DATABASE_URL", url)
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", url)
-        .withEnv("CAMUNDA_OPERATE_" + type.toUpperCase() + "_URL", url)
-        .withEnv("CAMUNDA_TASKLIST_" + type.toUpperCase() + "_URL", url)
-        // Unified Configuration: DB type + compatibility
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", type)
-        .withEnv("CAMUNDA_DATABASE_TYPE", type)
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE", type)
-        .withEnv("CAMUNDA_OPERATE_DATABASE", type)
-        .withEnv("CAMUNDA_TASKLIST_DATABASE", type)
-        // ---
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME", exporterClassName)
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_WAITPERIODBEFOREARCHIVING", "1s");
-    if (testContext.getIndexPrefix() != null) {
-      zeebeBroker.withEnv(
-          "CAMUNDA_DATA_SECONDARY_STORAGE_" + type.toUpperCase() + "_INDEX_PREFIX",
-          testContext.getIndexPrefix());
-    }*/
   }
 
   public void stopZeebeAndTasklist(final TestContext testContext) {

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -9,11 +9,12 @@ package io.camunda.tasklist.qa.util;
 
 import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
 
-import com.github.dockerjava.api.model.Bind;
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.util.RetryOperation;
-import io.zeebe.containers.ZeebeContainer;
-import io.zeebe.containers.ZeebePort;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
@@ -35,7 +36,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.cluster.HealthResponse;
-import org.opensearch.testcontainers.OpenSearchContainer;
+import org.opensearch.testcontainers.OpensearchContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -98,8 +99,8 @@ public class TestContainerUtil {
   private static final String APPLICATION_MEMBER_TYPE = "APPLICATION";
   private static final String TASKLIST = "tasklist";
   private ElasticsearchContainer elsContainer;
-  private OpenSearchContainer osContainer;
-  private ZeebeContainer broker;
+  private OpensearchContainer osContainer;
+  private TestStandaloneBroker broker;
   private GenericContainer tasklistContainer;
   private GenericContainer identityContainer;
   private GenericContainer keycloakContainer;
@@ -258,8 +259,8 @@ public class TestContainerUtil {
   public void startOpenSearch(final TestContext testContext) {
     LOGGER.info("************ Starting OpenSearch ************");
     osContainer =
-        (OpenSearchContainer)
-            new OpenSearchContainer(
+        (OpensearchContainer)
+            new OpensearchContainer(
                     String.format(
                         "%s:%s", DOCKER_OPENSEARCH_IMAGE_NAME, DOCKER_OPENSEARCH_IMAGE_VERSION))
                 .withNetwork(Network.SHARED)
@@ -396,6 +397,8 @@ public class TestContainerUtil {
     tasklistContainer =
         new GenericContainer<>(String.format("%s:%s", dockerImageName, version))
             .withExposedPorts(exposedPorts)
+            .withAccessToHost(true)
+            .withExtraHost("host.testcontainers.internal", "host-gateway")
             .withNetwork(testContext.getNetwork())
             .waitingFor(
                 new HttpWaitStrategy()
@@ -478,68 +481,88 @@ public class TestContainerUtil {
           .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
     }
 
-    final String zeebeContactPoint = testContext.getInternalZeebeContactPoint();
+    final String zeebeContactPoint =
+        String.format("host.testcontainers.internal:%d", broker.mappedPort(TestZeebePort.GATEWAY));
     if (zeebeContactPoint != null) {
       tasklistContainer.withEnv("CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS", zeebeContactPoint);
     }
   }
 
-  public ZeebeContainer startZeebe(final String version, final TestContext<?> testContext) {
-    return startZeebe("", version, testContext);
-  }
-
-  public ZeebeContainer startZeebe(
-      final String host, final String version, final TestContext<?> testContext) {
+  public TestStandaloneBroker startStandaloneBroker(final TestContext<?> testContext) {
     if (broker == null) {
-      LOGGER.info("************ Starting Zeebe {} ************", version);
       broker =
-          new ZeebeContainer(DockerImageName.parse(host + "camunda/zeebe:" + version))
-              .withNetwork(testContext.getNetwork())
-              .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
-              .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
-              .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
-              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
-              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
-              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
-              .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
-
-      if (testContext.getZeebeDataFolder() != null) {
-        broker.withCreateContainerCmdModifier(
-            cmd -> {
-              final String zeebeDataFolderPath = testContext.getZeebeDataFolder().getPath();
-              final String bindVolume = zeebeDataFolderPath + ":/usr/local/zeebe/data";
-              cmd.withUser("1001:0")
-                  .getHostConfig()
-                  .withBinds(Bind.parse(bindVolume))
-                  .withPrivileged(true);
-            });
-      }
-      broker.setWaitStrategy(
-          new HostPortWaitStrategy().withStartupTimeout(Duration.ofSeconds(240L)));
+          new TestStandaloneBroker()
+              .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))
+              .withSecurityConfig(
+                  cfg -> {
+                    cfg.getAuthentication().setUnprotectedApi(true);
+                    cfg.getAuthorizations().setEnabled(false);
+                    final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
+                    cfg.getInitialization().setUsers(List.of(user));
+                  });
+      LOGGER.info("************ Starting StandaloneBroker {} ************");
       addConfig(broker, testContext);
       broker.start();
-      LOGGER.info("************ Zeebe started  ************");
+      LOGGER.info("************ StandaloneBroker started  ************");
 
-      testContext.setInternalZeebeContactPoint(
-          broker.getInternalAddress(ZeebePort.GATEWAY.getPort()));
-      testContext.setZeebeGrpcAddress(broker.getGrpcAddress());
+      testContext.setInternalZeebeContactPoint(broker.address(TestZeebePort.GATEWAY));
+      testContext.setZeebeGrpcAddress(broker.grpcAddress());
     } else {
       throw new IllegalStateException("Broker is already started. Call stopZeebe first.");
     }
     return broker;
   }
 
-  protected void addConfig(final ZeebeContainer zeebeBroker, final TestContext testContext) {
+  protected void addConfig(final TestStandaloneBroker zeebeBroker, final TestContext testContext) {
     final var url =
         TestUtil.isOpenSearch()
             ? "http://%s:%s"
-                .formatted(testContext.getInternalOsHost(), testContext.getInternalOsPort())
+                .formatted(testContext.getExternalOsHost(), testContext.getExternalOsPort())
             : "http://%s:%s"
-                .formatted(testContext.getInternalElsHost(), testContext.getInternalElsPort());
+                .formatted(testContext.getExternalElsHost(), testContext.getExternalElsPort());
     final var type = TestUtil.isOpenSearch() ? "opensearch" : "elasticsearch";
-    final String exporterClassName = "io.camunda.exporter.CamundaExporter";
 
-    zeebeBroker
+    zeebeBroker.withExporter(
+        CamundaExporter.class.getSimpleName().toLowerCase(),
+        cfg -> {
+          cfg.setClassName(CamundaExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "connect",
+                  Map.of(
+                      "url",
+                      url,
+                      "type",
+                      type,
+                      "indexPrefix",
+                      testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : "",
+                      "index",
+                      Map.of(
+                          "prefix",
+                          testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : ""),
+                      "bulk",
+                      Map.of("size", 1)),
+                  "history",
+                  Map.of("waitPeriodBeforeArchiving", "1s")));
+        });
+
+    zeebeBroker.withAdditionalProperties(
+        Map.of(
+            "camunda.data.secondary-storage.type",
+            type,
+            "camunda.data.secondary-storage." + type + ".url",
+            url,
+            "camunda.database.type",
+            type,
+            "camunda.database.url",
+            url));
+
+    if (testContext.getIndexPrefix() != null) {
+      zeebeBroker.withProperty(
+          "camunda.data.secondary-storage." + type + ".index-prefix", testContext.getIndexPrefix());
+    }
+
+    /*    zeebeBroker
         // Unified Configuration: DB URL + compatibility
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_" + type.toUpperCase() + "_URL", url)
         .withEnv("CAMUNDA_DATABASE_URL", url)
@@ -560,7 +583,7 @@ public class TestContainerUtil {
       zeebeBroker.withEnv(
           "CAMUNDA_DATA_SECONDARY_STORAGE_" + type.toUpperCase() + "_INDEX_PREFIX",
           testContext.getIndexPrefix());
-    }
+    }*/
   }
 
   public void stopZeebeAndTasklist(final TestContext testContext) {
@@ -582,7 +605,7 @@ public class TestContainerUtil {
 
   protected void stopZeebe(final TestContext testContext) {
     if (broker != null) {
-      broker.shutdownGracefully(Duration.ofSeconds(3));
+      broker.close();
       broker = null;
     }
     testContext.setInternalZeebeContactPoint(null);

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -37,7 +37,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.cluster.HealthResponse;
-import org.opensearch.testcontainers.OpensearchContainer;
+import org.opensearch.testcontainers.OpenSearchContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -100,7 +100,7 @@ public class TestContainerUtil {
   private static final String APPLICATION_MEMBER_TYPE = "APPLICATION";
   private static final String TASKLIST = "tasklist";
   private ElasticsearchContainer elsContainer;
-  private OpensearchContainer osContainer;
+  private OpenSearchContainer osContainer;
   private TestStandaloneBroker broker;
   private GenericContainer tasklistContainer;
   private GenericContainer identityContainer;
@@ -260,8 +260,8 @@ public class TestContainerUtil {
   public void startOpenSearch(final TestContext testContext) {
     LOGGER.info("************ Starting OpenSearch ************");
     osContainer =
-        (OpensearchContainer)
-            new OpensearchContainer(
+        (OpenSearchContainer)
+            new OpenSearchContainer(
                     String.format(
                         "%s:%s", DOCKER_OPENSEARCH_IMAGE_NAME, DOCKER_OPENSEARCH_IMAGE_VERSION))
                 .withNetwork(Network.SHARED)

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -499,7 +499,7 @@ public class TestContainerUtil {
                     final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
                     cfg.getInitialization().setUsers(List.of(user));
                   });
-      LOGGER.info("************ Starting StandaloneBroker {} ************");
+      LOGGER.info("************ Starting StandaloneBroker ************");
       addConfig(broker, testContext);
       broker.start();
       LOGGER.info("************ StandaloneBroker started  ************");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Replace usages of `ZeebContainer` with the Spring Application of `TestStandaloneBroker`. Also, remove the step from the CI pipeline that builds the `camunda/zeebe:current-test` container that was used in the past.

This step should provide some speed up in the execution of tests for Tasklist and align it with the current approach for providint test dependencies.

Comparing this run with the previous Tasklist ES/OS IT jobs is roughly ~10min execution less.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41355
