### PR TITLE
[Backport stable/8.6] ci: remove `macos-latest-large` runners from zeebe-ci

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -33,11 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos, windows, linux ]
+        os: [ windows, linux ]
         arch: [ amd64 ]
         include:
-          - os: macos
-            runner: macos-latest-large
           - os: macos
             runner: macos-latest
             arch: arm64


### PR DESCRIPTION
# Description
Backport of #41583 to `stable/8.6`.

relates to 