### PR TITLE
feat: Fix mis alignments post PR (41434)

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
@@ -122,16 +123,6 @@ public class SearchClusterVariableTest extends ClientRestTest {
   }
 
   @Test
-  void shouldSearchClusterVariablesByIsTruncated() {
-    // when
-    client.newClusterVariableSearchRequest().filter(f -> f.isTruncated(true)).send().join();
-
-    // then
-    final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
-  }
-
-  @Test
   void shouldSearchClusterVariablesWithMultipleFilters() {
     // when
     client
@@ -175,23 +166,25 @@ public class SearchClusterVariableTest extends ClientRestTest {
   }
 
   @Test
-  void shouldSearchClusterVariablesFilterByIsTruncatedTrue() {
-    // when
-    client.newClusterVariableSearchRequest().filter(f -> f.isTruncated(true)).send().join();
-
-    // then
-    final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
-  }
-
-  @Test
   void shouldSearchClusterVariablesFilterByIsTruncatedFalse() {
     // when
     client.newClusterVariableSearchRequest().filter(f -> f.isTruncated(false)).send().join();
 
     // then
-    final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getClusterVariablesSearchUrl());
+    final ClusterVariableSearchQueryRequest request =
+        gatewayService.getLastRequest(ClusterVariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getIsTruncated()).isEqualTo(false);
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByIsTruncatedTrue() {
+    // when
+    client.newClusterVariableSearchRequest().filter(f -> f.isTruncated(true)).send().join();
+
+    // then
+    final ClusterVariableSearchQueryRequest request =
+        gatewayService.getLastRequest(ClusterVariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getIsTruncated()).isEqualTo(true);
   }
 
   @Test


### PR DESCRIPTION
This pull request refactors and improves the test coverage for cluster variable search requests in the Java client. The main focus is on clarifying and strengthening tests related to the `isTruncated` filter, ensuring both true and false cases are explicitly checked. Additionally, the changes update how requests are verified in tests, making assertions more precise.

### Test improvements and refactoring

* Removed the redundant test `shouldSearchClusterVariablesByIsTruncated`, consolidating the logic into more explicit true/false filter tests.
* Refactored `shouldSearchClusterVariablesFilterByIsTruncatedTrue` to now test for the false case and renamed it to `shouldSearchClusterVariablesFilterByIsTruncatedFalse`. The test now verifies the actual value of the `isTruncated` filter in the request object.
* Refactored `shouldSearchClusterVariablesFilterByIsTruncatedFalse` to now test for the true case and renamed it to `shouldSearchClusterVariablesByIsTruncatedTrue`, also verifying the filter value directly.

### Test assertion enhancements

* Updated test assertions to check the value of the `isTruncated` filter in the `ClusterVariableSearchQueryRequest` object, instead of only checking the request URL.

### Import updates

* Added import for `ClusterVariableSearchQueryRequest` to support new test assertions.
