### PR TITLE
[Backport stable/8.8] fix: NextValue does not have a default to avoid serializing -1

### DIFF
--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -89,6 +89,14 @@
       <artifactId>micrometer-commons</artifactId>
     </dependency>
 
+    <!--    TEST DEPENDENCIES -->
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -158,6 +158,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/NextValue.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/NextValue.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 
 public class NextValue extends UnpackedObject implements DbValue {
-  private final LongProperty nextValueProp = new LongProperty("nextValue", -1L);
+  private final LongProperty nextValueProp = new LongProperty("nextValue");
 
   public NextValue() {
     super(1);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/NextValue.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/NextValue.java
@@ -20,6 +20,10 @@ public class NextValue extends UnpackedObject implements DbValue {
   }
 
   public void set(final long value) {
+    if (value < 0) {
+      throw new IllegalArgumentException(
+          "Invalid value: expected positive number, but got " + value);
+    }
     nextValueProp.setValue(value);
   }
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/NextValueTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/NextValueTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.camunda.zeebe.msgpack.MsgpackPropertyException;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.stream.impl.state.NextValue;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+public class NextValueTest {
+  @Test
+  public void shouldNotSerializeWithoutValue() {
+    final var value = new NextValue();
+
+    final var writer = new MsgPackWriter();
+    final var buffer = new UnsafeBuffer(new byte[1024]);
+    writer.wrap(buffer, 0);
+
+    assertThatThrownBy(() -> value.write(writer)).isInstanceOf(MsgpackPropertyException.class);
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/NextValueTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/NextValueTest.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.stream.impl.state.NextValue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class NextValueTest {
   @Test
@@ -25,5 +27,14 @@ public class NextValueTest {
     writer.wrap(buffer, 0);
 
     assertThatThrownBy(() -> value.write(writer)).isInstanceOf(MsgpackPropertyException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {-1, -100, (long) Integer.MIN_VALUE, Long.MIN_VALUE})
+  public void shouldRequirePositiveValueInSetter(final long v) {
+    final var value = new NextValue();
+    assertThatThrownBy(() -> value.set(v))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid value: expected positive number, but got " + v);
   }
 }


### PR DESCRIPTION
# Description
Backport of #41607 to `stable/8.8`.

relates to #41041