### PR TITLE
fix: use right endpoint for rebalancing

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -393,7 +393,7 @@ jobs:
               --namespace ${{ inputs.name }} \
               --image=curlimages/curl:7.87.0 \
               --schedule="*/10 * * * *" \
-              -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
+              -- curl -L -v -X POST http://zeebe-gateway:9600/actuator/rebalance
           else
             echo "Leader balancer cronjob already exists"
           fi


### PR DESCRIPTION
## Description

When [migrating](https://camunda.slack.com/archives/C013MEVQ4M9/p1763726144029939?thread_ts=1763648223.069159&cid=C013MEVQ4M9) the release load tests I realized the leader rebalancing doesnt work

 * Load balancer was failing as it used camunda as service
<!-- Describe the goal and purpose of this PR. -->

```
$ kgpo
NAME                             READY   STATUS             RESTARTS        AGE
elastic-0                        1/1     Running            0               9m38s
elastic-1                        1/1     Running            0               9m38s
elastic-2                        1/1     Running            0               9m38s
leader-balancer-29395430-jqbmz   0/1     CrashLoopBackOff   5 (2m10s ago)   5m2s
starter-67c7db457f-47x48         1/1     Running            0               6m36s
worker-668498b749-2hdm8          1/1     Running            0               6m36s
worker-668498b749-h28cf          1/1     Running            0               6m36s
worker-668498b749-qt6vs          1/1     Running            0               6m36s
zeebe-0                          1/1     Running            0               9m38s
zeebe-1                          1/1     Running            0               9m38s
zeebe-2                          1/1     Running            0               9m38s
zeebe-gateway-5879d98959-g6q8b   1/1     Running            0               9m39s
zeebe-gateway-5879d98959-pjf9h   1/1     Running            0               9m39s
```


related #38829 



## Example 

I tried it on release-8-7-x.

```
$             kubectl create cronjob leader-balancer \
              --namespace release-8-7-x \
              --image=curlimages/curl:7.87.0 \
              --schedule="*/10 * * * *" \
              -- curl -L -v -X POST http://zeebe-gateway:9600/actuator/rebalance
cronjob.batch/leader-balancer created

```


```sh
$ k describe cronjobs.batch leader-balancer -n release-8-7-x 
Name:                          leader-balancer
Namespace:                     release-8-7-x
Labels:                        <none>
Annotations:                   <none>
Schedule:                      */10 * * * *
Concurrency Policy:            Allow
Suspend:                       False
Successful Job History Limit:  3
Failed Job History Limit:      1
Starting Deadline Seconds:     <unset>
Selector:                      <unset>
Parallelism:                   <unset>
Completions:                   <unset>
Pod Template:
  Labels:  <none>
  Containers:
   leader-balancer:
    Image:      curlimages/curl:7.87.0
    Port:       <none>
    Host Port:  <none>
    Command:
      curl
      -L
      -v
      -X
      POST
      http://zeebe-gateway:9600/actuator/rebalance
    Environment:     <none>
    Mounts:          <none>
  Volumes:           <none>
  Node-Selectors:    <none>
  Tolerations:       <none>
Last Schedule Time:  Fri, 21 Nov 2025 13:10:00 +0100
Active Jobs:         <none>
Events:
  Type    Reason            Age   From                Message
  ----    ------            ----  ----                -------
  Normal  SuccessfulCreate  108s  cronjob-controller  Created job leader-balancer-29395450
  Normal  SawCompletedJob   105s  cronjob-controller  Saw completed job: leader-balancer-29395450, condition: Complete
```

Success

```
 k logs -n release-8-7-x leader-balancer-29395450-t29xr
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 10.4.13.75:9600...
* Connected to zeebe-gateway (10.4.13.75) port 9600 (#0)
> POST /actuator/rebalance HTTP/1.1
> Host: zeebe-gateway:9600
> User-Agent: curl/7.87.0-DEV
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 
< Content-Length: 0
< Date: Fri, 21 Nov 2025 12:10:01 GMT
< 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host zeebe-gateway left intact
```