### PR TITLE
feat: add modification icons to element instance history v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/Bar.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/Bar.tsx
@@ -12,6 +12,7 @@ import {NodeName, Container, StateIcon} from '../Bar/styled';
 import {Layer, Stack, Tag} from '@carbon/react';
 import {formatDate} from 'modules/utils/date';
 import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {ModificationIcons} from './ModificationIcons';
 
 type Props = {
   elementInstanceKey: string;
@@ -19,23 +20,26 @@ type Props = {
   elementName: string;
   elementInstanceState: ElementInstance['state'];
   hasIncident: boolean;
-  endDate: string | undefined;
+  endDate?: string;
   isTimestampLabelVisible: boolean;
   isRoot: boolean;
   latestMigrationDate: string | undefined;
+  instanceKeyHierarchy: string[];
 };
 
 const Bar = forwardRef<HTMLDivElement, Props>(
   (
     {
       elementInstanceKey,
+      elementId,
       elementName,
       elementInstanceState,
       hasIncident,
-      endDate = null,
+      endDate,
       isTimestampLabelVisible,
       isRoot,
       latestMigrationDate,
+      instanceKeyHierarchy,
     },
     ref,
   ) => {
@@ -51,12 +55,18 @@ const Bar = forwardRef<HTMLDivElement, Props>(
           {isRoot && latestMigrationDate !== undefined && (
             <Tag type="green">{`Migrated ${formatDate(latestMigrationDate)}`}</Tag>
           )}
-          {isTimestampLabelVisible && (
+          {isTimestampLabelVisible && endDate && (
             <Layer>
               <TimeStampLabel timeStamp={endDate} />
             </Layer>
           )}
         </Stack>
+        <ModificationIcons
+          elementId={elementId}
+          isPlaceholder={false}
+          endDate={endDate}
+          instanceKeyHierarchy={instanceKeyHierarchy}
+        />
       </Container>
     );
   },

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/Bar.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/Bar.tsx
@@ -24,7 +24,7 @@ type Props = {
   isTimestampLabelVisible: boolean;
   isRoot: boolean;
   latestMigrationDate: string | undefined;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const Bar = forwardRef<HTMLDivElement, Props>(
@@ -39,7 +39,7 @@ const Bar = forwardRef<HTMLDivElement, Props>(
       isTimestampLabelVisible,
       isRoot,
       latestMigrationDate,
-      instanceKeyHierarchy,
+      scopeKeyHierarchy,
     },
     ref,
   ) => {
@@ -65,7 +65,7 @@ const Bar = forwardRef<HTMLDivElement, Props>(
           elementId={elementId}
           isPlaceholder={false}
           endDate={endDate}
-          instanceKeyHierarchy={instanceKeyHierarchy}
+          scopeKeyHierarchy={scopeKeyHierarchy}
         />
       </Container>
     );

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.test.tsx
@@ -71,7 +71,7 @@ describe('<ModificationIcons /> v3', () => {
       <ModificationIcons
         elementId="some-flow-node-id"
         isPlaceholder={true}
-        instanceKeyHierarchy={[
+        scopeKeyHierarchy={[
           'some-other-parent-flow-node-id',
           'some-parent-flow-node-id',
           'some-flow-node-id',
@@ -98,7 +98,7 @@ describe('<ModificationIcons /> v3', () => {
       <ModificationIcons
         elementId="user_task"
         isPlaceholder={false}
-        instanceKeyHierarchy={[
+        scopeKeyHierarchy={[
           'some-other-parent-flow-node-id',
           'some-parent-flow-node-id',
           'some-flow-node-id',
@@ -125,7 +125,7 @@ describe('<ModificationIcons /> v3', () => {
       <ModificationIcons
         elementId="user_task"
         isPlaceholder={false}
-        instanceKeyHierarchy={[
+        scopeKeyHierarchy={[
           'some-other-parent-flow-node-id',
           'some-parent-flow-node-id',
           'some-flow-node-id',
@@ -150,7 +150,7 @@ describe('<ModificationIcons /> v3', () => {
       <ModificationIcons
         elementId="user_task"
         isPlaceholder={false}
-        instanceKeyHierarchy={[
+        scopeKeyHierarchy={[
           'some-other-parent-flow-node-id',
           'some-parent-flow-node-id',
           'some-flow-node-id',
@@ -179,7 +179,7 @@ describe('<ModificationIcons /> v3', () => {
       <ModificationIcons
         elementId="user_task"
         isPlaceholder={false}
-        instanceKeyHierarchy={[
+        scopeKeyHierarchy={[
           'some-other-parent-flow-node-id',
           'some-parent-flow-node-id',
           'some-flow-node-id',
@@ -208,7 +208,7 @@ describe('<ModificationIcons /> v3', () => {
       <ModificationIcons
         elementId="user_task"
         isPlaceholder={false}
-        instanceKeyHierarchy={[
+        scopeKeyHierarchy={[
           'some-other-parent-flow-node-id',
           'some-parent-flow-node-id',
           'some-flow-node-id',

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.test.tsx
@@ -33,7 +33,7 @@ const Wrapper = ({children}: Props) => {
   );
 };
 
-describe('<ModificationIcons /> v3', () => {
+describe('<ModificationIcons />', () => {
   beforeEach(() => {
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {act, render, screen} from 'modules/testing-library';
+import {ModificationIcons} from './index';
+import {modificationsStore} from 'modules/stores/modifications';
+import {useEffect} from 'react';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {cancelAllTokens} from 'modules/utils/modifications';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {open} from 'modules/mocks/diagrams';
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+const Wrapper = ({children}: Props) => {
+  useEffect(() => {
+    return modificationsStore.reset;
+  }, []);
+
+  return (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+describe('<ModificationIcons /> v3', () => {
+  beforeEach(() => {
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: 'parent_sub_process',
+          active: 3,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+        {
+          elementId: 'inner_sub_process',
+          active: 3,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+        {
+          elementId: 'user_task',
+          active: 3,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    });
+
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
+  });
+
+  it('should show correct icons for modifications planning to be added', () => {
+    render(
+      <ModificationIcons
+        elementId="some-flow-node-id"
+        isPlaceholder={true}
+        instanceKeyHierarchy={[
+          'some-other-parent-flow-node-id',
+          'some-parent-flow-node-id',
+          'some-flow-node-id',
+        ]}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(
+      screen.getByTitle(
+        'Ensure to add/edit variables if required, input/output mappings are not executed during modification',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTitle('This flow node instance is planned to be added'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show modification planned to be canceled icon if all the running tokens on the flow node is canceled', async () => {
+    render(
+      <ModificationIcons
+        elementId="user_task"
+        isPlaceholder={false}
+        instanceKeyHierarchy={[
+          'some-other-parent-flow-node-id',
+          'some-parent-flow-node-id',
+          'some-flow-node-id',
+        ]}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(
+      screen.queryByTitle('This flow node instance is planned to be canceled'),
+    ).not.toBeInTheDocument();
+
+    act(() => cancelAllTokens('user_task', 0, 0, {}));
+
+    expect(
+      screen.getByTitle('This flow node instance is planned to be canceled'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show modification planned to be canceled icon if one of the running tokens on the flow node is canceled', async () => {
+    render(
+      <ModificationIcons
+        elementId="user_task"
+        isPlaceholder={false}
+        instanceKeyHierarchy={[
+          'some-other-parent-flow-node-id',
+          'some-parent-flow-node-id',
+          'some-flow-node-id',
+        ]}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    act(() =>
+      modificationsStore.cancelToken('user_task', 'some-flow-node-id', {}),
+    );
+
+    expect(
+      screen.getByTitle('This flow node instance is planned to be canceled'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show modification planned to be canceled icon if one of the other running tokens on the flow node is canceled', async () => {
+    render(
+      <ModificationIcons
+        elementId="user_task"
+        isPlaceholder={false}
+        instanceKeyHierarchy={[
+          'some-other-parent-flow-node-id',
+          'some-parent-flow-node-id',
+          'some-flow-node-id',
+        ]}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    act(() =>
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-other-flow-node-id',
+        {},
+      ),
+    );
+
+    expect(
+      screen.queryByTitle('This flow node instance is planned to be canceled'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show modification planned to be canceled icon if one of the parent running tokens on the flow node is canceled', async () => {
+    render(
+      <ModificationIcons
+        elementId="user_task"
+        isPlaceholder={false}
+        instanceKeyHierarchy={[
+          'some-other-parent-flow-node-id',
+          'some-parent-flow-node-id',
+          'some-flow-node-id',
+        ]}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    act(() =>
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-parent-flow-node-id',
+        {},
+      ),
+    );
+
+    expect(
+      screen.getByTitle('This flow node instance is planned to be canceled'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show modification planned to be canceled icon if one of the other parent running tokens on the flow node is canceled', async () => {
+    render(
+      <ModificationIcons
+        elementId="user_task"
+        isPlaceholder={false}
+        instanceKeyHierarchy={[
+          'some-other-parent-flow-node-id',
+          'some-parent-flow-node-id',
+          'some-flow-node-id',
+        ]}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    act(() =>
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-second-parent-flow-node-id',
+        {},
+      ),
+    );
+
+    expect(
+      screen.queryByTitle('This flow node instance is planned to be canceled'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.tsx
@@ -17,16 +17,16 @@ type Props = {
   elementId: string;
   isPlaceholder?: boolean;
   endDate?: string;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const ModificationIcons: React.FC<Props> = observer(
-  ({elementId, isPlaceholder = false, endDate, instanceKeyHierarchy}) => {
+  ({elementId, isPlaceholder = false, endDate, scopeKeyHierarchy}) => {
     const modificationsByFlowNode = useModificationsByFlowNode();
 
     const hasCancelModification =
       modificationsByFlowNode[elementId]?.areAllTokensCanceled ||
-      instanceKeyHierarchy.some((flowNodeInstanceKey) =>
+      scopeKeyHierarchy.some((flowNodeInstanceKey) =>
         hasPendingCancelOrMoveModification({
           flowNodeId: elementId,
           flowNodeInstanceKey,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/index.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {observer} from 'mobx-react';
+import {Container, AddIcon, CancelIcon, WarningIcon} from './styled';
+import {Stack} from '@carbon/react';
+import {useModificationsByFlowNode} from 'modules/hooks/modifications';
+import {hasPendingCancelOrMoveModification} from 'modules/utils/modifications';
+
+type Props = {
+  elementId: string;
+  isPlaceholder?: boolean;
+  endDate?: string;
+  instanceKeyHierarchy: string[];
+};
+
+const ModificationIcons: React.FC<Props> = observer(
+  ({elementId, isPlaceholder = false, endDate, instanceKeyHierarchy}) => {
+    const modificationsByFlowNode = useModificationsByFlowNode();
+
+    const hasCancelModification =
+      modificationsByFlowNode[elementId]?.areAllTokensCanceled ||
+      instanceKeyHierarchy.some((flowNodeInstanceKey) =>
+        hasPendingCancelOrMoveModification({
+          flowNodeId: elementId,
+          flowNodeInstanceKey,
+          modificationsByFlowNode,
+        }),
+      );
+
+    return (
+      <Container>
+        <>
+          {isPlaceholder && (
+            <Stack orientation="horizontal" gap={3}>
+              <WarningIcon data-testid="warning-icon">
+                <title>
+                  Ensure to add/edit variables if required, input/output
+                  mappings are not executed during modification
+                </title>
+              </WarningIcon>
+              <AddIcon data-testid="add-icon">
+                <title>This flow node instance is planned to be added</title>
+              </AddIcon>
+            </Stack>
+          )}
+
+          {hasCancelModification && !isPlaceholder && endDate === undefined && (
+            <CancelIcon data-testid="cancel-icon">
+              <title>This flow node instance is planned to be canceled</title>
+            </CancelIcon>
+          )}
+        </>
+      </Container>
+    );
+  },
+);
+
+export {ModificationIcons};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/ModificationIcons/styled.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {WarningAltFilled, Error, Add} from '@carbon/react/icons';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-self: flex-end;
+`;
+
+const iconStyles = css`
+  color: var(--cds-icon-disabled);
+`;
+
+const AddIcon = styled(Add)`
+  ${iconStyles}
+`;
+
+const CancelIcon = styled(Error)`
+  ${iconStyles}
+`;
+
+const WarningIcon = styled(WarningAltFilled)`
+  color: var(--cds-support-warning);
+`;
+
+export {Container, AddIcon, CancelIcon, WarningIcon};

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/VirtualBar.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/VirtualBar.tsx
@@ -15,11 +15,11 @@ type Props = {
   elementInstanceKey: string;
   elementName: string;
   elementId: string;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const VirtualBar = forwardRef<HTMLDivElement, Props>(
-  ({elementInstanceKey, elementId, elementName, instanceKeyHierarchy}, ref) => {
+  ({elementInstanceKey, elementId, elementName, scopeKeyHierarchy}, ref) => {
     return (
       <Container ref={ref} data-testid={`node-details-${elementInstanceKey}`}>
         <Stack orientation="horizontal" gap={5}>
@@ -28,7 +28,7 @@ const VirtualBar = forwardRef<HTMLDivElement, Props>(
         <ModificationIcons
           elementId={elementId}
           isPlaceholder
-          instanceKeyHierarchy={instanceKeyHierarchy}
+          scopeKeyHierarchy={scopeKeyHierarchy}
         />
       </Container>
     );

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/VirtualBar.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/VirtualBar.tsx
@@ -9,19 +9,27 @@
 import {forwardRef} from 'react';
 import {NodeName, Container} from '../Bar/styled';
 import {Stack} from '@carbon/react';
+import {ModificationIcons} from './ModificationIcons';
 
 type Props = {
   elementInstanceKey: string;
   elementName: string;
+  elementId: string;
+  instanceKeyHierarchy: string[];
 };
 
 const VirtualBar = forwardRef<HTMLDivElement, Props>(
-  ({elementInstanceKey, elementName}, ref) => {
+  ({elementInstanceKey, elementId, elementName, instanceKeyHierarchy}, ref) => {
     return (
       <Container ref={ref} data-testid={`node-details-${elementInstanceKey}`}>
         <Stack orientation="horizontal" gap={5}>
           <NodeName>{elementName}</NodeName>
         </Stack>
+        <ModificationIcons
+          elementId={elementId}
+          isPlaceholder
+          instanceKeyHierarchy={instanceKeyHierarchy}
+        />
       </Container>
     );
   },

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -94,7 +94,7 @@ type NonFoldableElementInstancesNodeProps = {
   endDate: string | undefined;
   elementType: ElementInstance['type'];
   renderIcon: () => React.ReactNode | null;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeProps> =
@@ -108,7 +108,7 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
       endDate,
       elementType,
       renderIcon,
-      instanceKeyHierarchy,
+      scopeKeyHierarchy,
       ...rest
     }) => {
       const rowRef = useRef<HTMLDivElement>(null);
@@ -154,7 +154,7 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
               isTimestampLabelVisible={false}
               isRoot={isRoot}
               latestMigrationDate={latestMigrationDate}
-              instanceKeyHierarchy={instanceKeyHierarchy}
+              scopeKeyHierarchy={scopeKeyHierarchy}
               ref={rowRef}
             />
           }
@@ -169,7 +169,7 @@ type NonFoldableVirtualElementInstanceNodeProps = {
   elementName: string;
   elementType: ElementType;
   renderIcon: () => React.ReactNode | null;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementInstanceNodeProps> =
@@ -180,7 +180,7 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
       elementName,
       elementType,
       renderIcon,
-      instanceKeyHierarchy,
+      scopeKeyHierarchy,
       ...rest
     }) => {
       const rowRef = useRef<HTMLDivElement>(null);
@@ -220,7 +220,7 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
             <VirtualBar
               elementInstanceKey={scopeKey}
               elementName={elementName}
-              instanceKeyHierarchy={instanceKeyHierarchy}
+              scopeKeyHierarchy={scopeKeyHierarchy}
               elementId={elementId}
               ref={rowRef}
             />
@@ -233,14 +233,14 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
 const ScrollableNodes: React.FC<
   Omit<React.ComponentProps<typeof InfiniteScroller>, 'children'> & {
     visibleChildren: (ElementInstance | VirtualElementInstance)[];
-    instanceKeyHierarchy: string[];
+    scopeKeyHierarchy: string[];
   }
 > = ({
   onVerticalScrollEndReach,
   onVerticalScrollStartReach,
   visibleChildren,
   scrollableContainerRef,
-  instanceKeyHierarchy,
+  scopeKeyHierarchy,
   ...carbonTreeNodeProps
 }) => {
   return (
@@ -255,8 +255,8 @@ const ScrollableNodes: React.FC<
             <ElementInstanceSubTreeRoot
               key={elementInstance.elementInstanceKey}
               elementInstance={elementInstance}
-              instanceKeyHierarchy={[
-                ...instanceKeyHierarchy,
+              scopeKeyHierarchy={[
+                ...scopeKeyHierarchy,
                 elementInstance.elementInstanceKey,
               ]}
               {...carbonTreeNodeProps}
@@ -274,7 +274,7 @@ type FoldableVirtualElementInstanceNodeProps = {
   elementName: string;
   elementType: ElementType;
   renderIcon: () => React.ReactNode;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanceNodeProps> =
@@ -285,7 +285,7 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
       elementName,
       elementType,
       renderIcon,
-      instanceKeyHierarchy,
+      scopeKeyHierarchy,
       ...carbonTreeNodeProps
     }) => {
       const rowRef = useRef<HTMLDivElement>(null);
@@ -339,7 +339,7 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
           <VirtualBar
             elementInstanceKey={scopeKey}
             elementName={elementName}
-            instanceKeyHierarchy={instanceKeyHierarchy}
+            scopeKeyHierarchy={scopeKeyHierarchy}
             elementId={elementId}
             ref={rowRef}
           />
@@ -380,7 +380,7 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
               }
             }}
             scrollableContainerRef={scrollableContainerRef}
-            instanceKeyHierarchy={instanceKeyHierarchy}
+            scopeKeyHierarchy={scopeKeyHierarchy}
             visibleChildren={virtualChildren}
           />
         </TreeNode>
@@ -397,7 +397,7 @@ type FoldableElementInstancesNodeProps = {
   endDate: string | undefined;
   elementType: ElementInstance['type'];
   renderIcon: () => React.ReactNode;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> =
@@ -411,7 +411,7 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
       endDate,
       elementType,
       renderIcon,
-      instanceKeyHierarchy,
+      scopeKeyHierarchy,
       ...carbonTreeNodeProps
     }) => {
       const rowRef = useRef<HTMLDivElement>(null);
@@ -515,7 +515,7 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
             isTimestampLabelVisible={false}
             isRoot={isRoot}
             latestMigrationDate={latestMigrationDate}
-            instanceKeyHierarchy={instanceKeyHierarchy}
+            scopeKeyHierarchy={scopeKeyHierarchy}
             ref={rowRef}
           />
         ),
@@ -547,7 +547,7 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
               }
             }}
             scrollableContainerRef={scrollableContainerRef}
-            instanceKeyHierarchy={instanceKeyHierarchy}
+            scopeKeyHierarchy={scopeKeyHierarchy}
             visibleChildren={
               elementInstancesTreeStore.hasNextPage(scopeKey)
                 ? elementInstancesTreeStore.getItems(scopeKey)
@@ -570,11 +570,11 @@ function isVirtualElementInstance(
 
 type Props = {
   elementInstance: ElementInstance | VirtualElementInstance;
-  instanceKeyHierarchy: string[];
+  scopeKeyHierarchy: string[];
 };
 
 const ElementInstanceSubTreeRoot: React.FC<Props> = observer(
-  ({elementInstance, instanceKeyHierarchy, ...rest}) => {
+  ({elementInstance, scopeKeyHierarchy, ...rest}) => {
     const {businessObjects, processInstance} = useElementInstanceHistoryTree();
 
     if (isVirtualElementInstance(elementInstance)) {
@@ -590,7 +590,7 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer(
         elementId: elementInstance.elementId,
         elementName: elementInstance.elementName ?? elementInstance.elementId,
         elementType: elementInstance.type,
-        instanceKeyHierarchy,
+        scopeKeyHierarchy,
       };
 
       if (hasChildren) {
@@ -631,7 +631,7 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer(
       elementInstanceState: elementInstance.state,
       hasIncident: elementInstance.hasIncident,
       endDate: elementInstance.endDate,
-      instanceKeyHierarchy,
+      scopeKeyHierarchy,
     };
     const isFoldable = FOLDABLE_ELEMENT_TYPES.includes(elementInstance.type);
     if (isFoldable) {
@@ -707,7 +707,7 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
         <ElementInstanceSubTreeRoot
           {...rest}
           elementInstance={rootElementInstance}
-          instanceKeyHierarchy={[processInstance.processInstanceKey]}
+          scopeKeyHierarchy={[processInstance.processInstanceKey]}
         />
       </ElementInstanceHistoryTree.Provider>
     );

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -123,6 +123,10 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
       });
 
       const handleSelect = () => {
+        if (isRoot) {
+          return;
+        }
+
         selectFlowNode(rootNode, {
           flowNodeId: elementId,
           flowNodeInstanceId: scopeKey,
@@ -449,6 +453,10 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
       });
 
       const handleSelect = async () => {
+        if (isRoot) {
+          return;
+        }
+
         if (elementType !== 'AD_HOC_SUB_PROCESS_INNER_INSTANCE') {
           selectFlowNode(rootNode, {
             flowNodeId: elementId,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -114,6 +114,7 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
       const rowRef = useRef<HTMLDivElement>(null);
       const latestMigrationDate = undefined;
       const isRoot = elementType === 'PROCESS';
+      const {processInstance} = useElementInstanceHistoryTree();
 
       const rootNode = useRootNode();
       const isSelected = flowNodeSelectionStore.isSelected({
@@ -124,6 +125,9 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
 
       const handleSelect = () => {
         if (isRoot) {
+          selectFlowNode(rootNode, {
+            processInstanceId: processInstance.processInstanceKey,
+          });
           return;
         }
 
@@ -454,6 +458,9 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
 
       const handleSelect = async () => {
         if (isRoot) {
+          selectFlowNode(rootNode, {
+            processInstanceId: processInstance.processInstanceKey,
+          });
           return;
         }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR migrations the modifications icons to the new element instance history.

Please check https://github.com/camunda/camunda/pull/41364 before

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#27330](https://github.com/camunda/camunda/issues/27330)
