### PR TITLE
Seamless Access to All Tenants: first option POC

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -23,6 +23,7 @@ public class InitializationConfiguration {
   private List<ConfiguredUser> users = new ArrayList<>();
   private List<ConfiguredMappingRule> mappingRules = new ArrayList<>();
   private Map<String, Map<String, Collection<String>>> defaultRoles = new HashMap<>();
+  private Map<String, Map<String, Collection<String>>> defaultGroups = new HashMap<>();
   private List<ConfiguredAuthorization> authorizations = new ArrayList<>();
 
   public List<ConfiguredUser> getUsers() {
@@ -47,6 +48,14 @@ public class InitializationConfiguration {
 
   public void setDefaultRoles(final Map<String, Map<String, Collection<String>>> defaultRoles) {
     this.defaultRoles = defaultRoles;
+  }
+
+  public Map<String, Map<String, Collection<String>>> getDefaultGroups() {
+    return defaultGroups;
+  }
+
+  public void setDefaultGroups(final Map<String, Map<String, Collection<String>>> defaultGroups) {
+    this.defaultGroups = defaultGroups;
   }
 
   public List<ConfiguredAuthorization> getAuthorizations() {

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum DefaultRole {
   ADMIN("admin"),
+  ALL_TENANTS("all-tenants"),
   RPA("rpa"),
   CONNECTORS("connectors"),
   APP_INTEGRATIONS("app-integrations");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -15,12 +15,14 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
@@ -55,6 +57,8 @@ public final class IdentitySetupInitializeProcessor
     createRoleMembers(initializationKey, setupRecord.getRoleMembers());
     createTenantMembers(initializationKey, setupRecord.getTenantMembers());
     createAuthorizations(initializationKey, setupRecord.getAuthorizations());
+    createGroups(initializationKey, setupRecord.getGroups());
+    createGroupMembers(initializationKey, setupRecord.getGroupMembers());
 
     stateWriter.appendFollowUpEvent(
         initializationKey, IdentitySetupIntent.INITIALIZED, setupRecord);
@@ -63,6 +67,16 @@ public final class IdentitySetupInitializeProcessor
   @Override
   public boolean shouldProcessResultsInSeparateBatches() {
     return true;
+  }
+
+  private void createGroupMembers(final long key, final Collection<GroupRecordValue> roleMembers) {
+    roleMembers.forEach(
+        groupMember ->
+            commandWriter.appendFollowUpCommand(key, GroupIntent.ADD_ENTITY, groupMember));
+  }
+
+  private void createGroups(final long key, final Collection<GroupRecordValue> groups) {
+    groups.forEach(group -> commandWriter.appendFollowUpCommand(key, GroupIntent.CREATE, group));
   }
 
   private void createDefaultTenant(final long key, final TenantRecord defaultTenant) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -69,8 +69,8 @@ public final class IdentitySetupInitializeProcessor
     return true;
   }
 
-  private void createGroupMembers(final long key, final Collection<GroupRecordValue> roleMembers) {
-    roleMembers.forEach(
+  private void createGroupMembers(final long key, final Collection<GroupRecordValue> groupMembers) {
+    groupMembers.forEach(
         groupMember ->
             commandWriter.appendFollowUpCommand(key, GroupIntent.ADD_ENTITY, groupMember));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
-import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -42,7 +41,6 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
       "Expected to delete tenant with id '%s', but no tenant with this id exists.";
   private final TenantState tenantState;
   private final AuthorizationState authorizationState;
-  private final UserState userState;
   private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -60,7 +58,6 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
       final CommandDistributionBehavior commandDistributionBehavior) {
     tenantState = state.getTenantState();
     authorizationState = state.getAuthorizationState();
-    userState = state.getUserState();
     membershipState = state.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
-import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -40,7 +39,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
 
   private final TenantState tenantState;
   private final MappingRuleState mappingRuleState;
-  private final GroupState groupState;
   private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -58,7 +56,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
       final CommandDistributionBehavior commandDistributionBehavior) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
-    groupState = state.getGroupState();
     membershipState = state.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -10,9 +10,11 @@ package io.camunda.zeebe.protocol.impl.record.value.authorization;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
@@ -27,7 +29,11 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   private final ArrayProperty<RoleRecord> rolesProp = new ArrayProperty<>("roles", RoleRecord::new);
   private final ArrayProperty<RoleRecord> roleMembersProp =
       new ArrayProperty<>("roleMembers", RoleRecord::new);
+  private final ArrayProperty<GroupRecord> groupProp =
+      new ArrayProperty<>("defaultGroup", GroupRecord::new);
   private final ArrayProperty<UserRecord> usersProp = new ArrayProperty<>("users", UserRecord::new);
+  private final ArrayProperty<GroupRecord> groupMembersProp =
+      new ArrayProperty<>("groupMembers", GroupRecord::new);
   private final ObjectProperty<TenantRecord> defaultTenantProp =
       new ObjectProperty<>("defaultTenant", new TenantRecord());
   private final ArrayProperty<TenantRecord> tenantMembersProp =
@@ -38,14 +44,16 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
       new ArrayProperty<>("authorizations", AuthorizationRecord::new);
 
   public IdentitySetupRecord() {
-    super(7);
+    super(8);
     declareProperty(rolesProp)
         .declareProperty(roleMembersProp)
         .declareProperty(usersProp)
         .declareProperty(defaultTenantProp)
         .declareProperty(tenantMembersProp)
         .declareProperty(mappingRulesProp)
-        .declareProperty(authorizationsProp);
+        .declareProperty(authorizationsProp)
+        .declareProperty(groupProp)
+        .declareProperty(groupMembersProp);
   }
 
   @Override
@@ -56,6 +64,16 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   @Override
   public Collection<RoleRecordValue> getRoleMembers() {
     return roleMembersProp.stream().map(RoleRecordValue.class::cast).collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<GroupRecordValue> getGroups() {
+    return groupProp.stream().map(GroupRecordValue.class::cast).collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<GroupRecordValue> getGroupMembers() {
+    return groupMembersProp.stream().map(GroupRecordValue.class::cast).collect(Collectors.toList());
   }
 
   @Override
@@ -102,8 +120,18 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
     return this;
   }
 
+  public IdentitySetupRecord addGroup(final GroupRecord group) {
+    groupProp.add().copyFrom(group);
+    return this;
+  }
+
   public IdentitySetupRecord addRoleMember(final RoleRecord role) {
     roleMembersProp.add().copyFrom(role);
+    return this;
+  }
+
+  public IdentitySetupRecord addGroupMember(final GroupRecord group) {
+    groupMembersProp.add().copyFrom(group);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
@@ -29,6 +29,10 @@ public interface IdentitySetupRecordValue extends RecordValue {
 
   Collection<RoleRecordValue> getRoleMembers();
 
+  Collection<GroupRecordValue> getGroups();
+
+  Collection<GroupRecordValue> getGroupMembers();
+
   List<UserRecordValue> getUsers();
 
   TenantRecordValue getDefaultTenant();


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This is the first POC for [seamless access to all tenants epic](https://github.com/camunda/identity/issues/3772)

**Proposal:**

Currently, we have two types of checks when verifying user access:
1.  Authorizations check
2. Tenant check

`Admin` role provides users with tenant authorizations (crud operations for tenants). As role `admin` has only default tenant assigned by default, authorisations are only applied to this tenant.
We could update `admin` role, but this approach would not work for `support` role for example. Also, users can create their own `admin` roles  so we can not really hardcode tenant access to admin role.

**Solution:**
This can be solved by introducing a special role `all-tenants`:
- Created by default
- On population all existing tenants are assigned to it
- When tenant is created, it's automatically assigned to it
- When tenant is deleted, it's automatically un-assigned from it

This allows to create groups combining a role with authorizations and `all-tenants` role giving access to all tenants (for example, `alltenantsadmin` group).
For example, the default group with admin authorizations and all tenants data access will be defined as having 2 roles:
- `admin` role. This would give authorisations that we want.
-  `all-tenants` role. This will give access to all tenants. We would want to make this role non-editable (one of the ways we could approach it is to introduce a flag that indicates this role is read-only, and then update UI to disable edits.

So, this group gives users necessary authorisations (admin) and these authorisations are applied to all tenants in the system.
In the same way other groups can be created if the user needs a custom authorization and access to all tenants data.

How can we configure the default group:
We can use env variable `CAMUNDA_SECURITY_INITIALIZATION_DEFAULTGROUPS_ALLTENANTSADMIN_USERS` with `demo` value. This way ` demo` user will be assigned to the required group.

**Notes**
Currently, tenants search does not filter by tenants, and as a result all `admin` users can see all tenants.
However, they don't have access to tenant data by default because `admin` role is not assigned to all tenants.

**Pros**: this will allow support agents to have access to all tenants as well. Gives users flexibility of configuration, meaning user can re-use the group if they feel some other roles might need access to all tenants.
**Cons**: users will need to use a default group instead of a role and it might be counterintuitive.

Steps to verify the proposal (UI + debug):
1. Start standalone Camunda
2. Create a tenant (lets say "testTenant"), and check that `all-tenants` role is assigned to this tenant automatically.
4. Create user `testUserA` and give this user admin role
5. Create user `testUserB` and assign this user to `alltenantsadmin` group
6. Logout 
7. In the code, put a breakpoint in `IndexFilterTransformer` on line 98 (this is verification of what tenants are assigned to this user)
8. Login as `testUserB` - check the breakpoint, both `default` and `testTenant` should be present. Both tenants are also present in UI
9. Login as `testUserA` - check the breakpoint, only `default` tenant should be there. Both tenants are visible in UI as `admin` role gives authorisations for all tenants and tenant search is not filtering by allowed tenant. This user, however, won’t have access to tenant data if the tenant is not assigned to it (so no access to `testTenant` data).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to [discovery for seamless access to all tenants epic](https://github.com/camunda/identity/issues/3772)
