### PR TITLE
Fix medic load test workflow

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -67,7 +67,7 @@ jobs:
       ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
-      realistic: 'true'
+      realistic: true
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/camunda-load-test.yml


### PR DESCRIPTION
## Description

The Medic workflow [didn't run properly](https://github.com/camunda/camunda/actions/runs/19620710931) because the input value was broken. This means no weekly load tests have been created yet.

* Use the correct type of realistic input value

