### PR TITLE
fix: C8Run Docker shutdown docker fix

### DIFF
--- a/c8run/shutdown.sh
+++ b/c8run/shutdown.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./c8run stop
+./c8run stop "$@"


### PR DESCRIPTION
## Description

shundown.sh just missed ability to proxy passed flags to c8run and always tries to shutdown local standalone installation instead of docker version

closes #37323 
