### PR TITLE
feat: adjust PIM preconditions for user tasks

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -263,7 +263,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
-    requireSameUserTaskImplementation(
+    requireSupportedUserTaskImplementation(
         sourceProcessDefinition,
         targetProcessDefinition,
         targetElementId,
@@ -727,7 +727,7 @@ public class ProcessInstanceMigrationMigrateProcessor
           targetProcessDefinition.getProcess().getElementById(targetElementId);
 
       final ExecutableAdHocSubProcess targetAhsp;
-      if (element instanceof ExecutableMultiInstanceBody mi) {
+      if (element instanceof final ExecutableMultiInstanceBody mi) {
         targetAhsp = (ExecutableAdHocSubProcess) mi.getInnerActivity();
       } else {
         targetAhsp = (ExecutableAdHocSubProcess) element;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -133,12 +133,11 @@ public final class ProcessInstanceMigrationPreconditions {
       but active element with id '%s' and type '%s' is mapped to \
       an element with id '%s' and different type '%s'. \
       Elements must be mapped to elements of the same type.""";
-  private static final String ERROR_USER_TASK_IMPLEMENTATION_CHANGED =
+  private static final String ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION =
       """
       Expected to migrate process instance '%s' \
       but active user task with id '%s' and implementation '%s' is mapped to \
-      an user task with id '%s' and different implementation '%s'. \
-      Elements must be mapped to elements of the same implementation.""";
+      a user task with id '%s' and deprecated implementation '%s'.""";
   private static final String ERROR_MESSAGE_ELEMENT_FLOW_SCOPE_CHANGED =
       """
       Expected to migrate process instance '%s' \
@@ -566,9 +565,8 @@ public final class ProcessInstanceMigrationPreconditions {
   }
 
   /**
-   * Since we introduce zeebe user tasks and job worker tasks has the same bpmn element type, we
-   * need to check whether the given element instance and target element has the same user task
-   * type. Throws an exception if they have different types.
+   * Checks whether the given user task implementations are supported for migration. Throws an
+   * exception if a zeebe user task is migrated to the deprecated job worker user task type.
    *
    * @param sourceProcessDefinition source process definition to retrieve the source element type
    * @param targetProcessDefinition target process definition to retrieve the target element type
@@ -576,7 +574,7 @@ public final class ProcessInstanceMigrationPreconditions {
    * @param elementInstance element instance to do the check
    * @param processInstanceKey process instance key to be logged
    */
-  public static void requireSameUserTaskImplementation(
+  public static void requireSupportedUserTaskImplementation(
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
@@ -612,10 +610,11 @@ public final class ProcessInstanceMigrationPreconditions {
             ? ZEEBE_USER_TASK_IMPLEMENTATION
             : JOB_WORKER_IMPLEMENTATION;
 
-    if (!targetUserTaskType.equals(sourceUserTaskType)) {
+    if (!sourceUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)
+        && targetUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)) {
       final String reason =
           String.format(
-              ERROR_USER_TASK_IMPLEMENTATION_CHANGED,
+              ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION,
               processInstanceKey,
               elementInstanceRecord.getElementId(),
               sourceUserTaskType,
@@ -1237,7 +1236,7 @@ public final class ProcessInstanceMigrationPreconditions {
     final var elementType = element.getElementType();
 
     return isAdHocSubProcess(elementType)
-        || (element instanceof ExecutableMultiInstanceBody mi
+        || (element instanceof final ExecutableMultiInstanceBody mi
             && isAdHocSubProcess(mi.getInnerActivity().getElementType()));
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Changed user task process instance migration preconditions to only reject migrations from camunda user tasks to the deprecated job worker.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/29265
