### PR TITLE
Add auth type and url to identity-e2e

### DIFF
--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -132,6 +132,9 @@ jobs:
           CORE_APPLICATION_URL: http://localhost:8080
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
         run: npm run test -- --project=identity-e2e
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -130,6 +130,8 @@ jobs:
         env:
           LOCAL_TEST: "false"
           CORE_APPLICATION_URL: http://localhost:8080
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
         run: npm run test -- --project=identity-e2e
       - uses: actions/upload-artifact@v4

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -108,7 +108,7 @@ test.describe.serial('groups CRUD', () => {
         await page.goto(relativizePath(Paths.groups()));
         await Promise.race([
           identityGroupsPage.groupsList.waitFor({timeout: 15000}),
-          identityGroupsPage.emptyStateLocator.waitFor({timeout: 15000}),
+          identityGroupsPage.emptyStateLocator.waitFor({timeout: 20000}),
         ]);
       },
     });


### PR DESCRIPTION
## Description

These two values need to be filled for c8 client. Added the the workflows.
```
CAMUNDA_AUTH_STRATEGY: "BASIC"
ZEEBE_REST_ADDRESS: "http://localhost:8080"
```

Successful identity e2e run: https://github.com/camunda/camunda/actions/runs/19759947868/job/56619294757?pr=41737

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
