### PR TITLE
fix: remove permission check for retry single incident

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
@@ -19,7 +19,6 @@ import {Link} from 'modules/components/Link';
 import {Paths} from 'modules/Routes';
 import {useLocation} from 'react-router-dom';
 import {tracking} from 'modules/tracking';
-import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {Button} from '@carbon/react';
 import {SortableTable} from 'modules/components/SortableTable';
 import {useState} from 'react';
@@ -67,8 +66,6 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
   );
 
   const isJobIdPresent = sortedIncidents.some(({jobId}) => jobId !== null);
-  const hasPermissionForRetryOperation =
-    processInstanceDetailsStore.hasPermission(['UPDATE_PROCESS_INSTANCE']);
 
   const hasIncidentInCalledInstance = sortedIncidents.some(
     ({rootCauseInstance}) =>
@@ -144,15 +141,11 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
                 },
               ]
             : []),
-          ...(hasPermissionForRetryOperation
-            ? [
-                {
-                  header: 'Operations',
-                  key: 'operations',
-                  isDisabled: true,
-                },
-              ]
-            : []),
+          {
+            header: 'Operations',
+            key: 'operations',
+            isDisabled: true,
+          },
         ]}
         rows={sortedIncidents.map((incident) => {
           const {rootCauseInstance} = incident;
@@ -209,14 +202,13 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
                 )
               ) : undefined,
 
-            operations:
-              hasPermissionForRetryOperation && areOperationsVisible ? (
-                <IncidentOperation
-                  instanceId={processInstanceId}
-                  incident={incident}
-                  showSpinner={incident.hasActiveOperation}
-                />
-              ) : undefined,
+            operations: areOperationsVisible ? (
+              <IncidentOperation
+                instanceId={processInstanceId}
+                incident={incident}
+                showSpinner={incident.hasActiveOperation}
+              />
+            ) : undefined,
           };
         })}
       />

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/tests/index.test.tsx
@@ -47,26 +47,6 @@ describe('IncidentsTable', () => {
     expect(screen.getByText('Root Cause Instance')).toBeInTheDocument();
   });
 
-  it('should render the right column headers for restricted user (with resource-based permissions)', () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
-    mockMe().withSuccess(createUser());
-    vi.stubGlobal('clientConfig', {
-      resourcePermissionsEnabled: true,
-    });
-
-    incidentsStore.setIncidents(incidentsMock);
-
-    render(<IncidentsTable />, {wrapper: Wrapper});
-
-    expect(screen.getByText('Incident Type')).toBeInTheDocument();
-    expect(screen.getByText('Failing Flow Node')).toBeInTheDocument();
-    expect(screen.getByText('Job Id')).toBeInTheDocument();
-    expect(screen.getByText('Creation Date')).toBeInTheDocument();
-    expect(screen.getByText('Error Message')).toBeInTheDocument();
-    expect(screen.queryByText('Operations')).not.toBeInTheDocument();
-    expect(screen.getByText('Root Cause Instance')).toBeInTheDocument();
-  });
-
   it('should render incident details', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     incidentsStore.setIncidents(incidentsMock);
@@ -114,67 +94,6 @@ describe('IncidentsTable', () => {
     expect(
       withinRow.getByRole('button', {name: 'Retry Incident'}),
     ).toBeInTheDocument();
-  });
-
-  it('should render incident details (with resource-based permissions enabled)', () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
-    mockMe().withSuccess(createUser());
-    vi.stubGlobal('clientConfig', {
-      resourcePermissionsEnabled: true,
-    });
-
-    incidentsStore.setIncidents(incidentsMock);
-
-    render(<IncidentsTable />, {wrapper: Wrapper});
-    let withinRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(firstIncident.errorType.name),
-      }),
-    );
-
-    expect(
-      withinRow.getByText(firstIncident.errorType.name),
-    ).toBeInTheDocument();
-    expect(withinRow.getByText(firstIncident.flowNodeId)).toBeInTheDocument();
-    expect(withinRow.getByText(firstIncident.jobId!)).toBeInTheDocument();
-    expect(
-      withinRow.getByText(formatDate(firstIncident.creationTime) || '--'),
-    ).toBeInTheDocument();
-    expect(withinRow.getByText(firstIncident.errorMessage)).toBeInTheDocument();
-
-    expect(
-      withinRow.getByRole('link', {
-        description: /view root cause instance/i,
-      }),
-    ).toBeInTheDocument();
-    expect(
-      withinRow.queryByRole('button', {name: 'Retry Incident'}),
-    ).not.toBeInTheDocument();
-
-    withinRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(secondIncident.errorType.name),
-      }),
-    );
-    expect(
-      withinRow.getByText(secondIncident.errorType.name),
-    ).toBeInTheDocument();
-    expect(withinRow.getByText(secondIncident.flowNodeId)).toBeInTheDocument();
-    expect(withinRow.getByText(secondIncident.jobId!)).toBeInTheDocument();
-    expect(
-      withinRow.getByText(formatDate(secondIncident.creationTime) || '--'),
-    ).toBeInTheDocument();
-    expect(
-      withinRow.getByText(secondIncident.errorMessage),
-    ).toBeInTheDocument();
-    expect(
-      withinRow.queryByRole('button', {name: 'Retry Incident'}),
-    ).not.toBeInTheDocument();
-    expect(
-      withinRow.queryByRole('link', {
-        description: /view root cause instance/i,
-      }),
-    ).not.toBeInTheDocument();
   });
 
   it('should display -- for jobId', () => {


### PR DESCRIPTION
## Description

This PR changes the incidents table to always show the "retry incident" operation regardless of the resource-based permissions. The check never succeeded, because the `processInstanceDetailsStore` is never initialized with data. This change is inline with our approach for the C8 API migration of avoiding client-side resource permission checks.

The method `processInstanceDetailsStore.hasPermission(...)` is only used by the incidents-table. No other components should be affected - at least in terms of permission checks. I added a list of other usages of this store to [the underlying bug report](https://github.com/camunda/camunda/issues/41647#issuecomment-3585201190).

@pedesen @tmetzke I am not sure what flags/configurations are missing on the underlying bug report to align with our workflow. Further, is this PR missing something? Is stable/8.8 the right target branch?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41647
