### PR TITLE
fix: exporter error on incident resolution rejection causes operate list view update failures

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
@@ -41,6 +41,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandler<
   @Override
   public boolean handlesRecord(final Record<R> record) {
     return record.getBatchOperationReference() != batchOperationReferenceNullValue()
+        && record.getValue().getProcessInstanceKey() > 0
         && (isCompleted(record) || isFailed(record))
         && isRelevantForBatchOperation(record);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandler.java
@@ -11,6 +11,7 @@ import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -33,7 +34,9 @@ public class ListViewFromIncidentResolutionOperationHandler
   @Override
   protected boolean isFailed(final Record<IncidentRecordValue> record) {
     return record.getIntent().equals(IncidentIntent.RESOLVE)
-        && record.getRejectionType() != RejectionType.NULL_VAL;
+        && record.getRecordType() == RecordType.COMMAND_REJECTION
+        && record.getRejectionType() != RejectionType.NULL_VAL
+        && record.getRejectionType() != RejectionType.NOT_FOUND;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandler.java
@@ -11,6 +11,7 @@ import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -43,7 +44,9 @@ public class ListViewFromProcessInstanceCancellationOperationHandler
   protected boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
     return isRootProcessInstance(record)
         && record.getIntent().equals(ProcessInstanceIntent.CANCEL)
-        && record.getRejectionType() != RejectionType.NULL_VAL;
+        && record.getRecordType() == RecordType.COMMAND_REJECTION
+        && record.getRejectionType() != RejectionType.NULL_VAL
+        && record.getRejectionType() != RejectionType.NOT_FOUND;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandler.java
@@ -11,6 +11,7 @@ import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -33,7 +34,9 @@ public class ListViewFromProcessInstanceMigrationOperationHandler
   @Override
   protected boolean isFailed(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATE)
-        && record.getRejectionType() != RejectionType.NULL_VAL;
+        && record.getRecordType() == RecordType.COMMAND_REJECTION
+        && record.getRejectionType() != RejectionType.NULL_VAL
+        && record.getRejectionType() != RejectionType.NOT_FOUND;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandler.java
@@ -11,6 +11,7 @@ import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -34,7 +35,9 @@ public class ListViewFromProcessInstanceModificationOperationHandler
   @Override
   protected boolean isFailed(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFY)
-        && record.getRejectionType() != RejectionType.NULL_VAL;
+        && record.getRecordType() == RecordType.COMMAND_REJECTION
+        && record.getRejectionType() != RejectionType.NULL_VAL
+        && record.getRejectionType() != RejectionType.NOT_FOUND;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
   @Test
   void shouldHandleCompletedRecord() {
     // Given
-    final var record = createCompletedRecord();
+    final var record = createCompletedRecord(123456789L);
     when(CACHE.get(Mockito.anyString()))
         .thenReturn(
             Optional.of(
@@ -92,7 +92,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
     // Given
     final var record =
         ImmutableRecord.<R>builder()
-            .from(createCompletedRecord())
+            .from(createCompletedRecord(123456789L))
             .withBatchOperationReference(batchOperationReferenceNullValue())
             .build();
     when(CACHE.get(Mockito.anyString()))
@@ -109,9 +109,27 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
   }
 
   @Test
+  void shouldNotHandleRecordsWithInvalidProcessInstanceKey() {
+    // Given
+    final var record = createCompletedRecord(-1L);
+    when(CACHE.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(record.getBatchOperationReference()),
+                    map(underTest.getRelevantOperationType()))));
+
+    // When
+    final boolean result = underTest.handlesRecord(record);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
   void shouldNotHandleIrrelevantRecord() {
     // Given
-    final var record = createCompletedRecord();
+    final var record = createCompletedRecord(123456789L);
     final var irrelevantOperationType =
         Arrays.stream(OperationType.values())
             .filter(t -> t != underTest.getRelevantOperationType())
@@ -135,7 +153,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
   @Test
   void shouldGenerateId() {
     // Given
-    final var record = createCompletedRecord();
+    final var record = createCompletedRecord(123456789L);
 
     // When
     final var idList = underTest.generateIds(record);
@@ -147,7 +165,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
   @Test
   void shouldUpdateEntityFromRecord() {
     // Given
-    final var record = createCompletedRecord();
+    final var record = createCompletedRecord(123456789L);
     final var entity = underTest.createNewEntity("test-id");
 
     // When
@@ -177,7 +195,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
             eq(Map.of("batchOperationId", "batch-op-1")));
   }
 
-  protected abstract Record<R> createCompletedRecord();
+  protected abstract Record<R> createCompletedRecord(final long processInstanceKey);
 
   protected abstract Record<R> createRejectedRecord();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -74,6 +74,20 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
   }
 
   @Test
+  void shouldNotHandleNotFoundRejectionRecord() {
+    // Given
+    final var record = createNotFoundRejectedRecord();
+    when(CACHE.get(Mockito.anyString()))
+        .thenReturn(
+            Optional.of(
+                new CachedBatchOperationEntity(
+                    String.valueOf(record.getBatchOperationReference()),
+                    map(underTest.getRelevantOperationType()))));
+
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
   void shouldNotHandleRecordsWithNoOperationReference() {
     // Given
     final var record =
@@ -166,4 +180,6 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
   protected abstract Record<R> createCompletedRecord();
 
   protected abstract Record<R> createRejectedRecord();
+
+  protected abstract Record<R> createNotFoundRejectedRecord();
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 
 class ListViewFromIncidentResolutionOperationHandlerTest
@@ -22,18 +23,31 @@ class ListViewFromIncidentResolutionOperationHandlerTest
   }
 
   @Override
-  protected io.camunda.zeebe.protocol.record.Record<IncidentRecordValue> createCompletedRecord() {
-    return factory.generateRecord(ValueType.INCIDENT, b -> b.withIntent(IncidentIntent.RESOLVED));
+  protected io.camunda.zeebe.protocol.record.Record<IncidentRecordValue> createCompletedRecord(
+      final long processInstanceKey) {
+    final var value =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+    return factory.generateRecord(
+        ValueType.INCIDENT, b -> b.withIntent(IncidentIntent.RESOLVED).withValue(value));
   }
 
   @Override
   protected Record<IncidentRecordValue> createRejectedRecord() {
+    final var value =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .withProcessInstanceKey(123456789L)
+            .build();
     return factory.generateRecord(
         ValueType.INCIDENT,
         b ->
             b.withRecordType(RecordType.COMMAND_REJECTION)
                 .withRejectionType(RejectionType.INVALID_STATE)
-                .withIntent(IncidentIntent.RESOLVE));
+                .withIntent(IncidentIntent.RESOLVE)
+                .withValue(value));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromIncidentResolutionOperationHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers.batchoperation.listview;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -29,6 +30,19 @@ class ListViewFromIncidentResolutionOperationHandlerTest
   protected Record<IncidentRecordValue> createRejectedRecord() {
     return factory.generateRecord(
         ValueType.INCIDENT,
-        b -> b.withRejectionType(RejectionType.NOT_FOUND).withIntent(IncidentIntent.RESOLVE));
+        b ->
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(IncidentIntent.RESOLVE));
+  }
+
+  @Override
+  protected Record<IncidentRecordValue> createNotFoundRejectedRecord() {
+    return factory.generateRecord(
+        ValueType.INCIDENT,
+        b ->
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.NOT_FOUND)
+                .withIntent(IncidentIntent.RESOLVE));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
@@ -43,11 +43,13 @@ class ListViewFromProcessInstanceCancellationOperationHandlerTest
   }
 
   @Override
-  protected Record<ProcessInstanceRecordValue> createCompletedRecord() {
+  protected Record<ProcessInstanceRecordValue> createCompletedRecord(
+      final long processInstanceKey) {
     final var value =
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
             .withBpmnElementType(BpmnElementType.PROCESS)
+            .withProcessInstanceKey(processInstanceKey)
             .withParentProcessInstanceKey(-1)
             .build();
     return factory.generateRecord(
@@ -61,6 +63,7 @@ class ListViewFromProcessInstanceCancellationOperationHandlerTest
         ImmutableProcessInstanceRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
             .withBpmnElementType(BpmnElementType.PROCESS)
+            .withProcessInstanceKey(123456789L)
             .withParentProcessInstanceKey(-1)
             .build();
     return factory.generateRecord(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceCancellationOperationHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.batchoperation.listview;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -65,7 +66,25 @@ class ListViewFromProcessInstanceCancellationOperationHandlerTest
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE,
         b ->
-            b.withRejectionType(RejectionType.NOT_FOUND)
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceIntent.CANCEL)
+                .withValue(value));
+  }
+
+  @Override
+  protected Record<ProcessInstanceRecordValue> createNotFoundRejectedRecord() {
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .withParentProcessInstanceKey(-1)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE,
+        b ->
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.NOT_FOUND)
                 .withIntent(ProcessInstanceIntent.CANCEL)
                 .withValue(value));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers.batchoperation.listview;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -33,7 +34,18 @@ class ListViewFromProcessInstanceMigrationOperationHandlerTest
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         b ->
-            b.withRejectionType(RejectionType.NOT_FOUND)
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceMigrationIntent.MIGRATE));
+  }
+
+  @Override
+  protected Record<ProcessInstanceMigrationRecordValue> createNotFoundRejectedRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        b ->
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.NOT_FOUND)
                 .withIntent(ProcessInstanceMigrationIntent.MIGRATE));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceMigrationOperationHandlerTest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 
 class ListViewFromProcessInstanceMigrationOperationHandlerTest
