### PR TITLE
Add missing record test runtime instruction

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -60,6 +61,7 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProperty.getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
@@ -35,8 +35,9 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return bufferAsString(elementIdProperty.getValue());
   }
 
-  public void setElementId(final String interruptingElementId) {
+  public RuntimeInstructionRecord setElementId(final String interruptingElementId) {
     elementIdProperty.setValue(interruptingElementId);
+    return this;
   }
 
   @Override
@@ -44,8 +45,9 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return processInstanceKeyProperty.getValue();
   }
 
-  public void setProcessInstanceKey(final long processInstanceKey) {
+  public RuntimeInstructionRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
   }
 
   @Override
@@ -53,8 +55,9 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return bufferAsString(tenantIdProperty.getValue());
   }
 
-  public void setTenantId(final String tenantId) {
+  public RuntimeInstructionRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
   }
 
   public DirectBuffer getElementIdBuffer() {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3897,7 +3897,6 @@ final class JsonSerializableToJsonTest {
         """
       {
         "tenantId": "tenant_1",
-        "elementIdBuffer": {"expandable": false},
         "elementId": "element_1",
         "processInstanceKey": 12345
       }
@@ -3912,7 +3911,6 @@ final class JsonSerializableToJsonTest {
         """
       {
         "tenantId": "",
-        "elementIdBuffer": {"expandable": false},
         "elementId": "",
         "processInstanceKey": -1
       }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -68,6 +68,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
@@ -3882,6 +3883,41 @@ final class JsonSerializableToJsonTest {
                 }
                 """
       },
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////// RuntimeInstructionRecord ////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "RuntimeInstructionRecord",
+        (Supplier<RuntimeInstructionRecord>)
+            () ->
+                new RuntimeInstructionRecord()
+                    .setProcessInstanceKey(12345L)
+                    .setTenantId("tenant_1")
+                    .setElementId("element_1"),
+        """
+      {
+        "tenantId": "tenant_1",
+        "elementIdBuffer": {"expandable": false},
+        "elementId": "element_1",
+        "processInstanceKey": 12345
+      }
+      """
+      },
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty RuntimeInstructionRecord ///////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty RuntimeInstructionRecord",
+        (Supplier<RuntimeInstructionRecord>) RuntimeInstructionRecord::new,
+        """
+      {
+        "tenantId": "",
+        "elementIdBuffer": {"expandable": false},
+        "elementId": "",
+        "processInstanceKey": -1
+      }
+      """
+      }
     };
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

1. Added a missing `JsonSerializableToJsonTest` test case for the runtime instruction record (added originally in #35685)
2. Adjusted the return type of setters in the record to match other record classes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
