### PR TITLE
ci: fix CODEOWNERS patterns

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # If you'd like to be added as an owner, don't hesitate to reach out to one of the existing ones.
 
 # C8 REST OpenAPI specification
-/zeebe/gateway-protocol/src/main/proto/v2/* @camunda/c8-api-team
+/zeebe/gateway-protocol/src/main/proto/v2/ @camunda/c8-api-team
 
 # Testing guide
 /docs/testing.md       @npepinpe @ChrisKujawa
@@ -19,8 +19,8 @@
 /c8run/ @camunda/distribution
 
 # Camunda Ex Team Clients, SDK and CPT
-/clients/*        @camunda/camundaex
-/testing/*        @camunda/camundaex
+/clients/        @camunda/camundaex
+/testing/        @camunda/camundaex
 
 # General Automation, Unified CI and release helpers by Monorepo DevOps team
 /.github/actions/build*/*                                @camunda/monorepo-devops-team
@@ -126,6 +126,6 @@
 /zeebe/load-tests @camunda/zeebe-distributed-platform
 
 # Identity
-/identity/*        @camunda/identity
-/authentication/*  @camunda/identity
-/security/*        @camunda/identity
+/identity/        @camunda/identity
+/authentication/  @camunda/identity
+/security/        @camunda/identity


### PR DESCRIPTION
## Description

Some camundaex, c8-api-team and identity directory patterns used a wildcard at the end,
which only matches files within the directory but no nested files.

See this Github example:
```
# In this example, @doctocat owns any file in the `/docs`
# directory in the root of your repository and any of its
# subdirectories.
/docs/ @doctocat
```
vs.
```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/* docs@example.com
```

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
