### PR TITLE
ci: stop macos-arm64 bleeding

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -47,9 +47,10 @@ jobs:
         include:
           - os: macos
             runner: macos-latest-large
-          - os: macos
-            runner: macos-latest
-            arch: arm64
+          # TODO: reactivate once https://camunda.slack.com/archives/C071KP5BTHB/p1763975893969429 has been resolved
+          # - os: macos
+          #   runner: macos-latest
+          #   arch: arm64
           - os: windows
             runner: windows-latest
           - os: linux


### PR DESCRIPTION
## Description

A current issue with macos-arm64 runner images makes our CI fail more frequently. This bandaid just removes the test until the underlying issue has been fixed.
Reference Thread: https://camunda.slack.com/archives/C071KP5BTHB/p1763975893969429

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://app.incident.io/camunda/incidents/3921
