### PR TITLE
perf: performance improvements in NextValueManager

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -36,9 +36,10 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
     this.partitionId = partitionId;
     keyStartValue = Protocol.encodePartitionId(partitionId, INITIAL_VALUE);
     nextValueManager =
-        new NextValueManager(keyStartValue, zeebeDb, transactionContext, ZbColumnFamilies.KEY);
+        new NextValueManager(
+            keyStartValue, zeebeDb, transactionContext, ZbColumnFamilies.KEY, LATEST_KEY);
 
-    final var currentKey = nextValueManager.getCurrentValue(LATEST_KEY);
+    final var currentKey = nextValueManager.getCurrentValue();
     if (Protocol.decodePartitionId(currentKey) != partitionId) {
       throw new UnrecoverableException(
           new IllegalStateException(
@@ -50,7 +51,7 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
 
   @Override
   public long nextKey() {
-    final var nextKey = nextValueManager.getNextValue(LATEST_KEY);
+    final var nextKey = nextValueManager.getNextValue();
     if (Protocol.decodePartitionId(nextKey) != partitionId) {
       throw new UnrecoverableException(
           new IllegalStateException(
@@ -69,12 +70,12 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
    */
   @VisibleForTesting
   public long getCurrentKey() {
-    return nextValueManager.getCurrentValue(LATEST_KEY);
+    return nextValueManager.getCurrentValue();
   }
 
   @Override
   public void setKeyIfHigher(final long key) {
-    final var currentKey = nextValueManager.getCurrentValue(LATEST_KEY);
+    final var currentKey = nextValueManager.getCurrentValue();
 
     if (key > currentKey) {
       if (Protocol.decodePartitionId(key) != partitionId) {


### PR DESCRIPTION
## Description
A couple of performance improvements in `NextValueManager`
- Do not wrap the `DbKey` over a dynamic string at every get/set since the key is static every time, just wrap it once in the constructor

The last point is beneficial, considering the other PR (#41656)  since it requires checking the currentKey for every record.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #41041
