### PR TITLE
fix: do not handle incident RESOLVE records in the exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -14,9 +14,11 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,9 @@ public class FlowNodeInstanceFromIncidentHandler
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FlowNodeInstanceFromIncidentHandler.class);
+
+  private static final Set<IncidentIntent> SUPPORTED_INTENTS =
+      EnumSet.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);
 
   private final String indexName;
 
@@ -44,7 +49,7 @@ public class FlowNodeInstanceFromIncidentHandler
 
   @Override
   public boolean handlesRecord(final Record<IncidentRecordValue> record) {
-    return true;
+    return SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -26,15 +26,19 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentHandler.class);
+  private static final Set<IncidentIntent> SUPPORTED_INTENTS =
+      EnumSet.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED);
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
 
@@ -56,8 +60,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
 
   @Override
   public boolean handlesRecord(final Record<IncidentRecordValue> record) {
-    final var intent = record.getIntent();
-    return !intent.equals(IncidentIntent.RESOLVED);
+    return SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
@@ -17,9 +17,11 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +30,9 @@ public class ListViewFlowNodeFromIncidentHandler
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromIncidentHandler.class);
+
+  private static final Set<IncidentIntent> SUPPORTED_INTENTS =
+      EnumSet.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);
 
   private final String indexName;
 
@@ -47,7 +52,7 @@ public class ListViewFlowNodeFromIncidentHandler
 
   @Override
   public boolean handlesRecord(final Record<IncidentRecordValue> record) {
-    return true;
+    return SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.time.OffsetDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -23,7 +24,7 @@ public class PostImporterQueueFromIncidentHandler
     implements ExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
 
   private static final Set<IncidentIntent> SUPPORTED_INTENTS =
-      Set.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);
+      EnumSet.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);
   private final String indexName;
 
   public PostImporterQueueFromIncidentHandler(final String indexName) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class FlowNodeInstanceFromIncidentHandlerTest {
 
@@ -153,5 +155,28 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
 
     // then
     assertThat(flowNodeInstanceEntity.getIncidentKey()).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"CREATED", "MIGRATED", "RESOLVED"})
+  void shouldHandleRecordWithSupportedIntent(final IncidentIntent intent) {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleResolveIntentRecords() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVE));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -46,12 +46,6 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
   }
 
   @Test
-  public void shouldHandleRecord() {
-    final Record<IncidentRecordValue> incidentRecord = factory.generateRecord(ValueType.INCIDENT);
-    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
-  }
-
-  @Test
   public void shouldGenerateIds() {
     // given
     final IncidentRecordValue incidentRecordValue =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -54,16 +54,6 @@ public class IncidentHandlerTest {
     assertThat(underTest.getEntityType()).isEqualTo(IncidentEntity.class);
   }
 
-  @Test
-  void shouldHandleRecord() {
-    // given
-    final Record<IncidentRecordValue> incidentRecord =
-        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.CREATED));
-
-    // when - then
-    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
-  }
-
   @ParameterizedTest
   @EnumSource(
       value = IncidentIntent.class,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -35,6 +35,8 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class IncidentHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -62,14 +64,30 @@ public class IncidentHandlerTest {
     assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
   }
 
-  @Test
-  void shouldNotHandleRecord() {
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"RESOLVE", "RESOLVED"})
+  void shouldNotHandleRecordWithUnsupportedIntent(final IncidentIntent intent) {
     // given
     final Record<IncidentRecordValue> incidentRecord =
-        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVED));
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(intent));
 
     // when - then
     assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"CREATED", "MIGRATED"})
+  void shouldHandleRecordWithSupportedIntent(final IncidentIntent intent) {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
 public class ListViewFlowNodeFromIncidentHandlerTest {
@@ -137,5 +139,28 @@ public class ListViewFlowNodeFromIncidentHandlerTest {
     underTest.updateEntity(incidentRecord, flowNodeInstanceForListViewEntity);
     // then
     assertThat(flowNodeInstanceForListViewEntity.getErrorMessage()).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"CREATED", "MIGRATED", "RESOLVED"})
+  void shouldHandleRecordWithSupportedIntent(final IncidentIntent intent) {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleResolveIntentRecords() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVE));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Mockito;
 
 public class ListViewFlowNodeFromIncidentHandlerTest {
 
@@ -41,12 +40,6 @@ public class ListViewFlowNodeFromIncidentHandlerTest {
   @Test
   public void testGetEntityType() {
     assertThat(underTest.getEntityType()).isEqualTo(FlowNodeInstanceForListViewEntity.class);
-  }
-
-  @Test
-  public void shouldHandlesRecord() {
-    final Record<IncidentRecordValue> mockIncidentRecord = Mockito.mock(Record.class);
-    assertThat(underTest.handlesRecord(mockIncidentRecord)).isTrue();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class PostImporterQueueFromIncidentHandlerTest {
 
@@ -40,11 +42,14 @@ public class PostImporterQueueFromIncidentHandlerTest {
     assertThat(underTest.getEntityType()).isEqualTo(PostImporterQueueEntity.class);
   }
 
-  @Test
-  void shouldHandleRecord() {
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"CREATED", "MIGRATED", "RESOLVED"})
+  void shouldHandleRecordWithSupportedIntent(final IncidentIntent intent) {
     // given
     final Record<IncidentRecordValue> incidentRecord =
-        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.CREATED));
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(intent));
 
     // when - then
     assertThat(underTest.handlesRecord(incidentRecord)).isTrue();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Details can be found [here](https://github.com/camunda/camunda/issues/39636#issuecomment-3553582397)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39636 
