### PR TITLE
Seamless Access to All Tenants: second option POC

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -76,7 +76,12 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
   }
 
   private RoleEntity map(final RoleDbModel model) {
-    return new RoleEntity(model.roleKey(), model.roleId(), model.name(), model.description());
+    return new RoleEntity(
+        model.roleKey(),
+        model.roleId(),
+        model.name(),
+        model.description(),
+        model.isAllTenantsAccess());
   }
 
   private boolean shouldReturnEmptyResult(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -18,6 +18,7 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
   private String name;
   private String description;
   private List<RoleMemberDbModel> members;
+  private boolean allTenantsAccess;
 
   public Long roleKey() {
     return roleKey;
@@ -25,6 +26,14 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
 
   public void roleKey(final Long roleKey) {
     this.roleKey = roleKey;
+  }
+
+  public boolean isAllTenantsAccess() {
+    return allTenantsAccess;
+  }
+
+  public void setAllTenantsAccess(final boolean allTenantsAccess) {
+    this.allTenantsAccess = allTenantsAccess;
   }
 
   public String roleId() {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/RoleEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/RoleEntityTransformer.java
@@ -18,6 +18,10 @@ public class RoleEntityTransformer
   public RoleEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.RoleEntity value) {
     return new RoleEntity(
-        value.getKey(), value.getRoleId(), value.getName(), value.getDescription());
+        value.getKey(),
+        value.getRoleId(),
+        value.getName(),
+        value.getDescription(),
+        value.isAllTenantsAccess());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -11,5 +11,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String roleId, String name, String description)
+public record RoleEntity(
+    Long roleKey, String roleId, String name, String description, boolean allTenantsAccess)
     implements Serializable {}

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -12,6 +12,7 @@ import static io.camunda.service.authorization.Authorizations.TENANT_READER_AUTH
 import io.camunda.search.clients.TenantSearchClient;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.TenantMemberEntity;
+import io.camunda.search.query.SearchQueryBase.AbstractQueryBuilder;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantMemberQuery;
 import io.camunda.search.query.TenantQuery;
@@ -123,6 +124,10 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             TenantQuery.of(
                 q -> q.filter(f -> f.memberIdsByType(memberTypesToMemberIds)).unlimited()))
         .items();
+  }
+
+  public List<TenantEntity> getAllIds() {
+    return search(TenantQuery.of(AbstractQueryBuilder::unlimited)).items();
   }
 
   public TenantEntity getById(final String tenantId) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -15,6 +15,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
   private String roleId;
   private String name;
   private String description;