@@ -23,20 +24,32 @@ class ListViewFromProcessInstanceMigrationOperationHandlerTest
   }
 
   @Override
-  protected Record<ProcessInstanceMigrationRecordValue> createCompletedRecord() {
+  protected Record<ProcessInstanceMigrationRecordValue> createCompletedRecord(
+      final long processInstanceKey) {
+    final var value =
+        ImmutableProcessInstanceMigrationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE_MIGRATION,
-        b -> b.withIntent(ProcessInstanceMigrationIntent.MIGRATED));
+        b -> b.withIntent(ProcessInstanceMigrationIntent.MIGRATED).withValue(value));
   }
 
   @Override
   protected Record<ProcessInstanceMigrationRecordValue> createRejectedRecord() {
+    final var value =
+        ImmutableProcessInstanceMigrationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+            .withProcessInstanceKey(123456789L)
+            .build();
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         b ->
             b.withRecordType(RecordType.COMMAND_REJECTION)
                 .withRejectionType(RejectionType.INVALID_STATE)
-                .withIntent(ProcessInstanceMigrationIntent.MIGRATE));
+                .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
+                .withValue(value));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers.batchoperation.listview;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -33,7 +34,18 @@ class ListViewFromProcessInstanceModificationOperationHandlerTest
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         b ->
-            b.withRejectionType(RejectionType.NOT_FOUND)
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.INVALID_STATE)
+                .withIntent(ProcessInstanceModificationIntent.MODIFY));
+  }
+
+  @Override
+  protected Record<ProcessInstanceModificationRecordValue> createNotFoundRejectedRecord() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_MODIFICATION,
+        b ->
+            b.withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionType(RejectionType.NOT_FOUND)
                 .withIntent(ProcessInstanceModificationIntent.MODIFY));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromProcessInstanceModificationOperationHandlerTest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 
 class ListViewFromProcessInstanceModificationOperationHandlerTest
