### PR TITLE
[Backport stable/8.8] fix: add assertions to avoid encoding an invalid key in Protocol

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -265,7 +264,7 @@ public class Engine implements RecordProcessor {
                 Expected to process command %d (%s.%s) without errors, but unexpected error occurred. \
                 Check your broker logs (partition %d), or ask your operator, for more details."""
                   .formatted(
-                      Protocol.encodePartitionId(record.getPartitionId(), record.getKey()),
+                      record.getKey(),
                       record.getValueType(),
                       record.getIntent(),
                       record.getPartitionId()));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -116,13 +116,13 @@ public final class Protocol {
   public static long encodePartitionId(final int partitionId, final long key) {
     if (key < 0) {
       throw new IllegalArgumentException(
-          "Invalid key provided: got " + key + ", expected a positive value");
+          "Expected to receive a positive value as key, but got: '" + key + "'");
     }
     if (decodePartitionId(key) != 0) {
       throw new IllegalArgumentException(
-          "Invalid key provided: got "
+          "Expected that the provided value is smaller and doesn't contain the partition Id already, but got: '"
               + key
-              + ", but it has the partitionId encoded already (partitionId="
+              + "', which contains (partitionId="
               + Protocol.decodePartitionId(key)
               + ")");
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -114,6 +114,10 @@ public final class Protocol {
   public static final String LINKED_RESOURCES_HEADER_NAME = "linkedResources";
 
   public static long encodePartitionId(final int partitionId, final long key) {
+    if (key < 0) {
+      throw new IllegalArgumentException(
+          "Invalid key provided: got " + key + ", expected a positive value");
+    }
     return ((long) partitionId << KEY_BITS) + key;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -118,6 +118,14 @@ public final class Protocol {
       throw new IllegalArgumentException(
           "Invalid key provided: got " + key + ", expected a positive value");
     }
+    if (decodePartitionId(key) != 0) {
+      throw new IllegalArgumentException(
+          "Invalid key provided: got "
+              + key
+              + ", but it has the partitionId encoded already (partitionId="
+              + Protocol.decodePartitionId(key)
+              + ")");
+    }
     return ((long) partitionId << KEY_BITS) + key;
   }
 

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.protocol;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
@@ -26,4 +27,15 @@ public final class ProtocolTest {
   public void testEndiannessConstant() {
     assertThat(Protocol.ENDIANNESS).isEqualTo(ByteOrder.LITTLE_ENDIAN);
   }
+  @Test
+  public void shouldNotEncodeNegativeKeys() {
+    // given
+    final long value = -1029819L;
+
+    // when/then
+    assertThatThrownBy(() -> Protocol.encodePartitionId(128, value))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid key provided: got -1029819, expected a positive value");
+  }
+  @Test
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
@@ -27,6 +27,7 @@ public final class ProtocolTest {
   public void testEndiannessConstant() {
     assertThat(Protocol.ENDIANNESS).isEqualTo(ByteOrder.LITTLE_ENDIAN);
   }
+
   @Test
   public void shouldNotEncodeNegativeKeys() {
     // given
@@ -37,5 +38,17 @@ public final class ProtocolTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid key provided: got -1029819, expected a positive value");
   }
+
   @Test
+  public void shouldNotEncodeKeyAlreadyEncoded() {
+    // given
+    final long value = 1029819L;
+    final long encoded = Protocol.encodePartitionId(128, value);
+
+    // when/then
+    assertThatThrownBy(() -> Protocol.encodePartitionId(128, encoded))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Invalid key provided: got 288230376152741563, but it has the partitionId encoded already (partitionId=128)");
+  }
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
@@ -36,7 +36,7 @@ public final class ProtocolTest {
     // when/then
     assertThatThrownBy(() -> Protocol.encodePartitionId(128, value))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid key provided: got -1029819, expected a positive value");
+        .hasMessageContaining("Expected to receive a positive value as key, but got: '-1029819'");
   }
 
   @Test
@@ -49,6 +49,6 @@ public final class ProtocolTest {
     assertThatThrownBy(() -> Protocol.encodePartitionId(128, encoded))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Invalid key provided: got 288230376152741563, but it has the partitionId encoded already (partitionId=128)");
+            "Expected that the provided value is smaller and doesn't contain the partition Id already, but got: '288230376152741563', which contains (partitionId=128)");
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.log.WriteContext;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -476,7 +475,7 @@ public final class ProcessingStateMachine {
             Expected to process command %d (%s.%s), but caught an exception. Check broker logs \
             (partition %s) for details, or ask your operator to do so."""
             .formatted(
-                Protocol.encodePartitionId(context.getPartitionId(), currentRecord.getKey()),
+                currentRecord.getKey(),
                 metadata.getValueType(),
                 metadata.getIntent(),
                 context.getPartitionId());


### PR DESCRIPTION
# Description
Backport of #41606 to `stable/8.8`.

relates to #41041