### PR TITLE
feat: validate that the key() in Record is not higher than current key

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
 import java.time.InstantSource;
 
@@ -43,9 +44,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             context.getPartitionId(),
             zeebeDb,
             zeebeDbContext,
-            () -> {
-              throw new IllegalCallerException("New keys cannot be generated during migration");
-            },
+            KeyGenerator.immutable(),
             transientMessageSubscriptionState,
             transientProcessMessageSubscriptionState,
             context.getBrokerCfg().getExperimental().getEngine().createEngineConfiguration(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -44,7 +44,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             context.getPartitionId(),
             zeebeDb,
             zeebeDbContext,
-            KeyGenerator.immutable(),
+            KeyGenerator.immutable(context.getPartitionId()),
             transientMessageSubscriptionState,
             transientProcessMessageSubscriptionState,
             context.getBrokerCfg().getExperimental().getEngine().createEngineConfiguration(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -118,14 +118,13 @@ public class Engine implements RecordProcessor {
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
     eventApplier = new EventAppliers();
-    writers =
-        new Writers(recordProcessorContext.getPartitionId(), resultBuilderMutex, eventApplier);
+    writers = new Writers(resultBuilderMutex, eventApplier);
 
     final var typedProcessorContext =
         new TypedRecordProcessorContextImpl(
             recordProcessorContext, writers, config, securityConfig);
     processingState = typedProcessorContext.getProcessingState();
-    writers.setKeyGenerator(processingState.getKeyGenerator());
+    writers.setKeyValidator(processingState.getKeyGenerator());
 
     ((EventAppliers) eventApplier).registerEventAppliers(processingState);
     final TypedRecordProcessors typedRecordProcessors =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -118,12 +118,14 @@ public class Engine implements RecordProcessor {
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
     eventApplier = new EventAppliers();
-    writers = new Writers(resultBuilderMutex, eventApplier);
+    writers =
+        new Writers(recordProcessorContext.getPartitionId(), resultBuilderMutex, eventApplier);
 
     final var typedProcessorContext =
         new TypedRecordProcessorContextImpl(
             recordProcessorContext, writers, config, securityConfig);
     processingState = typedProcessorContext.getProcessingState();
+    writers.setKeyGenerator(processingState.getKeyGenerator());
 
     ((EventAppliers) eventApplier).registerEventAppliers(processingState);
     final TypedRecordProcessors typedRecordProcessors =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata.Builder;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -49,7 +51,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    validateKey(key);
+    // key is validated in appendFollowUpEvent
     final int latestVersion = eventApplier.getLatestVersion(intent);
     appendFollowUpEvent(key, intent, value, latestVersion);
   }
@@ -57,7 +59,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
-    validateKey(key);
+    // key is validated in appendFollowUpEvent
     appendFollowUpEvent(key, intent, value, m -> m.recordVersion(recordVersion));
   }
 
@@ -86,6 +88,16 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
 
     resultBuilder().appendRecord(key, value, recordMetadata);
     eventApplier.applyState(key, intent, value, recordVersion);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final Consumer<Builder> builderConsumer) {
+    validateKey(key);
+    StateWriter.super.appendFollowUpEvent(key, intent, value, builderConsumer);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.KeyValidator;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -32,21 +32,18 @@ import java.util.function.Supplier;
 final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBuilderBackedWriter
     implements StateWriter {
 
-  private final int partitionId;
   private final EventApplier eventApplier;
-  private KeyGenerator keyGenerator;
+  private KeyValidator keyValidator;
 
   public ResultBuilderBackedEventApplyingStateWriter(
-      final int partitionId,
       final Supplier<ProcessingResultBuilder> resultBuilderSupplier,
       final EventApplier eventApplier) {
     super(resultBuilderSupplier);
-    this.partitionId = partitionId;
     this.eventApplier = eventApplier;
   }
 
-  public void setKeyGenerator(final KeyGenerator keyGenerator) {
-    this.keyGenerator = keyGenerator;
+  public void setKeyValidator(final KeyValidator keyValidator) {
+    this.keyValidator = keyValidator;
   }
 
   @Override
@@ -106,8 +103,8 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   }
 
   private void validateKey(final long key) {
-    if (keyGenerator != null) {
-      TypedEventWriter.validateKey(key, partitionId, keyGenerator);
+    if (keyValidator != null) {
+      keyValidator.validateKey(key);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.function.Supplier;
 
 /**
@@ -29,17 +30,26 @@ import java.util.function.Supplier;
 final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBuilderBackedWriter
     implements StateWriter {
 
+  private final int partitionId;
   private final EventApplier eventApplier;
+  private KeyGenerator keyGenerator;
 
   public ResultBuilderBackedEventApplyingStateWriter(
+      final int partitionId,
       final Supplier<ProcessingResultBuilder> resultBuilderSupplier,
       final EventApplier eventApplier) {
     super(resultBuilderSupplier);
+    this.partitionId = partitionId;
     this.eventApplier = eventApplier;
+  }
+
+  public void setKeyGenerator(final KeyGenerator keyGenerator) {
+    this.keyGenerator = keyGenerator;
   }
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
+    validateKey(key);
     final int latestVersion = eventApplier.getLatestVersion(intent);
     appendFollowUpEvent(key, intent, value, latestVersion);
   }
@@ -47,6 +57,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
+    validateKey(key);
     appendFollowUpEvent(key, intent, value, m -> m.recordVersion(recordVersion));
   }
 
@@ -56,6 +67,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
       final Intent intent,
       final RecordValue value,
       final FollowUpEventMetadata metadata) {
+    validateKey(key);
     final int recordVersion =
         metadata.getRecordVersion() == FollowUpEventMetadata.VERSION_NOT_SET
             ? eventApplier.getLatestVersion(intent)
@@ -79,5 +91,11 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   @Override
   public boolean canWriteEventOfLength(final int eventLength) {
     return resultBuilder().canWriteEventOfLength(eventLength);
+  }
+
+  private void validateKey(final long key) {
+    if (keyGenerator != null) {
+      TypedEventWriter.validateKey(key, partitionId, keyGenerator);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -157,7 +157,7 @@ public interface TypedEventWriter {
     final var decodedPartitionId = Protocol.decodePartitionId(key);
     if (decodedPartitionId == expectedPartitionId && key > keyGenerator.getCurrentKey()) {
       throw new UnrecoverableException(
-          "Expected to receive a key lesser than %d, but got %d"
+          "Expected to append event with key lesser than the last generated key %d, but got %d"
               .formatted(keyGenerator.getCurrentKey(), key));
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -8,12 +8,9 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.util.function.Consumer;
 
 public interface TypedEventWriter {
@@ -140,25 +137,4 @@ public interface TypedEventWriter {
    * @return true if an event of length {@code eventLength} can be written
    */
   boolean canWriteEventOfLength(final int eventLength);
-
-  /**
-   * Validate that the provided key is valid: - it's assigned to the expected partition - it's not
-   * higher than the current key
-   *
-   * @param key to validate
-   * @param expectedPartitionId expected partition
-   * @param keyGenerator to verify the key is not exceeding the highest key generated
-   */
-  static void validateKey(
-      final long key, final int expectedPartitionId, final KeyGenerator keyGenerator) {
-    if (key == -1L) {
-      return;
-    }
-    final var decodedPartitionId = Protocol.decodePartitionId(key);
-    if (decodedPartitionId == expectedPartitionId && key > keyGenerator.getCurrentKey()) {
-      throw new UnrecoverableException(
-          "Expected to append event with key lesser than the last generated key %d, but got %d"
-              .formatted(keyGenerator.getCurrentKey(), key));
-    }
-  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.util.function.Consumer;
 
 public interface TypedEventWriter {
@@ -155,7 +156,7 @@ public interface TypedEventWriter {
     }
     final var decodedPartitionId = Protocol.decodePartitionId(key);
     if (decodedPartitionId == expectedPartitionId && key > keyGenerator.getCurrentKey()) {
-      throw new IllegalArgumentException(
+      throw new UnrecoverableException(
           "Expected to receive a key lesser than %d, but got %d"
               .formatted(keyGenerator.getCurrentKey(), key));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.function.Consumer;
 
 public interface TypedEventWriter {
@@ -137,4 +139,25 @@ public interface TypedEventWriter {
    * @return true if an event of length {@code eventLength} can be written
    */
   boolean canWriteEventOfLength(final int eventLength);
+
+  /**
+   * Validate that the provided key is valid: - it's assigned to the expected partition - it's not
+   * higher than the current key
+   *
+   * @param key to validate
+   * @param expectedPartitionId expected partition
+   * @param keyGenerator to verify the key is not exceeding the highest key generated
+   */
+  static void validateKey(
+      final long key, final int expectedPartitionId, final KeyGenerator keyGenerator) {
+    if (key == -1L) {
+      return;
+    }
+    final var decodedPartitionId = Protocol.decodePartitionId(key);
+    if (decodedPartitionId == expectedPartitionId && key > keyGenerator.getCurrentKey()) {
+      throw new IllegalArgumentException(
+          "Expected to receive a key lesser than %d, but got %d"
+              .formatted(keyGenerator.getCurrentKey(), key));
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/Writers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/Writers.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.stream.api.KeyValidator;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.function.Supplier;
 
 /** Convenience class to aggregate all the writers */
@@ -23,22 +23,20 @@ public final class Writers {
   private final SideEffectWriter sideEffectWriter;
 
   public Writers(
-      final int partitionId,
       final Supplier<ProcessingResultBuilder> resultBuilderSupplier,
       final EventApplier eventApplier) {
 
     commandWriter = new ResultBuilderBackedTypedCommandWriter(resultBuilderSupplier);
     rejectionWriter = new ResultBuilderBackedRejectionWriter(resultBuilderSupplier);
     stateWriter =
-        new ResultBuilderBackedEventApplyingStateWriter(
-            partitionId, resultBuilderSupplier, eventApplier);
+        new ResultBuilderBackedEventApplyingStateWriter(resultBuilderSupplier, eventApplier);
 
     responseWriter = new ResultBuilderBackedTypedResponseWriter(resultBuilderSupplier);
     sideEffectWriter = new ResultBuilderBackedSideEffectWriter(resultBuilderSupplier);
   }
 
-  public void setKeyGenerator(final KeyGenerator keyGenerator) {
-    stateWriter.setKeyGenerator(keyGenerator);
+  public void setKeyValidator(final KeyValidator keyGenerator) {
+    stateWriter.setKeyValidator(keyGenerator);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/Writers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/Writers.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.function.Supplier;
 
 /** Convenience class to aggregate all the writers */
@@ -16,22 +17,28 @@ public final class Writers {
 
   private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final StateWriter stateWriter;
+  private final ResultBuilderBackedEventApplyingStateWriter stateWriter;
 
   private final TypedResponseWriter responseWriter;
   private final SideEffectWriter sideEffectWriter;
 
   public Writers(
+      final int partitionId,
       final Supplier<ProcessingResultBuilder> resultBuilderSupplier,
       final EventApplier eventApplier) {
 
     commandWriter = new ResultBuilderBackedTypedCommandWriter(resultBuilderSupplier);
     rejectionWriter = new ResultBuilderBackedRejectionWriter(resultBuilderSupplier);
     stateWriter =
-        new ResultBuilderBackedEventApplyingStateWriter(resultBuilderSupplier, eventApplier);
+        new ResultBuilderBackedEventApplyingStateWriter(
+            partitionId, resultBuilderSupplier, eventApplier);
 
     responseWriter = new ResultBuilderBackedTypedResponseWriter(resultBuilderSupplier);
     sideEffectWriter = new ResultBuilderBackedSideEffectWriter(resultBuilderSupplier);
+  }
+
+  public void setKeyGenerator(final KeyGenerator keyGenerator) {
+    stateWriter.setKeyGenerator(keyGenerator);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -82,7 +82,7 @@ public final class StateQueryService implements QueryService {
               Protocol.DEPLOYMENT_PARTITION,
               zeebeDb,
               zeebeDb.createContext(),
-              KeyGenerator.immutable(),
+              KeyGenerator.immutable(Protocol.DEPLOYMENT_PARTITION),
               new TransientPendingSubscriptionState(),
               new TransientPendingSubscriptionState(),
               new EngineConfiguration(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -81,9 +82,7 @@ public final class StateQueryService implements QueryService {
               Protocol.DEPLOYMENT_PARTITION,
               zeebeDb,
               zeebeDb.createContext(),
-              () -> {
-                throw new UnsupportedOperationException("Not allowed to generate a new key");
-              },
+              KeyGenerator.immutable(),
               new TransientPendingSubscriptionState(),
               new TransientPendingSubscriptionState(),
               new EngineConfiguration(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -18,12 +18,12 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.AtomicKeyGenerator;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -57,13 +58,14 @@ import org.junit.jupiter.api.Test;
  */
 class CommandDistributionBehaviorTest {
 
+  private static final int PARTITION_ID = 1;
   private DistributionState mockDistributionState;
   private DistributionMetrics mockDistributionMetrics;
   private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
   private InterPartitionCommandSender mockInterpartitionCommandSender;
   private Writers writers;
 
-  private long key;
+  private KeyGenerator keyGenerator;
   private ValueType valueType;
   private DeploymentIntent intent;
   private MockTypedRecord<DeploymentRecord> command;
@@ -75,9 +77,11 @@ class CommandDistributionBehaviorTest {
     mockDistributionState = mock(DistributionState.class);
     fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
-    writers = new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+    writers =
+        new Writers(PARTITION_ID, () -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+    keyGenerator = new AtomicKeyGenerator(PARTITION_ID);
+    writers.setKeyGenerator(keyGenerator);
 
-    key = Protocol.encodePartitionId(1, 100);
     valueType = ValueType.DEPLOYMENT;
     intent = DeploymentIntent.CREATE;
     authInfo =
@@ -88,7 +92,7 @@ class CommandDistributionBehaviorTest {
 
     command =
         new MockTypedRecord<>(
-            key,
+            keyGenerator.nextKey(),
             new RecordMetadata().valueType(valueType).intent(intent).authorization(authInfo),
             new DeploymentRecord());
   }
@@ -106,7 +110,7 @@ class CommandDistributionBehaviorTest {
             mockDistributionMetrics);
 
     // when distributing to all partitions
-    behavior.withKey(key).unordered().distribute(command);
+    behavior.withKey(keyGenerator.nextKey()).unordered().distribute(command);
 
     // then no command distribution is started
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords()).isEmpty();
@@ -129,6 +133,7 @@ class CommandDistributionBehaviorTest {
             mockDistributionMetrics);
 
     // when distributing to all partitions
+    final var key = keyGenerator.nextKey();
     behavior.withKey(key).unordered().distribute(command);
 
     // then command distribution is started on partition 1 and distributing to all other partitions
@@ -166,6 +171,7 @@ class CommandDistributionBehaviorTest {
             mockDistributionMetrics);
 
     // when distributing to partitions 1 and 3
+    final var key = keyGenerator.nextKey();
     behavior.withKey(key).unordered().forPartitions(Set.of(1, 3)).distribute(command);
 
     // then command distribution is started on partition 2 and distributing to all other partitions
@@ -208,6 +214,8 @@ class CommandDistributionBehaviorTest {
             .setFormat(AuthDataFormat.JWT)
             .setAuthData("some-jwt-token")
             .setClaims(Map.of("a", "b", "c", 3));
+
+    final var key = keyGenerator.nextKey();
     final var command =
         new MockTypedRecord<>(
             key,
@@ -252,6 +260,7 @@ class CommandDistributionBehaviorTest {
             mockDistributionMetrics);
 
     // when distributing first command in queue to all partitions
+    final var key = keyGenerator.nextKey();
     behavior.withKey(key).inQueue("test-queue").distribute(command);
 
     // then command distribution is started on partition 1, distribution is enqueued and triggered
@@ -286,8 +295,8 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender,
             mockDistributionMetrics);
 
-    final var firstKey = Protocol.encodePartitionId(1, 100);
-    final var secondKey = Protocol.encodePartitionId(1, 101);
+    final var firstKey = keyGenerator.nextKey();
+    final var secondKey = keyGenerator.nextKey();
 
     // when adding two distributions to the same queue
     behavior.withKey(firstKey).inQueue("test-queue").distribute(command);
@@ -329,7 +338,7 @@ class CommandDistributionBehaviorTest {
           new CommandDistributionBehavior(
               mockDistributionState,
               writers,
-              1,
+              PARTITION_ID,
               RoutingInfo.forStaticPartitions(2),
               mockInterpartitionCommandSender,
               mockDistributionMetrics);
@@ -339,28 +348,30 @@ class CommandDistributionBehaviorTest {
     public void shouldAcknowledgeCommandAndFinishDistribution() {
       final CommandDistributionRecord record = new CommandDistributionRecord().setPartitionId(2);
 
-      when(mockDistributionState.hasPendingDistribution(123L)).thenReturn(false);
+      final var key = keyGenerator.nextKey();
+      when(mockDistributionState.hasPendingDistribution(key)).thenReturn(false);
 
-      behavior.onAcknowledgeDistribution(123L, record);
+      behavior.onAcknowledgeDistribution(key, record);
 
       Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
           .extracting(Record::getKey, Record::getIntent, r -> r.getValue().getPartitionId())
           .containsExactly(
-              tuple(123L, CommandDistributionIntent.ACKNOWLEDGED, 2),
-              tuple(123L, CommandDistributionIntent.FINISH, 1));
+              tuple(key, CommandDistributionIntent.ACKNOWLEDGED, 2),
+              tuple(key, CommandDistributionIntent.FINISH, 1));
     }
 
     @Test
     public void shouldAcknowledgeCommandAndNotFinishDistribution() {
       final CommandDistributionRecord record = new CommandDistributionRecord().setPartitionId(2);
 
-      when(mockDistributionState.hasPendingDistribution(123L)).thenReturn(true);
+      final var key = keyGenerator.nextKey();
+      when(mockDistributionState.hasPendingDistribution(key)).thenReturn(true);
 
-      behavior.onAcknowledgeDistribution(123L, record);
+      behavior.onAcknowledgeDistribution(key, record);
 
       Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
           .extracting(Record::getKey, Record::getIntent, r -> r.getValue().getPartitionId())
-          .containsExactly(tuple(123L, CommandDistributionIntent.ACKNOWLEDGED, 2));
+          .containsExactly(tuple(key, CommandDistributionIntent.ACKNOWLEDGED, 2));
     }
 
     @Test
@@ -369,20 +380,22 @@ class CommandDistributionBehaviorTest {
       final CommandDistributionRecord otherRecord =
           new CommandDistributionRecord().setPartitionId(2);
 
-      when(mockDistributionState.getQueueIdForDistribution(123L)).thenReturn(Optional.of("queue"));
+      final var key = keyGenerator.nextKey();
+      final var nextKey = keyGenerator.nextKey();
+      when(mockDistributionState.getQueueIdForDistribution(key)).thenReturn(Optional.of("queue"));
       when(mockDistributionState.getNextQueuedDistributionKey("queue", 2))
-          .thenReturn(Optional.of(124L));
-      when(mockDistributionState.getCommandDistributionRecord(124L, 2)).thenReturn(otherRecord);
-      when(mockDistributionState.hasPendingDistribution(123L)).thenReturn(false);
+          .thenReturn(Optional.of(nextKey));
+      when(mockDistributionState.getCommandDistributionRecord(nextKey, 2)).thenReturn(otherRecord);
+      when(mockDistributionState.hasPendingDistribution(key)).thenReturn(false);
 
-      behavior.onAcknowledgeDistribution(123L, record);
+      behavior.onAcknowledgeDistribution(key, record);
 
       Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
           .extracting(Record::getKey, Record::getIntent, r -> r.getValue().getPartitionId())
           .containsExactly(
-              tuple(123L, CommandDistributionIntent.ACKNOWLEDGED, 2),
-              tuple(124L, CommandDistributionIntent.DISTRIBUTING, 2),
-              tuple(123L, CommandDistributionIntent.FINISH, 1));
+              tuple(key, CommandDistributionIntent.ACKNOWLEDGED, 2),
+              tuple(nextKey, CommandDistributionIntent.DISTRIBUTING, 2),
+              tuple(key, CommandDistributionIntent.FINISH, 1));
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -77,10 +77,9 @@ class CommandDistributionBehaviorTest {
     mockDistributionState = mock(DistributionState.class);
     fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
-    writers =
-        new Writers(PARTITION_ID, () -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+    writers = new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
     keyGenerator = new AtomicKeyGenerator(PARTITION_ID);
-    writers.setKeyGenerator(keyGenerator);
+    writers.setKeyValidator(keyGenerator);
 
     valueType = ValueType.DEPLOYMENT;
     intent = DeploymentIntent.CREATE;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -70,8 +70,8 @@ public class CommandDistributionScalingTest {
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
     final var eventAppliers = new EventAppliers().registerEventAppliers(state);
     keyGenerator = new AtomicKeyGenerator(1);
-    writers = new Writers(PARTITION_ID, () -> fakeProcessingResultBuilder, eventAppliers);
-    writers.setKeyGenerator(keyGenerator);
+    writers = new Writers(() -> fakeProcessingResultBuilder, eventAppliers);
+    writers.setKeyValidator(keyGenerator);
 
     valueType = ValueType.DEPLOYMENT;
     intent = DeploymentIntent.CREATE;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.AtomicKeyGenerator;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
@@ -28,7 +29,6 @@ import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,17 +47,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessingStateExtension.class)
 public class CommandDistributionScalingTest {
+  private static final int PARTITION_ID = 1;
   /* Injected from {@link ProcessingStateExtension} */
   private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private MutableProcessingState state;
   private TransactionContext transactionContext;
-
   private DistributionState distributionState;
   private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
   private InterPartitionCommandSender mockInterpartitionCommandSender;
   private Writers writers;
 
-  private long key;
+  private KeyGenerator keyGenerator;
   private ValueType valueType;
   private DeploymentIntent intent;
   private MockTypedRecord<DeploymentRecord> command;
@@ -68,14 +69,17 @@ public class CommandDistributionScalingTest {
     fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
     final var eventAppliers = new EventAppliers().registerEventAppliers(state);
-    writers = new Writers(() -> fakeProcessingResultBuilder, eventAppliers);
+    keyGenerator = new AtomicKeyGenerator(1);
+    writers = new Writers(PARTITION_ID, () -> fakeProcessingResultBuilder, eventAppliers);
+    writers.setKeyGenerator(keyGenerator);
 
-    key = Protocol.encodePartitionId(1, 100);
     valueType = ValueType.DEPLOYMENT;
     intent = DeploymentIntent.CREATE;
     command =
         new MockTypedRecord<>(
-            key, new RecordMetadata().valueType(valueType).intent(intent), new DeploymentRecord());
+            keyGenerator.getCurrentKey(),
+            new RecordMetadata().valueType(valueType).intent(intent),
+            new DeploymentRecord());
 
     // given a scale operation ongoing to transition to 3 partitions
     state.getRoutingState().initializeRoutingInfo(2);
@@ -94,6 +98,7 @@ public class CommandDistributionScalingTest {
   public void shouldWaitInQueueDuringScaling() {
 
     // when distributing first command in queue to all partitions
+    final var key = keyGenerator.nextKey();
     behavior.withKey(key).inQueue("test-queue").distribute(command);
 
     // then command distribution is started on partition 1, distribution is enqueued and triggered
@@ -122,7 +127,8 @@ public class CommandDistributionScalingTest {
     // given
 
     // when a distribution command is sent for two records
-    final var otherKey = Protocol.encodePartitionId(1, 101);
+    final var key = keyGenerator.getCurrentKey();
+    final var otherKey = keyGenerator.nextKey();
     behavior.withKey(key).inQueue("test-queue").distribute(command);
     behavior.withKey(otherKey).inQueue("test-queue").distribute(command);
 
@@ -171,8 +177,9 @@ public class CommandDistributionScalingTest {
     // given
 
     // when a distribution command is sent for two records
-    final var otherKey = Protocol.encodePartitionId(1, 101);
+    final var key = keyGenerator.nextKey();
     behavior.withKey(key).inQueue("test-queue").distribute(command);
+    final var otherKey = keyGenerator.nextKey();
     behavior.withKey(otherKey).inQueue("test-queue").forPartition(2).distribute(command);
 
     // then command distribution is started on partition 1

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.AtomicKeyGenerator;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -125,8 +126,10 @@ public class CommandRedistributorTest {
       final Duration redistributionInterval,
       final Duration maxBackoffDuration) {
     final var fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
+    final var keyGenerator = new AtomicKeyGenerator(1);
     final Writers writers =
-        new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+        new Writers(1, () -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+    writers.setKeyGenerator(keyGenerator);
 
     final RoutingInfo routingInfo =
         RoutingInfo.dynamic(routingState, new StaticRoutingInfo(Set.of(1, 2), 2));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
@@ -128,8 +128,8 @@ public class CommandRedistributorTest {
     final var fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     final var keyGenerator = new AtomicKeyGenerator(1);
     final Writers writers =
-        new Writers(1, () -> fakeProcessingResultBuilder, mock(EventAppliers.class));
-    writers.setKeyGenerator(keyGenerator);
+        new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+    writers.setKeyValidator(keyGenerator);
 
     final RoutingInfo routingInfo =
         RoutingInfo.dynamic(routingState, new StaticRoutingInfo(Set.of(1, 2), 2));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.AtomicKeyGenerator;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
@@ -44,7 +45,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
@@ -59,10 +59,11 @@ import org.junit.Test;
 
 public final class MessageStreamProcessorTest {
 
+  private static final int PARTITION_ID = 1;
   private static final EngineConfiguration DEFAULT_ENGINE_CONFIGURATION = new EngineConfiguration();
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
 
-  @Rule public final StreamProcessorRule rule = new StreamProcessorRule();
+  @Rule public final StreamProcessorRule rule = new StreamProcessorRule(PARTITION_ID);
 
   private SubscriptionCommandSender spySubscriptionCommandSender;
   private InterPartitionCommandSender mockInterpartitionCommandSender;
@@ -71,13 +72,15 @@ public final class MessageStreamProcessorTest {
   @Before
   public void setup() {
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
-    final var mockKeyGenerator = mock(KeyGenerator.class);
+    final var keyGenerator = new AtomicKeyGenerator(PARTITION_ID);
     final var mockDistributionState = mock(DistributionState.class);
     final var mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var mockEventAppliers = mock(EventAppliers.class);
-    final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
+    final var writers =
+        new Writers(PARTITION_ID, () -> mockProcessingResultBuilder, mockEventAppliers);
+    writers.setKeyGenerator(keyGenerator);
     spySubscriptionCommandSender =
-        spy(new SubscriptionCommandSender(1, mockInterpartitionCommandSender));
+        spy(new SubscriptionCommandSender(PARTITION_ID, mockInterpartitionCommandSender));
     spySubscriptionCommandSender.setWriters(writers);
     final var routingInfo = RoutingInfo.forStaticPartitions(1);
     spyCommandDistributionBehavior =
@@ -85,7 +88,7 @@ public final class MessageStreamProcessorTest {
             new CommandDistributionBehavior(
                 mockDistributionState,
                 writers,
-                1,
+                PARTITION_ID,
                 routingInfo,
                 mockInterpartitionCommandSender,
                 mock(DistributionMetrics.class)));
@@ -98,7 +101,7 @@ public final class MessageStreamProcessorTest {
           when(mockAuthCheckBehavior.isAuthorizedOrInternalCommand(any(AuthorizationRequest.class)))
               .thenReturn(Either.right(null));
           MessageEventProcessors.addMessageProcessors(
-              1,
+              PARTITION_ID,
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
               processingState,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -76,9 +76,8 @@ public final class MessageStreamProcessorTest {
     final var mockDistributionState = mock(DistributionState.class);
     final var mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var mockEventAppliers = mock(EventAppliers.class);
-    final var writers =
-        new Writers(PARTITION_ID, () -> mockProcessingResultBuilder, mockEventAppliers);
-    writers.setKeyGenerator(keyGenerator);
+    final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
+    writers.setKeyValidator(keyGenerator);
     spySubscriptionCommandSender =
         spy(new SubscriptionCommandSender(PARTITION_ID, mockInterpartitionCommandSender));
     spySubscriptionCommandSender.setWriters(writers);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -58,9 +58,8 @@ public class SubscriptionCommandSenderTest {
         new SubscriptionCommandSender(SAME_PARTITION, mockInterPartitionCommandSender);
     mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var mockEventAppliers = mock(EventAppliers.class);
-    final var writers =
-        new Writers(SAME_PARTITION, () -> mockProcessingResultBuilder, mockEventAppliers);
-    writers.setKeyGenerator(new AtomicKeyGenerator(SAME_PARTITION));
+    final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
+    writers.setKeyValidator(new AtomicKeyGenerator(SAME_PARTITION));
     subscriptionCommandSender.setWriters(writers);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.AtomicKeyGenerator;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -57,7 +58,9 @@ public class SubscriptionCommandSenderTest {
         new SubscriptionCommandSender(SAME_PARTITION, mockInterPartitionCommandSender);
     mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var mockEventAppliers = mock(EventAppliers.class);
-    final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
+    final var writers =
+        new Writers(SAME_PARTITION, () -> mockProcessingResultBuilder, mockEventAppliers);
+    writers.setKeyGenerator(new AtomicKeyGenerator(SAME_PARTITION));
     subscriptionCommandSender.setWriters(writers);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -56,16 +56,21 @@ import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.test.util.TestUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import org.agrona.CloseHelper;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -189,6 +194,73 @@ public final class EngineErrorHandlingTest {
     final DeploymentRecord event = new DeploymentRecord();
     event.resources().add().setResource(wrapString("foo")).setResourceName(wrapString(name));
     return event;
+  }
+
+  @Test
+  public void shouldFailWhenWritingAnEventWithWrongKey() {
+    streamProcessor =
+        streams.startStreamProcessor(
+            STREAM_NAME,
+            DefaultZeebeDbFactory.defaultFactory(),
+            (processingContext) -> {
+              processingState = processingContext.getProcessingState();
+              keyGenerator = processingState.getKeyGenerator();
+              return TypedRecordProcessors.processors(
+                      processingState.getKeyGenerator(), processingContext.getWriters())
+                  .onCommand(
+                      ValueType.PROCESS_INSTANCE,
+                      ProcessInstanceIntent.ACTIVATE_ELEMENT,
+                      record -> {
+                        processingContext
+                            .getWriters()
+                            .state()
+                            .appendFollowUpEvent(
+                                keyGenerator.getCurrentKey() + 1000,
+                                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                                record.getValue());
+                      });
+            });
+    final AtomicReference<HealthReport> reportRef = new AtomicReference<>();
+    final AtomicBoolean unrecoverableFailure = new AtomicBoolean(false);
+    streamProcessor.addFailureListener(
+        new FailureListener() {
+          @Override
+          public void onFailure(final HealthReport report) {
+            reportRef.set(report);
+          }
+
+          @Override
+          public void onRecovered(final HealthReport report) {
+            reportRef.set(report);
+          }
+
+          @Override
+          public void onUnrecoverableFailure(final HealthReport report) {
+            reportRef.set(report);
+            unrecoverableFailure.set(true);
+          }
+        });
+
+    // when
+    final long failingEventPosition =
+        streams
+            .newRecord(STREAM_NAME)
+            .event(Records.processInstance(1))
+            .recordType(RecordType.COMMAND)
+            .intent(ProcessInstanceIntent.ACTIVATE_ELEMENT)
+            .key(keyGenerator.nextKey())
+            .write();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(streamProcessor.isFailed()).isTrue();
+              assertThat(reportRef.get())
+                  .isNotNull()
+                  .returns(HealthStatus.DEAD, HealthReport::getStatus);
+              assertThat(unrecoverableFailure.get()).isTrue();
+            });
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -31,22 +31,20 @@ import org.junit.Test;
 
 public class ScaleUpTest {
   @Rule public final EngineRule engine = EngineRule.multiplePartition(2);
-  private int index;
+  private long key;
 
   @Before
   public void beforeEach() {
     RecordingExporter.reset();
     clearInvocations(engine.getCommandResponseWriter());
-    index = 10012093;
+    key = Protocol.encodePartitionId(1, 0);
   }
 
   @Test
   public void shouldRespondToScaleUp() {
     // given
     final var command =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3)).key(key);
 
     command.recordMetadata().requestId(123);
 
@@ -63,16 +61,14 @@ public class ScaleUpTest {
     // given
 
     final var command =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3)).key(key);
 
     final var bootstrapPartitions =
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
                 new ScaleRecord().markPartitionBootstrapped(3))
-            .key(Protocol.encodePartitionId(1, index++));
+            .key(key);
     // when
     engine.writeRecords(command, bootstrapPartitions);
 
@@ -94,9 +90,7 @@ public class ScaleUpTest {
     engine.withInitializeRoutingState(false);
     engine.start();
     final var command =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3)).key(key);
 
     // when
     engine.writeRecords(command);
@@ -116,9 +110,7 @@ public class ScaleUpTest {
   public void shouldRejectEmptyScaleUp() {
     // given
     final var command =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord())
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord()).key(key);
 
     // when
     engine.writeRecords(command);
@@ -140,7 +132,7 @@ public class ScaleUpTest {
     final var command =
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(10000))
-            .key(Protocol.encodePartitionId(1, index++));
+            .key(key);
 
     // when
     engine.writeRecords(command);
@@ -159,9 +151,7 @@ public class ScaleUpTest {
   public void shouldRejectScaleDown() {
     // given
     final var command =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(1))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(1)).key(key);
 
     // when
     engine.writeRecords(command);
@@ -185,9 +175,7 @@ public class ScaleUpTest {
 
     // when
     engine.writeRecords(
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3))
-            .key(Protocol.encodePartitionId(1, index++)));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3)).key(key));
 
     // then
     assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst())
@@ -203,9 +191,7 @@ public class ScaleUpTest {
   public void shouldRespondWithTheCurrentNumberOfRedistributedPartitionsAndMessageCorrelation() {
     // given
     final var scaleUpCommand =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(4))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(4)).key(key);
 
     final var getStatusCommand =
         RecordToWrite.command().scale(ScaleIntent.STATUS, new ScaleRecord().status());
@@ -250,18 +236,16 @@ public class ScaleUpTest {
   @Test
   public void shouldScaleUpContinuously() {
     // given
-    var index = 1023;
+    final var index = 1023;
     final var scaleTo3 =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3)).key(key);
 
     final var bootstrapPartitionsTo3 =
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
                 new ScaleRecord().markPartitionBootstrapped(3))
-            .key(Protocol.encodePartitionId(1, index++));
+            .key(key);
     // when
     engine.writeRecords(scaleTo3, bootstrapPartitionsTo3);
 
@@ -281,15 +265,13 @@ public class ScaleUpTest {
 
     // when scaling up again
     final var scaleTo4 =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(4))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(4)).key(key);
     final var bootstrapPartitionsTo4 =
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
                 new ScaleRecord().markPartitionBootstrapped(4))
-            .key(Protocol.encodePartitionId(1, index++));
+            .key(key);
     engine.writeRecords(scaleTo4, bootstrapPartitionsTo4);
 
     // then
@@ -310,18 +292,16 @@ public class ScaleUpTest {
     // set a lower maximum time as we don't expect to see the SCALED_UP event
     RecordingExporter.setMaximumWaitTime(200);
     // given
-    var index = 99;
+    final var index = 99;
     final var scaleTo3 =
-        RecordToWrite.command()
-            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3))
-            .key(Protocol.encodePartitionId(1, index++));
+        RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord().scaleUp(3)).key(key);
 
     final var bootstrapPartitionsTo3 =
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
                 new ScaleRecord().markPartitionBootstrapped(3))
-            .key(Protocol.encodePartitionId(1, index++));
+            .key(key);
     bootstrapPartitionsTo3.recordMetadata().requestId(1234);
     // when
     engine.writeRecords(scaleTo3, bootstrapPartitionsTo3);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/AtomicKeyGenerator.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/AtomicKeyGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AtomicKeyGenerator implements KeyGenerator {
+
+  private final AtomicLong currentKey = new AtomicLong();
+
+  public AtomicKeyGenerator(final int partitionId) {
+    currentKey.set(Protocol.encodePartitionId(partitionId, 0));
+  }
+
+  @Override
+  public long nextKey() {
+    return currentKey.incrementAndGet();
+  }
+
+  @Override
+  public long getCurrentKey() {
+    return currentKey.get();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/AtomicKeyGenerator.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/AtomicKeyGenerator.java
@@ -14,9 +14,16 @@ import java.util.concurrent.atomic.AtomicLong;
 public class AtomicKeyGenerator implements KeyGenerator {
 
   private final AtomicLong currentKey = new AtomicLong();
+  private final int partitionId;
 
   public AtomicKeyGenerator(final int partitionId) {
+    this.partitionId = partitionId;
     currentKey.set(Protocol.encodePartitionId(partitionId, 0));
+  }
+
+  @Override
+  public int partitionId() {
+    return partitionId;
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -55,7 +55,7 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   private static final Logger LOG = LoggerFactory.getLogger("io.camunda.zeebe.broker.test");
 
-  private static final int PARTITION_ID = 0;
+  private static final int PARTITION_ID = 1;
 
   // environment
   private final TemporaryFolder tempFolder;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/KeyValidator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/KeyValidator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.api;
+
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+public interface KeyValidator {
+  /**
+   * Validates that a key is valid and can be written to the log.
+   *
+   * <ul>
+   *   <li>it's assigned to the expected partition
+   *   <li>it's not higher than the current key
+   * </ul>
+   *
+   * @param key to append to the log
+   * @throws UnrecoverableException if the key is not valid
+   */
+  void validateKey(final long key);
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/KeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/KeyGenerator.java
@@ -17,8 +17,20 @@ public interface KeyGenerator {
    */
   long nextKey();
 
+  /**
+   * Returns the current key value from the state, which represents the last generated key.
+   *
+   * @return the current key value
+   */
   long getCurrentKey();
 
+  /**
+   * Returns an immutable {@code KeyGenerator} that throws {@link UnsupportedOperationException} for
+   * all operations. Useful for contexts where key generation should not be allowed, such as
+   * read-only or restricted environments.
+   *
+   * @return an immutable KeyGenerator instance
+   */
   static KeyGenerator immutable() {
     return new KeyGenerator() {
       @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/KeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/KeyGenerator.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.stream.api.state;
 
 /** Generate unique keys. Should be used for records only. */
-@FunctionalInterface
 public interface KeyGenerator {
 
   /**
@@ -17,4 +16,20 @@ public interface KeyGenerator {
    * @return the next key for a new record
    */
   long nextKey();
+
+  long getCurrentKey();
+
+  static KeyGenerator immutable() {
+    return new KeyGenerator() {
+      @Override
+      public long nextKey() {
+        throw new UnsupportedOperationException("Not allowed to generate a new key");
+      }
+
+      @Override
+      public long getCurrentKey() {
+        throw new UnsupportedOperationException("Not allowed to fetch current key");
+      }
+    };
+  }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -106,6 +106,7 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
    *
    * @return the current key from the state
    */
+  @Override
   public long getCurrentKey() {
     return nextValueManager.getCurrentValue();
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -80,6 +80,11 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
   }
 
   @Override
+  public int partitionId() {
+    return partitionId;
+  }
+
+  @Override
   public long nextKey() {
     final var nextKey = nextValueManager.getNextValue();
     if (Protocol.decodePartitionId(nextKey) != partitionId) {


### PR DESCRIPTION
## Description
In the Engine before appending a new event, we verify that the key is not higher than the last generated key if the partition encoded in the key is the same as the current one. 
I see that sometimes the key encoded is `-1`, for example with message correlation & job activation, so I left an exception for that.

This is mainly to avoid setting an invalid key when replaying, since we do  `setKeyIfHigher` for every event.

I tried a different approach by validating records before processing but it leads to difference in behaviour that made that approach trickier/incorrect.

The only downside of this approach is that the processor will retry to process that record again, so we need to add a way to make the processor stop without wasting cpu time.

Considering that we don't change how we handle events this change should not require any changes to the events versions correct?

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #41041 
