### PR TITLE
feat: Add support for Opensearch in StandaloneBackupManagerIT

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -7,15 +7,12 @@
  */
 package io.camunda.application;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import io.camunda.application.commons.search.SearchClientDatabaseConfiguration;
+import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
-import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.TakeBackupRequestDto;
@@ -32,14 +29,14 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 /**
- * Backup Camunda, Operate and Tasklist indices for ElasticSearch by running this standalone
- * application.
+ * Standalone backup manager to create backups for Camunda, Operate and Tasklist indices in the
+ * configured search engine (e.g. Elasticsearch or OpenSearch).
  *
  * <p>Example properties:
  *
  * <pre>
  * camunda.database.index-prefix=operate
- * camunda.database.cluster-name=elasticsearch
+ * camunda.database.cluster-name=search-cluster
  * camunda.database.url=https://localhost:9200
  * camunda.database.security.self-signed=true
  * camunda.database.security.verify-hostname=false
@@ -47,12 +44,11 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
  * camunda.database.username=camunda-admin
  * camunda.database.password=camunda123
  *
- * camunda.data.backup.repository-name=els-test
- * *
+ * camunda.data.backup.repository-name=search-backup-repo
  * </pre>
  *
  * All of those properties can also be handed over via environment variables, e.g.
- * `CAMUNDA_DATABASE_INDEXPREFIX`
+ * `CAMUNDA_DATABASE_INDEXPREFIX`.
  */
 @SpringBootConfiguration(proxyBeanMethods = false)
 public class StandaloneBackupManager implements CommandLineRunner {
@@ -77,7 +73,7 @@ public class StandaloneBackupManager implements CommandLineRunner {
     MainSupport.putSystemPropertyIfAbsent(
         "spring.banner.location", "classpath:/assets/camunda_banner.txt");
 
-    LOG.info("Creating a backup for Camunda, Operate and Tasklist elasticsearch indices ...");
+    LOG.info("Creating a backup for Camunda, Operate and Tasklist search engine indices ...");
 
     MainSupport.createDefaultApplicationBuilder()
         .web(WebApplicationType.NONE)
@@ -92,12 +88,13 @@ public class StandaloneBackupManager implements CommandLineRunner {
             // ---
             BackupManagerConfiguration.class,
             StandaloneBackupManager.class,
-            SearchClientDatabaseConfiguration.class)
+            NativeSearchClientsConfiguration.class)
         .addCommandLineProperties(true)
         .run(args);
 
-    // Explicit exit needed because there are daemon threads (at least from the ES client) that are
-    // blocking shutdown.
+    // Explicit exit needed because there are daemon threads (at least from the search engine
+    // client)
+    // that are blocking shutdown.
     System.exit(0);
   }
 
@@ -120,9 +117,10 @@ public class StandaloneBackupManager implements CommandLineRunner {
       final var takeBackupRequestDto = new TakeBackupRequestDto();
       takeBackupRequestDto.setBackupId(backupId);
       final var backupResponse = backupService.takeBackup(takeBackupRequestDto);
-      LOG.info("Triggered ES snapshots: {}", backupResponse.getScheduledSnapshots());
+      LOG.info("Triggered search engine snapshots: {}", backupResponse.getScheduledSnapshots());
     } catch (final Exception e) {
-      LOG.error("Expected to trigger ES snapshots for backupId {}, but failed", backupId, e);
+      LOG.error(
+          "Expected to trigger search engine snapshots for backupId {}, but failed", backupId, e);
       throw e;
     }
 
