### PR TITLE
Fix errors with TaskService in tests

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -378,7 +378,7 @@ public class TaskService {
     return new String[] {
       TAG_KEY_BPMN_PROCESS_ID, task.getBpmnProcessId(),
       TAG_KEY_FLOW_NODE_ID, task.getFlowNodeBpmnId(),
-      TAG_KEY_USER_ID, keyUserId,
+      TAG_KEY_USER_ID, Optional.ofNullable(keyUserId).orElse(DEFAULT_USER),
       TAG_KEY_ORGANIZATION_ID, organizationService.getOrganizationIfPresent()
     };
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -9,7 +9,6 @@ package io.camunda.tasklist.webapp.service;
 
 import static io.camunda.tasklist.Metrics.*;
 import static io.camunda.tasklist.util.CollectionUtil.countNonNullObjects;
-import static io.camunda.tasklist.webapp.service.OrganizationService.DEFAULT_ORGANIZATION;
 import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNullElse;
 
@@ -18,7 +17,6 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
-import io.camunda.tasklist.property.Auth0Properties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.FormStore;
 import io.camunda.tasklist.store.FormStore.FormIdView;
@@ -381,11 +379,5 @@ public class TaskService {
       TAG_KEY_USER_ID, Optional.ofNullable(keyUserId).orElse(DEFAULT_USER),
       TAG_KEY_ORGANIZATION_ID, organizationService.getOrganizationIfPresent()
     };
-  }
-
-  private String getOrganizationIfPresent() {
-    return Optional.ofNullable(tasklistProperties.getAuth0())
-        .map(Auth0Properties::getOrganization)
-        .orElse(DEFAULT_ORGANIZATION);
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -376,8 +376,8 @@ public class TaskService {
     }
 
     return new String[] {
-      TAG_KEY_BPMN_PROCESS_ID, task.getBpmnProcessId(),
-      TAG_KEY_FLOW_NODE_ID, task.getFlowNodeBpmnId(),
+      TAG_KEY_BPMN_PROCESS_ID, Optional.ofNullable(task.getBpmnProcessId()).orElse("unknown"),
+      TAG_KEY_FLOW_NODE_ID, Optional.ofNullable(task.getFlowNodeBpmnId()).orElse("unknown"),
       TAG_KEY_USER_ID, Optional.ofNullable(keyUserId).orElse(DEFAULT_USER),
       TAG_KEY_ORGANIZATION_ID, organizationService.getOrganizationIfPresent()
     };

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -437,6 +437,8 @@ class TaskServiceTest {
 
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(mock(CamundaAuthentication.class));
+    when(authenticationProvider.getCamundaAuthentication().authenticatedClientId())
+        .thenReturn("testclientid");
     final var taskBefore = mock(TaskEntity.class);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
     final var completedTask =
@@ -455,6 +457,7 @@ class TaskServiceTest {
     // Then
     verify(taskValidator).validateCanComplete(taskBefore);
     verify(tasklistServicesAdapter).completeUserTask(eq(taskBefore), any());
+    verify(metrics).recordCounts(eq("completed.tasks"), eq(1L), any(String[].class));
     verify(variableService).persistTaskVariables(taskId, variables, List.of(runtimeVariable), true);
     verify(variableService).deleteDraftTaskVariables(taskId);
     assertThat(result).isEqualTo(TaskDTO.createFrom(completedTask, objectMapper));
@@ -468,6 +471,8 @@ class TaskServiceTest {
 
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(mock(CamundaAuthentication.class));
+    when(authenticationProvider.getCamundaAuthentication().authenticatedClientId())
+        .thenReturn("testclientid");
     final var taskBefore = mock(TaskEntity.class);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
     final var completedTask =
@@ -486,6 +491,7 @@ class TaskServiceTest {
     // Then
     verify(taskValidator).validateCanComplete(taskBefore);
     verify(tasklistServicesAdapter).completeUserTask(eq(taskBefore), any());
+    verify(metrics).recordCounts(eq("completed.tasks"), eq(1L), any(String[].class));
     verify(variableService).persistTaskVariables(taskId, variables, List.of(runtimeVariable), true);
     verify(variableService).deleteDraftTaskVariables(taskId);
     assertThat(result).isEqualTo(TaskDTO.createFrom(completedTask, objectMapper));


### PR DESCRIPTION
## Description

In `BackupRestoreTest` I was seeing these errors being logged:

```
[2025-11-24 13:49:48.253] [http-nio-0.0.0.0-8080-exec-5] ERROR io.camunda.tasklist.webapp.service.TaskService - Error updating completed task metric for task with ID: 2251799813685631
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Unknown Source)
	at io.micrometer.core.instrument.ImmutableTag.<init>(ImmutableTag.java:37)
	at io.micrometer.core.instrument.Tag.of(Tag.java:31)
	at io.micrometer.core.instrument.Tags.of(Tags.java:367)
	at io.micrometer.core.instrument.MeterRegistry.counter(MeterRegistry.java:453)
	at io.camunda.tasklist.Metrics.recordCounts(Metrics.java:77)
	at io.camunda.tasklist.webapp.service.TaskService.updateCompletedMetric(TaskService.java:353)
	at io.camunda.tasklist.webapp.service.TaskService.completeTask(TaskService.java:256)
	at io.camunda.tasklist.webapp.api.rest.v1.controllers.TaskController.completeTask(TaskController.java:407)
```

This tweaks the `TaskService` class to stop those happening by ensuring we always return a non-null value for the `userId` tag for metrics.

Also tweaked the `TaskServiceTest` class as that was showing errors too (plus verifying metrics get recorded there too).

