### PR TITLE
[Backport stable/8.6] fix: don't accidentally skip processing after log truncation

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
@@ -174,6 +174,10 @@ public final class LogEntryDescriptor {
     buffer.putByte(flagsOffset(offset), (byte) (shouldSkip ? 1 : 0));
   }
 
+  public static void zeroReserved(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putByte(flagsOffset(offset) + 1, (byte) 0);
+  }
+
   public static int timestampOffset(final int offset) {
     return TIMESTAMP_OFFSET + offset;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
@@ -169,8 +169,9 @@ public final class LogEntryDescriptor {
     return buffer.getByte(flagsOffset(offset)) != 0;
   }
 
-  public static void skipProcessing(final MutableDirectBuffer buffer, final int offset) {
-    buffer.putByte(flagsOffset(offset), (byte) 1);
+  public static void skipProcessing(
+      final MutableDirectBuffer buffer, final int offset, final boolean shouldSkip) {
+    buffer.putByte(flagsOffset(offset), (byte) (shouldSkip ? 1 : 0));
   }
 
   public static int timestampOffset(final int offset) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/DataFrameDescriptor.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/DataFrameDescriptor.java
@@ -23,9 +23,11 @@ public final class DataFrameDescriptor {
 
   public static final int HEADER_LENGTH = 12;
 
-  public static void setFramedLength(
-      final MutableDirectBuffer buffer, final int offset, final int length) {
+  public static void write(final MutableDirectBuffer buffer, final int offset, final int length) {
     buffer.putInt(offset + FRAME_LENGTH_OFFSET, length);
+    for (int i = 4; i < HEADER_LENGTH; i++) {
+      buffer.putByte(offset + i, (byte) 0);
+    }
   }
 
   public static int alignedLength(final int msgLength) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -16,6 +16,7 @@ import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setTimesta
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setVersion;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.skipProcessing;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.valueOffset;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.zeroReserved;
 
 import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
@@ -85,12 +86,13 @@ final class LogAppendEntrySerializer {
     final var framedEntryLength = framedLength(entry);
 
     // Write the dispatcher framing
-    DataFrameDescriptor.setFramedLength(writeBuffer, writeBufferOffset, framedEntryLength);
+    DataFrameDescriptor.write(writeBuffer, writeBufferOffset, framedEntryLength);
     final var entryOffset = writeBufferOffset + DataFrameDescriptor.HEADER_LENGTH;
 
     // Write the entry
     setVersion(writeBuffer, entryOffset);
     skipProcessing(writeBuffer, entryOffset, entry.isProcessed());
+    zeroReserved(writeBuffer, entryOffset);
     setPosition(writeBuffer, entryOffset, position);
     setSourceEventPosition(writeBuffer, entryOffset, sourcePosition);
     setKey(writeBuffer, entryOffset, key);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -90,9 +90,7 @@ final class LogAppendEntrySerializer {
 
     // Write the entry
     setVersion(writeBuffer, entryOffset);
-    if (entry.isProcessed()) {
-      skipProcessing(writeBuffer, entryOffset);
-    }
+    skipProcessing(writeBuffer, entryOffset, entry.isProcessed());
     setPosition(writeBuffer, entryOffset, position);
     setSourceEventPosition(writeBuffer, entryOffset, sourcePosition);
     setKey(writeBuffer, entryOffset, key);

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -33,7 +33,7 @@ final class LogEntryDescriptorTest {
     final var buffer = new UnsafeBuffer(new byte[128]);
 
     // when
-    LogEntryDescriptor.skipProcessing(buffer, 0);
+    LogEntryDescriptor.skipProcessing(buffer, 0, true);
 
     // then
     assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
@@ -155,38 +155,14 @@ final class LogAppendEntrySerializerTest {
 
     // then - both buffers should have the same contents
     for (int i = 0; i < framedLength; i++) {
-      if (i >= 4 && i < 12) {
-        assertThat(buffer1.getByte(i))
-            .as(
-                "Byte %d should be an unused part of the DataFrameDescriptor and show original buffer content",
-                i)
-            .isEqualTo((byte) 0xFF);
-        assertThat(buffer2.getByte(i))
-            .as(
-                "Byte %d should be an unused part of the DataFrameDescriptor and show original buffer content",
-                i)
-            .isEqualTo((byte) 0x00);
-      } else if (i == 15) {
-        assertThat(buffer1.getByte(i))
-            .as(
-                "Byte %d should be an unused reserved byte of the LoggedEventImpl and show original buffer content",
-                i)
-            .isEqualTo((byte) 0xFF);
-        assertThat(buffer2.getByte(i))
-            .as(
-                "Byte %d should be an unused reserved byte of the LoggedEventImpl and show original buffer content",
-                i)
-            .isEqualTo((byte) 0x00);
-      } else {
-        assertThat(buffer1.getByte(i))
-            .as(
-                """
-                    Byte %d shows original buffer content, even though it is used and should be overwritten
-                    Buffer 1: %s
-                    Buffer 2: %s""",
-                i, Arrays.toString(buffer1.byteArray()), Arrays.toString(buffer2.byteArray()))
-            .isEqualTo(buffer2.getByte(i));
-      }
+      assertThat(buffer1.getByte(i))
+          .as(
+              """
+                  Byte %d shows original buffer content, even though it is used and should be overwritten
+                  Buffer 1: %s
+                  Buffer 2: %s""",
+              i, Arrays.toString(buffer1.byteArray()), Arrays.toString(buffer2.byteArray()))
+          .isEqualTo(buffer2.getByte(i));
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #41400 to `stable/8.6`.

relates to #41325