### PR TITLE
[Backport stable/8.8] ci: fix CODEOWNERS patterns

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,8 +20,8 @@
 /c8run/ @camunda/distribution
 
 # Camunda Ex Team Clients, SDK and CPT
-/clients/*        @camunda/camundaex
-/testing/*        @camunda/camundaex
+/clients/        @camunda/camundaex
+/testing/        @camunda/camundaex
 
 # General Automation, Unified CI and release helpers by Monorepo DevOps team
 /.github/actions/build*/*                                @camunda/monorepo-devops-team
@@ -121,6 +121,6 @@
 /zeebe/benchmarks @camunda/zeebe-distributed-platform
 
 # Identity
-/identity/*        @camunda/identity
-/authentication/*  @camunda/identity
-/security/*        @camunda/identity
+/identity/        @camunda/identity
+/authentication/  @camunda/identity
+/security/        @camunda/identity


### PR DESCRIPTION
# Description
Backport of #41538 to `stable/8.8`.

relates to 