### PR TITLE
fix: label load-test namespaces before installing the platform

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -276,6 +276,23 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}
+      - name: Create namespace if not exists
+        run: |
+          if ! kubectl get namespace ${{ inputs.name }} >/dev/null 2>&1; then
+            kubectl create namespace ${{ inputs.name }}
+          else
+            echo "Namespace '${{ inputs.name }}' already exists"
+          fi
+      - name: Label namespace with creator
+        run: >
+          kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
+      - name: Label namespace with deadline
+        run: |
+          # Calculate deadline date with the TTL days from now
+          # Use basic ISO date format (YYYY-MM-DD), as it is compatible with kubectl label values
+          # Must use minus (-) instead of / to be compatible with kubectl label value restrictions
+          deadlineDate=$(date -d "+${{ inputs.ttl }} days" +%Y-%m-%d)
+          kubectl label namespace ${{ inputs.name }} deadline-date="$deadlineDate" --overwrite
       - name: Add Camunda Helm repo
         run: |
           helm repo add camunda https://helm.camunda.io/
@@ -290,7 +307,6 @@ jobs:
         run: >
           helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --create-namespace
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -300,16 +316,6 @@ jobs:
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/load-tests/setup/default/values-stable.yaml', github.ref) || '' }}
-      - name: Label namespace with creator
-        run: >
-            kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
-      - name: Label namespace with deadline
-        run: |
-          # Calculate deadline date with the TTL days from now
-          # Use basic ISO date format (YYYY-MM-DD), as it is compatible with kubectl label values
-          # Must use minus (-) instead of / to be compatible with kubectl label value restrictions
-          deadlineDate=$(date -d "+${{ inputs.ttl }} days" +%Y-%m-%d)
-          kubectl label namespace ${{ inputs.name }} deadline-date="$deadlineDate" --overwrite
       - name: Summarize deployment
         if: success()
         run: |
@@ -373,7 +379,6 @@ jobs:
           helm upgrade --install ${{ inputs.name }}-test camunda-load-tests/camunda-load-tests
           --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --create-namespace
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The installation step only completes once all pods are up and running. If there's, for example, a CrashLoopBackoff in
 one of the pods, this step will fail after 30 minutes. The namespace will never be labelled with an author or TTL.
 This makes it hard to determine who owns the namespace and if it could be cleaned. By creating the namespace and
 labeling it before the install we circumvent this issue.


Sucessfull initial run: https://github.com/camunda/camunda/actions/runs/19736235945
Successfull second run with same namespace: https://github.com/camunda/camunda/actions/runs/19736734348

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

N/A
