### PR TITLE
feat: add support for move modifications in multi-instance scenarios

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -369,6 +369,13 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
           return;
         }
 
+        if (modificationsStore.state.status === 'requires-ancestor-selection') {
+          return modificationsStore.setAncestorFlowNodeKeyForMoveOperation({
+            instanceKey: scopeKey,
+            flowNodeId: elementId,
+          });
+        }
+
         if (modificationsStore.state.status === 'adding-token') {
           modificationsStore.finishAddingToken(
             businessObjects,
@@ -526,6 +533,13 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
 
         if (modificationsStore.state.status === 'moving-token') {
           return;
+        }
+
+        if (modificationsStore.state.status === 'requires-ancestor-selection') {
+          return modificationsStore.setAncestorFlowNodeKeyForMoveOperation({
+            instanceKey: scopeKey,
+            flowNodeId: elementId,
+          });
         }
 
         if (modificationsStore.state.status === 'adding-token') {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -114,26 +114,6 @@ vi.mock('react-transition-group', () => {
   };
 });
 
-vi.mock('modules/components/Diagram', async () => {
-  const actual = await vi.importActual<
-    typeof import('modules/components/Diagram')
-  >('modules/components/Diagram');
-
-  return {
-    Diagram: (props: React.ComponentProps<typeof actual.Diagram>) => (
-      <div>
-        <button
-          data-testid="select-task-2"
-          onClick={() => props.onFlowNodeSelection?.('task-2', false)}
-        >
-          Select task-2
-        </button>
-        <actual.Diagram {...props} />
-      </div>
-    ),
-  };
-});
-
 const mockProcessInstance: ProcessInstance = {
   processInstanceKey: 'instance_id',
   state: 'ACTIVE',
@@ -646,9 +626,7 @@ describe('TopPanel', () => {
       await screen.findByText(/select the target flow node in the diagram/i),
     ).toBeInTheDocument();
 
-    await user.click(
-      await screen.findByRole('button', {name: /Select task-2/}),
-    );
+    await user.click(await screen.findByTestId('task-2'));
 
     expect(
       await screen.findByText(

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -376,7 +376,6 @@ const TopPanel: React.FC = observer(() => {
                 }
                 selectedFlowNodeIds={selectedFlowNode}
                 onFlowNodeSelection={(flowNodeId, isMultiInstance) => {
-                  console.log({flowNodeId});
                   if (modificationsStore.state.status === 'moving-token') {
                     const ancestorSelectionRequired = hasMultipleScopes(
                       businessObjects[flowNodeId ?? ''],

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -46,6 +46,7 @@ import {
   selectFlowNode,
 } from 'modules/utils/flowNodeSelection';
 import {
+  useTotalRunningInstancesByFlowNode,
   useTotalRunningInstancesForFlowNode,
   useTotalRunningInstancesVisibleForFlowNode,
 } from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
@@ -74,6 +75,7 @@ import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {isInstanceRunning} from 'modules/utils/instance';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
+import {hasMultipleScopes} from 'modules/utils/processInstanceDetailsDiagram';
 
 const OVERLAY_TYPE_STATE = 'flowNodeState';
 const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
@@ -108,6 +110,8 @@ const TopPanel: React.FC = observer(() => {
   const {data: totalRunningInstances} = useTotalRunningInstancesForFlowNode(
     currentSelection?.flowNodeId,
   );
+  const {data: totalRunningInstancesByFlowNode} =
+    useTotalRunningInstancesByFlowNode();
   const {data: businessObjects} = useBusinessObjects();
   const {data: totalMoveOperationRunningInstances} =
     useTotalRunningInstancesForFlowNode(
@@ -319,6 +323,10 @@ const TopPanel: React.FC = observer(() => {
           isOpen={isIncidentBarOpen}
         />
       )}
+
+      {modificationsStore.state.status === 'requires-ancestor-selection' && (
+        <ModificationInfoBanner text="Target flow node has multiple parent scopes. Please select parent node from Instance History to move." />
+      )}
       {modificationsStore.state.status === 'moving-token' &&
         businessObjects && (
           <ModificationInfoBanner
@@ -368,7 +376,13 @@ const TopPanel: React.FC = observer(() => {
                 }
                 selectedFlowNodeIds={selectedFlowNode}
                 onFlowNodeSelection={(flowNodeId, isMultiInstance) => {
+                  console.log({flowNodeId});
                   if (modificationsStore.state.status === 'moving-token') {
+                    const ancestorSelectionRequired = hasMultipleScopes(
+                      businessObjects[flowNodeId ?? ''],
+                      totalRunningInstancesByFlowNode,
+                    );
+
                     if (IS_ELEMENT_SELECTION_V2) {
                       clearSelection();
                     } else {
@@ -380,6 +394,7 @@ const TopPanel: React.FC = observer(() => {
                       businessObjects,
                       processInstance?.processDefinitionId,
                       flowNodeId,
+                      ancestorSelectionRequired,
                     );
                   } else {
                     if (modificationsStore.state.status !== 'adding-token') {

--- a/operate/client/src/modules/bpmn-js/utils/isMoveModificationTarget.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMoveModificationTarget.ts
@@ -8,7 +8,6 @@
 
 import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import isNil from 'lodash/isNil';
-import {isWithinMultiInstance} from './isWithinMultiInstance';
 import {isAttachedToAnEventBasedGateway} from './isAttachedToAnEventBasedGateway';
 import {hasType} from './hasType';
 
@@ -17,7 +16,6 @@ const isMoveModificationTarget = (
 ) => {
   return (
     !isNil(businessObject) &&
-    !isWithinMultiInstance(businessObject) &&
     !isAttachedToAnEventBasedGateway(businessObject) &&
     !hasType({businessObject, types: ['bpmn:StartEvent', 'bpmn:BoundaryEvent']})
   );

--- a/operate/client/src/modules/bpmn-js/utils/isWithinMultiInstance.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isWithinMultiInstance.ts
@@ -15,4 +15,18 @@ const isWithinMultiInstance = (businessObject: BusinessObject) => {
   );
 };
 
-export {isWithinMultiInstance};
+const getFirstMultiInstanceParent = (
+  businessObject?: BusinessObject,
+): BusinessObject | undefined => {
+  if (!businessObject) {
+    return undefined;
+  }
+
+  if (isWithinMultiInstance(businessObject)) {
+    return businessObject.$parent;
+  }
+
+  return getFirstMultiInstanceParent(businessObject.$parent);
+};
+
+export {isWithinMultiInstance, getFirstMultiInstanceParent};

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -7,12 +7,16 @@
  */
 
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
+import {getFirstMultiInstanceParent} from 'modules/bpmn-js/utils/isWithinMultiInstance';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 import {useTotalRunningInstancesByFlowNode} from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {modificationsStore} from 'modules/stores/modifications';
-import {hasMultipleScopes} from 'modules/utils/processInstanceDetailsDiagram';
+import {
+  hasMultipleScopes,
+  hasSingleScope,
+} from 'modules/utils/processInstanceDetailsDiagram';
 
 const useFlowNodes = () => {
   const {data: statistics} = useFlownodeInstancesStatistics();
@@ -21,6 +25,7 @@ const useFlowNodes = () => {
   const {data: businessObjects} = useBusinessObjects();
 
   return Object.values(businessObjects ?? {}).map((flowNode) => {
+    const firstMultiInstanceParent = getFirstMultiInstanceParent(flowNode);
     const flowNodeState = statistics?.items.find(
       ({elementId}) => elementId === flowNode.id,
     );
@@ -31,27 +36,57 @@ const useFlowNodes = () => {
         flowNodeState !== undefined &&
         (flowNodeState.active > 0 || flowNodeState.incidents > 0),
       isMoveModificationTarget: isMoveModificationTarget(flowNode),
+      firstMultiInstanceParent,
       hasMultipleScopes: hasMultipleScopes(
         flowNode.$parent,
         totalRunningInstancesByFlowNode,
       ),
+      hasSingleScope:
+        !firstMultiInstanceParent ||
+        hasSingleScope(flowNode.$parent, totalRunningInstancesByFlowNode),
     };
   });
 };
 
 const useAppendableFlowNodes = () => {
-  return useFlowNodes()
+  const flowNodes = useFlowNodes();
+  const {
+    state: {status, sourceFlowNodeIdForMoveOperation},
+    isMoveAllOperation,
+  } = modificationsStore;
+
+  const sourceMultiInstanceParent = flowNodes.find(
+    ({id}) => id === sourceFlowNodeIdForMoveOperation,
+  )?.firstMultiInstanceParent;
+
+  return flowNodes
     .filter((flowNode) => {
       if (!flowNode.isMoveModificationTarget) {
         return false;
       }
 
-      if (flowNode.hasMultipleScopes) {
-        const {state, isMoveAllOperation} = modificationsStore;
-        return (
-          (state.status === 'moving-token' && !isMoveAllOperation) ||
-          IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED
-        );
+      // Add token
+      if (status !== 'moving-token') {
+        if (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED) {
+          return flowNode.hasMultipleScopes || flowNode.hasSingleScope;
+        } else {
+          return flowNode.hasSingleScope && !flowNode.hasMultipleScopes;
+        }
+      }
+
+      // Moving token is allowed for 1 scope
+      if (flowNode.hasSingleScope) {
+        return true;
+      }
+
+      // Moving multiple tokens to another element inside the multi-instance is not allowed
+      if (isMoveAllOperation) {
+        return false;
+      }
+
+      // Moving to/from different multi-instance parents is not allowed
+      if (sourceMultiInstanceParent !== flowNode.firstMultiInstanceParent) {
+        return false;
       }
 
       return true;

--- a/operate/client/src/modules/mocks/diagrams/subprocessInsideMultiInstance.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/subprocessInsideMultiInstance.bpmn
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0xcnckm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1k58pkt" isExecutable="true">
+    <bpmn:startEvent id="Event_1wsph46">
+      <bpmn:outgoing>Flow_1g2hwek</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="Activity_1beeu50" name="sub 1">
+      <bpmn:incoming>Flow_0ina3j0</bpmn:incoming>
+      <bpmn:outgoing>Flow_1r9z39r</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=instances" inputElement="instance" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_09rgese">
+        <bpmn:outgoing>Flow_1uu2qfw</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1uu2qfw" sourceRef="Event_09rgese" targetRef="sub-2" />
+      <bpmn:subProcess id="sub-2" name="sub 2">
+        <bpmn:incoming>Flow_1uu2qfw</bpmn:incoming>
+        <bpmn:outgoing>Flow_1ogyhc1</bpmn:outgoing>
+        <bpmn:startEvent id="Event_0vms1jk">
+          <bpmn:outgoing>Flow_1so9zyt</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1so9zyt" sourceRef="Event_0vms1jk" targetRef="task-1" />
+        <bpmn:endEvent id="Event_0pgre0v">
+          <bpmn:incoming>Flow_16drsk0</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_0kckok3" sourceRef="task-1" targetRef="task-2" />
+        <bpmn:userTask id="task-1" name="task 1">
+          <bpmn:extensionElements>
+            <zeebe:userTask />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1so9zyt</bpmn:incoming>
+          <bpmn:outgoing>Flow_0kckok3</bpmn:outgoing>
+        </bpmn:userTask>
+        <bpmn:task id="task-2" name="task 2">
+          <bpmn:incoming>Flow_0kckok3</bpmn:incoming>
+          <bpmn:outgoing>Flow_16drsk0</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_16drsk0" sourceRef="task-2" targetRef="Event_0pgre0v" />
+      </bpmn:subProcess>
+      <bpmn:userTask id="task-3" name="task 3">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1ogyhc1</bpmn:incoming>
+        <bpmn:outgoing>Flow_0mb8d20</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_1ogyhc1" sourceRef="sub-2" targetRef="task-3" />
+      <bpmn:endEvent id="Event_004cqzz">
+        <bpmn:incoming>Flow_0mb8d20</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0mb8d20" sourceRef="task-3" targetRef="Event_004cqzz" />
+    </bpmn:subProcess>
+    <bpmn:scriptTask id="Activity_0u5h69x" name="Task 0">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=[1, 2, 3]" target="instances" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=[1,2,3]" resultVariable="instances" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1g2hwek</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ina3j0</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:userTask id="task-4" name="task 4">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1r9z39r</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c3cehu</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1areiof">
+      <bpmn:incoming>Flow_0c3cehu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1g2hwek" sourceRef="Event_1wsph46" targetRef="Activity_0u5h69x" />
+    <bpmn:sequenceFlow id="Flow_0ina3j0" sourceRef="Activity_0u5h69x" targetRef="Activity_1beeu50" />
+    <bpmn:sequenceFlow id="Flow_0c3cehu" sourceRef="task-4" targetRef="Event_1areiof" />
+    <bpmn:sequenceFlow id="Flow_1r9z39r" sourceRef="Activity_1beeu50" targetRef="task-4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1k58pkt">
+      <bpmndi:BPMNShape id="Activity_1cfekr8_di" bpmnElement="Activity_0u5h69x">
+        <dc:Bounds x="240" y="195" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwq2in" bpmnElement="Event_1wsph46">
+        <dc:Bounds x="152" y="217" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13g5s8s" bpmnElement="task-4">
+        <dc:Bounds x="1350" y="195" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1areiof_di" bpmnElement="Event_1areiof">
+        <dc:Bounds x="1502" y="217" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hp2oem_di" bpmnElement="Activity_1beeu50" isExpanded="true">
+        <dc:Bounds x="390" y="80" width="900" height="310" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02bet53" bpmnElement="Event_09rgese">
+        <dc:Bounds x="422" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_004cqzz_di" bpmnElement="Event_004cqzz">
+        <dc:Bounds x="1222" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0pnqimo" bpmnElement="task-3">
+        <dc:Bounds x="1090" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d6t921_di" bpmnElement="sub-2" isExpanded="true">
+        <dc:Bounds x="520" y="140" width="530" height="180" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vms1jk_di" bpmnElement="Event_0vms1jk">
+        <dc:Bounds x="560.3333333333333" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s9mn4h_di" bpmnElement="task-1">
+        <dc:Bounds x="650" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1uyxisf_di" bpmnElement="task-2">
+        <dc:Bounds x="820" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pgre0v_di" bpmnElement="Event_0pgre0v">
+        <dc:Bounds x="992" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1so9zyt_di" bpmnElement="Flow_1so9zyt">
+        <di:waypoint x="596" y="230" />
+        <di:waypoint x="650" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kckok3_di" bpmnElement="Flow_0kckok3">
+        <di:waypoint x="750" y="230" />
+        <di:waypoint x="820" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16drsk0_di" bpmnElement="Flow_16drsk0">
+        <di:waypoint x="920" y="230" />
+        <di:waypoint x="992" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uu2qfw_di" bpmnElement="Flow_1uu2qfw">
+        <di:waypoint x="458" y="230" />
+        <di:waypoint x="520" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mb8d20_di" bpmnElement="Flow_0mb8d20">
+        <di:waypoint x="1190" y="230" />
+        <di:waypoint x="1222" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ogyhc1_di" bpmnElement="Flow_1ogyhc1">
+        <di:waypoint x="1050" y="230" />
+        <di:waypoint x="1090" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ina3j0_di" bpmnElement="Flow_0ina3j0">
+        <di:waypoint x="340" y="235" />
+        <di:waypoint x="390" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1r9z39r_di" bpmnElement="Flow_1r9z39r">
+        <di:waypoint x="1290" y="235" />
+        <di:waypoint x="1350" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g2hwek_di" bpmnElement="Flow_1g2hwek">
+        <di:waypoint x="188" y="235" />
+        <di:waypoint x="240" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c3cehu_di" bpmnElement="Flow_0c3cehu">
+        <di:waypoint x="1450" y="235" />
+        <di:waypoint x="1502" y="235" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -87,6 +87,7 @@ type State = {
     | 'enabled'
     | 'adding-token'
     | 'moving-token'
+    | 'requires-ancestor-selection'
     | 'disabled'
     | 'applying-modifications';
   modifications: Modification[];
@@ -215,6 +216,19 @@ class Modifications {
     this.state.sourceFlowNodeIdForMoveOperation = sourceFlowNodeId;
   };
 
+  setAncestorFlowNodeKeyForMoveOperation = (ancestorElement: {
+    instanceKey: string;
+    flowNodeId: string;
+  }) => {
+    const lastModification =
+      this.state.modifications[this.state.modifications.length - 1];
+
+    if (lastModification.payload.operation === 'MOVE_TOKEN') {
+      lastModification.payload.ancestorElement = ancestorElement;
+      modificationsStore.setStatus('enabled');
+    }
+  };
+
   setSourceFlowNodeInstanceKeyForMoveOperation = (
     sourceFlowNodeInstanceKey: string | null,
   ) => {
@@ -312,6 +326,13 @@ class Modifications {
 
   get isModificationModeEnabled() {
     return !['disabled', 'applying-modifications'].includes(this.state.status);
+  }
+
+  get isMoveAllOperation() {
+    return (
+      this.state.status === 'moving-token' &&
+      this.state.sourceFlowNodeInstanceKeyForMoveOperation === null
+    );
   }
 
   get lastModification() {
@@ -512,6 +533,7 @@ class Modifications {
             ...(payload.flowNodeInstanceKey === undefined
               ? {fromFlowNodeId: flowNode.id}
               : {fromFlowNodeInstanceKey: payload.flowNodeInstanceKey}),
+            ancestorElementInstanceKey: payload.ancestorElement?.instanceKey,
             toFlowNodeId: targetFlowNode.id,
             newTokensCount: scopeIds.length,
             variables:

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -34,6 +34,7 @@ const finishMovingToken = (
   businessObjects: BusinessObjects,
   bpmnProcessId?: string,
   targetFlowNodeId?: string,
+  ancestorSelectionRequired?: boolean,
 ) => {
   tracking.track({
     eventName: 'move-token',
@@ -71,7 +72,11 @@ const finishMovingToken = (
     });
   }
 
-  modificationsStore.setStatus('enabled');
+  if (ancestorSelectionRequired) {
+    modificationsStore.setStatus('requires-ancestor-selection');
+  } else {
+    modificationsStore.setStatus('enabled');
+  }
   modificationsStore.setSourceFlowNodeIdForMoveOperation(null);
   modificationsStore.setSourceFlowNodeInstanceKeyForMoveOperation(null);
 };


### PR DESCRIPTION
## Description

This PR adds support for move modifications in multi-instance scenarios within the Operate client. Previously, moving tokens within multi-instance subprocesses was restricted, but this change enables users to move tokens to flow nodes that have multiple parent scopes by introducing an ancestor selection step.

Key changes:
- Introduced a new `requires-ancestor-selection` status for the modifications flow
- Added `ancestorElement` support to move token operations to specify the parent scope
- Updated UI logic to detect when ancestor selection is required and guide users through the process
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41514, #41519
