### PR TITLE
Add newMappingRulesByTenantSearchRequest to Java Client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -145,6 +145,7 @@ import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequ
 import io.camunda.client.api.search.request.JobSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesByGroupSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesByRoleSearchRequest;
+import io.camunda.client.api.search.request.MappingRulesByTenantSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesSearchRequest;
 import io.camunda.client.api.search.request.MessageSubscriptionSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
@@ -2823,6 +2824,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the mapping rules by role search request
    */
   MappingRulesByRoleSearchRequest newMappingRulesByRoleSearchRequest(String roleId);
+
+  /**
+   * Executes a search request to query mapping rules by tenant.
+   *
+   * <pre>
+   * camundaClient
+   *  .newMappingRulesByTenantSearchRequest("tenantId")
+   *  .filter((f) -> f.mappingRuleId("mapping-rule-123"))
+   *  .sort((s) -> s.mappingRuleId().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @param tenantId the ID of the tenant
+   * @return a builder for the mapping rules by tenant search request
+   */
+  MappingRulesByTenantSearchRequest newMappingRulesByTenantSearchRequest(String tenantId);
 
   /**
    * Executes a search request to query mapping rules.

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/MappingRulesByTenantSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/MappingRulesByTenantSearchRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.MappingRuleFilter;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.client.api.search.sort.MappingRuleSort;
+
+public interface MappingRulesByTenantSearchRequest
+    extends TypedSearchRequest<
+            MappingRuleFilter, MappingRuleSort, MappingRulesByTenantSearchRequest>,
+        FinalSearchRequestStep<MappingRule> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -156,6 +156,7 @@ import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequ
 import io.camunda.client.api.search.request.JobSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesByGroupSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesByRoleSearchRequest;
+import io.camunda.client.api.search.request.MappingRulesByTenantSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesSearchRequest;
 import io.camunda.client.api.search.request.MessageSubscriptionSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
@@ -305,6 +306,7 @@ import io.camunda.client.impl.search.request.IncidentsByProcessInstanceSearchReq
 import io.camunda.client.impl.search.request.JobSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingRulesByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingRulesByRoleSearchRequestImpl;
+import io.camunda.client.impl.search.request.MappingRulesByTenantSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingRulesSearchRequestImpl;
 import io.camunda.client.impl.search.request.MessageSubscriptionSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessDefinitionSearchRequestImpl;
@@ -1436,6 +1438,12 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public MappingRulesByRoleSearchRequest newMappingRulesByRoleSearchRequest(final String roleId) {
     return new MappingRulesByRoleSearchRequestImpl(httpClient, jsonMapper, roleId);
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest newMappingRulesByTenantSearchRequest(
+      final String tenantId) {
+    return new MappingRulesByTenantSearchRequestImpl(httpClient, jsonMapper, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingRulesByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingRulesByTenantSearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.mappingRuleFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.mappingRuleSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.MappingRuleFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.MappingRulesByTenantSearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.MappingRuleSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryRequest;
+import io.camunda.client.protocol.rest.MappingRuleSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class MappingRulesByTenantSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<MappingRuleSearchQueryRequest>
+    implements MappingRulesByTenantSearchRequest {
+
+  private final MappingRuleSearchQueryRequest request;
+  private final String tenantId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public MappingRulesByTenantSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String tenantId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.tenantId = tenantId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new MappingRuleSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<MappingRule> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<MappingRule>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    final HttpCamundaFuture<SearchResponse<MappingRule>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/tenants/%s/mapping-rules/search", tenantId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        MappingRuleSearchQueryResult.class,
+        SearchResponseMapper::toMappingRulesResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest filter(final MappingRuleFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest filter(final Consumer<MappingRuleFilter> fn) {
+    return filter(mappingRuleFilter(fn));
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest sort(final MappingRuleSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toMappingRuleSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest sort(final Consumer<MappingRuleSort> fn) {
+    return sort(mappingRuleSort(fn));
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public MappingRulesByTenantSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected MappingRuleSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/role/MappingRulesByTenantSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/MappingRulesByTenantSearchRequestTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.role;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class MappingRulesByTenantSearchRequestTest extends ClientRestTest {
+
+  @Test
+  void shouldSendSearchRequest() {
+    // given
+    final String tenantId = "testId";
+
+    // when
+    client.newMappingRulesByTenantSearchRequest(tenantId).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .startsWith(REST_API_PATH + "/tenants/" + tenantId + "/mapping-rules/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldFailOnNullOrEmpty(final String tenantId) {
+    // when / then
+    assertThatThrownBy(() -> client.newMappingRulesByTenantSearchRequest(tenantId).send().join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/MappingRulesByTenantSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/MappingRulesByTenantSearchRequestTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.role;
+package io.camunda.client.tenant;
 
 import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesByTenantSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesByTenantSearchIT.java
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesByTenantSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesByTenantSearchIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class MappingRulesByTenantSearchIT {
+
+  private static CamundaClient camundaClient;
+
+  private static final String MAPPING_RULE_ID_1 = "a" + Strings.newRandomValidUsername();
+  private static final String MAPPING_RULE_ID_2 = "b" + Strings.newRandomValidUsername();
+  private static final String MAPPING_RULE_ID_3 = "c" + Strings.newRandomValidUsername();
+  private static final String TENANT_ID = Strings.newRandomValidTenantId();
+
+  @BeforeAll
+  static void setup() {
+    createMappingRule(MAPPING_RULE_ID_1);
+    createMappingRule(MAPPING_RULE_ID_2);
+    createMappingRule(MAPPING_RULE_ID_3);
+
+    createTenant(TENANT_ID);
+
+    assignMappingRuleToTenant(MAPPING_RULE_ID_1, TENANT_ID);
+    assignMappingRuleToTenant(MAPPING_RULE_ID_2, TENANT_ID);
+
+    waitForFixturesToBeExported();
+  }
+
+  @Test
+  void shouldReturnMappingRulesByTenant() {
+    // when
+    final var mappingRules =
+        camundaClient.newMappingRulesByTenantSearchRequest(TENANT_ID).send().join();
+
+    // then
+    assertThat(mappingRules.items())
+        .hasSize(2)
+        .extracting(
+            MappingRule::getMappingRuleId,
+            MappingRule::getClaimName,
+            MappingRule::getClaimValue,
+            MappingRule::getName)
+        .contains(
+            tuple(
+                MAPPING_RULE_ID_1,
+                MAPPING_RULE_ID_1 + "claimName",
+                MAPPING_RULE_ID_1 + "claimValue",
+                "name"),
+            tuple(
+                MAPPING_RULE_ID_2,
+                MAPPING_RULE_ID_2 + "claimName",
+                MAPPING_RULE_ID_2 + "claimValue",
+                "name"));
+  }
+
+  @Test
+  void shouldReturnMappingRulesByTenantFiltered() {
+    // when
+    final var mappingRules =
+        camundaClient
+            .newMappingRulesByTenantSearchRequest(TENANT_ID)
+            .filter(fn -> fn.mappingRuleId(MAPPING_RULE_ID_1))
+            .send()
+            .join();
+
+    // then
+    assertThat(mappingRules.items())
+        .hasSize(1)
+        .extracting(MappingRule::getMappingRuleId)
+        .containsExactly(MAPPING_RULE_ID_1);
+  }
+
+  @Test
+  void shouldReturnMappingRuleByTenantSorted() {
+    // when
+    final var mappingRules =
+        camundaClient
+            .newMappingRulesByTenantSearchRequest(TENANT_ID)
+            .sort(fn -> fn.mappingRuleId().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(mappingRules.items())
+        .hasSize(2)
+        .extracting(MappingRule::getMappingRuleId)
+        .containsExactly(MAPPING_RULE_ID_2, MAPPING_RULE_ID_1);
+  }
+
+  private static void createMappingRule(final String mappingRuleId) {
+    camundaClient
+        .newCreateMappingRuleCommand()
+        .mappingRuleId(mappingRuleId)
+        .name("name")
+        .claimName(mappingRuleId + "claimName")
+        .claimValue(mappingRuleId + "claimValue")
+        .send()
+        .join();
+  }
+
+  private static void createTenant(final String tenantId) {
+    camundaClient.newCreateTenantCommand().tenantId(tenantId).name("name").send().join();
+  }
+
+  private static void assignMappingRuleToTenant(final String mappingRuleId, final String tenantId) {
+    camundaClient
+        .newAssignMappingRuleToTenantCommand()
+        .mappingRuleId(mappingRuleId)
+        .tenantId(tenantId)
+        .send()
+        .join();
+  }
+
+  private static void waitForFixturesToBeExported() {
+    Awaitility.await("tenant and mapping rule should be visible in secondary storage")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final Future<SearchResponse<MappingRule>> response =
+                  camundaClient.newMappingRulesByTenantSearchRequest(TENANT_ID).send();
+
+              assertThat(response)
+                  .succeedsWithin(Duration.ofSeconds(10))
+                  .extracting(
+                      SearchResponse::items, InstanceOfAssertFactories.list(MappingRule.class))
+                  .hasSize(2);
+            });
+  }
+}


### PR DESCRIPTION
## Description

This PR completes full coverage of the Java client for Identity APIs by adding the `newMappingRulesByTenantSearchRequest` API.

## Related issues

closes #35821