+  private boolean allTenantsAccess;
   private EntityJoinRelation join;
 
   public Long getKey() {
@@ -23,6 +24,15 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
 
   public RoleEntity setKey(final Long key) {
     this.key = key;
+    return this;
+  }
+
+  public boolean isAllTenantsAccess() {
+    return allTenantsAccess;
+  }
+
+  public RoleEntity setAllTenantsAccess(final boolean allTenantsAccess) {
+    this.allTenantsAccess = allTenantsAccess;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
@@ -23,6 +23,9 @@
       "memberType": {
         "type": "keyword"
       },
+      "allTenantsAccess": {
+        "type": "boolean"
+      },
       "join": {
         "type": "join",
         "eager_global_ordinals": true,

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
@@ -23,6 +23,9 @@
       "memberType": {
         "type": "keyword"
       },
+      "allTenantsAccess": {
+        "type": "boolean"
+      },
       "join": {
         "type": "join",
         "relations": {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
@@ -68,7 +68,7 @@ public class PlatformDefaultEntities {
 
   private static void setupAdminRole(final IdentitySetupRecord setupRecord) {
     final var adminRoleId = DefaultRole.ADMIN.getId();
-    setupRecord.addRole(new RoleRecord().setRoleId(adminRoleId).setName("Admin"));
+    setupRecord.addRole(new RoleRecord().setRoleId(adminRoleId).setName("Admin").setAllTenantsAccess(true));
     for (final var resourceType : AuthorizationResourceType.values()) {
       if (resourceType == AuthorizationResourceType.UNSPECIFIED) {
         // We shouldn't add empty permissions for an unspecified resource type

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/PlatformDefaultEntities.java
@@ -68,7 +68,8 @@ public class PlatformDefaultEntities {
 
   private static void setupAdminRole(final IdentitySetupRecord setupRecord) {
     final var adminRoleId = DefaultRole.ADMIN.getId();
-    setupRecord.addRole(new RoleRecord().setRoleId(adminRoleId).setName("Admin").setAllTenantsAccess(true));
+    setupRecord.addRole(
+        new RoleRecord().setRoleId(adminRoleId).setName("Admin").setAllTenantsAccess(true));
     for (final var resourceType : AuthorizationResourceType.values()) {
       if (resourceType == AuthorizationResourceType.UNSPECIFIED) {
         // We shouldn't add empty permissions for an unspecified resource type

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.authorization;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
@@ -20,13 +21,16 @@ public class PersistedRole extends UnpackedObject implements DbValue {
   private final StringProperty roleIdProp = new StringProperty("roleId");
   private final StringProperty descriptionProp = new StringProperty("description");
   private final StringProperty nameProp = new StringProperty("name");
+  private final BooleanProperty allTenantsAccessProp =
+      new BooleanProperty("allTenantsAccess", false);
 
   public PersistedRole() {
-    super(4);
+    super(5);
     declareProperty(roleKeyProp)
         .declareProperty(roleIdProp)
         .declareProperty(nameProp)
-        .declareProperty(descriptionProp);
+        .declareProperty(descriptionProp)
+        .declareProperty(allTenantsAccessProp);
   }
 
   public long getRoleKey() {
@@ -60,6 +64,15 @@ public class PersistedRole extends UnpackedObject implements DbValue {
     return this;
   }
 
+  public boolean isAllTenantsAccess() {
+    return allTenantsAccessProp.getValue();
+  }
+
+  public PersistedRole setAllTenantsAccess(final boolean allTenantsAccess) {
+    allTenantsAccessProp.setValue(allTenantsAccess);
+    return this;
+  }
+
   public PersistedRole copy() {
     final var copy = new PersistedRole();
     copy.copyFrom(this);
@@ -78,5 +91,6 @@ public class PersistedRole extends UnpackedObject implements DbValue {
     roleIdProp.setValue(roleRecord.getRoleId());
     nameProp.setValue(roleRecord.getName());
     descriptionProp.setValue(roleRecord.getDescription());
+    allTenantsAccessProp.setValue(roleRecord.isAllTenantsAccess());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -59,6 +59,7 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
         .setRoleId(value.getRoleId())
         .setName(value.getName())
         .setDescription(value.getDescription())
+        .setAllTenantsAccess(value.isAllTenantsAccess())
         .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createParent());
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -25,7 +25,8 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
-  private final BooleanProperty allTenantsAccessProp = new BooleanProperty("allTenantsAccess");
+  private final BooleanProperty allTenantsAccessProp =
+      new BooleanProperty("allTenantsAccess", false);
 
   public RoleRecord() {
     super(7);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.authorization;
 
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -24,15 +25,17 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
+  private final BooleanProperty allTenantsAccessProp = new BooleanProperty("allTenantsAccess");
 
   public RoleRecord() {
-    super(6);
+    super(7);
     declareProperty(roleKeyProp)
         .declareProperty(roleIdProp)
         .declareProperty(nameProp)
         .declareProperty(descriptionProp)
         .declareProperty(entityIdProp)
-        .declareProperty(entityTypeProp);
+        .declareProperty(entityTypeProp)
+        .declareProperty(allTenantsAccessProp);
   }
 
   @Override
@@ -97,6 +100,16 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
 
   public RoleRecord setEntityType(final EntityType entityType) {
     entityTypeProp.setValue(entityType);
+    return this;
+  }
+
+  @Override
+  public boolean isAllTenantsAccess() {
+    return allTenantsAccessProp.getValue();
+  }
+
+  public RoleRecord setAllTenantsAccess(final boolean allTenantsAccess) {
+    allTenantsAccessProp.setValue(allTenantsAccess);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -102,7 +102,6 @@ import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -125,7 +124,6 @@ final class JsonSerializableToJsonTest {
       new UnsafeBuffer(MsgPackConverter.convertToMsgPack(USAGE_METRICS_JSON));
 
   private static final RuntimeException RUNTIME_EXCEPTION = new RuntimeException("test");
-  private static final Instant TIMESTAMP = Instant.now();
   private static final String STACK_TRACE;
 
   static {
@@ -3144,6 +3142,7 @@ final class JsonSerializableToJsonTest {
                     .setRoleId("id")
                     .setName("role")
                     .setDescription("description")
+                    .setAllTenantsAccess(true)
                     .setEntityId("entityId")
                     .setEntityType(EntityType.USER),
         """
@@ -3152,6 +3151,7 @@ final class JsonSerializableToJsonTest {
                   "roleId": "id",
                   "name": "role",
                   "description": "description",
+                  "allTenantsAccess": true,
                   "entityId": "entityId",
                   "entityType": "USER"
                 }
@@ -3171,6 +3171,7 @@ final class JsonSerializableToJsonTest {
                   "roleId": "roleId",
                   "name": "",
                   "description": "",
+                  "allTenantsAccess": false,
                   "entityId": "",
                   "entityType": "UNSPECIFIED"
                 }
@@ -3382,6 +3383,7 @@ final class JsonSerializableToJsonTest {
                             .setRoleId("id")
                             .setName("roleName")
                             .setDescription("description")
+                            .setAllTenantsAccess(true)
                             .setEntityId("entityId")
                             .setEntityType(EntityType.USER))
                     .addRoleMember(
@@ -3440,6 +3442,7 @@ final class JsonSerializableToJsonTest {
                       "roleId": "id",
                       "name": "roleName",
                       "description": "description",
+                      "allTenantsAccess": true,
                       "entityId": "entityId",
                       "entityType": "USER"
                     }
@@ -3450,6 +3453,7 @@ final class JsonSerializableToJsonTest {
                       "roleId": "id",
                       "name": "",
                       "description": "",
+                      "allTenantsAccess": false,
                       "entityId": "username",
                       "entityType": "USER"
                     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
@@ -40,4 +40,7 @@ public interface RoleRecordValue extends RecordValue {
 
   /** The type of the entity to assign/remove from a role. */
   EntityType getEntityType();
+
+  /** Whether the role has access to all tenants. */
+  boolean isAllTenantsAccess();
 }


### PR DESCRIPTION
## Description
-----This is WIP POC, not all files are commited------

This is the second POC for https://github.com/camunda/identity/issues/3772

Proposal:
Introduce a new `allTenantsAccess` field for a `Role`. This field will indicate if Role has access to all tenants, or not.

Solution:
- on initial `admin` role creation set `allTenantsAccess` value to be `true`. It will be `false` by default.
- when we login, we load assigned `tenant IDs` from ES (`UsernamePasswordAuthenticationTokenConverter` class, through user, user group and user roles). When loading tenant IDs assigned to role, we will first checks if it's all tenants access, and if so, then we just return all tenant IDs.
- when we authorize access, depending on the use case, we use tenant IDs that were originally loaded from ES or in some cases we query rocks DB (to be investigated further). Then same logic as for ES should be applied  here (`AuthorizationCheckBehavior` class) - when loading tenant IDs assigned to role, verify if it's all tenants access, and return all tenant IDs if it is.

Implementation main changes (as current commits do not contain detailed descriptions):
- in authentication:
  - modify `convert` method to check if Role has `allTenantsAccess` set to true. Return all tenants IDs if so.
- in zeebe: 
  - add a new field `allTenantsAccess` to `RoleRecord` and `PersistedRole`. Default value is `false`.
  - update `RoleRecordValue` 
  - modify `PlatformDefaultEntities` `admin` role creation - set `allTenantsAccess` value to be `true`
  - Update `AuthorizationCheckBehavior` `getAuthorizedTenantIds` method to check if Role has `allTenantsAccess` set to true. Return all tenants IDs if so.
- In webapp-schema:
  - add `allTenantsAccess` field to `RoleEntity`
  - update role resource schema for OS and ES
- in search:
  - add `allTenantsAccess` field for `RoleEntity`
  - update `RoleEntiryTransformer` to contain this new field
- in service:
  - add `getAllIds` method to `TenantService`. This method will literally return IDs for all tenants.
- in db:
  -  read/service: add new Role field to `RoleDbReader`
  - write/domain: add new Role field to `RoleDbModel`

TODO (out of scope for this POC):
Update `OidcTokenAuthenticationConverter`, `OidcUserAuthenticationConverter` `DefaultMembershipService.resolveMemberships()` to calculate `tenantIds` to support new all tenants logic.

Potential performance improvement:
In lot of cases method `getAuthorizedTenantIds()` is needed only to check if there is access to a particular tenant. And we need actual list of tenant ids in just 2 places. Further investigation could be done and code potentially could be further optimized to avoid tenant ids load when not necessary. Note: that might require more investigation time and will have bigger impact on code base.

TODO (out of scope for this POC):
- REST API and UI to allow editing `allTenantsAccess` field.

Pros: intuitive approach, easy to follow and with minimal configuration efforts for the user side.
Cons: DB migration to update existing role records might be needed (not sure if it would just use `false` by default)

TO DO: finish and correct
Steps to verify the proposal (UI + debug):
- Start standalone Camunda
- Create a tenant (lets say `aTenant`), and check that all-tenants role is assigned to this tenant automatically.
- Create user `aUser` and give this user `admin` role (`demo` user can also be used for this test)
- Logout
- In the code, put a breakpoint in `IndexFilterTransformer` on line 98 (this is verification of what tenants are assigned to this user)
- Login as `aUser` - check the breakpoint during login -> both tenant should be present in Tenant check

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to [Seamless Access to All Tenants discovery stage](https://github.com/camunda/identity/issues/3772)
