### PR TITLE
Improve backup error message.

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupAlreadyExistException.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupAlreadyExistException.java
@@ -11,7 +11,7 @@ public class BackupAlreadyExistException extends RuntimeException {
 
   public BackupAlreadyExistException(final long expectedBackupId, final long latestBackupId) {
     super(
-        "Requested backup has id %d. The latest backup has id %d. Id of new backups must be higher than the previous one. "
+        "Requested backup has id %d. The latest backup has id %d. A backupId is an integer and must be greater than the ID of previous backups that are completed, failed, or deleted. Zeebe does not take two backups with the same ids."
             .formatted(expectedBackupId, latestBackupId));
   }
 }


### PR DESCRIPTION
## Description

Improve the backup error message to specify that IDs are not reusable. This is in line with the docs here: https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/zeebe-backup-and-restore/#request.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36191
