### PR TITLE
[Backport stable/8.8] Add missing record test runtime instruction

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -60,6 +61,7 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProperty.getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
@@ -35,8 +35,9 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return bufferAsString(elementIdProperty.getValue());
   }
 
-  public void setElementId(final String interruptingElementId) {
+  public RuntimeInstructionRecord setElementId(final String interruptingElementId) {
     elementIdProperty.setValue(interruptingElementId);
+    return this;
   }
 
   @Override
@@ -44,8 +45,9 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return processInstanceKeyProperty.getValue();
   }
 
-  public void setProcessInstanceKey(final long processInstanceKey) {
+  public RuntimeInstructionRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
   }
 
   @Override
@@ -53,8 +55,9 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
     return bufferAsString(tenantIdProperty.getValue());
   }
 
-  public void setTenantId(final String tenantId) {
+  public RuntimeInstructionRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
   }
 
   public DirectBuffer getElementIdBuffer() {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3649,7 +3649,6 @@ final class JsonSerializableToJsonTest {
         """
       {
         "tenantId": "tenant_1",
-        "elementIdBuffer": {"expandable": false},
         "elementId": "element_1",
         "processInstanceKey": 12345
       }
@@ -3664,7 +3663,6 @@ final class JsonSerializableToJsonTest {
         """
       {
         "tenantId": "",
-        "elementIdBuffer": {"expandable": false},
         "elementId": "",
         "processInstanceKey": -1
       }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -68,6 +68,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
@@ -3634,6 +3635,41 @@ final class JsonSerializableToJsonTest {
       }
       """
       },
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////// RuntimeInstructionRecord ////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "RuntimeInstructionRecord",
+        (Supplier<RuntimeInstructionRecord>)
+            () ->
+                new RuntimeInstructionRecord()
+                    .setProcessInstanceKey(12345L)
+                    .setTenantId("tenant_1")
+                    .setElementId("element_1"),
+        """
+      {
+        "tenantId": "tenant_1",
+        "elementIdBuffer": {"expandable": false},
+        "elementId": "element_1",
+        "processInstanceKey": 12345
+      }
+      """
+      },
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty RuntimeInstructionRecord ///////////////////////////
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty RuntimeInstructionRecord",
+        (Supplier<RuntimeInstructionRecord>) RuntimeInstructionRecord::new,
+        """
+      {
+        "tenantId": "",
+        "elementIdBuffer": {"expandable": false},
+        "elementId": "",
+        "processInstanceKey": -1
+      }
+      """
+      }
     };
   }
 


### PR DESCRIPTION
# Description
Backport of #41625 to `stable/8.8`.

relates to 