### PR TITLE
ci: remove `macos-latest-large` runners from zeebe-ci

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -33,11 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos, windows, linux ]
+        os: [ windows, linux ]
         arch: [ amd64 ]
         include:
-          - os: macos
-            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
## Description

Altered backport (different filename) of https://github.com/camunda/camunda/pull/41417

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
