### PR TITLE
Fix: broadcasted signal creates a process instance on every partition

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -210,7 +210,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
         subscription -> {
           final var subscriptionRecord = subscription.getRecord();
           final var isStartEvent = subscriptionRecord.getCatchEventInstanceKey() == -1;
-          if (isStartEvent) {
+          if (isStartEvent && !command.isCommandDistributed()) {
             eventHandle.activateProcessInstanceForStartEvent(
                 subscriptionRecord.getProcessDefinitionKey(),
                 keyGenerator.nextKey(),


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

A change in the `SignalBroadcastProcessor` [here](https://github.com/camunda/camunda/pull/39523) changed the behaviour of distributed commands. Instead of only triggering signal subscriptions that are waiting inside of a process instance, it now also triggers signal start events. This is something we must avoid. Only the partition that receives the original broadcast command should create the process instance.

Because of this change we now create a process instance for every partition in the cluster upon a signal broadcast. This PR fixes this and adds a test case to ensure we don't accidentally break this in the future.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41576 
