### PR TITLE
Improve update tests and add caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,7 +638,7 @@ jobs:
         if: matrix.group == 'qa-update'
         uses: actions/cache@v4
         with:
-          path: .cache
+          path: .cache/camunda
           key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
           restore-keys: |
             zeebe-versions-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,6 @@ jobs:
       CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
       DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
-      GH_TOKEN: ${{ github.token }}
     services:
       registry:
         image: registry:3
@@ -632,9 +631,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Generate cache key with current hour
+        if: matrix.group == 'qa-update'
         id: cache-key
-        run: echo "hour=$(date -u +%Y%m%d%H)" >> $GITHUB_OUTPUT
+        run: echo "hour=$(date -u +%Y%m%d%H)" >> "$GITHUB_OUTPUT"
       - name: Cache Zeebe versions (hourly refresh)
+        if: matrix.group == 'qa-update'
         uses: actions/cache@v4
         with:
           path: .cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,6 +630,16 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v4
+      - name: Generate cache key with current hour
+        id: cache-key
+        run: echo "hour=$(date -u +%Y%m%d%H)" >> $GITHUB_OUTPUT
+      - name: Cache Zeebe versions (hourly refresh)
+        uses: actions/cache@v4
+        with:
+          path: .cache
+          key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
+          restore-keys: |
+            zeebe-versions-
       - name: Print metadata
         uses: ./.github/actions/print-metadata
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,7 @@ jobs:
       CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
       DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
+      GH_TOKEN: ${{ github.token }}
     services:
       registry:
         image: registry:3
@@ -684,6 +685,7 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build Integration
         env:
+          GH_TOKEN: ${{ github.token }}
           # Propagate matrix test filters (may be empty for other matrix entries)
           TEST_FILTER: ${{ matrix.test-filter }}
         shell: bash

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -67,6 +67,7 @@ jobs:
           -D skipChecks
           verify
         env:
