### PR TITLE
Identity Migration: add entity IDs normalization configuration

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/EntitiesProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/EntitiesProperties.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config;
+
+public class EntitiesProperties {
+
+  private static final String DEFAULT_PATTERN = "[^a-z0-9_@.-]";
+
+  private NormalizationConfig defaults = new NormalizationConfig(true, DEFAULT_PATTERN);
+  private NormalizationConfig role = new NormalizationConfig();
+  private NormalizationConfig group = new NormalizationConfig();
+  private NormalizationConfig user = new NormalizationConfig();
+  private NormalizationConfig mappingRule = new NormalizationConfig();
+
+  public NormalizationConfig getDefaults() {
+    return defaults;
+  }
+
+  public void setDefaults(final NormalizationConfig defaults) {
+    this.defaults = defaults;
+  }
+
+  public NormalizationConfig getRole() {
+    return role;
+  }
+
+  public void setRole(final NormalizationConfig role) {
+    this.role = role;
+  }
+
+  public NormalizationConfig getGroup() {
+    return group;
+  }
+
+  public void setGroup(final NormalizationConfig group) {
+    this.group = group;
+  }
+
+  public NormalizationConfig getUser() {
+    return user;
+  }
+
+  public void setUser(final NormalizationConfig user) {
+    this.user = user;
+  }
+
+  public NormalizationConfig getMappingRule() {
+    return mappingRule;
+  }
+
+  public void setMappingRule(final NormalizationConfig mappingRule) {
+    this.mappingRule = mappingRule;
+  }
+
+  /**
+   * Gets the effective normalization configuration for a specific entity type. Entity-specific
+   * settings override the defaults.
+   */
+  public NormalizationConfig getEffectiveConfig(final EntityType entityType) {
+    final NormalizationConfig specific =
+        switch (entityType) {
+          case ROLE -> role;
+          case GROUP -> group;
+          case USER -> user;
+          case MAPPING_RULE -> mappingRule;
+        };
+
+    return specific.mergeWithDefaults(defaults);
+  }
+
+  /** Configuration for ID normalization behavior. Supports inheritance from defaults. */
+  public static class NormalizationConfig {
+    private Boolean lowercase;
+    private String pattern;
+
+    public NormalizationConfig() {}
+
+    public NormalizationConfig(final boolean lowercase, final String pattern) {
+      this.lowercase = lowercase;
+      this.pattern = pattern;
+    }
+
+    public Boolean getLowercase() {
+      return lowercase;
+    }
+
+    public void setLowercase(final Boolean lowercase) {
+      this.lowercase = lowercase;
+    }
+
+    public String getPattern() {
+      return pattern;
+    }
+
+    public void setPattern(final String pattern) {
+      this.pattern = pattern;
+    }
+
+    /** Merges this configuration with defaults. Specific settings override defaults. */
+    public NormalizationConfig mergeWithDefaults(final NormalizationConfig defaults) {
+      return new NormalizationConfig(
+          lowercase != null ? lowercase : defaults.lowercase,
+          pattern != null ? pattern : defaults.pattern);
+    }
+
+    public boolean isLowercaseEnabled() {
+      return lowercase != null ? lowercase : true; // Default fallback
+    }
+
+    public String getEffectivePattern() {
+      return pattern != null ? pattern : DEFAULT_PATTERN; // Default fallback
+    }
+  }
+
+  public enum EntityType {
+    ROLE,
+    GROUP,
+    USER,
+    MAPPING_RULE
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
@@ -32,6 +32,7 @@ public class IdentityMigrationProperties {
   private OidcProperties oidc = new OidcProperties();
   private Integer backpressureDelay = 5000;
   private boolean resourceAuthorizationsEnabled = false;
+  private EntitiesProperties entities = new EntitiesProperties();
 
   public ManagementIdentityProperties getManagementIdentity() {
     return managementIdentity;
@@ -95,6 +96,14 @@ public class IdentityMigrationProperties {
 
   public void setResourceAuthorizationsEnabled(final boolean resourceAuthorizationsEnabled) {
     this.resourceAuthorizationsEnabled = resourceAuthorizationsEnabled;
+  }
+
+  public EntitiesProperties getEntities() {
+    return entities;
+  }
+
+  public void setEntities(final EntitiesProperties entities) {
+    this.entities = entities;
   }
 
   public enum Mode {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/saas/GroupMigrationHandler.java
@@ -13,6 +13,7 @@ import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ConsoleClient;
 import io.camunda.migration.identity.client.ConsoleClient.Member;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.EntitiesProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.handler.MigrationHandler;
@@ -32,6 +33,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
   private final ConsoleClient consoleClient;
   private final ManagementIdentityClient managementIdentityClient;
   private final GroupServices groupServices;
+  private final EntitiesProperties entitiesProperties;
 
   private final AtomicInteger createdGroupCount = new AtomicInteger();
   private final AtomicInteger assignedUserCount = new AtomicInteger();
@@ -48,6 +50,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
     this.consoleClient = consoleClient;
     this.managementIdentityClient = managementIdentityClient;
     this.groupServices = groupServices.withAuthentication(authentication);
+    entitiesProperties = migrationProperties.getEntities();
   }
 
   @Override
@@ -64,7 +67,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
             .collect(Collectors.toMap(Member::userId, Member::email));
     batch.forEach(
         group -> {
-          final var normalizedGroupId = normalizeGroupID(group);
+          final var normalizedGroupId = normalizeGroupID(group, entitiesProperties);
           logger.debug(
               "Migrating Group: {} to a Group with the identifier: {}.", group, normalizedGroupId);
           try {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandler.java
@@ -10,7 +10,7 @@ package io.camunda.migration.identity.handler.sm;
 import static io.camunda.migration.identity.MigrationUtil.convertDecisionPermissions;
 import static io.camunda.migration.identity.MigrationUtil.convertProcessPermissions;
 import static io.camunda.migration.identity.MigrationUtil.normalizeID;
-import static io.camunda.migration.identity.config.EntitiesProperties.EntityType.GROUP;
+import static io.camunda.migration.identity.config.EntitiesProperties.EntityType.ROLE;
 import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_DECISION_DEFINITION_RESOURCE_TYPE;
 import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_PROCESS_DEFINITION_RESOURCE_TYPE;
 
@@ -91,7 +91,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
     groupRoles.forEach(
         role -> {
           try {
-            final var roleId = normalizeID(role.name(), entitiesProperties, GROUP);
+            final var roleId = normalizeID(role.name(), entitiesProperties, ROLE);
             logger.debug("Assigning role '{}' to group '{}'", roleId, group.name());
             final var roleMember = new RoleMemberRequest(roleId, group.name(), EntityType.GROUP);
             retryOnBackpressure(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/GroupMigrationHandler.java
@@ -10,11 +10,13 @@ package io.camunda.migration.identity.handler.sm;
 import static io.camunda.migration.identity.MigrationUtil.convertDecisionPermissions;
 import static io.camunda.migration.identity.MigrationUtil.convertProcessPermissions;
 import static io.camunda.migration.identity.MigrationUtil.normalizeID;
+import static io.camunda.migration.identity.config.EntitiesProperties.EntityType.GROUP;
 import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_DECISION_DEFINITION_RESOURCE_TYPE;
 import static io.camunda.migration.identity.config.saas.StaticEntities.IDENTITY_PROCESS_DEFINITION_RESOURCE_TYPE;
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.EntitiesProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.dto.Authorization;
 import io.camunda.migration.identity.dto.Group;
@@ -38,6 +40,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
   private final ManagementIdentityClient managementIdentityClient;
   private final RoleServices roleServices;
   private final AuthorizationServices authorizationServices;
+  private final EntitiesProperties entitiesProperties;
 
   private final AtomicInteger createdGroupAuthorizationCount = new AtomicInteger();
   private final AtomicInteger totalGroupAuthorizationCount = new AtomicInteger();
@@ -54,6 +57,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
     this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices.withAuthentication(authentication);
     this.authorizationServices = authorizationServices.withAuthentication(authentication);
+    entitiesProperties = migrationProperties.getEntities();
   }
 
   @Override
@@ -87,7 +91,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
     groupRoles.forEach(
         role -> {
           try {
-            final var roleId = normalizeID(role.name());
+            final var roleId = normalizeID(role.name(), entitiesProperties, GROUP);
             logger.debug("Assigning role '{}' to group '{}'", roleId, group.name());
             final var roleMember = new RoleMemberRequest(roleId, group.name(), EntityType.GROUP);
             retryOnBackpressure(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
@@ -16,6 +16,7 @@ import static io.camunda.migration.identity.config.sm.StaticEntities.getAuthoriz
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.EntitiesProperties.EntityType;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.config.sm.OidcProperties.Audiences;
 import io.camunda.migration.identity.dto.Role;
@@ -72,7 +73,8 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
     roles.forEach(
         role -> {
           final var roleName = role.name();
-          final var roleId = normalizeID(roleName);
+          final var roleId =
+              normalizeID(roleName, migrationProperties.getEntities(), EntityType.ROLE);
           try {
             final var roleRequest = new CreateRoleRequest(roleId, roleName, role.description());
             retryOnBackpressure(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandler.java
@@ -8,10 +8,12 @@
 package io.camunda.migration.identity.handler.sm;
 
 import static io.camunda.migration.identity.MigrationUtil.normalizeID;
+import static io.camunda.migration.identity.config.EntitiesProperties.EntityType.ROLE;
 
 import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.client.ManagementIdentityClient;
+import io.camunda.migration.identity.config.EntitiesProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.handler.MigrationHandler;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -25,6 +27,7 @@ public class UserRoleMigrationHandler extends MigrationHandler<User> {
 
   private final ManagementIdentityClient managementIdentityClient;
   private final RoleServices roleServices;
+  private final EntitiesProperties entitiesProperties;
 
   private final AtomicInteger assignedUserCount = new AtomicInteger();
   private final AtomicInteger totalRoleCount = new AtomicInteger();
@@ -37,6 +40,7 @@ public class UserRoleMigrationHandler extends MigrationHandler<User> {
     super(migrationProperties.getBackpressureDelay());
     this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices.withAuthentication(authentication);
+    entitiesProperties = migrationProperties.getEntities();
   }
 
   @Override
@@ -55,7 +59,7 @@ public class UserRoleMigrationHandler extends MigrationHandler<User> {
           userRoles.forEach(
               role -> {
                 try {
-                  final var roleId = normalizeID(role.name());
+                  final var roleId = normalizeID(role.name(), entitiesProperties, ROLE);
                   logger.debug("Assigning role '{}' to user '{}'", roleId, userId);
                   final var roleMember = new RoleMemberRequest(roleId, userId, EntityType.USER);
                   retryOnBackpressure(

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/MigrationUtilTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/MigrationUtilTest.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity;
+
+import static io.camunda.migration.identity.MigrationUtil.normalizeGroupID;
+import static io.camunda.migration.identity.MigrationUtil.normalizeID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.identity.config.EntitiesProperties;
+import io.camunda.migration.identity.config.EntitiesProperties.EntityType;
+import io.camunda.migration.identity.config.EntitiesProperties.NormalizationConfig;
+import io.camunda.migration.identity.dto.Group;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MigrationUtilTest {
+
+  @Nested
+  class NormalizeIDTest {
+
+    @Test
+    void shouldApplyLowercaseByDefault() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "MyRoleName";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("myrolename");
+    }
+
+    @Test
+    void shouldNotApplyLowercaseWhenDisabledInDefaults() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setLowercase(false);
+      properties.getDefaults().setPattern("[^a-zA-Z0-9_@.-]"); // Allow uppercase
+      final String input = "MyRoleName";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("MyRoleName");
+    }
+
+    @Test
+    void shouldApplyEntitySpecificLowercaseConfig() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setLowercase(true);
+      properties.getRole().setLowercase(false);
+      properties.getRole().setPattern("[^a-zA-Z0-9_@.-]"); // Allow uppercase for roles
+      final String input = "MyRoleName";
+
+      // when
+      final String roleResult = normalizeID(input, properties, EntityType.ROLE);
+      final String groupResult = normalizeID(input, properties, EntityType.GROUP);
+
+      // then
+      assertThat(roleResult).isEqualTo("MyRoleName");
+      assertThat(groupResult).isEqualTo("myrolename");
+    }
+
+    @Test
+    void shouldReplaceDisallowedCharactersWithUnderscore() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "role@name#with$special%chars";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("role@name_with_special_chars");
+    }
+
+    @Test
+    void shouldAllowValidCharacters() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "valid-role.name_123@example.com";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("valid-role.name_123@example.com");
+    }
+
+    @Test
+    void shouldApplyCustomPattern() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setPattern("[^a-z0-9]");
+      final String input = "role-name.test@example";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("role_name_test_example");
+    }
+
+    @Test
+    void shouldApplyEntitySpecificPattern() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setPattern("[^a-z0-9_@.-]");
+      properties.getRole().setPattern("[^a-z0-9_]");
+      final String input = "role-name.test@example";
+
+      // when
+      final String roleResult = normalizeID(input, properties, EntityType.ROLE);
+      final String groupResult = normalizeID(input, properties, EntityType.GROUP);
+
+      // then
+      assertThat(roleResult).isEqualTo("role_name_test_example");
+      assertThat(groupResult).isEqualTo("role-name.test@example");
+    }
+
+    @Test
+    void shouldTruncateLongIdsTo256Characters() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "a".repeat(300);
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).hasSize(256);
+      assertThat(result).isEqualTo("a".repeat(256));
+    }
+
+    @Test
+    void shouldHandleExactly256Characters() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "a".repeat(256);
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).hasSize(256);
+      assertThat(result).isEqualTo(input);
+    }
+
+    @Test
+    void shouldNotTruncateIdsUnder256Characters() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "a".repeat(255);
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).hasSize(255);
+      assertThat(result).isEqualTo(input);
+    }
+
+    @Test
+    void shouldHandleEmptyString() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldApplyCombinedTransformations() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getRole().setLowercase(false);
+      properties.getRole().setPattern("[^a-zA-Z0-9_@.-]"); // Allow uppercase
+      final String input = "Role@Name#123";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("Role@Name_123");
+    }
+
+    @Test
+    void shouldWorkWithAllEntityTypes() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "Test@Entity#Name";
+
+      // when & then
+      assertThat(normalizeID(input, properties, EntityType.ROLE)).isEqualTo("test@entity_name");
+      assertThat(normalizeID(input, properties, EntityType.GROUP)).isEqualTo("test@entity_name");
+      assertThat(normalizeID(input, properties, EntityType.USER)).isEqualTo("test@entity_name");
+      assertThat(normalizeID(input, properties, EntityType.MAPPING_RULE))
+          .isEqualTo("test@entity_name");
+    }
+
+    @Test
+    void shouldRespectIndependentEntityConfigs() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getRole().setLowercase(false);
+      properties.getRole().setPattern("[^a-zA-Z0-9_@.-]"); // Allow uppercase for roles
+      properties.getGroup().setLowercase(true);
+      properties.getMappingRule().setPattern("[^a-z0-9]");
+      final String input = "Test-Name@123";
+
+      // when
+      final String roleResult = normalizeID(input, properties, EntityType.ROLE);
+      final String groupResult = normalizeID(input, properties, EntityType.GROUP);
+      final String mappingRuleResult = normalizeID(input, properties, EntityType.MAPPING_RULE);
+
+      // then
+      assertThat(roleResult).isEqualTo("Test-Name@123");
+      assertThat(groupResult).isEqualTo("test-name@123");
+      assertThat(mappingRuleResult).isEqualTo("test_name_123");
+    }
+
+    @Test
+    void shouldHandleUnicodeCharacters() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "rôle-名前";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      // Unicode characters are not in the allowed pattern, so they become underscores
+      assertThat(result).isEqualTo("r_le-__");
+    }
+
+    @Test
+    void shouldHandleMultipleConsecutiveSpecialCharacters() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String input = "role###name***test";
+
+      // when
+      final String result = normalizeID(input, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("role___name___test");
+    }
+  }
+
+  @Nested
+  class NormalizeGroupIDTest {
+
+    @Test
+    void shouldNormalizeGroupNameWhenPresent() {
+      // given
+      final var properties = new EntitiesProperties();
+      final var group = new Group("group-id", "Group@Name#123");
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).isEqualTo("group@name_123");
+    }
+
+    @Test
+    void shouldFallbackToGroupIdWhenNameIsNull() {
+      // given
+      final var properties = new EntitiesProperties();
+      final var group = new Group("fallback-id", null);
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).isEqualTo("fallback-id");
+    }
+
+    @Test
+    void shouldFallbackToGroupIdWhenNameIsEmpty() {
+      // given
+      final var properties = new EntitiesProperties();
+      final var group = new Group("fallback-id", "");
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).isEqualTo("fallback-id");
+    }
+
+    @Test
+    void shouldApplyGroupSpecificConfig() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getGroup().setLowercase(false);
+      properties.getGroup().setPattern("[^a-zA-Z0-9_@.-]"); // Allow uppercase
+      final var group = new Group("group-id", "GroupName");
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).isEqualTo("GroupName");
+    }
+
+    @Test
+    void shouldHandleLongGroupNames() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String longName = "Group-Name-".repeat(30); // Creates a name > 256 chars
+      final var group = new Group("group-id", longName);
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).hasSize(256);
+    }
+
+    @Test
+    void shouldApplyGroupPatternConfig() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getGroup().setPattern("[^a-z0-9_]");
+      final var group = new Group("group-id", "Group-Name@Test");
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).isEqualTo("group_name_test");
+    }
+  }
+
+  @Nested
+  class NormalizationConfigTest {
+
+    @Test
+    void shouldUseDefaultsWhenEntityConfigIsNull() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setLowercase(false);
+      properties.getDefaults().setPattern("[^a-z0-9]");
+      // role config is not set, should inherit from defaults
+
+      // when
+      final NormalizationConfig config = properties.getEffectiveConfig(EntityType.ROLE);
+
+      // then
+      assertThat(config.isLowercaseEnabled()).isFalse();
+      assertThat(config.getEffectivePattern()).isEqualTo("[^a-z0-9]");
+    }
+
+    @Test
+    void shouldOverrideDefaultsWithEntitySpecificConfig() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setLowercase(true);
+      properties.getDefaults().setPattern("[^a-z0-9_@.-]");
+      properties.getRole().setLowercase(false);
+      properties.getRole().setPattern("[^a-z0-9]");
+
+      // when
+      final NormalizationConfig config = properties.getEffectiveConfig(EntityType.ROLE);
+
+      // then
+      assertThat(config.isLowercaseEnabled()).isFalse();
+      assertThat(config.getEffectivePattern()).isEqualTo("[^a-z0-9]");
+    }
+
+    @Test
+    void shouldAllowPartialOverride() {
+      // given
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setLowercase(true);
+      properties.getDefaults().setPattern("[^a-z0-9_@.-]");
+      properties.getRole().setLowercase(false);
+      // pattern not set for role, should use default
+
+      // when
+      final NormalizationConfig config = properties.getEffectiveConfig(EntityType.ROLE);
+
+      // then
+      assertThat(config.isLowercaseEnabled()).isFalse();
+      assertThat(config.getEffectivePattern()).isEqualTo("[^a-z0-9_@.-]");
+    }
+
+    @Test
+    void shouldUseFallbacksWhenNotConfigured() {
+      // given
+      final var properties = new EntitiesProperties();
+
+      // when
+      final NormalizationConfig config = properties.getEffectiveConfig(EntityType.ROLE);
+
+      // then - should use hardcoded fallbacks in NormalizationConfig
+      assertThat(config.isLowercaseEnabled()).isTrue();
+      assertThat(config.getEffectivePattern()).isEqualTo("[^a-z0-9_@.-]");
+    }
+  }
+
+  @Nested
+  class RealWorldScenarios {
+
+    @Test
+    void shouldHandleKeycloakRoleNameWithSpecialChars() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String roleName = "Identity/Admin Role";
+
+      // when
+      final String result = normalizeID(roleName, properties, EntityType.ROLE);
+
+      // then
+      assertThat(result).isEqualTo("identity_admin_role");
+    }
+
+    @Test
+    void shouldHandleSaaSGroupNameWithSpaces() {
+      // given
+      final var properties = new EntitiesProperties();
+      final var group = new Group("id", "Engineering Team 2024");
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).isEqualTo("engineering_team_2024");
+    }
+
+    @Test
+    void shouldPreserveEmailLikeIdentifiers() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String email = "user@example.com";
+
+      // when
+      final String result = normalizeID(email, properties, EntityType.USER);
+
+      // then
+      assertThat(result).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void shouldHandleMixedCaseWithNumbersAndDots() {
+      // given
+      final var properties = new EntitiesProperties();
+      final String mappingRule = "App.User.Role.v1.2.3";
+
+      // when
+      final String result = normalizeID(mappingRule, properties, EntityType.MAPPING_RULE);
+
+      // then
+      assertThat(result).isEqualTo("app.user.role.v1.2.3");
+    }
+
+    @Test
+    void shouldAllowUsersToDisableLowercaseForRolesOnly() {
+      // given - User wants to preserve role case but lowercase other entities
+      final var properties = new EntitiesProperties();
+      properties.getDefaults().setLowercase(true);
+      properties.getRole().setLowercase(false);
+      properties.getRole().setPattern("[^a-zA-Z0-9_@.-]"); // Must also allow uppercase in pattern!
+
+      final String name = "MyEntity";
+
+      // when
+      final String roleResult = normalizeID(name, properties, EntityType.ROLE);
+      final String groupResult = normalizeID(name, properties, EntityType.GROUP);
+
+      // then
+      assertThat(roleResult).isEqualTo("MyEntity");
+      assertThat(groupResult).isEqualTo("myentity");
+    }
+
+    @Test
+    void shouldHandleVeryLongGroupNameFromSaaS() {
+      // given
+      final var properties = new EntitiesProperties();
+      // Create a string that's longer than 256 chars after normalization
+      final String longName =
+          "Group-Name-With-Many-Dashes-And-Spaces-".repeat(10); // 40 chars * 10 = 400 chars
+      final var group = new Group("short-id", longName);
+
+      // when
+      final String result = normalizeGroupID(group, properties);
+
+      // then
+      assertThat(result).hasSize(256);
+      assertThat(result).startsWith("group-name-with-many-dashes-and-spaces-");
+    }
+  }
+}

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractSaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractSaaSIdentityMigrationIT.java
@@ -227,7 +227,7 @@ public abstract class AbstractSaaSIdentityMigrationIT {
   }
 
   protected void createGroups() throws IOException, InterruptedException, URISyntaxException {
-    final var groupsNames = List.of("groupA", "groupB", "groupC");
+    final var groupsNames = List.of("groupA", "groupB", "groupC", "GROUP_123_@");
     for (final String groupName : groupsNames) {
       createGroup(groupName);
     }
@@ -260,7 +260,7 @@ public abstract class AbstractSaaSIdentityMigrationIT {
         getGroups().stream().map(io.camunda.migration.identity.dto.Group::id).toList();
     assignGroupToUser(groupIds.getFirst(), "user0");
     assignGroupToUser(groupIds.get(1), "user0");
-    assignGroupToUser(groupIds.getLast(), "user1");
+    assignGroupToUser(groupIds.get(2), "user1");
   }
 
   protected void assignGroupToUser(final String groupId, final String userId)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PRs add a new property class to allow users to configure the entity IDs normalization. Example:

```
# Set defaults
camunda.migration.identity.entities.defaults.lowercase=true
camunda.migration.identity.entities.defaults.pattern=[^a-z0-9_@.-]

# Override for roles only
camunda.migration.identity.entities.role.lowercase=false

# Override for groups
camunda.migration.identity.entities.group.lowercase=false
camunda.migration.identity.entities.group.pattern=[^a-z0-9_]
```

## Related issues

closes #41605 
