### PR TITLE
[Backport stable/8.7] fix: add assertions to avoid encoding an invalid key in Protocol

### DIFF
--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -99,6 +99,10 @@ public final class Protocol {
   public static final String LINKED_RESOURCES_HEADER_NAME = "linkedResources";
 
   public static long encodePartitionId(final int partitionId, final long key) {
+    if (key < 0) {
+      throw new IllegalArgumentException(
+          "Invalid key provided: got " + key + ", expected a positive value");
+    }
     return ((long) partitionId << KEY_BITS) + key;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -103,6 +103,14 @@ public final class Protocol {
       throw new IllegalArgumentException(
           "Invalid key provided: got " + key + ", expected a positive value");
     }
+    if (decodePartitionId(key) != 0) {
+      throw new IllegalArgumentException(
+          "Invalid key provided: got "
+              + key
+              + ", but it has the partitionId encoded already (partitionId="
+              + Protocol.decodePartitionId(key)
+              + ")");
+    }
     return ((long) partitionId << KEY_BITS) + key;
   }
 

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.protocol;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
@@ -26,4 +27,15 @@ public final class ProtocolTest {
   public void testEndiannessConstant() {
     assertThat(Protocol.ENDIANNESS).isEqualTo(ByteOrder.LITTLE_ENDIAN);
   }
+  @Test
+  public void shouldNotEncodeNegativeKeys() {
+    // given
+    final long value = -1029819L;
+
+    // when/then
+    assertThatThrownBy(() -> Protocol.encodePartitionId(128, value))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid key provided: got -1029819, expected a positive value");
+  }
+  @Test
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
@@ -27,6 +27,7 @@ public final class ProtocolTest {
   public void testEndiannessConstant() {
     assertThat(Protocol.ENDIANNESS).isEqualTo(ByteOrder.LITTLE_ENDIAN);
   }
+
   @Test
   public void shouldNotEncodeNegativeKeys() {
     // given
@@ -37,5 +38,17 @@ public final class ProtocolTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid key provided: got -1029819, expected a positive value");
   }
+
   @Test
+  public void shouldNotEncodeKeyAlreadyEncoded() {
+    // given
+    final long value = 1029819L;
+    final long encoded = Protocol.encodePartitionId(128, value);
+
+    // when/then
+    assertThatThrownBy(() -> Protocol.encodePartitionId(128, encoded))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Invalid key provided: got 288230376152741563, but it has the partitionId encoded already (partitionId=128)");
+  }
 }


### PR DESCRIPTION
# Description
Backport of #41606 to `stable/8.7`.

relates to #41041