### PR TITLE
fix: show error state when variables-panel cannot load flow-node metadata

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
@@ -252,4 +252,37 @@ describe('VariablePanel', () => {
       ).not.toBeInTheDocument();
     },
   );
+
+  it.each([true, false])(
+    'should show failed placeholder if network error occurs while fetching process instance flow-node metadata - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
+        wrapper: getWrapper(),
+      });
+
+      expect(
+        await screen.findByRole('button', {name: /add variable/i}),
+      ).toBeInTheDocument();
+
+      mockFetchFlowNodeMetadata().withNetworkError();
+
+      act(() => {
+        flowNodeSelectionStore.setSelection({
+          flowNodeId: 'TEST_FLOW_NODE',
+          flowNodeInstanceId: '2',
+        });
+      });
+
+      expect(
+        await screen.findByText('Variables could not be fetched'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
 });

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -16,6 +16,7 @@ import {
 } from './flowNodeSelection';
 import {useHasMultipleInstances} from './flowNodeMetadata';
 import {getScopeId} from 'modules/utils/variables';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 
 const useHasNoContent = () => {
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
@@ -48,7 +49,7 @@ const useDisplayStatus = ({
   const hasMultipleInstances = useHasMultipleInstances();
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
 
-  if (isError) {
+  if (isError || flowNodeMetaDataStore.state.status === 'error') {
     return 'error';
   }
 


### PR DESCRIPTION
## Description

This PR addresses an infinite spinner in the variables panel when Operate is opened with RDBMS in the background (v1 APIs all return 404). I mocked all v1 endpoints that I saw in the network tab (list below), but only "flow-node metadata" is explicitly called when selecting a flow-node. Handling its error state resolved the infinite spinner problem.

```ts
//handlers.ts
http.post('/api/process-instances/:instance/flow-node-metadata', () =>
  HttpResponse.json(null, {status: 404}),
),
http.get('/api/process-instances/:instance', () =>
  HttpResponse.json(null, {status: 404}),
),
http.post('/api/flow-node-instances', () =>
  HttpResponse.json(null, {status: 404}),
),
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #38964
