### PR TITLE
fix: v1 process instance search returns processes from deleted tenants

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/tenant/TenantCheckApplierHolder.java
+++ b/operate/common/src/main/java/io/camunda/operate/tenant/TenantCheckApplierHolder.java
@@ -14,12 +14,15 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
 @Component
-public class TenantCheckApplierHolder implements ApplicationContextAware {
+public class TenantCheckApplierHolder
+    implements ApplicationContextAware, ApplicationListener<ContextClosedEvent> {
   private static ApplicationContext applicationContext;
   private static TenantCheckApplier<Query> tenantCheckApplier;
 
@@ -39,5 +42,10 @@ public class TenantCheckApplierHolder implements ApplicationContextAware {
   public void setApplicationContext(final ApplicationContext applicationContext)
       throws BeansException {
     this.applicationContext = applicationContext;
+  }
+
+  @Override
+  public void onApplicationEvent(final ContextClosedEvent ignored) {
+    tenantCheckApplier = null;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionDefinitionDao.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -111,8 +110,8 @@ public class OpensearchDecisionDefinitionDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<DecisionDefinition> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<DecisionDefinition> query) {
     final DecisionDefinition filter = query.getFilter();
 
     if (filter != null) {
@@ -137,9 +136,10 @@ public class OpensearchDecisionDefinitionDao
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
@@ -82,8 +82,10 @@ public class OpensearchDecisionInstanceDao
   }
 
   @Override
-  protected SearchRequest.Builder buildSearchRequest(final Query<DecisionInstance> query) {
-    return super.buildSearchRequest(query)
+  protected SearchRequest.Builder buildSearchRequest(
+      final Query<DecisionInstance> query,
+      final org.opensearch.client.opensearch._types.query_dsl.Query filtering) {
+    return super.buildSearchRequest(query, filtering)
         .source(
             queryDSLWrapper.sourceExclude(
                 DecisionInstanceTemplate.EVALUATED_INPUTS,
@@ -106,8 +108,8 @@ public class OpensearchDecisionInstanceDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<DecisionInstance> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<DecisionInstance> query) {
     final DecisionInstance filter = query.getFilter();
 
     if (filter != null) {
@@ -146,9 +148,10 @@ public class OpensearchDecisionInstanceDao
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
@@ -20,11 +20,13 @@ import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -84,8 +86,9 @@ public class OpensearchDecisionInstanceDao
   @Override
   protected SearchRequest.Builder buildSearchRequest(
       final Query<DecisionInstance> query,
-      final org.opensearch.client.opensearch._types.query_dsl.Query filtering) {
-    return super.buildSearchRequest(query, filtering)
+      final org.opensearch.client.opensearch._types.query_dsl.Query filtering,
+      final ArrayList<SortOptions> sortOptions) {
+    return super.buildSearchRequest(query, filtering, sortOptions)
         .source(
             queryDSLWrapper.sourceExclude(
                 DecisionInstanceTemplate.EVALUATED_INPUTS,

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionRequirementsDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionRequirementsDao.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -122,8 +121,8 @@ public class OpensearchDecisionRequirementsDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<DecisionRequirements> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<DecisionRequirements> query) {
     final DecisionRequirements filter = query.getFilter();
     if (filter != null) {
       final var queryTerms =
@@ -142,9 +141,10 @@ public class OpensearchDecisionRequirementsDao
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDao.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -85,8 +84,8 @@ public class OpensearchFlowNodeInstanceDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<FlowNodeInstance> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<FlowNodeInstance> query) {
     final FlowNodeInstance filter = query.getFilter();
 
     if (filter != null) {
@@ -115,9 +114,10 @@ public class OpensearchFlowNodeInstanceDao
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchIncidentDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchIncidentDao.java
@@ -24,7 +24,6 @@ import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -90,7 +89,8 @@ public class OpensearchIncidentDao extends OpensearchKeyFilteringDao<Incident, O
   }
 
   @Override
-  protected void buildFiltering(final Query<Incident> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<Incident> query) {
     final Incident filter = query.getFilter();
     if (filter != null) {
       final var queryTerms =
@@ -113,9 +113,10 @@ public class OpensearchIncidentDao extends OpensearchKeyFilteringDao<Incident, O
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -100,8 +99,8 @@ public class OpensearchProcessDefinitionDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<ProcessDefinition> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<ProcessDefinition> query) {
     final ProcessDefinition filter = query.getFilter();
     if (filter != null) {
       final var queryTerms =
@@ -117,9 +116,10 @@ public class OpensearchProcessDefinitionDao
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessInstanceDao.java
@@ -79,8 +79,8 @@ public class OpensearchProcessInstanceDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<ProcessInstance> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<ProcessInstance> query) {
     final List<org.opensearch.client.opensearch._types.query_dsl.Query> queryTerms =
         new LinkedList<>();
     queryTerms.add(
@@ -121,7 +121,7 @@ public class OpensearchProcessInstanceDao
 
     final var nonNullQueryTerms = queryTerms.stream().filter(Objects::nonNull).toList();
 
-    request.query(queryDSLWrapper.and(nonNullQueryTerms));
+    return queryDSLWrapper.and(nonNullQueryTerms);
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDao.java
@@ -18,7 +18,6 @@ import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -54,8 +53,8 @@ public class OpensearchSequenceFlowDao extends OpensearchSearchableDao<SequenceF
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<SequenceFlow> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<SequenceFlow> query) {
     final SequenceFlow filter = query.getFilter();
 
     if (filter != null) {
@@ -70,9 +69,10 @@ public class OpensearchSequenceFlowDao extends OpensearchSearchableDao<SequenceF
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDao.java
@@ -18,7 +18,6 @@ import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +53,8 @@ public class OpensearchVariableDao extends OpensearchKeyFilteringDao<Variable, V
   }
 
   @Override
-  protected void buildFiltering(final Query<Variable> query, final SearchRequest.Builder request) {
+  protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+      final Query<Variable> query) {
     final Variable filter = query.getFilter();
 
     if (filter != null) {
@@ -72,9 +72,10 @@ public class OpensearchVariableDao extends OpensearchKeyFilteringDao<Variable, V
               .collect(Collectors.toList());
 
       if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
+        return queryDSLWrapper.and(queryTerms);
       }
     }
+    return queryDSLWrapper.matchAll();
   }
 
   @Override

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDaoTest.java
@@ -104,17 +104,14 @@ public class OpensearchFlowNodeInstanceDaoTest {
 
   @Test
   public void testBuildFilteringWithNullFilter() {
-    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
-    underTest.buildFiltering(new Query<>(), mockSearchRequest);
+    final var filtering = underTest.buildFiltering(new Query<>());
 
-    // Verify that the query was not modified in any way
-    verifyNoInteractions(mockSearchRequest);
-    verifyNoInteractions(mockQueryWrapper);
+    verify(mockQueryWrapper, times(1)).matchAll();
+    assertThat(filtering).isEqualTo(mockQueryWrapper.matchAll());
   }
 
   @Test
   public void testBuildFilteringWithValidFields() {
-    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
     final FlowNodeInstance filter =
         new FlowNodeInstance()
             .setKey(1L)
@@ -134,7 +131,7 @@ public class OpensearchFlowNodeInstanceDaoTest {
 
     final Query<FlowNodeInstance> inputQuery = new Query<FlowNodeInstance>().setFilter(filter);
 
-    underTest.buildFiltering(inputQuery, mockSearchRequest);
+    underTest.buildFiltering(inputQuery);
 
     // Verify that each field from the flow node filter was added as a query term to the query
     verify(mockQueryWrapper, times(1)).term(FlowNodeInstance.KEY, filter.getKey());

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
@@ -84,8 +84,10 @@ public class OpensearchKeyFilteringDaoTest {
           }
 
           @Override
-          protected void buildFiltering(
-              final Query<Object> query, final SearchRequest.Builder request) {}
+          protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+              final Query<Object> query) {
+            return null;
+          }
 
           @Override
           protected Object convertInternalToApiResult(final Object internalResult) {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
@@ -86,7 +86,7 @@ public class OpensearchKeyFilteringDaoTest {
           @Override
           protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
               final Query<Object> query) {
-            return null;
+            return mockQueryWrapper.matchAll();
           }
 
           @Override

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.client.opensearch.core.SearchRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchProcessDefinitionDaoTest {
@@ -57,7 +56,7 @@ public class OpensearchProcessDefinitionDaoTest {
         new Query<ProcessDefinition>().setFilter(processDefinition);
 
     // when
-    processDefinitionDao.buildFiltering(query, mock(SearchRequest.Builder.class));
+    processDefinitionDao.buildFiltering(query);
 
     // then
     verify(wrapper, times(1)).term(ProcessDefinition.NAME, processDefinition.getName());

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessInstanceDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessInstanceDaoTest.java
@@ -132,7 +132,7 @@ public class OpensearchProcessInstanceDaoTest {
   @Test
   public void testBuildFilteringWithNullFilter() {
     final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
-    underTest.buildFiltering(new Query<>(), mockSearchRequest);
+    underTest.buildFiltering(new Query<>());
 
     // Verify that the join relation was still set
     verify(mockQueryWrapper, times(1))
@@ -145,7 +145,7 @@ public class OpensearchProcessInstanceDaoTest {
     final Query<ProcessInstance> inputQuery =
         new Query<ProcessInstance>().setFilter(new ProcessInstance());
 
-    underTest.buildFiltering(inputQuery, mockSearchRequest);
+    underTest.buildFiltering(inputQuery);
 
     // Verify that the join relation was still set
     verify(mockQueryWrapper, times(1))
@@ -175,7 +175,7 @@ public class OpensearchProcessInstanceDaoTest {
 
     final Query<ProcessInstance> inputQuery = new Query<ProcessInstance>().setFilter(filter);
 
-    underTest.buildFiltering(inputQuery, mockSearchRequest);
+    underTest.buildFiltering(inputQuery);
 
     // Verify that each field from the process instance filter was added as a query term to the
     // query

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -66,7 +67,7 @@ public class OpensearchSearchableDaoTest {
           @Override
           protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
               final Query query) {
-            return null;
+            return mockQueryWrapper.matchAll();
           }
 
           @Override
@@ -81,17 +82,23 @@ public class OpensearchSearchableDaoTest {
     final SearchRequest.Builder mockRequestBuilder = Mockito.mock(SearchRequest.Builder.class);
     final org.opensearch.client.opensearch._types.query_dsl.Query mockOsQuery =
         Mockito.mock(org.opensearch.client.opensearch._types.query_dsl.Query.class);
+    final var mockSortOptions = Mockito.mock(SortOptions.class);
+    final var sortOptions = new java.util.ArrayList<SortOptions>();
+    sortOptions.add(mockSortOptions);
 
     when(mockRequestWrapper.searchRequestBuilder("index")).thenReturn(mockRequestBuilder);
     when(mockQueryWrapper.withTenantCheck(any())).thenReturn(mockOsQuery);
     when(mockRequestBuilder.query(mockOsQuery)).thenReturn(mockRequestBuilder);
+    when(mockRequestBuilder.sort(sortOptions)).thenReturn(mockRequestBuilder);
 
-    final SearchRequest.Builder result = underTest.buildSearchRequest(new Query<>(), mockOsQuery);
+    final SearchRequest.Builder result =
+        underTest.buildSearchRequest(new Query<>(), mockOsQuery, sortOptions);
 
     // Verify the request was built with a tenant check, the index name, and permissive matching
     assertThat(result).isSameAs(mockRequestBuilder);
     verify(mockQueryWrapper, times(1)).withTenantCheck(mockOsQuery);
     verify(mockRequestWrapper, times(1)).searchRequestBuilder("index");
+    verify(mockRequestBuilder, times(1)).sort(sortOptions);
   }
 
   @Test
@@ -161,7 +168,7 @@ public class OpensearchSearchableDaoTest {
     final String uniqueSortKey = "processId";
     final SearchRequest.Builder request = Mockito.mock(SearchRequest.Builder.class);
 
-    underTest.buildSorting(inputQuery, uniqueSortKey, request);
+    underTest.buildSorting(inputQuery, uniqueSortKey);
 
     verify(mockQueryWrapper, times(1)).sortOptions(any(), any());
     verify(mockQueryWrapper, times(1)).sortOptions(uniqueSortKey, SortOrder.Asc);
@@ -174,7 +181,7 @@ public class OpensearchSearchableDaoTest {
     final String uniqueSortKey = "processId";
     final SearchRequest.Builder request = Mockito.mock(SearchRequest.Builder.class);
 
-    underTest.buildSorting(inputQuery, uniqueSortKey, request);
+    underTest.buildSorting(inputQuery, uniqueSortKey);
 
     verify(mockQueryWrapper, times(2)).sortOptions(any(), any());
     verify(mockQueryWrapper, times(1)).sortOptions(uniqueSortKey, SortOrder.Asc);
@@ -188,7 +195,7 @@ public class OpensearchSearchableDaoTest {
     final String uniqueSortKey = "processId";
     final SearchRequest.Builder request = Mockito.mock(SearchRequest.Builder.class);
 
-    underTest.buildSorting(inputQuery, uniqueSortKey, request);
+    underTest.buildSorting(inputQuery, uniqueSortKey);
 
     verify(mockQueryWrapper, times(2)).sortOptions(any(), any());
     verify(mockQueryWrapper, times(1)).sortOptions(uniqueSortKey, SortOrder.Asc);

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
@@ -64,7 +64,10 @@ public class OpensearchSearchableDaoTest {
           }
 
           @Override
-          protected void buildFiltering(final Query query, final SearchRequest.Builder request) {}
+          protected org.opensearch.client.opensearch._types.query_dsl.Query buildFiltering(
+              final Query query) {
+            return null;
+          }
 
           @Override
           protected Object convertInternalToApiResult(final Object internalResult) {
@@ -83,12 +86,11 @@ public class OpensearchSearchableDaoTest {
     when(mockQueryWrapper.withTenantCheck(any())).thenReturn(mockOsQuery);
     when(mockRequestBuilder.query(mockOsQuery)).thenReturn(mockRequestBuilder);
 
-    final SearchRequest.Builder result = underTest.buildSearchRequest(new Query<>());
+    final SearchRequest.Builder result = underTest.buildSearchRequest(new Query<>(), mockOsQuery);
 
     // Verify the request was built with a tenant check, the index name, and permissive matching
     assertThat(result).isSameAs(mockRequestBuilder);
-    verify(mockQueryWrapper, times(1)).matchAll();
-    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
+    verify(mockQueryWrapper, times(1)).withTenantCheck(mockOsQuery);
     verify(mockRequestWrapper, times(1)).searchRequestBuilder("index");
   }
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDaoTest.java
@@ -10,7 +10,6 @@ package io.camunda.operate.webapp.api.v1.dao.opensearch;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -23,9 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.client.opensearch.core.SearchRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchSequenceFlowDaoTest {
@@ -66,17 +63,14 @@ public class OpensearchSequenceFlowDaoTest {
 
   @Test
   public void testBuildFilteringWithNullFilter() {
-    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
-    underTest.buildFiltering(new Query<>(), mockSearchRequest);
+    final var filtering = underTest.buildFiltering(new Query<>());
 
-    // Verify that the query was not modified in any way
-    verifyNoInteractions(mockSearchRequest);
-    verifyNoInteractions(mockQueryWrapper);
+    verify(mockQueryWrapper, times(1)).matchAll();
+    assertThat(filtering).isEqualTo(mockQueryWrapper.matchAll());
   }
 
   @Test
   public void testBuildFilteringWithValidFields() {
-    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
     final SequenceFlow filter =
         new SequenceFlow()
             .setId("id")
@@ -86,7 +80,7 @@ public class OpensearchSequenceFlowDaoTest {
 
     final Query<SequenceFlow> inputQuery = new Query<SequenceFlow>().setFilter(filter);
 
-    underTest.buildFiltering(inputQuery, mockSearchRequest);
+    underTest.buildFiltering(inputQuery);
 
     // Verify that each field from the flow node filter was added as a query term to the query
     verify(mockQueryWrapper, times(1)).term(SequenceFlow.ID, filter.getId());

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDaoTest.java
@@ -10,7 +10,6 @@ package io.camunda.operate.webapp.api.v1.dao.opensearch;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -23,9 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.client.opensearch.core.SearchRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchVariableDaoTest {
@@ -89,17 +86,14 @@ public class OpensearchVariableDaoTest {
 
   @Test
   public void testBuildFilteringWithNullFilter() {
-    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
-    underTest.buildFiltering(new Query<>(), mockSearchRequest);
+    final var filtering = underTest.buildFiltering(new Query<>());
 
-    // Verify that the query was not modified in any way
-    verifyNoInteractions(mockSearchRequest);
-    verifyNoInteractions(mockQueryWrapper);
+    verify(mockQueryWrapper, times(1)).matchAll();
+    assertThat(filtering).isEqualTo(mockQueryWrapper.matchAll());
   }
 
   @Test
   public void testBuildFilteringWithValidFields() {
-    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
     final Variable filter =
         new Variable()
             .setKey(1L)
@@ -112,7 +106,7 @@ public class OpensearchVariableDaoTest {
 
     final Query<Variable> inputQuery = new Query<Variable>().setFilter(filter);
 
-    underTest.buildFiltering(inputQuery, mockSearchRequest);
+    underTest.buildFiltering(inputQuery);
 
     // Verify that each field from the variable was added as a query term to the query
     verify(mockQueryWrapper, times(1)).term(Variable.KEY, filter.getKey());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1TenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1TenancyIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.operate;
+
+import static io.camunda.client.api.search.enums.PermissionType.DELETE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.it.util.TestHelper.createTenant;
+import static io.camunda.it.util.TestHelper.deleteTenant;
+import static io.camunda.it.util.TestHelper.deployResourceForTenant;
+import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
+import static io.camunda.it.util.TestHelper.waitForProcessInstances;
+import static io.camunda.it.util.TestHelper.waitForTenantDeletion;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.operate.webapp.api.v1.entities.ProcessInstance;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestRestOperateClient;
+import io.camunda.qa.util.cluster.TestRestOperateClient.ProcessInstanceResult;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class OperateV1TenancyIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final List<Permissions> AUTHORIZED_PERMISSIONS =
+      List.of(
+          new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+          new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
+          new Permissions(PROCESS_DEFINITION, DELETE_PROCESS_INSTANCE, List.of("*")),
+          new Permissions(DECISION_DEFINITION, READ_DECISION_DEFINITION, List.of("*")),
+          new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*")),
+          new Permissions(DECISION_REQUIREMENTS_DEFINITION, READ, List.of("*")));
+
+  private static final String ADMIN = "multiTenancyAdmin";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_TO_BE_DELETED = "tenantToBeDeleted";
+  private static final String PROCESS_ID = "service_tasks_v1";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, ADMIN, AUTHORIZED_PERMISSIONS);
+
+  @Test
+  public void shouldNotReturnProcessesFromDeletedTenants(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+
+    setupTwoTenantsWithProcessesBeforeDeletion(camundaClient);
+
+    try (final var operateClient = STANDALONE_CAMUNDA.newOperateClient(ADMIN, ADMIN)) {
+      // given
+
+      Awaitility.await()
+          .atMost(TIMEOUT_DATA_AVAILABILITY)
+          .untilAsserted(
+              () -> {
+                final var result = searchProcessInstancesV1(operateClient);
+                assertSearchResultsTenants(result, TENANT_A, TENANT_TO_BE_DELETED);
+              });
+
+      // when
+      deleteTenant(camundaClient, TENANT_TO_BE_DELETED);
+      waitForTenantDeletion(camundaClient, TENANT_TO_BE_DELETED);
+
+      // then
+      Awaitility.await()
+          .atMost(TIMEOUT_DATA_AVAILABILITY)
+          .untilAsserted(
+              () -> {
+                final var afterDeletionResult = searchProcessInstancesV1(operateClient);
+                assertSearchResultsTenants(afterDeletionResult, TENANT_A);
+              });
+    }
+  }
+
+  private void setupTwoTenantsWithProcessesBeforeDeletion(final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN);
+    createTenant(adminClient, TENANT_TO_BE_DELETED, TENANT_TO_BE_DELETED, ADMIN);
+
+    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_TO_BE_DELETED);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_TO_BE_DELETED);
+    waitForProcessInstances(adminClient, f -> f.processDefinitionId(PROCESS_ID), 2);
+  }
+
+  private Either<Exception, ProcessInstanceResult> searchProcessInstancesV1(
+      final TestRestOperateClient operateClient) throws Exception {
+    final var response = operateClient.sendV1SearchRequest("v1/process-instances", "{}");
+    return operateClient.mapResult(response, ProcessInstanceResult.class);
+  }
+
+  private void assertSearchResultsTenants(
+      final Either<Exception, ProcessInstanceResult> result,
+      final String... expectedProcessInstanceTenants) {
+
+    assertThat(result.isRight()).isTrue();
+
+    final var processInstanceResults = result.get();
+    final Set<String> tenants =
+        processInstanceResults.processInstances().stream()
+            .map(ProcessInstance::getTenantId)
+            .collect(Collectors.toSet());
+    assertThat(tenants).containsExactlyInAnyOrder(expectedProcessInstanceTenants);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
@@ -67,7 +67,51 @@ public class ProcessInstanceTenancyIT {
 
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
-    waitForProcessBeingExported(adminClient);
+    waitForProcessBeingExported(adminClient, 2);
+  }
+
+  @Test
+  public void shouldNotReturnProcessesFromDeletedTenants(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+
+    // given
+    final var tenantToBeDeleted = "toBeDeleted";
+    createTenant(camundaClient, tenantToBeDeleted);
+    assignUserToTenant(camundaClient, ADMIN, tenantToBeDeleted);
+
+    deployResource(camundaClient, "process/service_tasks_v1.bpmn", tenantToBeDeleted);
+    startProcessInstance(camundaClient, PROCESS_ID, tenantToBeDeleted);
+
+    waitForProcessBeingExported(camundaClient, 3);
+
+    final var beforeTenantDeletionResults =
+        camundaClient.newProcessInstanceSearchRequest().send().join();
+
+    assertThat(beforeTenantDeletionResults.items()).hasSize(3);
+    assertThat(
+            beforeTenantDeletionResults.items().stream()
+                .map(ProcessInstance::getTenantId)
+                .collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B, tenantToBeDeleted);
+
+    // when
+    deleteTenant(camundaClient, tenantToBeDeleted);
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> {
+              // then
+              final var afterTenantDeletionResults =
+                  camundaClient.newProcessInstanceSearchRequest().send().join();
+
+              assertThat(afterTenantDeletionResults.items()).hasSize(2);
+              assertThat(
+                      afterTenantDeletionResults.items().stream()
+                          .map(ProcessInstance::getTenantId)
+                          .collect(Collectors.toSet()))
+                  .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+            });
   }
 
   @Test
@@ -143,6 +187,10 @@ public class ProcessInstanceTenancyIT {
     camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
   }
 
+  private static void deleteTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newDeleteTenantCommand(tenant).send().join();
+  }
+
   private static void assignUserToTenant(
       final CamundaClient camundaClient, final String username, final String tenant) {
     camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
@@ -169,7 +217,8 @@ public class ProcessInstanceTenancyIT {
         .join();
   }
 
-  private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
+  private static void waitForProcessBeingExported(
+      final CamundaClient camundaClient, final int expectedProcessDefinitions) {
     Awaitility.await("should receive data from secondary storage")
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -182,7 +231,7 @@ public class ProcessInstanceTenancyIT {
                           .send()
                           .join()
                           .items())
-                  .hasSize(2);
+                  .hasSize(expectedProcessDefinitions);
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -36,6 +36,7 @@ import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -49,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 
 /**
@@ -167,12 +169,27 @@ public final class TestHelper {
     }
   }
 
+  public static void deleteTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newDeleteTenantCommand(tenant).send().join();
+  }
+
   public static ProcessInstanceEvent startProcessInstance(
       final CamundaClient camundaClient, final String bpmnProcessId) {
     return camundaClient
         .newCreateInstanceCommand()
         .bpmnProcessId(bpmnProcessId)
         .latestVersion()
+        .send()
+        .join();
+  }
+
+  public static ProcessInstanceEvent startProcessInstanceForTenant(
+      final CamundaClient camundaClient, final String bpmnProcessId, final String tenant) {
+    return camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(bpmnProcessId)
+        .latestVersion()
+        .tenantId(tenant)
         .send()
         .join();
   }
@@ -593,6 +610,20 @@ public final class TestHelper {
                             .join()
                             .items())
                     .hasSize(expectedProcessInstances));
+  }
+
+  public static void waitForTenantDeletion(
+      final CamundaClient camundaClient, final String tenantToBeDeleted) {
+    Awaitility.await("should wait until tenant is deleted")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient.newTenantsSearchRequest().send().join().items().stream()
+                            .map(Tenant::getTenantId)
+                            .collect(Collectors.toSet()))
+                    .doesNotContain(tenantToBeDeleted));
   }
 
   public static void waitForProcessesToBeDeployed(


### PR DESCRIPTION
## Description

This PR fixes a bug where the v1 process instance search API was returning process instances from deleted tenants. The root cause was that in the OpenSearch DAO layer, filtering queries were not being properly passed through the tenant check mechanism. 

The key changes include:
- Refactored `buildFiltering` methods in OpenSearch DAOs to return `Query` objects instead of mutating `SearchRequest.Builder` directly
- Added integration tests to verify that deleted tenant data is properly filtered out
- Added helper methods for tenant deletion testing in `TestHelper`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38297
