### PR TITLE
[Backport stable/8.8] fix: make sure tasks with forms fetch full variables

### DIFF
--- a/tasklist/client/e2e/fixtures/v2-visual.ts
+++ b/tasklist/client/e2e/fixtures/v2-visual.ts
@@ -173,7 +173,7 @@ const test = base.extend<PlaywrightFixtures>({
   mockQueryVariablesByUserTaskRequest: async ({page}, use) => {
     await use(async ({variables = [], userTaskKey}) => {
       await page.route(
-        endpoints.queryVariablesByUserTask.getUrl({userTaskKey}),
+        `**/v2/user-tasks/${userTaskKey}/variables/search**`,
         (route) =>
           route.fulfill({
             status: 200,

--- a/tasklist/client/src/v2/TaskDetails/FormJS/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/FormJS/index.test.tsx
@@ -517,4 +517,56 @@ describe('<FormJS />', () => {
       ).toBeEnabled(),
     );
   });
+
+  it("should make sure fetched variables don't truncate", async () => {
+    nodeMockServer.use(
+      http.post<never, QueryVariablesByUserTaskRequestBody>(
+        '/v2/user-tasks/:userTaskKey/variables/search',
+        async ({request}) => {
+          const url = new URL(request.url);
+
+          if (
+            hasRequestedVariables(await request.json(), REQUESTED_VARIABLES) &&
+            url.searchParams.get('truncateValues') === 'false'
+          ) {
+            return HttpResponse.json(
+              variableMocks.getQueryVariablesResponseMock(
+                variableMocks.variables,
+              ),
+            );
+          }
+
+          return HttpResponse.json(
+            [
+              {
+                message: 'Invalid variables',
+              },
+            ],
+            {
+              status: 404,
+            },
+          );
+        },
+        {once: true},
+      ),
+    );
+
+    render(
+      <FormJS
+        task={assignedTaskWithForm()}
+        user={userMocks.currentUser}
+        onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
+        onSubmitFailure={noop}
+        onSubmitSuccess={noop}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/my variable/i)).toHaveValue('0001'),
+    );
+  });
 });

--- a/tasklist/client/src/v2/api/index.ts
+++ b/tasklist/client/src/v2/api/index.ts
@@ -81,11 +81,18 @@ const api = {
     });
   },
   queryVariablesByUserTask: (
-    params: Pick<UserTask, 'userTaskKey'> & QueryVariablesByUserTaskRequestBody,
+    params: Pick<UserTask, 'userTaskKey'> &
+      QueryVariablesByUserTaskRequestBody & {truncateValues?: boolean},
   ) => {
-    const {userTaskKey, ...body} = params;
+    const {userTaskKey, truncateValues, ...body} = params;
+
     return new Request(
-      getFullURL(endpoints.queryVariablesByUserTask.getUrl({userTaskKey})),
+      getFullURL(
+        endpoints.queryVariablesByUserTask.getUrl({
+          userTaskKey,
+          truncateValues,
+        }),
+      ),
       {
         ...BASE_REQUEST_OPTIONS,
         method: endpoints.queryVariablesByUserTask.method,

--- a/tasklist/client/src/v2/api/useSelectedVariables.query.ts
+++ b/tasklist/client/src/v2/api/useSelectedVariables.query.ts
@@ -42,6 +42,7 @@ function useSelectedVariables(params: Params, options: Options = {}) {
       const {response, error} = await request(
         api.queryVariablesByUserTask({
           userTaskKey,
+          truncateValues: false,
           filter: {
             name: {
               $in: variableNames,


### PR DESCRIPTION
# Description
Backport of #41392 to `stable/8.8`.

relates to #39189