### PR TITLE
[Backport stable/8.8] Fix: broadcasted signal creates a process instance on every partition

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -210,7 +210,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
         subscription -> {
           final var subscriptionRecord = subscription.getRecord();
           final var isStartEvent = subscriptionRecord.getCatchEventInstanceKey() == -1;
-          if (isStartEvent) {
+          if (isStartEvent && !command.isCommandDistributed()) {
             eventHandle.activateProcessInstanceForStartEvent(
                 subscriptionRecord.getProcessDefinitionKey(),
                 keyGenerator.nextKey(),


### PR DESCRIPTION
# Description
Backport of #41579 to `stable/8.8`.

relates to #41576