@@ -23,20 +24,32 @@ class ListViewFromProcessInstanceModificationOperationHandlerTest
   }
 
   @Override
-  protected Record<ProcessInstanceModificationRecordValue> createCompletedRecord() {
+  protected Record<ProcessInstanceModificationRecordValue> createCompletedRecord(
+      final long processInstanceKey) {
+    final var value =
+        ImmutableProcessInstanceModificationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceModificationRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE_MODIFICATION,
-        b -> b.withIntent(ProcessInstanceModificationIntent.MODIFIED));
+        b -> b.withIntent(ProcessInstanceModificationIntent.MODIFIED).withValue(value));
   }
 
   @Override
   protected Record<ProcessInstanceModificationRecordValue> createRejectedRecord() {
+    final var value =
+        ImmutableProcessInstanceModificationRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceModificationRecordValue.class))
+            .withProcessInstanceKey(123456789L)
+            .build();
     return factory.generateRecord(
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         b ->
             b.withRecordType(RecordType.COMMAND_REJECTION)
                 .withRejectionType(RejectionType.INVALID_STATE)
-                .withIntent(ProcessInstanceModificationIntent.MODIFY));
+                .withIntent(ProcessInstanceModificationIntent.MODIFY)
+                .withValue(value));
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR fixes a bug where exporter errors occurred during incident resolution rejection, causing operate list view update failures. The issue was that `NOT_FOUND` rejection types were being incorrectly treated as exportable failures in batch operation handlers.

**Key Changes:**
- Updated all batch operation handler `isFailed()` methods to explicitly check for `RecordType.COMMAND_REJECTION` and exclude `RejectionType.NOT_FOUND` from failure tracking
- Added validation in `handlesRecord()` to skip records with invalid `processInstanceKey` (≤ 0)
- Added comprehensive test coverage for the new `NOT_FOUND` rejection handling and invalid process instance key scenarios
- Ensured consistency across all 4 handler implementations (incident resolution, process instance cancellation, migration, and modification)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41584
