### PR TITLE
feat: add operations actions on element instance history and add multi instance label

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -649,11 +649,14 @@ const ElementInstanceSubTreeRoot: React.FC<Props> = observer(
       );
     }
 
+    const isMultiInstanceBody = elementInstance.type === 'MULTI_INSTANCE_BODY';
     const nodeProps = {
       ...rest,
       scopeKey: elementInstance.elementInstanceKey,
       elementId: elementInstance.elementId,
-      elementName: elementInstance.elementName ?? elementInstance.elementId,
+      elementName: `${elementInstance.elementName ?? elementInstance.elementId}${
+        isMultiInstanceBody ? ' (Multi Instance)' : ''
+      }`,
       elementType: elementInstance.type,
       elementInstanceState: elementInstance.state,
       hasIncident: elementInstance.hasIncident,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/FlowNodeInstancesTree/v2/index.new.tsx
@@ -136,20 +136,25 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
           return;
         }
 
+        if (modificationsStore.state.status === 'moving-token') {
+          return;
+        }
+
         if (modificationsStore.state.status === 'adding-token') {
           modificationsStore.finishAddingToken(
             businessObjects,
             elementId,
             scopeKey,
           );
-        } else {
-          tracking.track({eventName: 'instance-history-item-clicked'});
-          selectFlowNode(rootNode, {
-            flowNodeId: elementId,
-            flowNodeInstanceId: scopeKey,
-            isMultiInstance: false,
-          });
+          return;
         }
+
+        tracking.track({eventName: 'instance-history-item-clicked'});
+        selectFlowNode(rootNode, {
+          flowNodeId: elementId,
+          flowNodeInstanceId: scopeKey,
+          isMultiInstance: false,
+        });
       };
 
       return (
@@ -220,21 +225,26 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
       });
 
       const handleSelect = () => {
+        if (modificationsStore.state.status === 'moving-token') {
+          return;
+        }
+
         if (modificationsStore.state.status === 'adding-token') {
           modificationsStore.finishAddingToken(
             businessObjects,
             elementId,
             scopeKey,
           );
-        } else {
-          tracking.track({eventName: 'instance-history-item-clicked'});
-          selectFlowNode(rootNode, {
-            flowNodeId: elementId,
-            flowNodeInstanceId: scopeKey,
-            isMultiInstance: false,
-            isPlaceholder: true,
-          });
+          return;
         }
+
+        tracking.track({eventName: 'instance-history-item-clicked'});
+        selectFlowNode(rootNode, {
+          flowNodeId: elementId,
+          flowNodeInstanceId: scopeKey,
+          isMultiInstance: false,
+          isPlaceholder: true,
+        });
       };
 
       return (
@@ -351,21 +361,26 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
         );
 
       const handleSelect = async () => {
+        if (modificationsStore.state.status === 'moving-token') {
+          return;
+        }
+
         if (modificationsStore.state.status === 'adding-token') {
           modificationsStore.finishAddingToken(
             businessObjects,
             elementId,
             scopeKey,
           );
-        } else {
-          tracking.track({eventName: 'instance-history-item-clicked'});
-          selectFlowNode(rootNode, {
-            flowNodeId: elementId,
-            flowNodeInstanceId: scopeKey,
-            isMultiInstance: isMultiInstance(businessObject),
-            isPlaceholder: true,
-          });
+          return;
         }
+
+        tracking.track({eventName: 'instance-history-item-clicked'});
+        selectFlowNode(rootNode, {
+          flowNodeId: elementId,
+          flowNodeInstanceId: scopeKey,
+          isMultiInstance: isMultiInstance(businessObject),
+          isPlaceholder: true,
+        });
       };
 
       const elementProps = {
@@ -500,6 +515,10 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
           selectFlowNode(rootNode, {
             processInstanceId: processInstance.processInstanceKey,
           });
+          return;
+        }
+
+        if (modificationsStore.state.status === 'moving-token') {
           return;
         }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On this PR:
- Add missing adding token operation logic
- Prevent node selection when moving a token
- Add multi instance label

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [#27330](https://github.com/camunda/camunda/issues/27330)
