### PR TITLE
[Backport stable/8.8] ci: remove `macos-latest-large` runners

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -42,11 +42,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos, windows, linux ]
+        os: [ windows, linux ]
         arch: [ amd64 ]
         include:
-          - os: macos
-            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
# Description
Backport of #41417 to `stable/8.8`.

relates to 