### PR TITLE
[Backport stable/8.6] perf: when reading object do not start matching from first property

### DIFF
--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -103,8 +103,10 @@ public class ObjectValue extends BaseValue {
       BaseProperty<? extends BaseValue> prop = null;
 
       for (int k = 0; k < declaredProperties.size(); ++k) {
-        // optimistically start from the same index as the map
-        // we serialize the keys in order, it's our best guess
+        // Cycle on all declared properties, but start iterating through them
+        // by starting on i:
+        // keys are serialized in the same order, so in most cases we can find the right
+        // key without having to iterate on declaredProperties at all.
         final var index = (i + k) % declaredProperties.size();
         final BaseProperty<?> declaredProperty = declaredProperties.get(index);
         final StringValue declaredKey = declaredProperty.getKey();

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -103,7 +103,10 @@ public class ObjectValue extends BaseValue {
       BaseProperty<? extends BaseValue> prop = null;
 
       for (int k = 0; k < declaredProperties.size(); ++k) {
-        final BaseProperty<?> declaredProperty = declaredProperties.get(k);
+        // optimistically start from the same index as the map
+        // we serialize the keys in order, it's our best guess
+        final var index = (i + k) % declaredProperties.size();
+        final BaseProperty<?> declaredProperty = declaredProperties.get(index);
         final StringValue declaredKey = declaredProperty.getKey();
 
         if (declaredKey.equals(decodedKey)) {
@@ -142,6 +145,18 @@ public class ObjectValue extends BaseValue {
     length += getEncodedLength(undeclaredProperties);
 
     return length;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("{");
+
+    writeJson(builder, declaredProperties);
+    writeJson(builder, undeclaredProperties);
+
+    builder.append("}");
+    return builder.toString();
   }
 
   private <T extends BaseProperty<?>> void writeJson(

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -128,14 +128,7 @@ public class ObjectValue extends BaseValue {
       }
     }
 
-    // verify that all required properties are set
-    for (int p = 0; p < declaredProperties.size(); p++) {
-      final BaseProperty<?> prop = declaredProperties.get(p);
-      if (!prop.hasValue()) {
-        throw new RuntimeException(
-            String.format("Property '%s' has no valid value", prop.getKey()));
-      }
-    }
+    verifyAllDeclaredPropertiesAreSet();
   }
 
   @Override
@@ -159,6 +152,15 @@ public class ObjectValue extends BaseValue {
 
     builder.append("}");
     return builder.toString();
+  }
+
+  private void verifyAllDeclaredPropertiesAreSet() {
+    for (final BaseProperty<?> prop : declaredProperties) {
+      if (!prop.hasValue()) {
+        throw new RuntimeException(
+            String.format("Property '%s' has no valid value", prop.getKey()));
+      }
+    }
   }
 
   private <T extends BaseProperty<?>> void writeJson(


### PR DESCRIPTION
# Description
Backport of #40969 to `stable/8.6`.

relates to #41014