### PR TITLE
ci: revert stop macos-arm64 bleeding

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -47,10 +47,9 @@ jobs:
         include:
           - os: macos
             runner: macos-latest-large
-          # TODO: reactivate once https://camunda.slack.com/archives/C071KP5BTHB/p1763975893969429 has been resolved
-          # - os: macos
-          #   runner: macos-latest
-          #   arch: arm64
+          - os: macos
+            runner: macos-latest
+            arch: arm64
           - os: windows
             runner: windows-latest
           - os: linux


### PR DESCRIPTION
## Description

Revert for https://github.com/camunda/camunda/pull/41384 since upstream claims the issue is mitigated https://github.com/actions/runner-images/issues/13341#issuecomment-3570231171

This reverts commit 6be973b57285b8e9a45c106d25db6376b03bdf8f.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - not needed since original workaround was not backported (backports got aborted due to upstream claiming the issue is resolved)

## Related issues

Related to https://app.incident.io/camunda/incidents/3921