### PR TITLE
feat: use process instance incident resolution endpoint

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstanceOperations.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstanceOperations.tsx
@@ -8,11 +8,12 @@
 
 import {Operations} from 'modules/components/Operations';
 import {notificationsStore} from 'modules/stores/notifications';
-import {handleOperationError as handleOperationErrorUtil} from 'modules/utils/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {tracking} from 'modules/tracking';
-import {operationsStore, type ErrorHandler} from 'modules/stores/operations';
+import {operationsStore} from 'modules/stores/operations';
 import {useCancelProcessInstance} from 'modules/mutations/processInstance/useCancelProcessInstance';
+import {useResolveProcessInstanceIncidents} from 'modules/mutations/processInstance/useResolveProcessInstanceIncidents';
 import type {OperationConfig} from 'modules/components/Operations/types';
 import type {OperationEntityType} from 'modules/types/operate';
 import {logger} from 'modules/logger';
@@ -49,9 +50,26 @@ const InstanceOperations: React.FC<Props> = ({
     },
   });
 
-  const handleOperationError: ErrorHandler = ({statusCode}) => {
-    handleOperationErrorUtil(statusCode);
-  };
+  const {
+    mutate: resolveProcessInstanceIncidents,
+    isPending: isResolveIncidentsPending,
+  } = useResolveProcessInstanceIncidents(processInstanceKey, {
+    onError: (error) => {
+      processInstancesStore.unmarkProcessInstancesWithActiveOperations({
+        instanceIds: [processInstanceKey],
+        operationType: 'RESOLVE_INCIDENT',
+      });
+
+      handleOperationError(error.status);
+    },
+    onSuccess: () => {
+      tracking.track({
+        eventName: 'single-operation',
+        operationType: 'RESOLVE_INCIDENT',
+        source: 'instances-list',
+      });
+    },
+  });
 
   const handleOperationSuccess = (operationType: OperationEntityType) => {
     tracking.track({
@@ -61,7 +79,8 @@ const InstanceOperations: React.FC<Props> = ({
     });
   };
 
-  const applyOperation = async (operationType: OperationEntityType) => {
+  const handleDelete = async () => {
+    const operationType = 'DELETE_PROCESS_INSTANCE';
     try {
       processInstancesStore.markProcessInstancesWithActiveOperations({
         ids: [processInstanceKey],
@@ -78,7 +97,7 @@ const InstanceOperations: React.FC<Props> = ({
             instanceIds: [processInstanceKey],
             operationType,
           });
-          handleOperationError(error);
+          handleOperationError(error.statusCode);
         },
         onSuccess: () => handleOperationSuccess(operationType),
       });
@@ -91,19 +110,21 @@ const InstanceOperations: React.FC<Props> = ({
     }
   };
 
-  const handleDelete = () => {
-    applyOperation('DELETE_PROCESS_INSTANCE');
-  };
-
   const operations: OperationConfig[] = [];
 
   if (isInstanceActive && hasIncident) {
     operations.push({
       type: 'RESOLVE_INCIDENT',
       onExecute: () => {
-        applyOperation('RESOLVE_INCIDENT');
+        processInstancesStore.markProcessInstancesWithActiveOperations({
+          ids: [processInstanceKey],
+          operationType: 'RESOLVE_INCIDENT',
+        });
+        resolveProcessInstanceIncidents();
       },
-      disabled: activeOperations.includes('RESOLVE_INCIDENT'),
+      disabled:
+        isResolveIncidentsPending ||
+        activeOperations.includes('RESOLVE_INCIDENT'),
     });
   }
 
@@ -134,7 +155,9 @@ const InstanceOperations: React.FC<Props> = ({
   const isLoading =
     processInstancesStore.processInstanceIdsWithActiveOperations.includes(
       processInstanceKey,
-    ) || isCancelProcessInstancePending;
+    ) ||
+    isCancelProcessInstancePending ||
+    isResolveIncidentsPending;
 
   return (
     <Operations

--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstanceOperations.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstanceOperations.tsx
@@ -63,11 +63,7 @@ const InstanceOperations: React.FC<Props> = ({
       handleOperationError(error.status);
     },
     onSuccess: () => {
-      tracking.track({
-        eventName: 'single-operation',
-        operationType: 'RESOLVE_INCIDENT',
-        source: 'instances-list',
-      });
+      handleOperationSuccess('RESOLVE_INCIDENT');
     },
   });
 

--- a/operate/client/src/modules/api/v2/processInstances/resolveProcessInstanceIncidents.ts
+++ b/operate/client/src/modules/api/v2/processInstances/resolveProcessInstanceIncidents.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type ResolveProcessInstanceIncidentsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {requestWithThrow} from 'modules/request';
+
+const resolveProcessInstanceIncidents = (processInstanceKey: string) => {
+  return requestWithThrow<ResolveProcessInstanceIncidentsResponseBody>({
+    url: endpoints.resolveProcessInstanceIncidents.getUrl({
+      processInstanceKey,
+    }),
+    method: endpoints.resolveProcessInstanceIncidents.method,
+  });
+};
+
+export {resolveProcessInstanceIncidents};

--- a/operate/client/src/modules/mocks/api/v2/processInstances/resolveProcessInstanceIncidents.ts
+++ b/operate/client/src/modules/mocks/api/v2/processInstances/resolveProcessInstanceIncidents.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+import {mockPostRequest} from '../../mockRequest';
+
+const mockResolveProcessInstanceIncidents = (contextPath = '') =>
+  mockPostRequest(
+    `${contextPath}${endpoints.resolveProcessInstanceIncidents.getUrl({processInstanceKey: ':processInstanceKey'})}`,
+  );
+
+export {mockResolveProcessInstanceIncidents};

--- a/operate/client/src/modules/mutations/processInstance/useResolveProcessInstanceIncidents.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useResolveProcessInstanceIncidents.tsx
@@ -55,7 +55,10 @@ function useResolveProcessInstanceIncidents(
             throw error;
           }
 
-          if (['ACTIVE', 'CREATED'].includes(batchOperation.state)) {
+          if (
+            batchOperation.state === 'ACTIVE' ||
+            batchOperation.state === 'CREATED'
+          ) {
             throw new Error('batch operation is still active');
           }
 

--- a/operate/client/src/modules/mutations/processInstance/useResolveProcessInstanceIncidents.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useResolveProcessInstanceIncidents.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ResolveProcessInstanceIncidentsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query';
+import {getBatchOperation} from 'modules/api/v2/batchOperations/getBatchOperation';
+import {resolveProcessInstanceIncidents} from 'modules/api/v2/processInstances/resolveProcessInstanceIncidents';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+type Options = Omit<
+  UseMutationOptions<
+    ResolveProcessInstanceIncidentsResponseBody,
+    {status?: number; statusText?: string},
+    void,
+    unknown
+  >,
+  'mutationFn'
+>;
+
+function useResolveProcessInstanceIncidents(
+  processInstanceKey: string,
+  options?: Options,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...options,
+    mutationFn: async () => {
+      const {response, error} =
+        await resolveProcessInstanceIncidents(processInstanceKey);
+      if (response === null) {
+        throw {
+          status: error.response?.status,
+          statusText: error.response?.statusText,
+        };
+      }
+
+      await queryClient.fetchQuery({
+        queryKey: queryKeys.batchOperations.get(response.batchOperationKey),
+        queryFn: async () => {
+          const {response: batchOperation, error} = await getBatchOperation({
+            batchOperationKey: response.batchOperationKey,
+          });
+
+          if (error !== null) {
+            throw error;
+          }
+
+          if (['ACTIVE', 'CREATED'].includes(batchOperation.state)) {
+            throw new Error('batch operation is still active');
+          }
+
+          return batchOperation;
+        },
+        retry: true,
+      });
+
+      return response;
+    },
+  });
+}
+
+export {useResolveProcessInstanceIncidents};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -132,6 +132,9 @@ const queryKeys = {
       payload,
     ],
   },
+  batchOperations: {
+    get: (batchOperationKey: string) => ['batchOperation', batchOperationKey],
+  },
 };
 
 export {queryKeys};


### PR DESCRIPTION
## Description

Migrates incident resolution from the deprecated v1 operations endpoint to the new v2 process instance-specific endpoint.

### Key Changes
- New API layer: Added resolveProcessInstanceIncidents() API method and useResolveProcessInstanceIncidents() mutation hook that polls batch operation status until completion
- Updated UI components: Both ProcessInstanceHeader and InstancesTable now use the new v2 endpoint instead of legacy operations
- Simplified state management: Removed v1 polling workaround, now uses mutation hook's built-in isPending state
- Better error handling: Added specific handling for permission errors (403)
- Updated tests: All tests now mock v2 endpoint with new permission error coverage

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38411 
