### PR TITLE
Add history deletion record and intent

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -99,6 +100,7 @@ public class CommandApiRequestReader implements RequestReader {
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
         BatchOperationLifecycleManagementRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USAGE_METRIC, UsageMetricRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.HISTORY_DELETION, HistoryDeletionRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -148,6 +149,7 @@ public final class EventAppliers implements EventApplier {
     registerUsageMetricsAppliers(state);
     registerMultiInstanceAppliers(state);
     registerClusterVariableEventAppliers(state);
+    registerHistoryDeletionAppliers();
     return this;
   }
 
@@ -700,6 +702,10 @@ public final class EventAppliers implements EventApplier {
     final var asyncRequestState = state.getAsyncRequestState();
     register(AsyncRequestIntent.RECEIVED, new AsyncRequestReceivedApplier(asyncRequestState));
     register(AsyncRequestIntent.PROCESSED, new AsyncRequestProcessedApplier(asyncRequestState));
+  }
+
+  private void registerHistoryDeletionAppliers() {
+    register(HistoryDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -130,7 +130,8 @@ final class TestSupport {
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             ValueType.BATCH_OPERATION_INITIALIZATION,
             ValueType.USAGE_METRIC,
-            ValueType.MULTI_INSTANCE);
+            ValueType.MULTI_INSTANCE,
+            ValueType.HISTORY_DELETION);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -131,7 +131,8 @@ final class TestSupport {
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             ValueType.BATCH_OPERATION_INITIALIZATION,
             ValueType.USAGE_METRIC,
-            ValueType.MULTI_INSTANCE);
+            ValueType.MULTI_INSTANCE,
+            ValueType.HISTORY_DELETION);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.history;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+
+public class HistoryDeletionRecord extends UnifiedRecordValue
+    implements HistoryDeletionRecordValue {
+
+  private static final StringValue RESOURCE_KEY = new StringValue("resourceKey");
+  private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
+  private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
+
+  private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
+  private final EnumProperty<HistoryDeletionType> resourceTypeProp =
+      new EnumProperty<>(RESOURCE_TYPE, HistoryDeletionType.class);
+  private final LongProperty batchOperationKeyProp = new LongProperty(BATCH_OPERATION_KEY);
+
+  public HistoryDeletionRecord() {
+    super(3);
+    declareProperty(resourceKeyProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(batchOperationKeyProp);
+  }
+
+  @Override
+  public long getResourceKey() {
+    return resourceKeyProp.getValue();
+  }
+
+  public HistoryDeletionRecord setResourceKey(final long resourceKey) {
+    resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+
+  @Override
+  public HistoryDeletionType getResourceType() {
+    return resourceTypeProp.getValue();
+  }
+
+  public HistoryDeletionRecord setResourceType(final HistoryDeletionType resourceType) {
+    resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  @Override
+  public long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public HistoryDeletionRecord setBatchOperationKey(final long batchOperationKey) {
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistribut
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -92,6 +93,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -3915,7 +3917,26 @@ final class JsonSerializableToJsonTest {
         "processInstanceKey": -1
       }
       """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// HistoryDeletionRecord //////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "HistoryDeletionRecord",
+        (Supplier<HistoryDeletionRecord>)
+            () ->
+                new HistoryDeletionRecord()
+                    .setResourceKey(1L)
+                    .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+                    .setBatchOperationKey(2L),
+        """
+      {
+        "resourceKey": 1,
+        "resourceType": "PROCESS_INSTANCE",
+        "batchOperationKey": 2
       }
+      """
+      },
     };
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/HistoryDeletionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/HistoryDeletionRecord.golden
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.history;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+
+public class HistoryDeletionRecord extends UnifiedRecordValue
+    implements HistoryDeletionRecordValue {
+
+  private static final StringValue RESOURCE_KEY = new StringValue("resourceKey");
+  private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
+  private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
+
+  private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
+  private final EnumProperty<HistoryDeletionType> resourceTypeProp =
+      new EnumProperty<>(RESOURCE_TYPE, HistoryDeletionType.class);
+  private final LongProperty batchOperationKeyProp = new LongProperty(BATCH_OPERATION_KEY);
+
+  public HistoryDeletionRecord() {
+    super(3);
+    declareProperty(resourceKeyProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(batchOperationKeyProp);
+  }
+
+  @Override
+  public long getResourceKey() {
+    return resourceKeyProp.getValue();
+  }
+
+  public HistoryDeletionRecord setResourceKey(final long resourceKey) {
+    resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+
+  @Override
+  public HistoryDeletionType getResourceType() {
+    return resourceTypeProp.getValue();
+  }
+
+  public HistoryDeletionRecord setResourceType(final HistoryDeletionType resourceType) {
+    resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  @Override
+  public long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public HistoryDeletionRecord setBatchOperationKey(final long batchOperationKey) {
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -89,6 +90,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -325,6 +327,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.CLUSTER_VARIABLE,
         new Mapping<>(ClusterVariableRecordValue.class, ClusterVariableIntent.class));
+    mapping.put(
+        ValueType.HISTORY_DELETION,
+        new Mapping<>(HistoryDeletionRecordValue.class, HistoryDeletionIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/HistoryDeletionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/HistoryDeletionIntent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum HistoryDeletionIntent implements Intent {
+  DELETE(0),
+  DELETED(1);
+
+  private final short value;
+
+  HistoryDeletionIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return DELETE;
+      case 1:
+        return DELETED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/HistoryDeletionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/HistoryDeletionIntent.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.protocol.record.intent;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -77,7 +77,8 @@ public interface Intent {
           UsageMetricIntent.class,
           MultiInstanceIntent.class,
           RuntimeInstructionIntent.class,
-          ClusterVariableIntent.class);
+          ClusterVariableIntent.class,
+          HistoryDeletionIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -207,6 +208,8 @@ public interface Intent {
         return RuntimeInstructionIntent.from(intent);
       case CLUSTER_VARIABLE:
         return ClusterVariableIntent.from(intent);
+      case HISTORY_DELETION:
+        return HistoryDeletionIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -324,6 +327,8 @@ public interface Intent {
         return RuntimeInstructionIntent.valueOf(intent);
       case CLUSTER_VARIABLE:
         return ClusterVariableIntent.valueOf(intent);
+      case HISTORY_DELETION:
+        return HistoryDeletionIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -41,6 +41,6 @@ public interface HistoryDeletionRecordValue extends RecordValue {
   /** Returns the type of resource to delete. */
   HistoryDeletionType getResourceType();
 
-  /** Returns the key of the batch operation that triggered this history deletion * */
+  /** Returns the key of the batch operation that triggered this history deletion */
   long getBatchOperationKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableHistoryDeletionRecordValue.Builder.class)
+public interface HistoryDeletionRecordValue extends RecordValue {
+
+  /**
+   * The key of the resource to delete. Depending on the {@link HistoryDeletionType} this can be one
+   * of four things:
+   *
+   * <ul>
+   *   <li>{@link HistoryDeletionType#PROCESS_INSTANCE}: the process instance key
+   *   <li>{@link HistoryDeletionType#PROCESS_DEFINITION}: the process definition key
+   *   <li>{@link HistoryDeletionType#DECISION_INSTANCE}: the decision instance key
+   *   <li>{@link HistoryDeletionType#DECISION_DEFINITION}: the decision definition key
+   * </ul>
+   *
+   * @return the key of the resource
+   */
+  long getResourceKey();
+
+  /** Returns the type of resource to delete. */
+  HistoryDeletionType getResourceType();
+
+  /** Returns the key of the batch operation that triggered this history deletion * */
+  long getBatchOperationKey();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.protocol.record.value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum HistoryDeletionType {
+  PROCESS_INSTANCE
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionType.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.protocol.record.value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionType.java
@@ -16,5 +16,8 @@
 package io.camunda.zeebe.protocol.record.value;
 
 public enum HistoryDeletionType {
-  PROCESS_INSTANCE
+  PROCESS_INSTANCE,
+  PROCESS_DEFINITION,
+  DECISION_INSTANCE,
+  DECISION_DEFINITION
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -77,6 +77,7 @@
       <validValue name="RUNTIME_INSTRUCTION">59</validValue>
       <validValue name="BATCH_OPERATION_INITIALIZATION">60</validValue>
       <validValue name="CLUSTER_VARIABLE">61</validValue>
+      <validValue name="HISTORY_DELETION">62</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -88,6 +88,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -299,6 +300,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.SCALE, this::summarizeScale);
     valueLoggers.put(ValueType.CHECKPOINT, this::summarizeCheckpoint);
     valueLoggers.put(ValueType.FORM, this::summarizeForm);
+    valueLoggers.put(ValueType.HISTORY_DELETION, this::summarizeHistoryDeletion);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -1703,6 +1705,17 @@ public class CompactRecordLogger {
     final var value = (CheckpointRecordValue) record.getValue();
     return "checkpoint %s @ #%s"
         .formatted(value.getCheckpointId(), formatPosition(value.getCheckpointPosition()));
+  }
+
+  private String summarizeHistoryDeletion(final Record<?> record) {
+    final var value = (HistoryDeletionRecordValue) record.getValue();
+
+    return "Resource key: "
+        + shortenKey(value.getResourceKey())
+        + ", Resource type: "
+        + value.getResourceType()
+        + ", Batch operation key: "
+        + shortenKey(value.getBatchOperationKey());
   }
 
   private String summarizeForm(final Record<?> record) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The history deletion record and intent will be used to manage deletion of historic data from secondary storage. This will be triggered by a batch operation and thus will go through the engine. The engine will write this record and these intents to ensure the data gets deleted in secondary storage down the line.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41135 
