### PR TITLE
[Backport stable/8.6] fix: label load-test namespaces before installing the platform

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -279,6 +279,23 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}
+      - name: Create namespace if not exists
+        run: |
+          if ! kubectl get namespace ${{ inputs.name }} >/dev/null 2>&1; then
+            kubectl create namespace ${{ inputs.name }}
+          else
+            echo "Namespace '${{ inputs.name }}' already exists"
+          fi
+      - name: Label namespace with creator
+        run: >
+          kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
+      - name: Label namespace with deadline
+        run: |
+          # Calculate deadline date with the TTL days from now
+          # Use basic ISO date format (YYYY-MM-DD), as it is compatible with kubectl label values
+          # Must use minus (-) instead of / to be compatible with kubectl label value restrictions
+          deadlineDate=$(date -d "+${{ inputs.ttl }} days" +%Y-%m-%d)
+          kubectl label namespace ${{ inputs.name }} deadline-date="$deadlineDate" --overwrite
       - name: Add Camunda Helm repo
         run: |
           helm repo add camunda https://helm.camunda.io/
@@ -293,7 +310,6 @@ jobs:
         run: >
           helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --create-namespace
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -305,16 +321,7 @@ jobs:
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
 
-      - name: Label namespace with creator
-        run: >
-            kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
-      - name: Label namespace with deadline
-        run: |
-          # Calculate deadline date with the TTL days from now
-          # Use basic ISO date format (YYYY-MM-DD), as it is compatible with kubectl label values
-          # Must use minus (-) instead of / to be compatible with kubectl label value restrictions
-          deadlineDate=$(date -d "+${{ inputs.ttl }} days" +%Y-%m-%d)
-          kubectl label namespace ${{ inputs.name }} deadline-date="$deadlineDate" --overwrite
+
       - name: Summarize deployment
         if: success()
         run: |
@@ -378,7 +385,6 @@ jobs:
           helm upgrade --install ${{ inputs.name }}-test camunda-load-tests/camunda-load-tests
           --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --create-namespace
           --reuse-values
           --render-subchart-notes
           --set global.connect.serviceName=zeebe-gateway


### PR DESCRIPTION
# Description
Backport of #41674 to `stable/8.6`.

relates to 