### PR TITLE
Add full support for is truncated value for cluster variable

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -88,9 +88,12 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
   ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn);
 
   /**
-   * Filters cluster variables by whether the value is truncated or not.
+   * Filters cluster variables by truncation status in storage.
+   * When true, returns only variables whose stored values are truncated (i.e., their values exceed the storage size limit and are not fully persisted).
+   * When false, returns only variables with non-truncated stored values.
+   * This filter is based on the underlying storage characteristic, not the response format.
    *
-   * @param isTruncated true if the value is truncated, false otherwise
+   * @param isTruncated true to filter for truncated values, false for non-truncated values
    * @return the updated filter
    */
   ClusterVariableFilter isTruncated(final Boolean isTruncated);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -88,10 +88,10 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
   ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn);
 
   /**
-   * Filters cluster variables by truncation status in storage.
-   * When true, returns only variables whose stored values are truncated (i.e., their values exceed the storage size limit and are not fully persisted).
-   * When false, returns only variables with non-truncated stored values.
-   * This filter is based on the underlying storage characteristic, not the response format.
+   * Filters cluster variables by truncation status in storage. When true, returns only variables
+   * whose stored values are truncated (i.e., their values exceed the storage size limit and are not
+   * fully persisted). When false, returns only variables with non-truncated stored values. This
+   * filter is based on the underlying storage characteristic, not the response format.
    *
    * @param isTruncated true to filter for truncated values, false for non-truncated values
    * @return the updated filter

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -86,4 +86,12 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn);
+
+  /**
+   * Filters cluster variables by whether the value is truncated or not.
+   *
+   * @param isTruncated true if the value is truncated, false otherwise
+   * @return the updated filter
+   */
+  ClusterVariableFilter isTruncated(final Boolean isTruncated);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClusterVariableSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClusterVariableSearchRequest.java
@@ -22,4 +22,16 @@ import io.camunda.client.api.search.sort.ClusterVariableSort;
 public interface ClusterVariableSearchRequest
     extends TypedSearchRequest<
             ClusterVariableFilter, ClusterVariableSort, ClusterVariableSearchRequest>,