@@ -169,12 +167,6 @@ public class StandaloneBackupManager implements CommandLineRunner {
     @Bean
     public ExitCodeExceptionMapper exitCodeExceptionMapper() {
       return ex -> 1;
-    }
-
-    @Bean
-    public ElasticsearchClient elasticsearchClient(
-        final ConnectConfiguration connectConfiguration) {
-      return new ElasticsearchConnector(connectConfiguration).createClient();
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/NativeSearchClientsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/NativeSearchClientsConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class NativeSearchClientsConfiguration {
+
+  @Bean
+  @ConditionalOnSecondaryStorageType(SecondaryStorageType.elasticsearch)
+  public ElasticsearchClient elasticsearchClient(final ConnectConfiguration configuration) {
+    final var connector = new ElasticsearchConnector(configuration);
+    return connector.createClient();
+  }
+
+  @Bean
+  @ConditionalOnSecondaryStorageType(SecondaryStorageType.opensearch)
+  public OpenSearchClient openSearchClient(final ConnectConfiguration configuration) {
+    final var connector = new OpensearchConnector(configuration);
+    return connector.createClient();
+  }
+
+  @Bean
+  @ConditionalOnSecondaryStorageType(SecondaryStorageType.opensearch)
+  public OpenSearchAsyncClient openSearchAsyncClient(final ConnectConfiguration configuration) {
+    final var connector = new OpensearchConnector(configuration);
+    return connector.createAsyncClient();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -47,22 +47,18 @@ import io.camunda.search.clients.reader.UserReader;
 import io.camunda.search.clients.reader.UserTaskReader;
 import io.camunda.search.clients.reader.VariableReader;
 import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
-import io.camunda.search.connect.es.ElasticsearchConnector;
-import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
 import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import java.util.List;
-import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
-public class SearchClientDatabaseConfiguration {
+public class SearchClientConfiguration {
 
   @Bean
   @ConditionalOnSecondaryStorageType(SecondaryStorageType.elasticsearch)
@@ -72,30 +68,9 @@ public class SearchClientDatabaseConfiguration {
   }
 
   @Bean
-  @ConditionalOnSecondaryStorageType(SecondaryStorageType.elasticsearch)
-  public ElasticsearchClient elasticsearchClient(final ConnectConfiguration configuration) {
-    final var connector = new ElasticsearchConnector(configuration);
-    return connector.createClient();
-  }
-
-  @Bean
   @ConditionalOnSecondaryStorageType(SecondaryStorageType.opensearch)
   public OpensearchSearchClient opensearchSearchClient(final OpenSearchClient openSearchClient) {
     return new OpensearchSearchClient(openSearchClient);
-  }
-
-  @Bean
-  @ConditionalOnSecondaryStorageType(SecondaryStorageType.opensearch)
-  public OpenSearchClient openSearchClient(final ConnectConfiguration configuration) {
-    final var connector = new OpensearchConnector(configuration);
-    return connector.createClient();
-  }
-
-  @Bean
-  @ConditionalOnSecondaryStorageType(SecondaryStorageType.opensearch)
-  public OpenSearchAsyncClient openSearchAsyncClient(final ConnectConfiguration configuration) {
-    final var connector = new OpensearchConnector(configuration);
-    return connector.createAsyncClient();
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
@@ -10,7 +10,7 @@ package io.camunda.application.initializers;
 import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import java.util.Objects;
+import java.util.Optional;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -26,7 +26,10 @@ public class StandaloneSchemaManagerInitializer
             .getProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE);
 
     final var storageType =
-        SecondaryStorageType.valueOf(Objects.requireNonNull(databaseTypeProperty).toLowerCase());
+        Optional.ofNullable(databaseTypeProperty)
+            .map(String::toLowerCase)
+            .map(SecondaryStorageType::valueOf)
+            .orElse(SecondaryStorageType.elasticsearch);
     if (!storageType.isElasticSearch() && !storageType.isOpenSearch()) {
       throw new IllegalArgumentException(
           "Cannot create schema for anything other than Elasticsearch and Opensearch with this script for now...");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -11,58 +11,32 @@ import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import io.camunda.application.Profile;
 import io.camunda.client.api.search.response.ProcessInstance;
-import io.camunda.exporter.CamundaExporter;
+import io.camunda.it.schema.strategy.ElasticsearchBackendStrategy;
+import io.camunda.it.schema.strategy.OpenSearchBackendStrategy;
+import io.camunda.it.schema.strategy.SearchBackendStrategy;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.cluster.TestStandaloneBackupManager;
 import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
-import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.awaitility.Awaitility;
-import org.elasticsearch.client.RestClient;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.images.builder.Transferable;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @ZeebeIntegration
-@Testcontainers
 final class StandaloneBackupManagerIT {
 
-  public static final String ADMIN_USER = "camunda-admin";
-  public static final String ADMIN_PASSWORD = "admin123";
-  public static final String ADMIN_ROLE = "superuser";
-
-  public static final String APP_USER = "camunda-app";
-  public static final String APP_PASSWORD = "app123";
-  public static final String APP_ROLE = "camunda_app_role";
-  public static final String APP_ROLE_DEFINITION =
-      // language=yaml
-      """
-          camunda_app_role:
-            indices:
-              - names: ['zeebe-*', 'operate-*', 'tasklist-*', 'camunda-*']
-                privileges: ['manage', 'read', 'write']
-          """;
-
-  private static final String REPOSITORY_NAME = "els-test";
+  private static final String REPOSITORY_NAME = "backup-test";
 
   private static final long BACKUP_ID = 12345L;
   public static final String SNAPSHOT_NAME_PREFIX =
@@ -72,148 +46,68 @@ final class StandaloneBackupManagerIT {
   @TestZeebe(autoStart = false)
   final TestStandaloneBackupManager backupManager =
       new TestStandaloneBackupManager()
-          .withProperty("camunda.data.backup.repository-name", "els-test")
-          .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
-          .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD);
+          .withProperty("camunda.data.backup.repository-name", REPOSITORY_NAME);
 
   // Configure the schema manager to create indices and templates in test setup
   @TestZeebe(autoStart = false)
-  final TestStandaloneSchemaManager schemaManager =
-      new TestStandaloneSchemaManager()
-          .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
-          .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
-          .withProperty("camunda.data.secondary-storage.retention.enabled", true);
+  final TestStandaloneSchemaManager schemaManager = new TestStandaloneSchemaManager();
 
-  // Configure the Camunda single application with restricted access to the Elasticsearch
+  // Configure the Camunda single application with restricted access to the search backend
   @TestZeebe(autoStart = false)
-  final TestCamundaApplication camunda =
-      new TestCamundaApplication()
-          .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
-          .withCreateSchema(false)
-          .withUnauthenticatedAccess()
-          .withProperty("camunda.operate.elasticsearch.health-check-enabled", "false")
-          .withProperty("camunda.tasklist.elasticsearch.health-check-enabled", "false")
-          .withUnifiedConfig(
-              cfg -> {
-                cfg.getData().getSecondaryStorage().getElasticsearch().setUsername(APP_USER);
-                cfg.getData().getSecondaryStorage().getElasticsearch().setPassword(APP_PASSWORD);
-                cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
-              })
-          .withExporter(
-              CamundaExporter.class.getSimpleName(),
-              cfg -> {
-                cfg.setClassName(CamundaExporter.class.getName());
-                cfg.setArgs(
-                    Map.of(
-                        "connect",
-                        Map.of("username", APP_USER, "password", APP_PASSWORD),
-                        "createSchema",
-                        false));
-              });
+  final TestCamundaApplication camunda = new TestCamundaApplication();
 
-  @Container
-  private final ElasticsearchContainer es =
-      new ElasticsearchContainer(
-              DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-                  .withTag(RestClient.class.getPackage().getImplementationVersion()))
-          // Enable security features
-          .withEnv("xpack.security.enabled", "true")
-          // Ensure a fast and reliable startup
-          .withStartupTimeout(Duration.ofMinutes(5))
-          .withStartupAttempts(3)
-          .withEnv("xpack.security.enabled", "true")
-          .withEnv("xpack.watcher.enabled", "false")
-          .withEnv("xpack.ml.enabled", "false")
-          // Configure with allowed repository storage path
-          .withEnv("path.repo", "~/")
-          // to be able to delete indices with wildcards
-          .withEnv("action.destructive_requires_name", "false")
-          .withCopyToContainer(
-              Transferable.of(APP_ROLE_DEFINITION), "/usr/share/elasticsearch/config/roles.yml")
-          .withClasspathResourceMapping(
-              "elasticsearch-fast-startup.options",
-              "/usr/share/elasticsearch/config/jvm.options.d/elasticsearch-fast-startup.options",
-              BindMode.READ_ONLY);
-
-  // Elasticsearch client with admin access to apply some manual operations
-  private ElasticsearchClient adminElasticsearchClient;
-
-  @BeforeEach
-  void setup() throws IOException, InterruptedException {
-    // setup ES admin user
-    es.execInContainer("elasticsearch-users", "useradd", ADMIN_USER, "-p", ADMIN_PASSWORD);
-    es.execInContainer("elasticsearch-users", "roles", ADMIN_USER, "-a", ADMIN_ROLE);
-
-    adminElasticsearchClient = createAdminElasticsearchClient("http://" + es.getHttpHostAddress());
-
-    // create app user with APP_ROLE role
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
-        .pollInterval(Duration.ofSeconds(1))
-        .ignoreExceptions()
-        .until(
-            () ->
-                adminElasticsearchClient
-                    .security()
-                    .putUser(r -> r.username(APP_USER).password(APP_PASSWORD).roles(APP_ROLE))
-                    .created());
-
-    final String esUrl = "http://" + es.getHttpHostAddress();
-
-    // Connect to ES in Standalone Schema Manager
-    schemaManager.withProperty("camunda.data.secondary-storage.elasticsearch.url", esUrl);
-
-    // Connect to ES in Camunda
-    camunda
-        .withUnifiedConfig(
-            cfg -> cfg.getData().getSecondaryStorage().getElasticsearch().setUrl(esUrl))
-        .updateExporterArgs(
-            CamundaExporter.class.getSimpleName(),
-            args -> ((Map) args.get("connect")).put("url", esUrl));
-
-    // Connect to ES in Backup Manager
-    backupManager.withProperty("camunda.data.secondary-storage.elasticsearch.url", esUrl);
+  static Stream<SearchBackendStrategy> strategies() {
+    return Stream.of(new ElasticsearchBackendStrategy(), new OpenSearchBackendStrategy());
   }
 
-  @Test
-  void canBackupRestore() throws Exception {
-    // GIVEN
-    // create the schema
-    schemaManager.start();
-    // Create a snapshot repository to store backups
-    createSnapshotRepository();
-    // Start the Camunda application
-    camunda.start();
-    // Generate test data
-    final long processInstanceKey = generateData();
-    // Assert that the data is created in Elasticsearch
-    final long userTaskKey =
-        assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance());
+  @ParameterizedTest
+  @MethodSource("strategies")
+  void canBackupRestore(final SearchBackendStrategy strategy) throws Exception {
+    try (strategy) {
+      // GIVEN
+      // Initialize the search backend container and clients
+      strategy.startContainer();
+      strategy.createAdminClient();
+      strategy.configureStandaloneSchemaManager(schemaManager);
+      strategy.configureStandaloneBackupManager(backupManager);
+      strategy.configureCamundaApplication(camunda);
+      // create the schema
+      schemaManager.start();
+      // Create a snapshot repository to store backups
+      strategy.createSnapshotRepository(REPOSITORY_NAME);
+      // Start the Camunda application
+      camunda.start();
+      // Generate test data
+      final long processInstanceKey = generateData();
+      // Assert that the data is created in the search backend
+      final long userTaskKey =
+          assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance());
 
-    // WHEN
-    // Start the backup process with a specific backup ID
-    backupManager.withBackupId(BACKUP_ID).start();
+      // WHEN
+      // Start the backup process with a specific backup ID
+      backupManager.withBackupId(BACKUP_ID).start();
 
-    // Wait for snapshots to be completed
-    final List<String> snapshots = waitForSnapshotsToBeCompleted(SNAPSHOT_NAME_PREFIX, 7);
-    // Update the current state by completing the user task and the process instance
-    completeUserTask(userTaskKey);
-    // Assert that the state is updated: process instance is completed
-    assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance().negate());
+      // Wait for snapshots to be completed
+      final List<String> snapshots = waitForSnapshotsToBeCompleted(strategy, SNAPSHOT_NAME_PREFIX);
+      // Update the current state by completing the user task and the process instance
+      completeUserTask(userTaskKey);
+      // Assert that the state is updated: process instance is completed
+      assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance().negate());
 
-    // Stop the Camunda application
-    camunda.stop();
-    // Delete indices to simulate a fresh start
-    deleteIndices();
-    // Restore the backup to recover deleted data
-    restoreBackup(snapshots);
-    // Restart Camunda after restoration
-    camunda.start();
+      // Stop the Camunda application
+      camunda.stop();
+      // Delete indices to simulate a fresh start
+      deleteIndices(strategy);
+      // Restore the backup to recover deleted data
+      restoreBackup(strategy, snapshots);
+      // Restart Camunda after restoration
+      camunda.start();
 
-    // THEN
-    // Validate that the data is restored successfully at the state before the backup: process
-    // instance is running
-    assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance());
+      // THEN
+      // Validate that the data is restored successfully at the state before the backup: process
+      // instance is running
+      assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance());
+    }
   }
 
   private long generateData() {
@@ -247,24 +141,57 @@ final class StandaloneBackupManagerIT {
   }
 
   private List<String> waitForSnapshotsToBeCompleted(
-      final String snapshotNamePrefix, final int count) {
-    final var snapshots = new ArrayList<String>();
+      final SearchBackendStrategy strategy, final String snapshotNamePrefix) {
+
+    final List<String> completed = new ArrayList<>();
+    final Pattern partPattern = Pattern.compile("part_(\\d+)_of_(\\d+)$");
+
     Awaitility.await("should find all snapshots completed")
-        .atMost(ofSeconds(30))
+        .atMost(ofSeconds(60))
         .pollDelay(ofSeconds(2))
         .untilAsserted(
             () -> {
-              final var response =
-                  adminElasticsearchClient
-                      .snapshot()
-                      .get(r -> r.repository(REPOSITORY_NAME).snapshot(snapshotNamePrefix + "*"))
-                      .snapshots();
-              assertThat(response).hasSize(count);
-              assertThat(response.stream().map(snapshot -> snapshot.state()))
-                  .allMatch(state -> "SUCCESS".equals(state));
-              snapshots.addAll(response.stream().map(snapshot -> snapshot.snapshot()).toList());
+              final var successSnapshots =
+                  strategy.getSuccessSnapshots(REPOSITORY_NAME, snapshotNamePrefix);
+
+              final int expectedTotal =
+                  successSnapshots.stream()
+                      .mapToInt(
+                          name -> {
+                            final var m = partPattern.matcher(name);
+                            return m.find() ? Integer.parseInt(m.group(2)) : 0;
+                          })
+                      .max()
+                      .orElse(0);
+
+              assertThat(expectedTotal)
+                  .withFailMessage("No snapshot parts detected yet")
+                  .isGreaterThan(0);
+
+              final var observedParts =
+                  successSnapshots.stream()
+                      .map(
+                          name -> {
+                            final var m = partPattern.matcher(name);
+                            return m.find() ? Integer.parseInt(m.group(1)) : -1;
+                          })
+                      .filter(p -> p > 0)
+                      .sorted()
+                      .toList();
+
+              assertThat(observedParts).hasSize(successSnapshots.size());
+              assertThat(successSnapshots).hasSize(expectedTotal);
+              assertThat(observedParts)
+                  .containsExactlyInAnyOrder(
+                      java.util.stream.IntStream.rangeClosed(1, expectedTotal)
+                          .boxed()
+                          .toArray(Integer[]::new));
+
+              completed.clear();
+              completed.addAll(successSnapshots);
             });
-    return snapshots;
+
+    return completed;
   }
 
   /**
@@ -301,69 +228,30 @@ final class StandaloneBackupManagerIT {
     return userTaskKey.get();
   }
 
-  private void deleteIndices() throws IOException {
-    adminElasticsearchClient
-        .indices()
-        .delete(r -> r.index("operate*", "tasklist*", "camunda*").ignoreUnavailable(true));
+  private void deleteIndices(final SearchBackendStrategy strategy) throws IOException {
+    strategy.deleteIndices("operate*", "tasklist*", "camunda*");
     Awaitility.await("should delete indices")
         .atMost(ofSeconds(30))
         .pollDelay(ofSeconds(2))
         .untilAsserted(
-            () ->
-                assertThat(
-                        adminElasticsearchClient
-                            .indices()
-                            .exists(
-                                r ->
-                                    r.index("operate*", "tasklist*", "camunda*")
-                                        .allowNoIndices(false))
-                            .value())
-                    .isFalse());
+            () -> assertThat(strategy.indicesExist("operate*", "tasklist*", "camunda*")).isFalse());
   }
 
-  /**
-   * As documented in
-   * https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/backup-and-restore/#restore
-   */
-  private void restoreBackup(final List<String> snapshots) {
-    snapshots.stream()
-        .forEach(
-            snapshot -> {
-              try {
-                adminElasticsearchClient
-                    .snapshot()
-                    .restore(
-                        r ->
-                            r.repository(REPOSITORY_NAME)
-                                .snapshot(snapshot)
-                                .waitForCompletion(true));
-              } catch (final IOException e) {
-                fail("Exception occurred while restoring the backup: " + e.getMessage(), e);
-              }
-            });
-  }
-
-  private void createSnapshotRepository() throws IOException {
-    adminElasticsearchClient
-        .snapshot()
-        .createRepository(
-            q ->
-                q.name(REPOSITORY_NAME)
-                    .repository(r -> r.fs(fs -> fs.settings(s -> s.location(REPOSITORY_NAME)))));
+  private void restoreBackup(final SearchBackendStrategy strategy, final List<String> snapshots) {
+    snapshots.forEach(
+        snapshot -> {
+          try {
+            strategy.restoreBackup(REPOSITORY_NAME, snapshot);
+          } catch (final IOException e) {
+            fail("Exception occurred while restoring the backup: " + e.getMessage(), e);
+          }
+        });
   }
 
   private void completeUserTask(final long userTaskKey) {
     try (final var camundaClient = camunda.newClientBuilder().build()) {
       camundaClient.newCompleteUserTaskCommand(userTaskKey).execute();
     }
-  }
-
-  private ElasticsearchClient createAdminElasticsearchClient(final String elasticSearchUrl) {
-    final var connectConfiguration = new ConnectConfiguration();
-    connectConfiguration.setUrl(elasticSearchUrl);
-    connectConfiguration.setUsername(ADMIN_USER);
-    connectConfiguration.setPassword(ADMIN_PASSWORD);
-    return new ElasticsearchConnector(connectConfiguration).createClient();
   }
 
   private static Predicate<ProcessInstance> isRunningProcessInstance() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -41,7 +41,7 @@ final class StandaloneSchemaManagerIT {
   @MethodSource("strategies")
   void canUseCamunda(final SearchBackendStrategy strategy) throws Exception {
     try (strategy) {
-      strategy.initialize(schemaManager, camunda);
+      initialize(strategy);
 
       final long processInstanceKey;
       try (final var client = camunda.newClientBuilder().build()) {
@@ -110,7 +110,7 @@ final class StandaloneSchemaManagerIT {
   @MethodSource("strategies")
   void canArchiveProcessInstances(final SearchBackendStrategy strategy) throws Exception {
     try (strategy) {
-      strategy.initialize(schemaManager, camunda);
+      initialize(strategy);
       final long processInstanceKey;
       try (final var client = camunda.newClientBuilder().build()) {
         client
@@ -147,5 +147,15 @@ final class StandaloneSchemaManagerIT {
                     .isEqualTo(0);
               });
     }
+  }
+
+  private void initialize(final SearchBackendStrategy strategy) throws Exception {
+    strategy.startContainer();
+    strategy.createAdminClient();
+    strategy.createSchema();
+    strategy.configureStandaloneSchemaManager(schemaManager);
+    strategy.configureCamundaApplication(camunda);
+    schemaManager.start();
+    camunda.start();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/SearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/SearchBackendStrategy.java
@@ -8,22 +8,13 @@
 package io.camunda.it.schema.strategy;
 
 import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestStandaloneBackupManager;
 import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import java.io.IOException;
+import java.util.List;
 import org.testcontainers.containers.GenericContainer;
 
 public interface SearchBackendStrategy extends AutoCloseable {
-
-  default void initialize(
-      final TestStandaloneSchemaManager schemaManager, final TestCamundaApplication camunda)
-      throws Exception {
-    startContainer();
-    createAdminClient();
-    createSchema();
-    configureStandaloneSchemaManager(schemaManager);
-    configureCamundaApplication(camunda);
-    schemaManager.start();
-    camunda.start();
-  }
 
   @Override
   default void close() {
@@ -44,6 +35,8 @@ public interface SearchBackendStrategy extends AutoCloseable {
 
   void configureStandaloneSchemaManager(final TestStandaloneSchemaManager schemaManager);
 
+  void configureStandaloneBackupManager(final TestStandaloneBackupManager schemaManager);
+
   void configureCamundaApplication(final TestCamundaApplication camunda);
 
   // Methods to interact with the search backend
@@ -52,4 +45,15 @@ public interface SearchBackendStrategy extends AutoCloseable {
   long countTemplates(final String namePattern) throws Exception;
 
   long searchByKey(final String indexPattern, final long key) throws Exception;
+
+  void deleteIndices(final String indexName, final String... indexNames) throws IOException;
+
+  boolean indicesExist(final String indexName, final String... indexNames) throws Exception;
+
+  List<String> getSuccessSnapshots(final String repositoryName, final String snapshotNamePrefix)
+      throws Exception;
+
+  void restoreBackup(final String repositoryName, final String snapshot) throws IOException;
+
+  void createSnapshotRepository(final String repositoryName) throws IOException;
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -10,6 +10,7 @@ package io.camunda.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandaloneBackupManager;
 import io.camunda.application.StandaloneBackupManager.BackupManagerConfiguration;
+import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
@@ -38,7 +39,8 @@ public class TestStandaloneBackupManager
         SearchEngineRetentionPropertiesOverride.class,
         // ---
         BackupManagerConfiguration.class,
-        StandaloneBackupManager.class);
+        StandaloneBackupManager.class,
+        NativeSearchClientsConfiguration.class);
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR extends the `StandaloneBackupManager` to work with both Elasticsearch and OpenSearch. 
Backend selection is now property driven via `camunda.data.secondary-storage.type` (default: elasticsearch). 
Conditional bean creation prevents failures when only one backend is in use.

### Key Changes

- Added `OpenSearch` client beans (sync + async) behind `@ConditionalOnProperty`.
- Removed Elasticsearch-only wording from logs and Javadocs, now refer generically to “search engine”.
- Updated integration test to run against both backends; dynamic snapshot completion logic replaces hard coded snapshot count (Elasticsearch=7, OpenSearch=5).
- Adjusted `SearchBackendStrategy` initialization (moved init logic out of default method for clarity).
- Updated backup trigger and observation flow to be backend agnostic.

`StandaloneBackupManager` previously hard coded Elasticsearch classes and terminology, blocking OpenSearch adoption and causing bean wiring errors. This refactor makes backup orchestration backend neutral and prepares for future variants (e.g. AWS OpenSearch).


Default behavior remains unchanged for users not setting the new type property.


closes #39528 #39530 
