### PR TITLE
fix: job deadline exceeded

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/CommandWrapper.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/CommandWrapper.java
@@ -19,7 +19,6 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.metrics.MetricsRecorder;
-import java.time.Instant;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -105,6 +104,6 @@ public class CommandWrapper {
   }
 
   private boolean jobDeadlineExceeded() {
-    return (Instant.now().getEpochSecond() > job.getDeadline());
+    return (System.currentTimeMillis() > job.getDeadline());
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes an issue where a seconds timestamp (Instant.getEpochSeconds()) is compared to a millis timestamp (job.getDeadline()).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