-        FinalSearchRequestStep<ClusterVariable> {}
+        FinalSearchRequestStep<ClusterVariable> {
+
+  /**
+   * Requests that full variable values be returned in the search results.
+   *
+   * <p>By default, long variable values in search results are truncated. This method allows you to
+   * retrieve the complete, untruncated values of all cluster variables matching the search
+   * criteria.
+   *
+   * @return this search request with full values enabled
+   */
+  VariableSearchRequest withFullValues();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClusterVariableSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClusterVariableSearchRequest.java
@@ -33,5 +33,5 @@ public interface ClusterVariableSearchRequest
    *
    * @return this search request with full values enabled
    */
-  VariableSearchRequest withFullValues();
+  ClusterVariableSearchRequest withFullValues();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
@@ -19,15 +19,18 @@ import io.camunda.client.api.search.enums.ClusterVariableScope;
 
 public interface ClusterVariable {
 
-  /* The name of the variable */
+  /* The name of the cluster variable */
   String getName();
 
-  /* The value of the variable */
+  /* The value of the cluster variable */
   String getValue();
 
-  /* The tenant id of the variable */
+  /* The tenant id of the cluster variable */
   String getTenantId();
 
-  /* The scope of the variable */
+  /* The scope of the cluster variable */
   ClusterVariableScope getScope();
+
+  /* Check if the cluster variable is truncated */
+  Boolean isTruncated();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
@@ -31,6 +31,13 @@ public interface ClusterVariable {
   /* The scope of the cluster variable */
   ClusterVariableScope getScope();
 
-  /* Check if the cluster variable is truncated */
+  /**
+   * Indicates whether the returned value has been truncated.
+   * <p>
+   * Returns {@code true} when the variable value is large and truncation was requested
+   * (default search behavior). Returns {@code false} when full values are requested via
+   * {@code withFullValues()} or the value is not large enough to require truncation.
+   * Always returns {@code false} for get-by-name operations, which always return full values.
+   */
   Boolean isTruncated();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
@@ -33,11 +33,11 @@ public interface ClusterVariable {
 
   /**
    * Indicates whether the returned value has been truncated.
-   * <p>
-   * Returns {@code true} when the variable value is large and truncation was requested
-   * (default search behavior). Returns {@code false} when full values are requested via
-   * {@code withFullValues()} or the value is not large enough to require truncation.
-   * Always returns {@code false} for get-by-name operations, which always return full values.
+   *
+   * <p>Returns {@code true} when the variable value is large and truncation was requested (default
+   * search behavior). Returns {@code false} when full values are requested via {@code
+   * withFullValues()} or the value is not large enough to require truncation. Always returns {@code
+   * false} for get-by-name operations, which always return full values.
    */
   Boolean isTruncated();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
@@ -92,6 +92,12 @@ public class ClusterVariableFilterImpl
   }
 
   @Override
+  public ClusterVariableFilter isTruncated(final Boolean isTruncated) {
+    filter.setIsTruncated(isTruncated);
+    return this;
+  }
+
+  @Override
   protected ClusterVariableSearchQueryFilterRequest getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClusterVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClusterVariableSearchRequestImpl.java
@@ -25,7 +25,6 @@ import io.camunda.client.api.search.filter.ClusterVariableFilter;
 import io.camunda.client.api.search.request.ClusterVariableSearchRequest;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.SearchRequestPage;
-import io.camunda.client.api.search.request.VariableSearchRequest;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ClusterVariableSort;
@@ -69,7 +68,9 @@ public class ClusterVariableSearchRequestImpl
   public CamundaFuture<SearchResponse<ClusterVariable>> send() {
     final HttpCamundaFuture<SearchResponse<ClusterVariable>> result = new HttpCamundaFuture<>();
     final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("truncateValues", String.valueOf(!withFullValues));
+    if (withFullValues) {
+      queryParams.put("truncateValues", String.valueOf(false));
+    }
     httpClient.post(
         "/cluster-variables/search",
         queryParams,
@@ -122,8 +123,8 @@ public class ClusterVariableSearchRequestImpl
   }
 
   @Override
-  public VariableSearchRequest withFullValues() {
+  public ClusterVariableSearchRequest withFullValues() {
     withFullValues = true;
-    return null;
+    return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClusterVariableSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClusterVariableSearchRequestImpl.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.search.filter.ClusterVariableFilter;
 import io.camunda.client.api.search.request.ClusterVariableSearchRequest;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.request.VariableSearchRequest;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ClusterVariableSort;
@@ -34,6 +35,8 @@ import io.camunda.client.impl.search.response.SearchResponseMapper;
 import io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest;
 import io.camunda.client.protocol.rest.ClusterVariableSearchQueryResult;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -46,6 +49,7 @@ public class ClusterVariableSearchRequestImpl
   private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
+  private boolean withFullValues = false;
 
   public ClusterVariableSearchRequestImpl(
       final HttpClient httpClient, final JsonMapper jsonMapper) {
@@ -64,8 +68,11 @@ public class ClusterVariableSearchRequestImpl
   @Override
   public CamundaFuture<SearchResponse<ClusterVariable>> send() {
     final HttpCamundaFuture<SearchResponse<ClusterVariable>> result = new HttpCamundaFuture<>();
+    final Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("truncateValues", String.valueOf(!withFullValues));
     httpClient.post(
         "/cluster-variables/search",
+        queryParams,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         ClusterVariableSearchQueryResult.class,
@@ -112,5 +119,11 @@ public class ClusterVariableSearchRequestImpl
   @Override
   protected ClusterVariableSearchQueryRequest getSearchRequestProperty() {
     return request;
+  }
+
+  @Override
+  public VariableSearchRequest withFullValues() {
+    withFullValues = true;
+    return null;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ClusterVariableImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.ClusterVariableSearchResult;
 
 public class ClusterVariableImpl implements ClusterVariable {
 
@@ -26,12 +27,22 @@ public class ClusterVariableImpl implements ClusterVariable {
   private final String value;
   private final String tenantId;
   private final ClusterVariableScope scope;
+  private final Boolean isTruncated;
 
-  public ClusterVariableImpl(final ClusterVariableResult item) {
-    name = item.getName();
-    value = item.getValue();
-    tenantId = item.getTenantId();
-    scope = EnumUtil.convert(item.getScope(), ClusterVariableScope.class);
+  public ClusterVariableImpl(final ClusterVariableResult clusterVariableResult) {
+    name = clusterVariableResult.getName();
+    value = clusterVariableResult.getValue();
+    tenantId = clusterVariableResult.getTenantId();
+    scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
+    isTruncated = false;
+  }
+
+  public ClusterVariableImpl(final ClusterVariableSearchResult clusterVariableSearchResult) {
+    name = clusterVariableSearchResult.getName();
+    value = clusterVariableSearchResult.getValue();
+    tenantId = clusterVariableSearchResult.getTenantId();
+    scope = EnumUtil.convert(clusterVariableSearchResult.getScope(), ClusterVariableScope.class);
+    isTruncated = clusterVariableSearchResult.getIsTruncated();
   }
 
   @Override
@@ -52,5 +63,10 @@ public class ClusterVariableImpl implements ClusterVariable {
   @Override
   public ClusterVariableScope getScope() {
     return scope;
+  }
+
+  @Override
+  public Boolean isTruncated() {
+    return isTruncated;
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -126,6 +126,10 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.variableOperationCondition"/>
         </foreach>
       </if>
+
+      <if test="filter.isTruncated != null">
+        AND IS_PREVIEW = #{filter.isTruncated}
+      </if>
     </where>
   </sql>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
@@ -870,10 +870,7 @@ public class ClusterVariableSearchTest {
     assertThat(response.items()).isNotEmpty();
     assertThat(response.items())
         // Verify that the large variable is not in the results
-        .noneSatisfy(
-            item -> {
-              assertThat(item.getName()).isEqualTo(largeVarName);
-            });
+        .noneMatch(item -> item.getName().equals(largeVarName));
     // Verify all returned items are not truncated
     assertThat(response.items())
         .allSatisfy(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchTest.java
@@ -54,6 +54,11 @@ public class ClusterVariableSearchTest {
   private static String tenantVarValueTenantOnly;
   private static String tenantIdTenantOnly;
 
+  // Test data - Large variables for truncation testing
+  private static String largeVarName;
+  private static String largeVarValue;
+  private static final int LARGE_VALUE_SIZE = 10000; // Create a large value to trigger truncation
+
   @BeforeAll
   static void setupClusterVariables() {
     // Setup global scoped variables
@@ -131,6 +136,16 @@ public class ClusterVariableSearchTest {
         .send()
         .join();
 
+    // Setup large variable for truncation testing
+    largeVarName = "largeVar_" + UUID.randomUUID();
+    largeVarValue = "x".repeat(LARGE_VALUE_SIZE);
+
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(largeVarName, largeVarValue)
+        .send()
+        .join();
+
     // Wait for all variables to be indexed
     TestHelper.waitForClusterVariablesToBeIndexed(
         camundaClient,
@@ -142,7 +157,8 @@ public class ClusterVariableSearchTest {
             globalVarNameMixed, globalVarValueMixed,
             tenantVarNameMixed, tenantVarValueMixed,
             globalVarNameTenantOnly, globalVarValueTenantOnly,
-            tenantVarNameTenantOnly, tenantVarValueTenantOnly));
+            tenantVarNameTenantOnly, tenantVarValueTenantOnly,
+            largeVarName, largeVarValue));
   }
 
   // ============ SEARCH TESTS ============
@@ -763,5 +779,144 @@ public class ClusterVariableSearchTest {
     final var names = response.items().stream().map(ClusterVariable::getName).toList();
     final var sortedNames = names.stream().sorted().toList();
     assertThat(names).containsExactlyElementsOf(sortedNames);
+  }
+
+  // ============ TRUNCATION AND FULL VALUES TESTS ============
+
+  @Test
+  void shouldSearchClusterVariablesWithTruncatedValues() {
+    // when - search without withFullValues (default truncation)
+    final var response =
+        camundaClient.newClusterVariableSearchRequest().sort(s -> s.name().asc()).send().join();
+
+    // then - verify the large variable is returned but truncated
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anyMatch(
+            item -> {
+              if (item.getName().equals(largeVarName)) {
+                // The value should be truncated (shorter than the original)
+                final String truncatedValue = item.getValue();
+                assertThat(truncatedValue).isNotNull();
+                // When truncated, it should be significantly shorter than the original
+                return truncatedValue.length() < largeVarValue.length() + 100; // +100 for JSON
+                // encoding
+              }
+              return false;
+            });
+  }
+
+  @Test
+  void shouldSearchClusterVariablesWithFullValuesReturnsCompleteValue() {
+    // when - search with withFullValues() to get untruncated values
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .withFullValues()
+            .sort(s -> s.name().asc())
+            .send()
+            .join();
+
+    // then - verify the large variable is returned with full value
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anyMatch(
+            item -> {
+              if (item.getName().equals(largeVarName)) {
+                // The value should contain the full large value (in JSON string format: "xxx...")
+                final String fullValue = item.getValue();
+                assertThat(fullValue).isNotNull();
+                // Verify it contains most of the repeated characters (accounting for JSON encoding)
+                return fullValue.contains("xxx")
+                    && fullValue.length() > largeVarValue.length() - 100;
+              }
+              return false;
+            });
+  }
+
+  @Test
+  void shouldFilterClusterVariablesByIsTruncatedTrue() {
+    // when - filter by isTruncated = true (only truncated values)
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.isTruncated(true))
+            .sort(s -> s.name().asc())
+            .send()
+            .join();
+
+    // then - should return the large variable which will be truncated
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        .anyMatch(item -> item.getName().equals(largeVarName) && item.isTruncated());
+  }
+
+  @Test
+  void shouldFilterClusterVariablesByIsTruncatedFalse() {
+    // when - filter by isTruncated = false (only non-truncated values)
+    final var response =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.isTruncated(false))
+            .sort(s -> s.name().asc())
+            .send()
+            .join();
+
+    // then - should NOT return the large variable, only small variables
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items())
+        // Verify that the large variable is not in the results
+        .noneSatisfy(
+            item -> {
+              assertThat(item.getName()).isEqualTo(largeVarName);
+            });
+    // Verify all returned items are not truncated
+    assertThat(response.items())
+        .allSatisfy(
+            item -> {
+              if (item.isTruncated() != null) {
+                assertThat(item.isTruncated()).isFalse();
+              }
+            });
+  }
+
+  @Test
+  void shouldCompareFullValuesWithTruncatedValues() {
+    // when - search with default truncation
+    final var truncatedResponse =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.eq(largeVarName)))
+            .send()
+            .join();
+
+    // when - search with full values
+    final var fullResponse =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(n -> n.eq(largeVarName)))
+            .withFullValues()
+            .send()
+            .join();
+
+    // then - verify both searches return the variable
+    assertThat(truncatedResponse.items()).isNotEmpty();
+    assertThat(fullResponse.items()).isNotEmpty();
+
+    final var truncatedVar = truncatedResponse.items().getFirst();
+    final var fullVar = fullResponse.items().getFirst();
+
+    // Verify both have the same name
+    assertThat(truncatedVar.getName()).isEqualTo(fullVar.getName()).isEqualTo(largeVarName);
+
+    // Verify the full value is longer than the truncated value
+    assertThat(fullVar.getValue().length()).isGreaterThan(truncatedVar.getValue().length());
+
+    // Verify the full value contains the original repeated characters
+    assertThat(fullVar.getValue()).contains("xxx");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -1152,11 +1152,7 @@ public final class TestHelper {
                 final var expectedValue = entry.getValue();
 
                 assertThat(response.items())
-                    .anySatisfy(
-                        item -> {
-                          assertThat(item.getName()).isEqualTo(expectedName);
-                          assertThat(item.getValue()).contains(expectedValue);
-                        });
+                    .anySatisfy(item -> assertThat(item.getName()).isEqualTo(expectedName));
               }
             });
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -13,6 +13,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperatio
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.search.clients.query.SearchQueryBuilders.variableOperations;
+import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.ClusterVariableFilter;
@@ -42,6 +43,7 @@ public final class ClusterVariableFilterTransformer
     queries.addAll(getValuesQuery(filter.valueOperations()));
     queries.addAll(getScopeQuery(filter.scopeOperations()));
     queries.addAll(getTenantQuery(filter.tenantIdOperations()));
+    ofNullable(getIsTruncatedQuery(filter.isTruncated())).ifPresent(queries::add);
     return and(queries);
   }
 
@@ -80,5 +82,12 @@ public final class ClusterVariableFilterTransformer
 
   private List<SearchQuery> getValuesQuery(final List<UntypedOperation> variableFilters) {
     return variableOperations(ClusterVariableIndex.VALUE, variableFilters);
+  }
+
+  private SearchQuery getIsTruncatedQuery(final Boolean isTruncated) {
+    if (isTruncated == null) {
+      return null;
+    }
+    return term(ClusterVariableIndex.IS_PREVIEW, isTruncated);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -20,7 +20,8 @@ public record ClusterVariableFilter(
     List<Operation<String>> nameOperations,
     List<UntypedOperation> valueOperations,
     List<Operation<String>> scopeOperations,
-    List<Operation<String>> tenantIdOperations)
+    List<Operation<String>> tenantIdOperations,
+    Boolean isTruncated)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<ClusterVariableFilter> {
@@ -28,6 +29,7 @@ public record ClusterVariableFilter(
     List<UntypedOperation> valueOperations;
     List<Operation<String>> scopeOperations;
     List<Operation<String>> tenantIdOperations;
+    Boolean isTruncated;
 
     public Builder nameOperations(final List<Operation<String>> operations) {
       nameOperations = addValuesToList(nameOperations, operations);
@@ -118,13 +120,19 @@ public record ClusterVariableFilter(
       return tenantIdOperations(collectValues(operation, operations));
     }
 
+    public Builder isTruncated(final Boolean value) {
+      isTruncated = value;
+      return this;
+    }
+
     @Override
     public ClusterVariableFilter build() {
       return new ClusterVariableFilter(
           Objects.requireNonNullElseGet(nameOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(valueOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(scopeOperations, Collections::emptyList),
-          Objects.requireNonNullElseGet(tenantIdOperations, Collections::emptyList));
+          Objects.requireNonNullElseGet(tenantIdOperations, Collections::emptyList),
+          isTruncated);
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -70,7 +70,14 @@ paths:
         - Cluster Variable
       operationId: searchClusterVariables
       x-eventually-consistent: true
-      description: Search for cluster variables based on given criteria.
+      description: Search for cluster variables based on given criteria. By default, long variable values in the response are truncated.
+      parameters:
+        - name: truncateValues
+          in: query
+          required: false
+          description: When true (default), long variable values in the response are truncated. When false, full variable values are returned.
+          schema:
+            type: boolean
       requestBody:
         required: false
         content:
@@ -255,6 +262,27 @@ components:
           description: The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
     ClusterVariableResult:
       type: object
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableResultBase'
+      properties:
+        value:
+          description: Full value of this cluster variable.
+          type: string
+    ClusterVariableSearchResult:
+      description: Cluster variable search response item.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableResultBase'
+      properties:
+        value:
+          description: Value of this cluster variable. Can be truncated.
+          type: string
+        isTruncated:
+          description: Whether the value is truncated or not.
+          type: boolean
+    ClusterVariableResultBase:
+      description: Cluster variable response item.
+      type: object
       required:
         - name
         - value
@@ -263,9 +291,6 @@ components:
         name:
           type: string
           description: The name of the cluster variable. Unique within its scope (global or tenant-specific).
-        value:
-          type: string
-          description: The value of the cluster variable as a JSON-serialized string. Regardless of the input type during creation, values are returned as strings.
         scope:
           $ref: '#/components/schemas/ClusterVariableScopeEnum'
         tenantId:
@@ -322,6 +347,9 @@ components:
           description: Tenant ID of this variable.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        isTruncated:
+          description: Whether the value is truncated or not.
+          type: boolean
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.
       type: object
@@ -365,4 +393,4 @@ components:
           description: The matching cluster variables.
           type: array
           items:
-            $ref: '#/components/schemas/ClusterVariableResult'
+            $ref: '#/components/schemas/ClusterVariableSearchResult'

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -348,7 +348,8 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         isTruncated:
-          description: Whether the value is truncated or not.
+          description: |
+            Filter cluster variables by truncation status of their stored values. When true, returns only variables whose stored values are truncated (i.e., the value exceeds the storage size limit and is truncated in storage). When false, returns only variables with non-truncated stored values. This filter is based on the underlying storage characteristic, not the response format.
           type: boolean
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -322,6 +322,7 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getTenantId())
         .map(mapToOperations(String.class))
         .ifPresent(builder::tenantIdOperations);
+    ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
 
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -67,6 +67,7 @@ import io.camunda.zeebe.gateway.protocol.rest.CamundaUserResult;
 import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableResult;
 import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ClusterVariableSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.CorrelatedMessageSubscriptionResult;
 import io.camunda.zeebe.gateway.protocol.rest.CorrelatedMessageSubscriptionSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionResult;
@@ -1197,29 +1198,37 @@ public final class SearchQueryResponseMapper {
   }
 
   public static ClusterVariableSearchQueryResult toClusterVariableSearchQueryResponse(
-      final SearchQueryResult<ClusterVariableEntity> result) {
+      final SearchQueryResult<ClusterVariableEntity> result, final boolean truncateValues) {
     final var page = toSearchQueryPageResponse(result);
     return new ClusterVariableSearchQueryResult()
         .page(page)
         .items(
             ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toClusterVariables)
+                .map(
+                    clusterVariableEntities ->
+                        toClusterVariablesSearchResult(clusterVariableEntities, truncateValues))
                 .orElseGet(Collections::emptyList));
   }
 
-  private static List<ClusterVariableResult> toClusterVariables(
-      final List<ClusterVariableEntity> clusterVariableEntities) {
+  private static List<ClusterVariableSearchResult> toClusterVariablesSearchResult(
+      final List<ClusterVariableEntity> clusterVariableEntities, final boolean truncateValues) {
     return clusterVariableEntities.stream()
-        .map(SearchQueryResponseMapper::toClusterVariable)
+        .map(
+            clusterVariableEntity ->
+                toClusterVariableSearchResult(clusterVariableEntity, truncateValues))
         .toList();
   }
 
-  public static ClusterVariableResult toClusterVariable(
-      final ClusterVariableEntity clusterVariableEntity) {
+  public static ClusterVariableSearchResult toClusterVariableSearchResult(
+      final ClusterVariableEntity clusterVariableEntity, final boolean truncateValues) {
     final var clusterVariableResult =
-        new ClusterVariableResult()
+        new ClusterVariableSearchResult()
             .name(clusterVariableEntity.name())
-            .value(clusterVariableEntity.value());
+            .value(
+                !truncateValues
+                    ? getFullValueIfPresent(clusterVariableEntity)
+                    : clusterVariableEntity.value())
+            .isTruncated(truncateValues && clusterVariableEntity.isPreview());
     return switch (clusterVariableEntity.scope()) {
       case GLOBAL -> clusterVariableResult.scope(ClusterVariableScopeEnum.GLOBAL);
       case TENANT ->
@@ -1227,6 +1236,28 @@ public final class SearchQueryResponseMapper {
               .scope(ClusterVariableScopeEnum.TENANT)
               .tenantId(clusterVariableEntity.tenantId());
     };
+  }
+
+  public static ClusterVariableResult toClusterVariableResult(
+      final ClusterVariableEntity clusterVariableEntity) {
+
+    final var clusterVariableResult =
+        new ClusterVariableResult()
+            .name(clusterVariableEntity.name())
+            .value(getFullValueIfPresent(clusterVariableEntity));
+    return switch (clusterVariableEntity.scope()) {
+      case GLOBAL -> clusterVariableResult.scope(ClusterVariableScopeEnum.GLOBAL);
+      case TENANT ->
+          clusterVariableResult
+              .scope(ClusterVariableScopeEnum.TENANT)
+              .tenantId(clusterVariableEntity.tenantId());
+    };
+  }
+
+  private static String getFullValueIfPresent(final ClusterVariableEntity clusterVariableEntity) {
+    return clusterVariableEntity.isPreview()
+        ? clusterVariableEntity.fullValue()
+        : clusterVariableEntity.value();
   }
 
   public static AuthorizationSearchResult toAuthorizationSearchQueryResponse(


### PR DESCRIPTION
This pull request adds support for handling truncated cluster variable values in the search API, allowing users to filter and retrieve full or truncated values as needed. The changes introduce new filtering and retrieval options, update the response model to indicate truncation, and include comprehensive tests to verify the new functionality.

### API enhancements for truncated variable values

* Added a new `isTruncated(Boolean)` filter method to `ClusterVariableFilter`, enabling searches for variables based on whether their values are truncated. [[1]](diffhunk://#diff-1cba3a0c14c7da229e87b617c011d0b2e3972b4d6f1da42115ac080d96caa4ffR89-R96) [[2]](diffhunk://#diff-41f100b753169625cc230a18abd8c40900fc0d5d2cccb38c2644cba1754d6357R94-R99)
* Introduced the `withFullValues()` method to `ClusterVariableSearchRequest`, allowing clients to request untruncated variable values in search results. [[1]](diffhunk://#diff-3dbe93e9c3506506114c1ae2feaef5f7d26940bd0056f0aa326c461fe202d47cL25-R37) [[2]](diffhunk://#diff-222a055e22eee9ab649de837f817cdfdaf99def09b4d57c361f54648267cf2a7R51) [[3]](diffhunk://#diff-222a055e22eee9ab649de837f817cdfdaf99def09b4d57c361f54648267cf2a7R124-R129) [[4]](diffhunk://#diff-222a055e22eee9ab649de837f817cdfdaf99def09b4d57c361f54648267cf2a7R70-R76)

### Model and response updates

* Extended the `ClusterVariable` interface and its implementation to include an `isTruncated()` property, indicating whether the variable value is truncated. [[1]](diffhunk://#diff-4a8b3a6c182fb58262cf0d816aafa018fd423fbc67a5dfecdc9d1ce8c3a922acL22-R35) [[2]](diffhunk://#diff-c95674853dc8af137bd659fa09baa3fa67faa1c51fe85cd136b06d202fedfe75R22-R45) [[3]](diffhunk://#diff-c95674853dc8af137bd659fa09baa3fa67faa1c51fe85cd136b06d202fedfe75R67-R71)

### Query and persistence changes

* Updated SQL mapping in `ClusterVariableMapper.xml` to support filtering by truncation status (`IS_PREVIEW`).

### Testing improvements

* Added unit and acceptance tests to verify searching, filtering, and retrieval of truncated and full variable values, including tests for large variable scenarios and chaining of filter and retrieval options. [[1]](diffhunk://#diff-26e5769b32068b263f4101aa751aaf13542c53ae16e6cb6175e91c256a11d89eR42-R64) [[2]](diffhunk://#diff-26e5769b32068b263f4101aa751aaf13542c53ae16e6cb6175e91c256a11d89eR124-R133) [[3]](diffhunk://#diff-26e5769b32068b263f4101aa751aaf13542c53ae16e6cb6175e91c256a11d89eR159-R212) [[4]](diffhunk://#diff-67f312e9acb6f77e5a0e95f2384abe084435e43d34334bce4445811cfbb7b611R57-R61) [[5]](diffhunk://#diff-67f312e9acb6f77e5a0e95f2384abe084435e43d34334bce4445811cfbb7b611R139-R148) [[6]](diffhunk://#diff-67f312e9acb6f77e5a0e95f2384abe084435e43d34334bce4445811cfbb7b611L145-R161) [[7]](diffhunk://#diff-67f312e9acb6f77e5a0e95f2384abe084435e43d34334bce4445811cfbb7b611R783-R921)

### Minor related changes

* Adjusted test helper logic to only verify variable names (not values) when waiting for cluster variables to be indexed, accommodating the new truncation behavior.