### PR TITLE
fix: Install dependencies for wait-for-it script in dockerfile

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -73,6 +73,9 @@ VOLUME /tmp
 
 # Switch to root to allow setting up our own user
 USER root
+# Install dependencies required for the wait-for.sh script
+RUN apk add --no-cache netcat-openbsd curl bash
+
 RUN mkdir -p /usr/local/bin/ && \
     wget -nv -O /usr/local/bin/wait-for-it.sh "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" && \
     chmod +x /usr/local/bin/wait-for-it.sh && \


### PR DESCRIPTION
Added dependencies for the wait-for.sh script.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
