### PR TITLE
fix: remove useless Renovate scans on 8.5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,8 +6,7 @@
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [
-    "/^stable\\/8\\.([5-9]|[1-9][0-9])/",
-    "stable/operate-8.5",
+    "/^stable\\/8\\.([6-9]|[1-9][0-9])/",
     "main"
   ],
   "dependencyDashboard": true,
@@ -60,27 +59,17 @@
       "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
       "separateMinorPatch": true,
       "matchBaseBranches": [
-        "/^stable\\/8\\..*/",
-        "stable/operate-8.5"
+        "/^stable\\/8\\..*/"
       ]
     },
     {
       "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
       "matchBaseBranches": [
-        "/^stable\\/8\\..*/",
-        "stable/operate-8.5"
+        "/^stable\\/8\\..*/"
       ],
       "matchUpdateTypes": [
         "minor",
         "major"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Disable all Renovate updates on EOL 8.5 stable branches to prevent unwanted PRs from Renovate.",
-      "matchBaseBranches": [
-        "stable/8.5",
-        "stable/operate-8.5"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Description

Simplifies the configuration after https://github.com/camunda/camunda/pull/40314 and speeds up runtime of Renovate.

Rationale: if we don't create any PRs ever for `stable/8.5` nor `stable/operate-8.5`, we can also remove those two branches from the `baseBranchPatterns` completely. Otherwise, Renovate continues to check out and scan those branches just to do nothing afterwards.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
