### PR TITLE
fix: use ImmutableMap in HealthReport to avoid ConcurrentModificationException

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetricsTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetricsTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.util.health.HealthStatus;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AutoClose;
@@ -118,8 +118,7 @@ public class HealthTreeMetricsTest {
 
     @Override
     public HealthReport getHealthReport() {
-      return report.orElse(
-          new HealthReport(name, HealthStatus.HEALTHY, null, Collections.emptyMap()));
+      return report.orElse(new HealthReport(name, HealthStatus.HEALTHY, null, ImmutableMap.of()));
     }
 
     @Override

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -79,6 +79,11 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
     </dependency>

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/health/HealthReportTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/health/HealthReportTest.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.util.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class HealthReportTest {
@@ -18,15 +18,15 @@ public class HealthReportTest {
   @Test
   public void shouldReportWorstHealthStatusFromChildren() {
     final var children =
-        Map.of(
+        ImmutableMap.of(
             "a",
-            new HealthReport("a", HealthStatus.HEALTHY, null, Map.of()),
+            new HealthReport("a", HealthStatus.HEALTHY, null, ImmutableMap.of()),
             "b",
             new HealthReport(
                 "b",
                 HealthStatus.UNHEALTHY,
                 new HealthIssue("storage is full", null, null, Instant.ofEpochMilli(19201223L)),
-                Map.of()));
+                ImmutableMap.of()));
     final var root = HealthReport.fromChildrenStatus("root", children);
 
     final var expected =


### PR DESCRIPTION


## Description
Previously the children Map in HealthReport was wrapped with Collection.unmodifiableMap, but this does not mean that the original map could not be modified by the previous owner.
Using ImmutableMap we can be sure that such error will not be raised in HealthReport

I didn't add any guava related jackson module as I think it's able to serialize the `ImmutableMap` without problems.
I think errors might be raised if we try to deserialize it,  so no build dependencies have been changed. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

