### PR TITLE
test: demonstrate race condition when completing tasks

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -204,6 +204,8 @@ public class TaskService {
       // persist completion and variables
       final TaskEntity completedTaskEntity = taskStore.persistTaskCompletion(task);
       try {
+        LOGGER.info("Waiting for zeebe to finish");
+        Thread.sleep(5000);
         LOGGER.info("Start variable persistence: {}", taskId);
         variableService.persistTaskVariables(
             taskId, variables, withDraftVariableValues, task.getProcessInstanceId());


### PR DESCRIPTION
if zeebe completes first then we do not copy over all variables

Same as #41585 but checking against 8.7
