### PR TITLE
[CPT] Fail to complete multiple instances of a user task

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -31,6 +31,9 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
   private static final String INITIAL_FAILURE_MESSAGE =
       "<No assertion error occurred. Maybe, the assertion timed out before it could be tested.>";
 
+  private static final String UNEXPECTED_FAILURE_MESSAGE =
+      "<No assertion error occurred, but an unexpected exception was thrown.>";
+
   private Duration assertionTimeout = CamundaAssert.DEFAULT_ASSERTION_TIMEOUT;
   private Duration assertionInterval = CamundaAssert.DEFAULT_ASSERTION_INTERVAL;
 
@@ -39,6 +42,7 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
     // If await() times out, the exception doesn't contain the assertion error. Use a reference to
     // store the error's failure message.
     final AtomicReference<String> failureMessage = new AtomicReference<>(INITIAL_FAILURE_MESSAGE);
+    final AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
     try {
       Awaitility.await()
           .timeout(assertionTimeout)
@@ -51,11 +55,18 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
                 } catch (final AssertionError e) {
                   failureMessage.set(e.getMessage());
                   throw e;
+                } catch (final Exception unexpected) {
+                  unexpectedException.set(unexpected);
+                  throw unexpected;
                 }
               });
 
     } catch (final ConditionTimeoutException ignore) {
-      fail(failureMessage.get());
+      if (unexpectedException.get() != null) {
+        fail(UNEXPECTED_FAILURE_MESSAGE, unexpectedException.get());
+      } else {
+        fail(failureMessage.get());
+      }
     }
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/util/AwaitilityBehavior.java
@@ -28,11 +28,11 @@ import org.awaitility.core.ConditionTimeoutException;
 
 public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
 
-  private static final String INITIAL_FAILURE_MESSAGE =
+  private static final String TIMEOUT_FAILURE_MESSAGE =
       "<No assertion error occurred. Maybe, the assertion timed out before it could be tested.>";
 
   private static final String UNEXPECTED_FAILURE_MESSAGE =
-      "<No assertion error occurred, but an unexpected exception was thrown.>";
+      "<No assertion error occurred, but an unexpected exception was thrown. Check the cause for details.>";
 
   private Duration assertionTimeout = CamundaAssert.DEFAULT_ASSERTION_TIMEOUT;
   private Duration assertionInterval = CamundaAssert.DEFAULT_ASSERTION_INTERVAL;
@@ -41,8 +41,8 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
   public void untilAsserted(final ThrowingRunnable assertion) throws AssertionError {
     // If await() times out, the exception doesn't contain the assertion error. Use a reference to
     // store the error's failure message.
-    final AtomicReference<String> failureMessage = new AtomicReference<>(INITIAL_FAILURE_MESSAGE);
-    final AtomicReference<Throwable> unexpectedException = new AtomicReference<>(null);
+    final AtomicReference<String> failureMessage = new AtomicReference<>();
+    final AtomicReference<Throwable> unexpectedException = new AtomicReference<>();
     try {
       Awaitility.await()
           .timeout(assertionTimeout)
@@ -62,10 +62,12 @@ public class AwaitilityBehavior implements CamundaAssertAwaitBehavior {
               });
 
     } catch (final ConditionTimeoutException ignore) {
-      if (unexpectedException.get() != null) {
+      if (failureMessage.get() != null) {
+        fail(failureMessage.get());
+      } else if (unexpectedException.get() != null) {
         fail(UNEXPECTED_FAILURE_MESSAGE, unexpectedException.get());
       } else {
-        fail(failureMessage.get());
+        fail(TIMEOUT_FAILURE_MESSAGE);
       }
     }
   }


### PR DESCRIPTION
## Description

Currently, CPT can't complete multiple instances of a user task. We fix the behavior by adding a default filter to the search request for completing user tasks. We can complete only user tasks in the state CREATED.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41512 
