### PR TITLE
[Backport stable/8.8] test: skip tasklist task details E2E test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -630,7 +630,9 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
   });
 
-  test('task completion with large variable form @v2-only', async ({
+  // TODO issue #41614
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip('task completion with large variable form @v2-only', async ({
     taskPanelPage,
     page,
   }) => {


### PR DESCRIPTION
# Description
Backport of #41616 to `stable/8.8`.

relates to camunda/camunda#41614