### PR TITLE
[Backport stable/8.8] fix: add missing key field to UserFilter.toBuilder()

### DIFF
--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
@@ -30,6 +30,7 @@ public record UserFilter(
 
   public Builder toBuilder() {
     return new Builder()
+        .key(key)
         .usernameOperations(usernameOperations)
         .nameOperations(nameOperations)
         .emailOperations(emailOperations)


### PR DESCRIPTION
# Description
Backport of #41186 to `stable/8.8`.

relates to 