### PR TITLE
[Backport release-8.9.0-alpha2] test: skip tasklist task details E2E test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -540,7 +540,9 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.bpmnDiagram).toBeVisible();
   });
 
-  test('task completion with large variable form', async ({
+  // TODO issue #41614
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip('task completion with large variable form', async ({
     taskPanelPage,
     page,
   }) => {


### PR DESCRIPTION
# Description
Backport of #41616 to `release-8.9.0-alpha2`.

relates to camunda/camunda#41614