+          ZEEBE_CI_CHECK_VERSION_COMPATIBILITY: true
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_INDEX: ${{ strategy.job-index }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_TOTAL: ${{ strategy.job-total }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT: ${{ github.workspace }}/zeebe-version-compatibility
@@ -89,6 +90,7 @@ jobs:
       - name: Generate cache key with current hour
         id: cache-key
         run: echo "hour=$(date -u +%Y%m%d%H)" >> "$GITHUB_OUTPUT"
+      - name: Cache Zeebe versions (hourly refresh)
         uses: actions/cache@v4
         with:
           path: .cache
@@ -117,6 +119,7 @@ jobs:
         env:
           ZEEBE_CI_CHECK_CURRENT_VERSION_COMPATIBILITY: true
       - uses: ./.github/actions/collect-test-artifacts
+        if: always()
         with:
           name: "Snapshot version compatibility"
   update-shared-report:

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache Zeebe versions (hourly refresh)
         uses: actions/cache@v4
         with:
-          path: .cache
+          path: .cache/camunda
           key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
           restore-keys: |
             zeebe-versions-
@@ -93,7 +93,7 @@ jobs:
       - name: Cache Zeebe versions (hourly refresh)
         uses: actions/cache@v4
         with:
-          path: .cache
+          path: .cache/camunda
           key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
           restore-keys: |
             zeebe-versions-

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -25,6 +25,16 @@ jobs:
         shards: [ 1, 2, 3] # Values are not used, we just need an array of the right length
     steps:
       - uses: actions/checkout@v4
+      - name: Generate cache key with current hour
+        id: cache-key
+        run: echo "hour=$(date -u +%Y%m%d%H)" >> $GITHUB_OUTPUT
+      - name: Cache Zeebe versions (hourly refresh)
+        uses: actions/cache@v4
+        with:
+          path: .cache
+          key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
+          restore-keys: |
+            zeebe-versions-
       - name: Find previous report
         id: get-last-run-id
         run: |
@@ -77,6 +87,16 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+      - name: Generate cache key with current hour
+        id: cache-key
+        run: echo "hour=$(date -u +%Y%m%d%H)" >> $GITHUB_OUTPUT
+      - name: Cache Zeebe versions (hourly refresh)
+        uses: actions/cache@v4
+        with:
+          path: .cache
+          key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
+          restore-keys: |
+            zeebe-versions-
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate cache key with current hour
         id: cache-key
-        run: echo "hour=$(date -u +%Y%m%d%H)" >> $GITHUB_OUTPUT
+        run: echo "hour=$(date -u +%Y%m%d%H)" >> "$GITHUB_OUTPUT"
       - name: Cache Zeebe versions (hourly refresh)
         uses: actions/cache@v4
         with:
@@ -67,8 +67,6 @@ jobs:
           -D skipChecks
           verify
         env:
-          GH_TOKEN: ${{ github.token }}
-          ZEEBE_CI_CHECK_VERSION_COMPATIBILITY: true
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_INDEX: ${{ strategy.job-index }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_TOTAL: ${{ strategy.job-total }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT: ${{ github.workspace }}/zeebe-version-compatibility
@@ -90,8 +88,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate cache key with current hour
         id: cache-key
-        run: echo "hour=$(date -u +%Y%m%d%H)" >> $GITHUB_OUTPUT
-      - name: Cache Zeebe versions (hourly refresh)
+        run: echo "hour=$(date -u +%Y%m%d%H)" >> "$GITHUB_OUTPUT"
         uses: actions/cache@v4
         with:
           path: .cache
@@ -118,10 +115,8 @@ jobs:
           -D skipChecks
           verify
         env:
-          GH_TOKEN: ${{ github.token }}
           ZEEBE_CI_CHECK_CURRENT_VERSION_COMPATIBILITY: true
       - uses: ./.github/actions/collect-test-artifacts
-        if: always()
         with:
           name: "Snapshot version compatibility"
   update-shared-report:

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -67,6 +67,7 @@ jobs:
           -D skipChecks
           verify
         env:
+          GH_TOKEN: ${{ github.token }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY: true
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_INDEX: ${{ strategy.job-index }}
           ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_TOTAL: ${{ strategy.job-total }}
@@ -117,6 +118,7 @@ jobs:
           -D skipChecks
           verify
         env:
+          GH_TOKEN: ${{ github.token }}
           ZEEBE_CI_CHECK_CURRENT_VERSION_COMPATIBILITY: true
       - uses: ./.github/actions/collect-test-artifacts
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ c8run/camunda-db*
 /camunda.trace.db
 
 cmd/renovate/renovate*/
+.cache/

--- a/zeebe/qa/update-tests/CACHE_README.md
+++ b/zeebe/qa/update-tests/CACHE_README.md
@@ -45,7 +45,7 @@ The `CachedVersionProvider`:
 
 The cache file is stored at: `.cache/camunda-versions.json`
 
-This file contains a JSON array of version strings discovered from GitHub tags.
+This file contains a JSON array of version metadata objects (version, isReleased, isLatest) discovered from GitHub tags.
 
 ## Cache Behavior
 
@@ -57,11 +57,13 @@ The version discovery automatically uses the `GH_TOKEN` environment variable if 
 - **Better for CI**: Reduces the chance of hitting rate limits in workflows
 
 **Local usage:**
+
 ```bash
 export GH_TOKEN=your_github_token
 ```
 
 **In GitHub Actions:**
+
 ```yaml
 env:
   GH_TOKEN: ${{ github.token }}
@@ -141,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: version-cache
-          path: .cache/zeebe-versions.json
+          path: .cache/camunda-versions.json
 
   test:
     needs: prepare-versions
@@ -164,24 +166,26 @@ jobs:
 ### View Cached Versions
 
 ```bash
-cat .cache/zeebe-versions.json | jq .
+cat .cache/camunda-versions.json | jq .
 ```
 
 ### Force Cache Refresh
 
 ```bash
-rm -f .cache/zeebe-versions.json
+rm -f .cache/camunda-versions.json
 ./mvnw test -pl zeebe/qa/update-tests
 ```
 
 ### Disable Caching (for debugging)
 
 Option 1: Delete the cache file before running tests
+
 ```bash
 rm -rf .cache
 ```
 
 Option 2: Use the provider directly in your test:
+
 ```java
 // Bypass caching by passing the provider directly
 new VersionCompatibilityMatrix(new GithubVersionProvider())

--- a/zeebe/qa/update-tests/CACHE_README.md
+++ b/zeebe/qa/update-tests/CACHE_README.md
@@ -49,6 +49,24 @@ This file contains a JSON array of version strings discovered from GitHub tags.
 
 ## Cache Behavior
 
+### GitHub API Authentication
+
+The version discovery automatically uses the `GH_TOKEN` environment variable if available for authenticated GitHub API requests. This provides:
+- **Higher rate limits**: 5,000 requests/hour (vs 60 for unauthenticated)
+- **More reliable**: Less likely to hit rate limiting issues
+- **Better for CI**: Reduces the chance of hitting rate limits in workflows
+
+**Local usage:**
+```bash
+export GH_TOKEN=your_github_token
+```
+
+**In GitHub Actions:**
+```yaml
+env:
+  GH_TOKEN: ${{ github.token }}
+```
+
 ### Application Cache
 
 **Cache Miss** (file doesn't exist):

--- a/zeebe/qa/update-tests/CACHE_README.md
+++ b/zeebe/qa/update-tests/CACHE_README.md
@@ -10,7 +10,7 @@ The `VersionCompatibilityMatrix` uses a two-level caching strategy to minimize G
 **First discovery** (cold start):
 - Fetches version tags from GitHub API
 - For each latest patch: checks if a release exists (additional API call)
-- Saves complete metadata (version, isReleased, isLatest) to `.cache/camunda-versions.json`
+- Saves complete metadata (version, isReleased, isLatest) to `.cache/camunda/camunda-versions.json`
 
 **Subsequent runs** (warm cache):
 - Reads from cached file
@@ -19,7 +19,7 @@ The `VersionCompatibilityMatrix` uses a two-level caching strategy to minimize G
 
 ## Cache Location
 
-The cache file is stored at: `.cache/camunda-versions.json` (relative to a given location, see below)
+The cache file is stored at: `.cache/camunda/camunda-versions.json` (relative to a given location, see below)
 
 **Path Resolution Strategy** (in priority order):
 1. **`GITHUB_WORKSPACE`**: Environment variable set in GitHub Actions workflows
@@ -29,7 +29,7 @@ The cache file is stored at: `.cache/camunda-versions.json` (relative to a given
 
 **Note for GitHub Actions**:
 - Make sure the `GH_TOKEN` is set in order to not run into GitHub API rate limits
-- Configure cache actions to use path `.cache` relative to the repository root and `GITHUB_WORKSPACE` is set
+- Configure cache actions to use path `.cache/camunda` relative to the repository root and `GITHUB_WORKSPACE` is set
 - The cache action's "save" step runs **after** tests complete, so the directory will exist if tests ran successfully
 - On first run (no cache), the directory is created during test execution
 
@@ -38,13 +38,13 @@ The cache file is stored at: `.cache/camunda-versions.json` (relative to a given
 ### View Cached Versions
 
 ```bash
-cat .cache/camunda-versions.json | jq .
+cat .cache/camunda/camunda-versions.json | jq .
 ```
 
 ### Force Cache Refresh
 
 ```bash
-rm -f .cache/camunda-versions.json
+rm -f .cache/camunda/camunda-versions.json
 ./mvnw test -pl zeebe/qa/update-tests
 ```
 
@@ -53,7 +53,7 @@ rm -f .cache/camunda-versions.json
 Option 1: Delete the cache file before running tests
 
 ```bash
-rm -rf .cache
+rm -rf .cache/camunda
 ```
 
 Option 2: Use the provider directly in your test:
@@ -77,7 +77,7 @@ To automatically refresh the cache every hour while still benefiting from cachin
 - name: Cache Zeebe versions (hourly refresh)
   uses: actions/cache@v4
   with:
-    path: .cache
+    path: .cache/camunda
     key: zeebe-versions-${{ steps.cache-key.outputs.hour }}
     restore-keys: |
       zeebe-versions-
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: version-cache
-          path: .cache/camunda-versions.json
+          path: .cache/camunda/camunda-versions.json
 
   test:
     needs: prepare-versions
@@ -126,7 +126,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: version-cache
-          path: .cache
+          path: .cache/camunda
 
       - name: Run tests
         run: ./mvnw verify -pl zeebe/qa/update-tests

--- a/zeebe/qa/update-tests/CACHE_README.md
+++ b/zeebe/qa/update-tests/CACHE_README.md
@@ -1,0 +1,204 @@
+# Version Compatibility Matrix Caching
+
+## Overview
+
+The `VersionCompatibilityMatrix` uses a two-level caching strategy to minimize GitHub API calls:
+
+1. **Application-level cache**: The `CachedVersionProvider` decorator caches discovered versions (with metadata) to a local JSON file
+2. **CI-level cache**: GitHub Actions can cache this file across workflow runs for even faster execution
+
+### How It Works
+
+**First discovery** (cold start):
+- Fetches version tags from GitHub API
+- For each latest patch: checks if a release exists (additional API call)
+- Saves complete metadata (version, isReleased, isLatest) to `.cache/camunda-versions.json`
+
+**Subsequent runs** (warm cache):
+- Reads from cached file
+- Zero GitHub API calls
+- Instant version discovery
+
+**With GitHub Actions caching**:
+- First workflow run: Creates cache file
+- Later workflow runs: Restores cache file from GitHub Actions cache
+- Cache persists across workflow runs (until manually invalidated or expired)
+
+This approach pairs perfectly with GitHub Actions caching - the application creates the cache file, and GitHub Actions persists it across runs.
+
+### Architecture
+
+```
+VersionCompatibilityMatrix
+  └── CachedVersionProvider (decorator)
+       └── GithubVersionProvider (delegate)
+```
+
+The `CachedVersionProvider`:
+- Intercepts version discovery calls
+- Returns cached data when available
+- Delegates to `GithubVersionProvider` only on cache miss
+- Automatically saves fetched data for future use
+
+## Cache Location
+
+The cache file is stored at: `.cache/camunda-versions.json`
+
+This file contains a JSON array of version strings discovered from GitHub tags.
+
+## Cache Behavior
+
+### Application Cache
+
+**Cache Miss** (file doesn't exist):
+1. Fetches version tags from GitHub
+2. Filters pre-releases and null versions
+3. Identifies latest patch for each minor version
+4. Checks release status (only for latest patches)
+5. Saves metadata to `.cache/camunda-versions.json`
+
+**Cache Hit** (file exists):
+1. Loads data from `.cache/camunda-versions.json`
+2. Zero GitHub API calls
+3. Returns cached version metadata
+
+### With GitHub Actions
+
+GitHub Actions can persist the `.cache/` directory across workflow runs:
+- **First run**: Creates cache, saves to GitHub Actions cache
+- **Later runs**: Restores from GitHub Actions cache, instant results
+- **Manual refresh**: Delete cache artifact or `.cache/` directory
+
+This two-level caching (application + CI) ensures minimal API usage and fast test execution.
+
+## GitHub Actions Integration
+
+### Option 1: Cache Between Workflow Runs
+
+Add this step to your GitHub Actions workflow to cache the file between runs:
+
+```yaml
+- name: Cache Zeebe versions
+  uses: actions/cache@v4
+  with:
+    path: .cache
+    key: zeebe-versions-${{ github.run_id }}
+    restore-keys: |
+      zeebe-versions-
+```
+
+This will:
+- Restore the cache from a previous run
+- Use the same cached versions throughout the workflow
+- Save the cache at the end of the run
+
+### Option 2: Daily Cache Refresh
+
+To refresh the cache daily while using it within the same day:
+
+```yaml
+- name: Cache Zeebe versions
+  uses: actions/cache@v4
+  with:
+    path: .cache
+    key: zeebe-versions-${{ github.run_id }}-${{ hashFiles('.cache/zeebe-versions.json') }}
+    restore-keys: |
+      zeebe-versions-${{ github.run_id }}-
+      zeebe-versions-
+```
+
+### Option 3: Manual Cache Control
+
+Generate the cache file once in a dedicated job:
+
+```yaml
+jobs:
+  prepare-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Generate version cache
+        run: |
+          ./mvnw test -pl zeebe/qa/update-tests -Dtest=VersionCompatibilityMatrixTest#testDiscoverVersions -DfailIfNoTests=false
+
+      - name: Upload cache
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-cache
+          path: .cache/zeebe-versions.json
+
+  test:
+    needs: prepare-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download version cache
+        uses: actions/download-artifact@v4
+        with:
+          name: version-cache
+          path: .cache
+
+      - name: Run tests
+        run: ./mvnw verify -pl zeebe/qa/update-tests
+```
+
+## Local Development
+
+### View Cached Versions
+
+```bash
+cat .cache/zeebe-versions.json | jq .
+```
+
+### Force Cache Refresh
+
+```bash
+rm -f .cache/zeebe-versions.json
+./mvnw test -pl zeebe/qa/update-tests
+```
+
+### Disable Caching (for debugging)
+
+Option 1: Delete the cache file before running tests
+```bash
+rm -rf .cache
+```
+
+Option 2: Use the provider directly in your test:
+```java
+// Bypass caching by passing the provider directly
+new VersionCompatibilityMatrix(new GithubVersionProvider())
+```
+
+## Cache File Format
+
+The cache file (`.cache/camunda-versions.json`) is a JSON array of version metadata:
+
+```json
+[
+  {
+    "version": "8.0.0",
+    "isReleased": true,
+    "isLatest": false
+  },
+  {
+    "version": "8.0.1",
+    "isReleased": true,
+    "isLatest": true
+  },
+  {
+    "version": "8.1.0",
+    "isReleased": false,
+    "isLatest": true
+  }
+]
+```
+

--- a/zeebe/qa/update-tests/CACHE_README.md
+++ b/zeebe/qa/update-tests/CACHE_README.md
@@ -32,14 +32,9 @@ This approach pairs perfectly with GitHub Actions caching - the application crea
 ```
 VersionCompatibilityMatrix
   └── CachedVersionProvider (decorator)
-       └── GithubVersionProvider (delegate)
+       └── AdvancedGithubVersionProvider (decorator)
+            └── GithubVersionProvider (delegate)
 ```
-
-The `CachedVersionProvider`:
-- Intercepts version discovery calls
-- Returns cached data when available
-- Delegates to `GithubVersionProvider` only on cache miss
-- Automatically saves fetched data for future use
 
 ## Cache Location
 

--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -95,6 +95,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -165,6 +165,9 @@
           <excludes>
             <exclude>io.camunda.zeebe.test.migration.**</exclude>
           </excludes>
+          <systemPropertyVariables>
+            <maven.multiModuleProjectDirectory>${maven.multiModuleProjectDirectory}</maven.multiModuleProjectDirectory>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -313,7 +313,7 @@ final class VersionCompatibilityMatrix {
       LOG.info("  maven.multiModuleProjectDirectory = {}", mavenMultiModule);
       LOG.info("  user.dir = {}", userDir);
 
-      return Paths.get(baseDir, ".cache", "camunda-versions.json");
+      return Paths.get(baseDir, ".cache/camunda", "camunda-versions.json");
     }
 
     @Override

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -21,9 +21,11 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SequencedCollection;
@@ -70,7 +72,7 @@ final class VersionCompatibilityMatrix {
   private final VersionProvider versionProvider;
 
   public VersionCompatibilityMatrix() {
-    versionProvider = new GithubVersionProvider();
+    versionProvider = new CachedVersionProvider(new GithubVersionProvider());
   }
 
   public VersionCompatibilityMatrix(final VersionProvider versionProvider) {
@@ -148,29 +150,31 @@ final class VersionCompatibilityMatrix {
   }
 
   public Stream<Arguments> full() {
-    final var versions = discoverVersions().sorted().toList();
-    final var latestVersionPerMinor = getLatestVersionPerMinor(versions);
+    final var versionInfos = discoverReleasedVersions().sorted().toList();
     final var combinations =
-        versions.stream()
-            .filter(version -> version.minor() > 0)
+        versionInfos.stream()
+            .filter(info -> info.version().minor() > 0)
             .flatMap(
-                version1 ->
-                    versions.stream()
-                        .filter(version2 -> version1.compareTo(version2) < 0)
-                        .filter(version2 -> version2.minor() - version1.minor() <= 1)
+                info1 ->
+                    versionInfos.stream()
+                        .filter(info2 -> info1.compareTo(info2) < 0)
+                        .filter(info2 -> info2.version().minor() - info1.version().minor() <= 1)
                         .filter(
-                            version2 -> {
-                              if (version1.minor() <= 4 && version2.minor() > version1.minor()) {
+                            info2 -> {
+                              if (info1.version().minor() <= 4
+                                  && info2.version().minor() > info1.version().minor()) {
                                 // When updating from 8.4 (or earlier) to the next minor, only test
                                 // the latest patch.
                                 // Only 8.5 and onwards allow updating to a not-latest patch.
-                                return latestVersionPerMinor.get(version2.minor()).equals(version2);
+                                return info2.isLatest();
                               } else {
                                 return true;
                               }
                             })
-                        .filter(version2 -> isCompatible(version1, version2))
-                        .map(version2 -> Arguments.of(version1.toString(), version2.toString())))
+                        .filter(info2 -> isCompatible(info1.version(), info2.version()))
+                        .map(
+                            info2 ->
+                                Arguments.of(info1.version.toString(), info2.version.toString())))
             .toList();
 
     final var index =
@@ -182,16 +186,6 @@ final class VersionCompatibilityMatrix {
             .map(Integer::parseInt)
             .orElse(1);
     return shard(combinations, index, total);
-  }
-
-  private Map<Integer, SemanticVersion> getLatestVersionPerMinor(
-      final List<SemanticVersion> versions) {
-    return versions.stream()
-        .collect(
-            Collectors.toMap(
-                SemanticVersion::minor,
-                Function.identity(),
-                BinaryOperator.maxBy(Comparator.comparing(SemanticVersion::patch))));
   }
 
   @VisibleForTesting
@@ -209,8 +203,8 @@ final class VersionCompatibilityMatrix {
   }
 
   /**
-   * Discovers Zeebe versions that aren't pre-releases. Sourced from the GitHub API and can fail on
-   * network issues. Includes all versions since 8.0.
+   * Discovers Zeebe versions that aren't pre-releases and are released. Sourced from the GitHub API
+   * and can fail on network issues. Includes all versions since 8.0.
    *
    * <p>For the latest patch version of each minor version, verifies that the version has been
    * published as a GitHub release before including it. This ensures that only versions with
@@ -221,27 +215,11 @@ final class VersionCompatibilityMatrix {
    *     API</a>
    */
   public Stream<SemanticVersion> discoverVersions() {
-    final var versions =
-        versionProvider
-            .discoverVersions()
-            .filter(version -> version != null && version.preRelease() == null)
-            .toList();
+    return discoverReleasedVersions().map(VersionInfo::version);
+  }
 
-    // Filter out unreleased versions which might not have the right artifacts like maven/docker
-    // published yet. The GitHub API for fetching releases is inflexible, thus we optimize to only
-    // check for the latest versions of each minor.
-    final var unreleasedVersions =
-        getLatestVersionPerMinor(versions).values().stream()
-            .filter(version -> !versionProvider.isReleased(version))
-            .peek(
-                version ->
-                    LOG.warn(
-                        "Latest patch {} for minor version 8.{} has no corresponding GitHub release yet. Excluding from compatibility matrix.",
-                        version,
-                        version.minor()))
-            .collect(Collectors.toSet());
-
-    return versions.stream().filter(version -> !unreleasedVersions.contains(version));
+  public Stream<VersionInfo> discoverReleasedVersions() {
+    return versionProvider.discoverVersions().filter(VersionInfo::isReleased);
   }
 
   private static SemanticVersion parseVersion(final String version) {
@@ -278,6 +256,81 @@ final class VersionCompatibilityMatrix {
             });
   }
 
+  static class CachedVersionProvider implements VersionProvider {
+
+    private static final Path CACHE_FILE = Paths.get(".cache", "camunda-versions.json");
+
+    private final VersionProvider delegate;
+
+    public CachedVersionProvider(final VersionProvider delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Stream<VersionInfo> discoverVersions() {
+      // Try to load from cache first
+      final var cachedVersions = loadFromCache();
+      if (cachedVersions.isPresent()) {
+        LOG.info("Loaded {} versions from cache file: {}", cachedVersions.get().size(), CACHE_FILE);
+        return cachedVersions.get().stream();
+      }
+
+      // Delegate to underlying provider and cache the results
+      LOG.info("Cache file not found, fetching versions from delegate provider");
+      final var versionInfos = delegate.discoverVersions().toList();
+      saveToCache(versionInfos);
+      return versionInfos.stream();
+    }
+
+    private Optional<List<VersionInfo>> loadFromCache() {
+      try {
+        if (!Files.exists(CACHE_FILE)) {
+          return Optional.empty();
+        }
+
+        final var json = Files.readString(CACHE_FILE);
+        final var mapper = new ObjectMapper();
+        final var cachedInfos = mapper.readValue(json, CachedVersionInfo[].class);
+        final var versionInfos =
+            Stream.of(cachedInfos)
+                .map(
+                    cached ->
+                        SemanticVersion.parse(cached.version())
+                            .map(v -> new VersionInfo(v, cached.isReleased(), cached.isLatest()))
+                            .orElse(null))
+                .filter(Objects::nonNull)
+                .toList();
+        return Optional.of(versionInfos);
+      } catch (final Exception e) {
+        LOG.warn("Failed to load versions from cache file: {}", CACHE_FILE, e);
+        return Optional.empty();
+      }
+    }
+
+    private void saveToCache(final List<VersionInfo> versionInfos) {
+      try {
+        Files.createDirectories(CACHE_FILE.getParent());
+        final var cachedInfos =
+            versionInfos.stream()
+                .map(
+                    info ->
+                        new CachedVersionInfo(
+                            info.version().toString(), info.isReleased(), info.isLatest()))
+                .toList();
+        final var mapper = new ObjectMapper();
+        final var json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(cachedInfos);
+        Files.writeString(CACHE_FILE, json);
+        LOG.info("Saved {} versions to cache file: {}", versionInfos.size(), CACHE_FILE);
+      } catch (final Exception e) {
+        LOG.warn("Failed to save versions to cache file: {}", CACHE_FILE, e);
+      }
+    }
+
+    // Helper record for JSON serialization (Jackson doesn't handle SemanticVersion directly)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record CachedVersionInfo(String version, boolean isReleased, boolean isLatest) {}
+  }
+
   static class GithubVersionProvider implements VersionProvider {
 
     final Retry retry =
@@ -289,13 +342,41 @@ final class VersionCompatibilityMatrix {
                 .build());
 
     @Override
-    public Stream<SemanticVersion> discoverVersions() {
-      return fetchTags().map(Ref::toSemanticVersion);
-    }
+    public Stream<VersionInfo> discoverVersions() {
+      final var allVersions =
+          fetchTags()
+              .map(Ref::toSemanticVersion)
+              .filter(Objects::nonNull) // Filter out null versions
+              .filter(version -> version.preRelease() == null) // Filter out pre-releases
+              .toList();
 
-    @Override
-    public boolean isReleased(final SemanticVersion version) {
-      return fetchRelease(version).isPresent();
+      // Identify latest patch per minor
+      final var latestPerMinor =
+          allVersions.stream()
+              .collect(
+                  Collectors.toMap(
+                      SemanticVersion::minor,
+                      Function.identity(),
+                      BinaryOperator.maxBy(Comparator.comparing(SemanticVersion::patch))));
+
+      // Create VersionInfo with isLatest flag and check release status only for latest patches
+      return allVersions.stream()
+          .map(
+              version -> {
+                final boolean isLatest = version.equals(latestPerMinor.get(version.minor()));
+
+                // We only probe for actual releases for the latest minor,
+                // for others we assume they are released
+                final boolean isReleased = !isLatest || fetchRelease(version).isPresent();
+
+                if (!isReleased) {
+                  LOG.warn(
+                      "{} has no corresponding GitHub release yet. Excluding from compatibility matrix.",
+                      version);
+                }
+
+                return new VersionInfo(version, isReleased, isLatest);
+              });
     }
 
     private Optional<Release> fetchRelease(final SemanticVersion tagName) {
@@ -371,11 +452,17 @@ final class VersionCompatibilityMatrix {
     }
   }
 
+  record VersionInfo(SemanticVersion version, boolean isReleased, boolean isLatest)
+      implements Comparable<VersionInfo> {
+    @Override
+    public int compareTo(final VersionInfo other) {
+      return version.compareTo(other.version);
+    }
+  }
+
   private record UpgradePath(SemanticVersion from, SemanticVersion to) {}
 
   interface VersionProvider {
-    Stream<SemanticVersion> discoverVersions();
-
-    boolean isReleased(SemanticVersion version);
+    Stream<VersionInfo> discoverVersions();
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -379,6 +379,16 @@ final class VersionCompatibilityMatrix {
               });
     }
 
+    private HttpRequest.Builder createAuthenticatedRequest(final URI endpoint) {
+      final var builder = HttpRequest.newBuilder().GET().uri(endpoint);
+      final var token = System.getenv("GH_TOKEN");
+      if (token != null && !token.isEmpty()) {
+        builder.header("Authorization", "Bearer " + token);
+        LOG.debug("Using authenticated GitHub API request with GH_TOKEN");
+      }
+      return builder;
+    }
+
     private Optional<Release> fetchRelease(final SemanticVersion tagName) {
       final var endpoint =
           URI.create(
@@ -388,8 +398,7 @@ final class VersionCompatibilityMatrix {
             retry.executeCallable(
                 () ->
                     httpClient.send(
-                        HttpRequest.newBuilder().GET().uri(endpoint).build(),
-                        BodyHandlers.ofByteArray()));
+                        createAuthenticatedRequest(endpoint).build(), BodyHandlers.ofByteArray()));
 
         final var statusCode = response.statusCode();
         if (statusCode == 404) {
@@ -418,8 +427,7 @@ final class VersionCompatibilityMatrix {
             retry.executeCallable(
                 () ->
                     httpClient.send(
-                        HttpRequest.newBuilder().GET().uri(endpoint).build(),
-                        BodyHandlers.ofByteArray()));
+                        createAuthenticatedRequest(endpoint).build(), BodyHandlers.ofByteArray()));
 
         final var statusCode = response.statusCode();
         if (statusCode < 200 || statusCode >= 300) {

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -201,7 +201,8 @@ final class VersionCompatibilityMatrix {
                         .filter(info2 -> isCompatible(info1.version(), info2.version()))
                         .map(
                             info2 ->
-                                Arguments.of(info1.version.toString(), info2.version.toString())))
+                                Arguments.of(
+                                    info1.version().toString(), info2.version().toString())))
             .toList();
 
     final var index =
@@ -522,19 +523,7 @@ final class VersionCompatibilityMatrix {
     }
   }
 
-  private record UpgradePath(SemanticVersion from, SemanticVersion to) {}
-
-  interface VersionProvider {
-    Stream<VersionInfo> discoverVersions();
-  }
-
-  interface VersionCompatibilityConfig {
-    SemanticVersion getCurrentVersion();
-
-    Optional<SemanticVersion> getPreviousMinorVersion();
-  }
-
-  public class GithubAPI {
+  static class GithubAPI {
 
     final Retry retry =
         Retry.of(
@@ -623,5 +612,17 @@ final class VersionCompatibilityMatrix {
         return SemanticVersion.parse(tag_name).orElse(null);
       }
     }
+  }
+
+  private record UpgradePath(SemanticVersion from, SemanticVersion to) {}
+
+  interface VersionProvider {
+    Stream<VersionInfo> discoverVersions();
+  }
+
+  interface VersionCompatibilityConfig {
+    SemanticVersion getCurrentVersion();
+
+    Optional<SemanticVersion> getPreviousMinorVersion();
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -99,13 +99,13 @@ final class VersionCompatibilityMatrix {
     final var api = new GithubAPI();
     return new VersionCompatibilityMatrix(
         new CachedVersionProvider(
-            new AdvancedGithubVersionProvider(new GithubVersionProvider(api), api)));
+            new ReleaseVerifiedGithubVersionProvider(new GithubVersionProvider(api), api)));
   }
 
   public static VersionCompatibilityMatrix useUncached() {
     final var api = new GithubAPI();
     return new VersionCompatibilityMatrix(
-        new AdvancedGithubVersionProvider(new GithubVersionProvider(api), api));
+        new ReleaseVerifiedGithubVersionProvider(new GithubVersionProvider(api), api));
   }
 
   /**
@@ -383,12 +383,13 @@ final class VersionCompatibilityMatrix {
     record CachedVersionInfo(String version, boolean isReleased, boolean isLatest) {}
   }
 
-  static class AdvancedGithubVersionProvider implements VersionProvider {
+  static class ReleaseVerifiedGithubVersionProvider implements VersionProvider {
 
     private final VersionProvider delegate;
     private final GithubAPI api;
 
-    public AdvancedGithubVersionProvider(final VersionProvider delegate, final GithubAPI api) {
+    public ReleaseVerifiedGithubVersionProvider(
+        final VersionProvider delegate, final GithubAPI api) {
       this.delegate = delegate;
       this.api = api;
     }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -194,7 +194,6 @@ class VersionCompatibilityMatrixTest {
     final var discoveredVersions = liveMatrix.discoverVersions().map(VersionInfo::version);
     final var legacyDiscoveredVersions =
         new LegacyVersionProvider().discoverVersions().map(VersionInfo::version);
-    ;
 
     assertThat(discoveredVersions)
         .containsExactlyInAnyOrderElementsOf(legacyDiscoveredVersions.toList());

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -189,7 +189,7 @@ class VersionCompatibilityMatrixTest {
       "During releases some tags might not be fully published yet and would make this and the rolling update test fail")
   @Test
   void testCompareLegacyToCurrentVersionDiscovery() {
-    final var liveMatrix = new VersionCompatibilityMatrix();
+    final var liveMatrix = VersionCompatibilityMatrix.useUncached();
 
     final var discoveredVersions = liveMatrix.discoverVersions().map(VersionInfo::version);
     final var legacyDiscoveredVersions =

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -9,20 +9,30 @@ package io.camunda.zeebe.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.AdvancedGithubVersionProvider;
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.CachedVersionProvider;
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.GithubAPI;
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.GithubVersionProvider;
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.LegacyVersionProvider;
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionCompatibilityConfig;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionInfo;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionProvider;
 import io.camunda.zeebe.util.SemanticVersion;
-import java.util.Comparator;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.LinkedList;
-import java.util.Objects;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,32 +40,90 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class VersionCompatibilityMatrixTest {
 
+  final VersionCompatibilityMatrix matrix =
+      new VersionCompatibilityMatrix(
+          () ->
+              Stream.of(
+                  VersionInfo.of("8.7.0"),
+                  VersionInfo.of("8.7.11"),
+                  VersionInfo.of("8.7.12"),
+                  VersionInfo.of("8.8.0"),
+                  VersionInfo.of("8.8.1"),
+                  VersionInfo.of("8.8.2")),
+          new VersionCompatibilityConfig() {
+            @Override
+            public SemanticVersion getCurrentVersion() {
+              return SemanticVersion.parse("8.8.2").orElseThrow();
+            }
+
+            @Override
+            public Optional<SemanticVersion> getPreviousMinorVersion() {
+              return SemanticVersion.parse("8.7.12");
+            }
+          });
+
   @Test
-  void filterPreReleaseVersion() {
-    final VersionCompatibilityMatrix matrix =
-        new VersionCompatibilityMatrix(
-            new StaticVersionProvider(
-                Set.of("8.7.11", "8.8.2", "8.8.2-optimize"),
-                Set.of("8.7.11", "8.8.2", "8.8.2-optimize")));
+  void testFromPreviousMinorToCurrent() {
+    final var paths =
+        matrix
+            .fromPreviousMinorToCurrent()
+            .map(args -> Stream.of(args.get()).map(Object::toString).toList())
+            .toList();
 
-    final var versions =
-        matrix.discoverVersions().map(SemanticVersion::toString).collect(Collectors.toSet());
-
-    assertThat(versions).isEqualTo(Set.of("8.7.11", "8.8.2"));
+    assertThat(paths).containsExactly(List.of("8.7.12", "CURRENT"));
   }
 
   @Test
-  void filterUnreleasedLatestVersion() {
-    final VersionCompatibilityMatrix matrix =
-        new VersionCompatibilityMatrix(
-            new StaticVersionProvider(
-                Set.of("8.7.11", "8.8.0", "8.8.1", "8.8.2", "8.8.2-optimize"),
-                Set.of("8.7.11", "8.8.0", "8.8.1")));
+  void testFromPreviousPatchesToCurrent() {
+    final var paths =
+        matrix
+            .fromPreviousPatchesToCurrent()
+            .map(args -> Stream.of(args.get()).map(Object::toString).toList())
+            .toList();
 
-    final var versions =
-        matrix.discoverVersions().map(SemanticVersion::toString).collect(Collectors.toSet());
+    assertThat(paths)
+        .containsExactlyInAnyOrder(
+            List.of("8.7.0", "CURRENT"),
+            List.of("8.7.11", "CURRENT"),
+            List.of("8.7.12", "CURRENT"),
+            List.of("8.8.0", "CURRENT"),
+            List.of("8.8.1", "CURRENT"));
+  }
 
-    assertThat(versions).isEqualTo(Set.of("8.7.11", "8.8.0", "8.8.1"));
+  @Test
+  void testFromFirstAndLastPatchToCurrent() {
+    final var paths =
+        matrix
+            .fromFirstAndLastPatchToCurrent()
+            .map(args -> Stream.of(args.get()).map(Object::toString).toList())
+            .toList();
+
+    assertThat(paths)
+        .containsExactlyInAnyOrder(List.of("8.7.0", "CURRENT"), List.of("8.7.12", "CURRENT"));
+  }
+
+  @Test
+  void testFull() {
+    final var paths =
+        matrix.full().map(args -> Stream.of(args.get()).map(Object::toString).toList()).toList();
+
+    assertThat(paths)
+        .containsExactlyInAnyOrder(
+            List.of("8.7.0", "8.7.11"),
+            List.of("8.7.0", "8.7.12"),
+            List.of("8.7.0", "8.8.0"),
+            List.of("8.7.0", "8.8.1"),
+            List.of("8.7.0", "8.8.2"),
+            List.of("8.7.11", "8.7.12"),
+            List.of("8.7.11", "8.8.0"),
+            List.of("8.7.11", "8.8.1"),
+            List.of("8.7.11", "8.8.2"),
+            List.of("8.7.12", "8.8.0"),
+            List.of("8.7.12", "8.8.1"),
+            List.of("8.7.12", "8.8.2"),
+            List.of("8.8.0", "8.8.1"),
+            List.of("8.8.0", "8.8.2"),
+            List.of("8.8.1", "8.8.2"));
   }
 
   @Test
@@ -73,7 +141,7 @@ class VersionCompatibilityMatrixTest {
             .collect(Collectors.toSet());
 
     final VersionCompatibilityMatrix matrix =
-        new VersionCompatibilityMatrix(new StaticVersionProvider(versions, versions));
+        new VersionCompatibilityMatrix(() -> versions.stream().map(VersionInfo::of));
 
     // when
     final var upgradePairs =
@@ -107,70 +175,227 @@ class VersionCompatibilityMatrixTest {
         .forEach(fromPatch -> assertThat(upgradePairs).contains("8.5." + fromPatch + "->8.6.13"));
   }
 
-  @ParameterizedTest(name = "Sharding {0} elements into {1} shards")
-  @MethodSource("sizeAndShards")
-  void shouldShardCompletely(final int size, final int totalShards) {
-    final var input = IntStream.range(0, size).boxed().toList();
-    final var sharded = new LinkedList<Integer>();
-    for (int i = 0; i < totalShards; i++) {
-      final var shard = VersionCompatibilityMatrix.shard(input, i, totalShards).toList();
-      assertThat(shard).isNotEmpty();
-      sharded.addAll(shard);
-    }
-    assertThat(sharded).isEqualTo(input);
+  /**
+   * During releases some tags might not be fully published yet and would make the rolling update
+   * test fail
+   *
+   * <p>Therefore, we created a smarter version discovery strategy that checks if tags have been
+   * fully released.
+   *
+   * <p>We are disabling this test by default to avoid flakiness during releases, but it's still
+   * helpful for refactoring.
+   */
+  @Disabled(
+      "During releases some tags might not be fully published yet and would make this and the rolling update test fail")
+  @Test
+  void testCompareLegacyToCurrentVersionDiscovery() {
+    final var liveMatrix = new VersionCompatibilityMatrix();
+
+    final var discoveredVersions = liveMatrix.discoverVersions().map(VersionInfo::version);
+    final var legacyDiscoveredVersions =
+        new LegacyVersionProvider().discoverVersions().map(VersionInfo::version);
+    ;
+
+    assertThat(discoveredVersions)
+        .containsExactlyInAnyOrderElementsOf(legacyDiscoveredVersions.toList());
   }
 
-  static Stream<Arguments> sizeAndShards() {
-    return IntStream.rangeClosed(0, 10)
-        .boxed()
-        .flatMap(
-            size ->
-                IntStream.rangeClosed(1, 10)
-                    .boxed()
-                    .filter(shards -> shards < size)
-                    .map(shards -> arguments(size, shards)));
-  }
-
-  static class StaticVersionProvider implements VersionProvider {
-
-    private final Set<SemanticVersion> versions;
-    private final Set<SemanticVersion> releasedVersions;
-
-    public StaticVersionProvider(final Set<String> versions, final Set<String> releasedVersions) {
-      this.versions =
-          versions.stream()
-              .map(SemanticVersion::parse)
-              .flatMap(Optional::stream)
-              .collect(Collectors.toSet());
-      this.releasedVersions =
-          releasedVersions.stream()
-              .map(SemanticVersion::parse)
-              .flatMap(Optional::stream)
-              .collect(Collectors.toSet());
+  @Nested
+  class ShardingTest {
+    @ParameterizedTest(name = "Sharding {0} elements into {1} shards")
+    @MethodSource("sizeAndShards")
+    void shouldShardCompletely(final int size, final int totalShards) {
+      final var input = IntStream.range(0, size).boxed().toList();
+      final var sharded = new LinkedList<Integer>();
+      for (int i = 0; i < totalShards; i++) {
+        final var shard = VersionCompatibilityMatrix.shard(input, i, totalShards).toList();
+        assertThat(shard).isNotEmpty();
+        sharded.addAll(shard);
+      }
+      assertThat(sharded).isEqualTo(input);
     }
 
-    @Override
-    public Stream<VersionInfo> discoverVersions() {
-      // Filter out null and pre-release versions
-      final var validVersions =
-          versions.stream().filter(Objects::nonNull).filter(v -> v.preRelease() == null).toList();
+    static Stream<Arguments> sizeAndShards() {
+      return IntStream.rangeClosed(0, 10)
+          .boxed()
+          .flatMap(
+              size ->
+                  IntStream.rangeClosed(1, 10)
+                      .boxed()
+                      .filter(shards -> shards < size)
+                      .map(shards -> arguments(size, shards)));
+    }
+  }
 
-      // Calculate latest per minor
-      final var latestPerMinor =
-          validVersions.stream()
-              .collect(
-                  Collectors.toMap(
-                      SemanticVersion::minor,
-                      Function.identity(),
-                      BinaryOperator.maxBy(Comparator.comparing(SemanticVersion::patch))));
+  @Nested
+  class VersionInfoTest {
 
-      return validVersions.stream()
-          .map(
-              version -> {
-                final boolean isLatest = version.equals(latestPerMinor.get(version.minor()));
-                final boolean isReleased = releasedVersions.contains(version);
-                return new VersionInfo(version, isReleased, isLatest);
-              });
+    @Test
+    void shouldHandleNullVersion() {
+      final SemanticVersion semanticVersion = null;
+      final var version = VersionInfo.of(semanticVersion);
+
+      assertThat(version).isNull();
+    }
+
+    @Test
+    void shouldReturnNullForInvalidVersionString() {
+      final var version = VersionInfo.of("whatsoever");
+
+      assertThat(version).isNull();
+    }
+
+    @Test
+    void shouldDetectPreReleaseVersion() {
+      final var version = VersionInfo.of("8.8.0-alpha.1");
+
+      assertThat(version.isReleased()).isFalse();
+    }
+
+    @Test
+    void shouldUpdateLatestForEmptyList() {
+      final var versions = VersionInfo.updateLatest(Collections.emptyList());
+
+      assertThat(versions).isEmpty();
+    }
+
+    @Test
+    void shouldUpdateLatest() {
+      final var version8711 = VersionInfo.of("8.7.11");
+      final var version8712 = VersionInfo.of("8.7.12");
+      final var version880 = VersionInfo.of("8.8.0");
+
+      final var versions = VersionInfo.updateLatest(List.of(version8711, version8712, version880));
+
+      assertThat(versions)
+          .containsExactlyInAnyOrder(version8711, version8712.asLatest(), version880.asLatest());
+    }
+  }
+
+  @Nested
+  class GithubVersionProviderTest {
+
+    @Test
+    void shouldFilterOutInvalidVersions() {
+      final var api = mock(GithubAPI.class);
+      final var provider = new GithubVersionProvider(api);
+
+      when(api.fetchTags())
+          .thenReturn(Stream.of("refs/tags/", "refs/tags/invalid-123").map(GithubAPI.Ref::new));
+
+      final var versions = provider.discoverVersions();
+
+      assertThat(versions).isEmpty();
+    }
+
+    @Test
+    void shouldFilterOutPreReleaseVersions() {
+      final var api = mock(GithubAPI.class);
+      final var provider = new GithubVersionProvider(api);
+
+      when(api.fetchTags())
+          .thenReturn(
+              Stream.of(
+                      "refs/tags/8.7.11",
+                      "refs/tags/8.7.12",
+                      "refs/tags/8.7.12-optimize",
+                      "refs/tags/8.8.0",
+                      "refs/tags/8.8.1-alpha")
+                  .map(GithubAPI.Ref::new));
+
+      final var versions = provider.discoverVersions().map(info -> info.version().toString());
+
+      assertThat(versions).containsExactlyInAnyOrder("8.7.11", "8.7.12", "8.8.0");
+    }
+
+    @Test
+    void shouldMarkLatestPerMinor() {
+      final var api = mock(GithubAPI.class);
+      final var provider = new GithubVersionProvider(api);
+
+      when(api.fetchTags())
+          .thenReturn(
+              Stream.of("refs/tags/8.7.11", "refs/tags/8.7.12", "refs/tags/8.8.0")
+                  .map(GithubAPI.Ref::new));
+
+      final var versions = provider.discoverVersions();
+
+      assertThat(versions)
+          .containsExactlyInAnyOrder(
+              VersionInfo.of("8.7.11"),
+              VersionInfo.of("8.7.12").asLatest(),
+              VersionInfo.of("8.8.0").asLatest());
+    }
+  }
+
+  @Nested
+  class AdvancedGithubVersionProviderTest {
+
+    @Test
+    void shouldPassThroughReleasedLatestVersions() {
+      final var api = mock(GithubAPI.class);
+      final var baseProvider = mock(VersionProvider.class);
+      final var provider = new AdvancedGithubVersionProvider(baseProvider, api);
+
+      final var info = VersionInfo.of("8.8.0").asLatest();
+      when(baseProvider.discoverVersions()).thenReturn(Stream.of(info));
+      when(api.fetchRelease(info.version()))
+          .thenReturn(Optional.of(new GithubAPI.Release(info.version().toString())));
+
+      assertThat(provider.discoverVersions()).isNotEmpty();
+    }
+
+    @Test
+    void shouldFilterUnReleasedLatestVersions() {
+      final var api = mock(GithubAPI.class);
+      final var baseProvider = mock(VersionProvider.class);
+      final var provider = new AdvancedGithubVersionProvider(baseProvider, api);
+
+      final var info = VersionInfo.of("8.8.0").asLatest();
+      when(baseProvider.discoverVersions()).thenReturn(Stream.of(info));
+      when(api.fetchRelease(info.version())).thenReturn(Optional.empty());
+
+      assertThat(provider.discoverVersions()).isEmpty();
+    }
+
+    @Test
+    void shouldUpdateLatestToLatestReleasedVersion() {
+      final var api = mock(GithubAPI.class);
+      final var baseProvider = mock(VersionProvider.class);
+      final var provider = new AdvancedGithubVersionProvider(baseProvider, api);
+
+      final var releasedVersion = VersionInfo.of("8.7.11");
+      final var unreleasedVersion = VersionInfo.of("8.7.12").asLatest();
+
+      when(baseProvider.discoverVersions())
+          .thenReturn(Stream.of(releasedVersion, unreleasedVersion));
+      when(api.fetchRelease(releasedVersion.version()))
+          .thenReturn(Optional.of(new GithubAPI.Release(releasedVersion.version().toString())));
+      when(api.fetchRelease(unreleasedVersion.version())).thenReturn(Optional.empty());
+
+      final var discoveredVersions = provider.discoverVersions();
+
+      assertThat(discoveredVersions).containsExactlyInAnyOrder(releasedVersion.asLatest());
+    }
+  }
+
+  @Nested
+  class CachedVersionProviderTest {
+    @Test
+    void shouldCacheOnDisk(@org.junit.jupiter.api.io.TempDir final Path tempDir) {
+      final var baseProvider = mock(VersionProvider.class);
+      final var cacheFile = tempDir.resolve("camunda-versions.json");
+      final var provider = new CachedVersionProvider(baseProvider, cacheFile);
+
+      final var versions = List.of(VersionInfo.of("8.7.9"), VersionInfo.of("8.8.0").asLatest());
+      when(baseProvider.discoverVersions()).thenReturn(versions.stream());
+
+      final var versions1 = provider.discoverVersions().toList();
+      final var versions2 = provider.discoverVersions().toList();
+
+      assertThat(versions1).containsExactlyInAnyOrderElementsOf(versions);
+      assertThat(versions2).containsExactlyInAnyOrderElementsOf(versions);
+      verify(baseProvider, times(1)).discoverVersions();
     }
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -396,6 +396,22 @@ class VersionCompatibilityMatrixTest {
       assertThat(versions1).containsExactlyInAnyOrderElementsOf(versions);
       assertThat(versions2).containsExactlyInAnyOrderElementsOf(versions);
       verify(baseProvider, times(1)).discoverVersions();
+
+      // Verify cache file exists and has proper contents
+      assertThat(cacheFile).exists();
+      final var cacheContent = Files.readString(cacheFile);
+      assertThat(cacheContent)
+          .isEqualTo(
+              """
+              [ {
+                "version" : "8.7.9",
+                "isReleased" : true,
+                "isLatest" : false
+              }, {
+                "version" : "8.8.0",
+                "isReleased" : true,
+                "isLatest" : true
+              } ]""");
     }
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -14,15 +14,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.test.VersionCompatibilityMatrix.AdvancedGithubVersionProvider;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.CachedVersionProvider;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.GithubAPI;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.GithubVersionProvider;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.LegacyVersionProvider;
+import io.camunda.zeebe.test.VersionCompatibilityMatrix.ReleaseVerifiedGithubVersionProvider;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionCompatibilityConfig;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionInfo;
 import io.camunda.zeebe.test.VersionCompatibilityMatrix.VersionProvider;
 import io.camunda.zeebe.util.SemanticVersion;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -334,7 +335,7 @@ class VersionCompatibilityMatrixTest {
     void shouldPassThroughReleasedLatestVersions() {
       final var api = mock(GithubAPI.class);
       final var baseProvider = mock(VersionProvider.class);
-      final var provider = new AdvancedGithubVersionProvider(baseProvider, api);
+      final var provider = new ReleaseVerifiedGithubVersionProvider(baseProvider, api);
 
       final var info = VersionInfo.of("8.8.0").asLatest();
       when(baseProvider.discoverVersions()).thenReturn(Stream.of(info));
@@ -348,7 +349,7 @@ class VersionCompatibilityMatrixTest {
     void shouldFilterUnReleasedLatestVersions() {
       final var api = mock(GithubAPI.class);
       final var baseProvider = mock(VersionProvider.class);
-      final var provider = new AdvancedGithubVersionProvider(baseProvider, api);
+      final var provider = new ReleaseVerifiedGithubVersionProvider(baseProvider, api);
 
       final var info = VersionInfo.of("8.8.0").asLatest();
       when(baseProvider.discoverVersions()).thenReturn(Stream.of(info));
@@ -361,7 +362,7 @@ class VersionCompatibilityMatrixTest {
     void shouldUpdateLatestToLatestReleasedVersion() {
       final var api = mock(GithubAPI.class);
       final var baseProvider = mock(VersionProvider.class);
-      final var provider = new AdvancedGithubVersionProvider(baseProvider, api);
+      final var provider = new ReleaseVerifiedGithubVersionProvider(baseProvider, api);
 
       final var releasedVersion = VersionInfo.of("8.7.11");
       final var unreleasedVersion = VersionInfo.of("8.7.12").asLatest();
@@ -381,7 +382,7 @@ class VersionCompatibilityMatrixTest {
   @Nested
   class CachedVersionProviderTest {
     @Test
-    void shouldCacheOnDisk(@org.junit.jupiter.api.io.TempDir final Path tempDir) {
+    void shouldCacheOnDisk(@org.junit.jupiter.api.io.TempDir final Path tempDir) throws Exception {
       final var baseProvider = mock(VersionProvider.class);
       final var cacheFile = tempDir.resolve("camunda-versions.json");
       final var provider = new CachedVersionProvider(baseProvider, cacheFile);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
@@ -52,6 +52,10 @@ public record SemanticVersion(
     }
   }
 
+  public boolean isPreRelease() {
+    return preRelease != null;
+  }
+
   public static Optional<SemanticVersion> parse(final String version) {
     if (version == null) {
       return Optional.empty();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
@@ -78,6 +78,10 @@ public final class VersionUtil {
     return lastVersion;
   }
 
+  public static Optional<SemanticVersion> getPreviousSemanticVersion() {
+    return SemanticVersion.parse(getPreviousVersion());
+  }
+
   private static String readProperty(final String property) {
     try (final InputStream lastVersionFileStream =
         VersionUtil.class.getResourceAsStream(VERSION_PROPERTIES_PATH)) {


### PR DESCRIPTION
## Description

We uncovered some [issues](https://github.com/camunda/camunda/actions/runs/19735773563/job/56547256089) with rate limiting to fetch versions/release from github

Thus this PR changes the following
- store the version discovery results on disk
- use github action cache to store the versions hourly (maybe change to daily?)
- uses GH_TOKEN for the API calls
- generally refactors a bit how we deal with versions in the matrix

⚠️ this PR contains some Copilot generated stuff, thus please review carefully