### PR TITLE
fix: give zeebe:*:write permissions with RBA

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -352,4 +352,8 @@ public class StaticEntities {
   public static String createTasklistWritePermissionString(final Audiences audiences) {
     return audiences.getTasklist() + ":write:*";
   }
+
+  public static String createZeebeWritePermissionString(final Audiences audiences) {
+    return audiences.getZeebe() + ":write:*";
+  }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -328,7 +328,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(15)).createAuthorization(results.capture());
+    verify(authorizationServices, times(18)).createAuthorization(results.capture());
     final var authorizationRequests = results.getAllValues();
     assertThat(authorizationRequests)
         .extracting(
@@ -337,7 +337,7 @@ public class KeycloakRoleMigrationHandlerTest {
             CreateAuthorizationRequest::resourceType,
             CreateAuthorizationRequest::permissionTypes)
         .containsExactlyInAnyOrder(
-            // Identity read/write
+            // Identity read/write (role_1)
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -393,13 +393,13 @@ public class KeycloakRoleMigrationHandlerTest {
                     PermissionType.CREATE,
                     PermissionType.UPDATE,
                     PermissionType.DELETE)),
-            // Operate read/write
+            // Operate read/write (role_1)
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
-            // Tasklist read
+            // Tasklist read (role_1)
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -415,13 +415,7 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(PermissionType.READ_USER_TASK)),
-            // zeebe write
-            tuple(
-                "role@name_with_special_chars",
-                AuthorizationOwnerType.ROLE,
-                AuthorizationResourceType.SYSTEM,
-                Set.of(PermissionType.READ, PermissionType.UPDATE)),
-            // tasklist read/write
+            // role@name_with_special_chars - tasklist read/write & zeebe write combined
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
@@ -435,8 +429,40 @@ public class KeycloakRoleMigrationHandlerTest {
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.MESSAGE,
+                Set.of(PermissionType.CREATE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.SYSTEM,
+                Set.of(PermissionType.READ, PermissionType.UPDATE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.CREATE,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_RESOURCE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
-                Set.of(PermissionType.READ_USER_TASK, PermissionType.UPDATE_USER_TASK)));
+                Set.of(
+                    PermissionType.READ_USER_TASK,
+                    PermissionType.UPDATE_USER_TASK,
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.DECISION_DEFINITION,
+                Set.of(
+                    PermissionType.CREATE_DECISION_INSTANCE,
+                    PermissionType.DELETE_DECISION_INSTANCE)));
   }
 
   @Test

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
@@ -72,7 +72,32 @@ public class KeycloakIdentityMigrationWithRBAIT extends AbstractKeycloakIdentity
             a -> new HashSet<>(a.getPermissionTypes()))
         .contains(
             tuple("operate", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
+            // Zeebe role with zeebe-api:write creates wildcard permissions even with RBA enabled
             tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
+            tuple("zeebe", ResourceType.MESSAGE, Set.of(PermissionType.CREATE)),
+            tuple(
+                "zeebe",
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.CREATE,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_RESOURCE)),
+            tuple(
+                "zeebe",
+                ResourceType.PROCESS_DEFINITION,
+                Set.of(
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.UPDATE_USER_TASK,
+                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
+            tuple(
+                "zeebe",
+                ResourceType.DECISION_DEFINITION,
+                Set.of(
+                    PermissionType.CREATE_DECISION_INSTANCE,
+                    PermissionType.DELETE_DECISION_INSTANCE)),
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
             tuple(
                 "tasklist",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allow the identity migration app to migrate also `zeebe:*:write` permissions to the OC when RBA is enabled

## Related issues

related to #41617 
