### PR TITLE
fix: Tasklist complete task persist task variables in an undefined manner

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskCompletionConcurrencyIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskCompletionConcurrencyIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.api.rest.v1.controllers;
+
+import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.entities.TaskEntity;
+import io.camunda.tasklist.entities.TaskState;
+import io.camunda.tasklist.store.VariableStore;
+import io.camunda.tasklist.util.MockMvcHelper;
+import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskCompleteRequest;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskResponse;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.VariableSearchResponse;
+import io.camunda.tasklist.webapp.graphql.entity.VariableInputDTO;
+import io.camunda.tasklist.webapp.security.TasklistURIs;
+import io.camunda.tasklist.webapp.security.tenant.TenantService;
+import io.camunda.tasklist.webapp.service.TasklistServicesAdapter;
+import io.camunda.tasklist.webapp.service.ZeebeClientBasedAdapter;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@Import(TaskCompletionConcurrencyIT.ConcurrencyTestConfiguration.class)
+public class TaskCompletionConcurrencyIT extends TasklistZeebeIntegrationTest {
+
+  @Autowired private VariableStore variableStore;
+
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  private MockMvcHelper mockMvcHelper;
+
+  @BeforeEach
+  public void setUp() {
+    mockMvcHelper =
+        new MockMvcHelper(MockMvcBuilders.webAppContextSetup(context).build(), objectMapper);
+    // Reset the latch before the test
+    ConcurrencyTestConfiguration.completionLatch = new CountDownLatch(1);
+  }
+
+  /**
+   * Test to reproduce concurrency issues when completing tasks with variables. This test runs the
+   * task completion asynchronously while allowing the importer to run in parallel, testing for race
+   * conditions in variable persistence.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void completeTaskWithVariablesConcurrentlyWithImporter(final boolean useZeebeUserTasks)
+      throws Exception {
+    // given
+    final String bpmnProcessId = "simpleTestProcess";
+    final String flowNodeBpmnId = "taskE_".concat(UUID.randomUUID().toString());
+
+    final String taskId =
+        tester
+            .createAndDeploySimpleProcess(
+                bpmnProcessId,
+                flowNodeBpmnId,
+                useZeebeUserTasks ? AbstractUserTaskBuilder::zeebeUserTask : (ignored) -> {},
+                task -> task.zeebeAssignee(DEFAULT_USER_ID))
+            .processIsDeployed()
+            .then()
+            .startProcessInstance(bpmnProcessId, "{\"process_var_0\": 0, \"process_var_1\": 1}")
+            .then()
+            .taskIsCreated(flowNodeBpmnId)
+            .getTaskId();
+
+    final var completeRequest =
+        new TaskCompleteRequest()
+            .setVariables(
+                List.of(
+                    new VariableInputDTO().setName("process_var_1").setValue("11"),
+                    new VariableInputDTO().setName("task_var_2").setValue("22")));
+
+    // when - run completion asynchronously to simulate concurrency
+    final SecurityContext securityContext = SecurityContextHolder.getContext();
+    final CompletableFuture<MockHttpServletResponse> asyncResult =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                SecurityContextHolder.setContext(securityContext);
+                return mockMvcHelper.doRequest(
+                    patch(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/complete"), taskId),
+                    completeRequest);
+              } finally {
+                SecurityContextHolder.clearContext();
+              }
+            });
+
+    // Allow the process instance to complete in Zeebe while task completion is waiting
+    // This simulates the race condition where variables are being persisted while
+    // the flow node is already terminated
+    tester.processInstanceIsCompleted();
+    // Now signal the adapter to finish task completion
+    ConcurrencyTestConfiguration.completionLatch.countDown();
+
+    // then - verify the async completion was successful
+    assertThat(asyncResult.get())
+        .hasOkHttpStatus()
+        .hasApplicationJsonContentType()
+        .extractingContent(objectMapper, TaskResponse.class)
+        .satisfies(
+            task -> {
+              assertThat(task.getId()).isEqualTo(taskId);
+              assertThat(task.getAssignee()).isEqualTo(DEFAULT_USER_ID);
+              assertThat(task.getTaskState()).isEqualTo(TaskState.COMPLETED);
+              assertThat(task.getCreationDate()).isNotNull();
+              assertThat(task.getCompletionDate()).isNotNull();
+            });
+
+    // when - fetch task variables via search API
+    final var result =
+        mockMvcHelper.doRequest(
+            post(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/variables/search"), taskId));
+
+    // then
+    assertThat(result)
+        .hasOkHttpStatus()
+        .hasApplicationJsonContentType()
+        .extractingListContent(objectMapper, VariableSearchResponse.class)
+        .extracting("name", "value", "previewValue")
+        .containsExactlyInAnyOrder(
+            tuple("process_var_0", "0", "0"),
+            tuple("process_var_1", "11", "11"),
+            tuple("task_var_2", "22", "22"));
+  }
+
+  /**
+   * Test configuration for custom TasklistServicesAdapter to reproduce concurrency with importer
+   * issues
+   */
+  @TestConfiguration
+  static class ConcurrencyTestConfiguration {
+
+    static volatile CountDownLatch completionLatch = new CountDownLatch(1);
+
+    @Bean
+    @Primary
+    public TasklistServicesAdapter concurrencyTestAdapter(
+        @Qualifier("tasklistZeebeClient") final ZeebeClient zeebeClient,
+        final TenantService tenantService) {
+      /** Custom adapter that waits on a latch after completing a task */
+      return new ZeebeClientBasedAdapter(zeebeClient, tenantService) {
+        @Override
+        public void completeUserTask(final TaskEntity task, final Map<String, Object> variables) {
+          // Call the parent implementation to complete the task
+          super.completeUserTask(task, variables);
+          // Wait for the test to signal that it's ready to proceed
+          try {
+            completionLatch.await(30, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for test synchronization", e);
+          }
+        }
+      };
+    }
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
@@ -88,7 +88,7 @@ public class VariableService {
       }
 
       final Map<String, VariableEntity> currentOriginalVariables = new HashMap<>();
-      getRuntimeVariablesByRequest(GetVariablesRequest.createFrom(task))
+      getTaskRuntimeVariables(task)
           .forEach(originalVar -> currentOriginalVariables.put(originalVar.getName(), originalVar));
 
       final int variableSizeThreshold = tasklistProperties.getImporter().getVariableSizeThreshold();
@@ -145,17 +145,14 @@ public class VariableService {
   public void persistTaskVariables(
       final String taskId,
       final List<VariableInputDTO> changedVariables,
+      final List<VariableEntity> runtimeVariables,
       final boolean withDraftVariableValues,
       final String processInstanceKey) {
     // take current runtime variables values and
     final TaskEntity task = taskStore.getTask(taskId);
-    final String taskFlowNodeInstanceId = task.getFlowNodeInstanceId();
-
-    final List<VariableEntity> taskVariables =
-        getRuntimeVariablesByRequest(GetVariablesRequest.createFrom(task));
 
     final Map<String, TaskVariableEntity> finalVariablesMap = new HashMap<>();
-    taskVariables.forEach(
+    runtimeVariables.forEach(
         variable ->
             finalVariablesMap.put(
                 variable.getName(),
@@ -193,11 +190,9 @@ public class VariableService {
     draftVariableStore.deleteAllByTaskId(taskId);
   }
 
-  private List<VariableEntity> getRuntimeVariablesByRequest(
-      final GetVariablesRequest getVariablesRequest) {
-    final List<GetVariablesRequest> requests = Collections.singletonList(getVariablesRequest);
+  public List<VariableEntity> getTaskRuntimeVariables(final TaskEntity task) {
     final Map<String, List<VariableEntity>> runtimeVariablesPerTaskId =
-        getRuntimeVariablesPerTaskId(requests);
+        getRuntimeVariablesPerTaskId(List.of(GetVariablesRequest.createFrom(task)));
     if (runtimeVariablesPerTaskId.size() > 0) {
       return runtimeVariablesPerTaskId.values().iterator().next();
     } else {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -27,6 +27,7 @@ import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.entities.TaskEntity;
 import io.camunda.tasklist.entities.TaskImplementation;
 import io.camunda.tasklist.entities.TaskState;
+import io.camunda.tasklist.entities.VariableEntity;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.FeatureFlagProperties;
@@ -426,6 +427,8 @@ class TaskServiceTest {
             .setAssignee("demo")
             .setCompletionTime(OffsetDateTime.now());
     when(taskStore.persistTaskCompletion(taskBefore)).thenReturn(completedTask);
+    final var runtimeVariable = new VariableEntity().setName("b").setValue("2");
+    when(variableService.getTaskRuntimeVariables(taskBefore)).thenReturn(List.of(runtimeVariable));
 
     // When
     final var result = instance.completeTask(taskId, variables, true);
@@ -434,7 +437,8 @@ class TaskServiceTest {
     verify(taskValidator).validateCanComplete(taskBefore);
     verify(tasklistServicesAdapter).completeUserTask(eq(taskBefore), any());
     verify(variableService)
-        .persistTaskVariables(taskId, variables, true, taskBefore.getProcessInstanceId());
+        .persistTaskVariables(
+            taskId, variables, List.of(runtimeVariable), true, taskBefore.getProcessInstanceId());
     verify(variableService).deleteDraftTaskVariables(taskId);
     assertThat(result).isEqualTo(TaskDTO.createFrom(completedTask, objectMapper));
   }
@@ -444,7 +448,6 @@ class TaskServiceTest {
     // Given
     final var taskId = "123";
     final var variables = List.of(new VariableInputDTO().setName("a").setValue("1"));
-    final Map<String, Object> variablesMap = Map.of("a", 1);
 
     final var mockedUser = mock(UserDTO.class);
     when(userReader.getCurrentUser()).thenReturn(mockedUser);
@@ -459,6 +462,8 @@ class TaskServiceTest {
             .setProcessInstanceId("1234")
             .setCompletionTime(OffsetDateTime.now());
     when(taskStore.persistTaskCompletion(taskBefore)).thenReturn(completedTask);
+    final var runtimeVariable = new VariableEntity().setName("b").setValue("2");
+    when(variableService.getTaskRuntimeVariables(taskBefore)).thenReturn(List.of(runtimeVariable));
 
     // When
     final var result = instance.completeTask(taskId, variables, true);
@@ -467,7 +472,8 @@ class TaskServiceTest {
     verify(taskValidator).validateCanComplete(taskBefore);
     verify(tasklistServicesAdapter).completeUserTask(eq(taskBefore), any());
     verify(variableService)
-        .persistTaskVariables(taskId, variables, true, taskBefore.getProcessInstanceId());
+        .persistTaskVariables(
+            taskId, variables, List.of(runtimeVariable), true, taskBefore.getProcessInstanceId());
     verify(variableService).deleteDraftTaskVariables(taskId);
     assertThat(result).isEqualTo(TaskDTO.createFrom(completedTask, objectMapper));
   }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
@@ -503,6 +503,7 @@ class VariableServiceTest {
         List.of(
             new VariableInputDTO().setName("varB").setValue("\"changedB\""),
             new VariableInputDTO().setName("varC").setValue("\"changedC\"")),
+        instance.getTaskRuntimeVariables(task),
         false,
         task.getProcessInstanceId());
 
@@ -569,6 +570,7 @@ class VariableServiceTest {
                 .setName("varD")
                 .setValue("\"changedD_longValueThatExceedLimit\""),
             new VariableInputDTO().setName("varE").setValue("\"changedE\"")),
+        instance.getTaskRuntimeVariables(task),
         true,
         task.getProcessInstanceId());
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes a concurrency issue where the importer updates the FNIs from ACTIVE to TERMINATED before Task V1 complete flow fetches the runtime variables to store them as a snapshot for the completed task. This make the fetched variables missing some of process variables.
Fetches the task runtime variables before sending the completion command to Zeebe.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40817 
