### PR TITLE
ci: remove `macos-latest-large` runners

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -42,11 +42,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos, windows, linux ]
+        os: [ windows, linux ]
         arch: [ amd64 ]
         include:
-          - os: macos
-            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
## Description
The `macos-latest-large` runners incur cost, even on public repositories. So we agreed on removing those runners from our CI: https://camunda.slack.com/archives/C9LLZAJMQ/p1763970946467789

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
