### PR TITLE
Revert "feat: when nodeId from old config is null, call nodeIdProvider"

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -48,10 +48,7 @@ public class BrokerBasedConfiguration {
     this.properties = properties;
     this.lifecycle = lifecycle;
 
-    if (properties.getCluster().getNodeId() == null) {
-      final var nodeIdFromProvider = nodeIdProvider.currentNodeInstance().id();
-      properties.getCluster().setNodeId(nodeIdFromProvider);
-    }
+    properties.getCluster().setNodeId(nodeIdProvider.currentNodeInstance().id());
     properties.init(workingDirectory.path().toAbsolutePath().toString());
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -45,7 +45,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
   private List<Integer> partitionIds;
-  private Integer nodeId;
+  private Integer nodeId = 0;
   private String clusterId;
   private int partitionsCount = DEFAULT_PARTITIONS_COUNT;
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -58,7 +58,6 @@ public final class SimpleBrokerStartTest {
   public void shouldFailToCreateBrokerWithSmallSnapshotPeriod() {
     // given
     final var brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setNodeId(0);
     brokerCfg.getData().setSnapshotPeriod(Duration.ofMillis(1));
     brokerCfg.init(newTemporaryFolder.getAbsolutePath());
 
@@ -90,7 +89,6 @@ public final class SimpleBrokerStartTest {
   public void shouldCallPartitionListenerAfterStart() throws Exception {
     // given
     final var brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setNodeId(0);
     assignSocketAddresses(brokerCfg);
     brokerCfg.init(newTemporaryFolder.getAbsolutePath());
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -131,7 +131,6 @@ public final class BrokerCfgTest {
     final ExporterCfg exporterCfgInternal2 = new ExporterCfg();
 
     final BrokerCfg config = new BrokerCfg();
-    config.getCluster().setNodeId(0);
     config.getExporters().put("external", exporterCfgExternal);
     config.getExporters().put("internal-1", exporterCfgInternal1);
     config.getExporters().put("internal-2", exporterCfgInternal2);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -223,7 +223,6 @@ public final class ClusterCfgTest {
     // given
     final ClusterCfg clusterCfg = new ClusterCfg();
     clusterCfg.setPartitionsCount(8);
-    clusterCfg.setNodeId(0);
 
     // when
     clusterCfg.init(new BrokerCfg(), "");

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/TestConfigReader.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/TestConfigReader.java
@@ -23,9 +23,6 @@ public final class TestConfigReader {
     final BrokerCfg config =
         new TestConfigurationFactory()
             .create(environmentVariables, "zeebe.broker", configPath, BrokerCfg.class);
-    if (config.getCluster().getNodeId() == null) {
-      config.getCluster().setNodeId(0);
-    }
     config.init(BROKER_BASE, environmentVariables);
 
     return config;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -313,10 +313,6 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     // set random port numbers
     assignSocketAddresses(brokerCfg);
 
-    if (brokerCfg.getCluster().getNodeId() == null) {
-      brokerCfg.getCluster().setNodeId(0);
-    }
-
     // initialize configuration
     brokerCfg.init(brokerBase.getAbsolutePath());
   }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
@@ -25,7 +25,6 @@ final class RestoreManagerTest {
   void shouldFailWhenDirectoryIsNotEmpty(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
-    configuration.getCluster().setNodeId(0);
     configuration.getData().setDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(
@@ -43,7 +42,6 @@ final class RestoreManagerTest {
   void shouldIgnoreConfigurableFilesInTarget(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
-    configuration.getCluster().setNodeId(0);
     configuration.getData().setDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(


### PR DESCRIPTION
## Description
This reverts commit b650f4a76423bb02abe855271472308e5bc0a816 as it was introduce because `TestCluster` and `TestStandaloneBroker` were not supporting UnifiedConfiguration

## Related issues

closes #40827
