### PR TITLE
feat: add partitioning to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -120,6 +121,19 @@ public class Cluster implements Cloneable {
    */
   @NestedConfigurationProperty
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
+
+  /**
+   * The partitioning configuration allow configuring experimental settings related to partitioning.
+   *
+   * <p>At the moment, it lets users configure the scheme - that is, how partitions are distributed
+   * across the brokers. The default scheme is currently {@link Scheme#ROUND_ROBIN}.
+   *
+   * <p>When using {@link Scheme#FIXED}, a map of brokers to a list of partitions should be
+   * specified under {@link Partitioning#fixed}. This map takes keys as the broker node IDs, with
+   * values as a list of partition IDs. The mapping must be exhaustive, meaning all brokers should
+   * appear, and all partitions should be specified with the appropriate replication factor.
+   */
+  @NestedConfigurationProperty private Partitioning partitioning = new Partitioning();
 
   public NodeIdProvider getNodeIdProvider() {
     return nodeIdProvider;
@@ -253,6 +267,14 @@ public class Cluster implements Cloneable {
 
   public void setGlobalListeners(final GlobalListenersCfg globalListeners) {
     this.globalListeners = globalListeners;
+  }
+
+  public Partitioning getPartitioning() {
+    return partitioning;
+  }
+
+  public void setPartitioning(final Partitioning partitioning) {
+    this.partitioning = partitioning;
   }
 
   @Override

--- a/configuration/src/main/java/io/camunda/configuration/FixedPartition.java
+++ b/configuration/src/main/java/io/camunda/configuration/FixedPartition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
+import java.util.Collections;
+import java.util.List;
+
+public class FixedPartition {
+
+  /**
+   * The default partition ID is 1, taken from the single node, single partition deployment commonly
+   * used for development.
+   */
+  private static final int DEFAULT_PARTITION_ID = 1;
+
+  /**
+   * The partition ID for this fixed partition configuration. Defaults to {@link
+   * #DEFAULT_PARTITION_ID} (1).
+   */
+  private int partitionId = DEFAULT_PARTITION_ID;
+
+  /**
+   * The list of nodes assigned to this fixed partition configuration. Initialized as an empty list.
+   */
+  private List<Node> nodes = Collections.emptyList();
+
+  public FixedPartition() {}
+
+  public FixedPartition(final int partitionId, final List<Node> nodes) {
+    this.partitionId = partitionId;
+    this.nodes = nodes;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  public void setNodes(final List<Node> nodes) {
+    this.nodes = nodes;
+  }
+
+  public FixedPartitionCfg toFixedPartitionCfg() {
+    final var fixedPartitionCfg = new FixedPartitionCfg();
+    fixedPartitionCfg.setPartitionId(partitionId);
+    fixedPartitionCfg.setNodes(nodes.stream().map(Node::toNodeCfg).toList());
+    return fixedPartitionCfg;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Node.java
+++ b/configuration/src/main/java/io/camunda/configuration/Node.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
+
+public class Node {
+
+  /**
+   * The default node ID is 0, taken from the single node deployment, commonly used for development.
+   */
+  private static final int DEFAULT_NODE_ID = 0;
+
+  /**
+   * The default priority is 1. When priority election is not enabled, this has no impact on the
+   * system, and can be left as is. If priority election is enabled, all nodes can have priority 1,
+   * but then the election is essentially the same as a normal election without any priorities.
+   */
+  private static final int DEFAULT_PRIORITY = 1;
+
+  /** The node ID for this node configuration. Defaults to {@link #DEFAULT_NODE_ID} (0). */
+  private int nodeId = DEFAULT_NODE_ID;
+
+  /** The priority for this node configuration. Defaults to {@link #DEFAULT_PRIORITY} (1) */
+  private int priority = DEFAULT_PRIORITY;
+
+  public Node() {}
+
+  public Node(final int nodeId) {
+    this.nodeId = nodeId;
+  }
+
+  public int getNodeId() {
+    return nodeId;
+  }
+
+  public void setNodeId(final int nodeId) {
+    this.nodeId = nodeId;
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public void setPriority(final int priority) {
+    this.priority = priority;
+  }
+
+  public NodeCfg toNodeCfg() {
+    final NodeCfg nodeCfg = new NodeCfg();
+    nodeCfg.setNodeId(nodeId);
+    nodeCfg.setPriority(priority);
+    return nodeCfg;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Partitioning.java
+++ b/configuration/src/main/java/io/camunda/configuration/Partitioning.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class Partitioning {
+  private static final String PREFIX = "camunda.cluster.partitioning";
+  private static final Set<String> LEGACY_SCHEME_PROPERTIES =
+      Set.of("zeebe.broker.experimental.partitioning.scheme");
+
+  /**
+   * The default partitioning {@link Scheme} is the {@link Scheme#ROUND_ROBIN} scheme. This is
+   * required for backwards compatibility, but it's also a good default for now as there is no
+   * better alternative in most cases.
+   */
+  private static final Scheme DEFAULT_SCHEME = Scheme.ROUND_ROBIN;
+
+  /**
+   * The partitioning scheme used for assigning partitions to nodes. Defaults to {@link
+   * Scheme#ROUND_ROBIN}.
+   */
+  private Scheme scheme = DEFAULT_SCHEME;
+
+  /**
+   * The list of fixed partition configurations for this partitioning setup. Initialized as an
+   * empty, list by default. Used when the {@link Scheme#FIXED} partitioning scheme is selected.
+   */
+  private List<FixedPartition> fixed = Collections.emptyList();
+
+  public Partitioning() {}
+
+  public Partitioning(final Scheme scheme, final List<FixedPartition> fixed) {
+    this.scheme = scheme;
+    this.fixed = fixed;
+  }
+
+  public Scheme getScheme() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".scheme",
+        scheme,
+        Scheme.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SCHEME_PROPERTIES);
+  }
+
+  public void setScheme(final Scheme scheme) {
+    this.scheme = scheme;
+  }
+
+  public List<FixedPartition> getFixed() {
+    return fixed;
+  }
+
+  public void setFixed(final List<FixedPartition> fixed) {
+    this.fixed = fixed;
+  }
+
+  public enum Scheme {
+    FIXED,
+    ROUND_ROBIN;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/PartitioningTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PartitioningTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class PartitioningTest {
+
+  private FixedPartitionCfg expectedFixedPartitionCfg1;
+  private FixedPartitionCfg expectedFixedPartitionCfg2;
+
+  private FixedPartitionCfg createFixedPartitionCfg(
+      final int partitionId, final List<NodeCfg> nodes) {
+    final var fixedPartitionCfg = new FixedPartitionCfg();
+    fixedPartitionCfg.setPartitionId(partitionId);
+    fixedPartitionCfg.setNodes(nodes);
+    return fixedPartitionCfg;
+  }
+
+  private NodeCfg createNodeCfg(final int nodeId, final int priority) {
+    final var nodeCfg = new NodeCfg();
+    nodeCfg.setNodeId(nodeId);
+    nodeCfg.setPriority(priority);
+    return nodeCfg;
+  }
+
+  @BeforeEach
+  void setUp() {
+    expectedFixedPartitionCfg1 =
+        createFixedPartitionCfg(2, List.of(createNodeCfg(208, 209), createNodeCfg(218, 219)));
+    expectedFixedPartitionCfg2 =
+        createFixedPartitionCfg(3, List.of(createNodeCfg(308, 309), createNodeCfg(318, 319)));
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.partitioning.scheme=fixed",
+        "camunda.cluster.partitioning.fixed.0.partition-id=2",
+        "camunda.cluster.partitioning.fixed.0.nodes.0.node-id=208",
+        "camunda.cluster.partitioning.fixed.0.nodes.0.priority=209",
+        "camunda.cluster.partitioning.fixed.0.nodes.1.node-id=218",
+        "camunda.cluster.partitioning.fixed.0.nodes.1.priority=219",
+        "camunda.cluster.partitioning.fixed.1.partition-id=3",
+        "camunda.cluster.partitioning.fixed.1.nodes.0.node-id=308",
+        "camunda.cluster.partitioning.fixed.1.nodes.0.priority=309",
+        "camunda.cluster.partitioning.fixed.1.nodes.1.node-id=318",
+        "camunda.cluster.partitioning.fixed.1.nodes.1.priority=319",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetPartitioning() {
+      assertThat(brokerCfg.getExperimental().getPartitioning().getScheme().name())
+          .isEqualTo(Partitioning.Scheme.FIXED.name());
+
+      assertThat(brokerCfg.getExperimental().getPartitioning().getFixed())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactlyInAnyOrder(expectedFixedPartitionCfg1, expectedFixedPartitionCfg2);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.partitioning.scheme=fixed",
+        "zeebe.broker.experimental.partitioning.fixed.0.partitionId=2",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.0.nodeId=208",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.0.priority=209",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.1.nodeId=218",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.1.priority=219",
+        "zeebe.broker.experimental.partitioning.fixed.1.partitionId=3",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.0.nodeId=308",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.0.priority=309",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.1.nodeId=318",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.1.priority=319",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetPartitioningFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getPartitioning().getScheme().name())
+          .isEqualTo(Partitioning.Scheme.FIXED.name());
+
+      assertThat(brokerCfg.getExperimental().getPartitioning().getFixed())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactlyInAnyOrder(expectedFixedPartitionCfg1, expectedFixedPartitionCfg2);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.partitioning.scheme=fixed",
+        "camunda.cluster.partitioning.fixed.0.partition-id=2",
+        "camunda.cluster.partitioning.fixed.0.nodes.0.node-id=208",
+        "camunda.cluster.partitioning.fixed.0.nodes.0.priority=209",
+        "camunda.cluster.partitioning.fixed.0.nodes.1.node-id=218",
+        "camunda.cluster.partitioning.fixed.0.nodes.1.priority=219",
+        "camunda.cluster.partitioning.fixed.1.partition-id=3",
+        "camunda.cluster.partitioning.fixed.1.nodes.0.node-id=308",
+        "camunda.cluster.partitioning.fixed.1.nodes.0.priority=309",
+        "camunda.cluster.partitioning.fixed.1.nodes.1.node-id=318",
+        "camunda.cluster.partitioning.fixed.1.nodes.1.priority=319",
+        // legacy
+        "zeebe.broker.experimental.partitioning.scheme=fixed",
+        "zeebe.broker.experimental.partitioning.fixed.0.partitionId=8",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.0.nodeId=808",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.0.priority=809",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.1.nodeId=818",
+        "zeebe.broker.experimental.partitioning.fixed.0.nodes.1.priority=819",
+        "zeebe.broker.experimental.partitioning.fixed.1.partitionId=9",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.0.nodeId=908",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.0.priority=909",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.1.nodeId=918",
+        "zeebe.broker.experimental.partitioning.fixed.1.nodes.1.priority=919"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetPartitioningFromNew() {
+      assertThat(brokerCfg.getExperimental().getPartitioning().getScheme().name())
+          .isEqualTo(Partitioning.Scheme.FIXED.name());
+
+      assertThat(brokerCfg.getExperimental().getPartitioning().getFixed())
+          .hasSize(2)
+          .usingRecursiveFieldByFieldElementComparator()
+          .containsExactlyInAnyOrder(expectedFixedPartitionCfg1, expectedFixedPartitionCfg2);
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FixedPartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FixedPartitionDistributionIT.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.it.cluster.clustering;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import io.camunda.configuration.FixedPartition;
+import io.camunda.configuration.Node;
+import io.camunda.configuration.Partitioning;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -59,17 +61,14 @@ final class FixedPartitionDistributionIT {
     broker.withUnifiedConfig(
         cfg -> {
           cfg.getCluster().getRaft().setPriorityElectionEnabled(false);
+          cfg.getCluster()
+              .setPartitioning(
+                  new Partitioning(
+                      Partitioning.Scheme.FIXED,
+                      List.of(
+                          new FixedPartition(1, List.of(new Node(1), new Node(2))),
+                          new FixedPartition(2, List.of(new Node(0), new Node(2))),
+                          new FixedPartition(3, List.of(new Node(0), new Node(1))))));
         });
-    // set partitioning via properties because it is not yet supported in unified config
-    broker.withProperty("zeebe.broker.experimental.partitioning.scheme", Scheme.FIXED);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[0].partitionId", 1);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[0].nodes.[0].nodeId", 1);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[0].nodes.[1].nodeId", 2);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[1].partitionId", 2);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[1].nodes.[0].nodeId", 0);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[1].nodes.[1].nodeId", 2);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[2].partitionId", 3);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[2].nodes.[0].nodeId", 0);
-    broker.withProperty("zeebe.broker.experimental.partitioning.fixed.[2].nodes.[1].nodeId", 1);
   }
 }


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.cluster.partitioning to unified configuration.

The legacy properties are:
zeebe.broker.experimental.partitioning.scheme
zeebe.broker.experimental.partitioning.fixed.[x].partitionId
zeebe.broker.experimental.partitioning.fixed.[x].nodes.[x].nodeId
zeebe.broker.experimental.partitioning.fixed.[x].nodes.[x].priority

The new properties are:
camunda.cluster.partitioning.scheme
camunda.cluster.partitioning.fixed.[x].partition-id
camunda.cluster.partitioning.fixed.[x].nodes.[x].node-id
camunda.cluster.partitioning.fixed.[x].nodes.[x].priority

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
