### PR TITLE
test: demonstrate race condition when completing tasks

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -250,6 +250,8 @@ public class TaskService {
       }
 
       try {
+        LOGGER.info("Waiting for zeebe to finish");
+        Thread.sleep(5000);
         LOGGER.info("Start variable persistence: {}", taskId);
         variableService.persistTaskVariables(taskId, variables, withDraftVariableValues);
         deleteDraftTaskVariablesSafely(taskId);


### PR DESCRIPTION
if zeebe completes first then we do not copy over all variables

It looks like this happens because the flownodes are moved from `ACTIVE` to `COMPLETE` and then we are unable to retrieve the original list of variables as we do not find any flow nodes in `VariableService`

Found out that @yohanfernando had already discovered this issue and has a bug for it in #40817
