### PR TITLE
[Backport release-8.9.0-alpha2] fix: remove processDefinitionVersionTag from query params

### DIFF
--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.test.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.test.ts
@@ -227,4 +227,16 @@ describe('buildProcessInstanceFilter', () => {
       elementInstanceState: {$neq: 'COMPLETED'},
     });
   });
+
+  it('does not add version or processDefinitionVersionTag to the filter', () => {
+    const filters: ProcessInstanceFilters = {
+      version: 'v1',
+      process: 'my-process',
+    };
+
+    const result = buildProcessInstanceFilter(filters);
+
+    expect(result.processDefinitionVersionTag).toBeUndefined();
+    expect(result.processDefinitionVersion).toBeUndefined();
+  });
 });

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
@@ -25,7 +25,6 @@ type NormalizedFilters = {
   elementId?: string;
   batchOperationId?: string;
   tenantId?: string;
-  processDefinitionVersionTag?: string;
   processDefinitionKey?: string[];
   variable?: {name: string; values: string[]};
   parentInstanceId?: string;
@@ -110,10 +109,6 @@ const inputFilterSchema = z
       normalized.tenantId = data.tenant;
     } else if (data.tenantId) {
       normalized.tenantId = data.tenantId;
-    }
-
-    if (data.version) {
-      normalized.processDefinitionVersionTag = data.version;
     }
 
     if (data.processIds && data.processIds.length > 0) {
@@ -310,11 +305,6 @@ const buildProcessInstanceFilter = (
 
   if (normalizedFilters.retriesLeft) {
     query.hasRetriesLeft = true;
-  }
-
-  if (normalizedFilters.processDefinitionVersionTag) {
-    query.processDefinitionVersionTag =
-      normalizedFilters.processDefinitionVersionTag;
   }
 
   if (normalizedFilters.processDefinitionKey) {


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/41521 to release-8.9.0-alpha2.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
