### PR TITLE
[Backport stable/8.8] test: force a default admin role for old routes redirection IT

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -24,7 +24,10 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
 
   @LocalServerPort private int port;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -9,8 +9,13 @@ package io.camunda.tasklist.webapp.controllers;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +30,7 @@ public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
   @LocalServerPort private int port;
 
   @Autowired private TestRestTemplate restTemplate;
+  @Autowired private CamundaSecurityProperties securityConfig;
 
   private String baseUrl() {
     return "http://localhost:" + port;
@@ -33,6 +39,17 @@ public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
   static Stream<String> redirectionTestDataProvider() {
     return Stream.of(
         "", "/processes", "/login", "/123456", "/processes/order/start", "/new/process_id");
+  }
+
+  @BeforeEach
+  public void setup() {
+    // force a default admin role so that AdminUserCheckFilter does not interfere and redirect to
+    // /identity/setup as otherwise we try to search in secondary storage for the roles and then
+    // things may or may not work depending on what else ran before
+    securityConfig
+        .getInitialization()
+        .getDefaultRoles()
+        .put("admin", Map.of("users", List.of(InitializationConfiguration.DEFAULT_USER_USERNAME)));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
# Description
Backport of #41309 to `stable/8.8`.

relates to #41204