### PR TITLE
ci: add frontend + backend area labels to Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -112,6 +112,24 @@
       ]
     },
     {
+      "description": "Identify updates related to frontend dependencies.",
+      "matchManagers": [
+        "npm"
+      ],
+      "addLabels": [
+        "area/frontend"
+      ]
+    },
+    {
+      "description": "Identify updates related to backend dependencies.",
+      "matchManagers": [
+        "maven"
+      ],
+      "addLabels": [
+        "area/backend"
+      ]
+    },
+    {
       "matchManagers": [
         "maven"
       ],


### PR DESCRIPTION
## Description

Allows tracking the number of open Renovate PRs per area [via Prometheus](https://monitor.int.camunda.com/query?g0.expr=renovate_open_prs&g0.show_tree=0&g0.tab=graph&g0.range_input=6h&g0.res_type=auto&g0.res_density=medium&g0.display_mode=lines&g0.show_exemplars=0). For existing Renovate PRs, I applied the labels manually.

This new addition uses a feature introduced in https://github.com/camunda/infra-github-exporter/pull/207

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/36956