### PR TITLE
feat: add distribution to unified configuration

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -93,6 +93,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/configuration/src/main/java/io/camunda/configuration/Distribution.java
+++ b/configuration/src/main/java/io/camunda/configuration/Distribution.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class Distribution {
+  private static final String PREFIX = "camunda.processing.engine.distribution";
+
+  private static final Set<String> LEGACY_MAX_BACKOFF_DURATION_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.distribution.maxBackoffDuration");
+  private static final Set<String> LEGACY_REDISTRIBUTION_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.distribution.redistributionInterval");
+
+  /**
+   * Allows configuring the maximum backoff duration for command redistribution retries. The retry
+   * interval is doubled after each retry until it reaches this maximum duration.
+   */
+  private Duration maxBackoffDuration = DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
+
+  /**
+   * Allows configuring command redistribution retry interval. This is the initial interval used
+   * when retrying command distributions that have not been acknowledged.
+   */
+  private Duration redistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
+
+  public Duration getMaxBackoffDuration() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-backoff-duration",
+        maxBackoffDuration,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_BACKOFF_DURATION_PROPERTIES);
+  }
+
+  public void setMaxBackoffDuration(final Duration maxBackoffDuration) {
+    this.maxBackoffDuration = maxBackoffDuration;
+  }
+
+  public Duration getRedistributionInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".redistribution-interval",
+        redistributionInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_REDISTRIBUTION_INTERVAL_PROPERTIES);
+  }
+
+  public void setRedistributionInterval(final Duration redistributionInterval) {
+    this.redistributionInterval = redistributionInterval;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class Engine {
+
+  /** Configuration properties for the engine's distribution settings. */
+  @NestedConfigurationProperty private Distribution distribution = new Distribution();
+
+  public Distribution getDistribution() {
+    return distribution;
+  }
+
+  public void setDistribution(final Distribution distribution) {
+    this.distribution = distribution;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Processing.java
+++ b/configuration/src/main/java/io/camunda/configuration/Processing.java
@@ -60,6 +60,9 @@ public class Processing {
    */
   @NestedConfigurationProperty FlowControl flowControl = new FlowControl();
 
+  /** Configuration properties for the engine. */
+  @NestedConfigurationProperty Engine engine = new Engine();
+
   /**
    * Sets the maximum number of commands that processed within one batch. The processor will process
    * until no more follow up commands are created by the initial command or the configured limit is
@@ -214,6 +217,14 @@ public class Processing {
 
   public void setSkipPositions(final Set<Long> skipPositions) {
     this.skipPositions = skipPositions;
+  }
+
+  public Engine getEngine() {
+    return engine;
+  }
+
+  public void setEngine(final Engine engine) {
+    this.engine = engine;
   }
 
   public boolean isEnablePreconditionsCheck() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -188,6 +188,21 @@ public class BrokerBasedPropertiesOverride {
         .getExperimental()
         .getFeatures()
         .setEnableMessageBodyOnExpired(processing.isEnableMessageBodyOnExpired());
+
+    populateFromEngine(override);
+  }
+
+  private void populateFromEngine(final BrokerBasedProperties override) {
+    populateFromDistribution(override);
+  }
+
+  private void populateFromDistribution(final BrokerBasedProperties override) {
+    final var distribution =
+        unifiedConfiguration.getCamunda().getProcessing().getEngine().getDistribution();
+
+    final var distributionCfg = override.getExperimental().getEngine().getDistribution();
+    distributionCfg.setMaxBackoffDuration(distribution.getMaxBackoffDuration());
+    distributionCfg.setRedistributionInterval(distribution.getRedistributionInterval());
   }
 
   private void populateFromFlowControl(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/DistributionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DistributionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.DistributionCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class DistributionTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.distribution.max-backoff-duration=10m",
+        "camunda.processing.engine.distribution.redistribution-interval=20s",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDistribution() {
+      assertThat(brokerCfg.getExperimental().getEngine().getDistribution())
+          .returns(Duration.ofMinutes(10), DistributionCfg::getMaxBackoffDuration)
+          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.distribution.maxBackoffDuration=10m",
+        "zeebe.broker.experimental.engine.distribution.redistributionInterval=20s"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDistributionFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getDistribution())
+          .returns(Duration.ofMinutes(10), DistributionCfg::getMaxBackoffDuration)
+          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.distribution.max-backoff-duration=10m",
+        "camunda.processing.engine.distribution.redistribution-interval=20s",
+        // legacy
+        "zeebe.broker.experimental.engine.distribution.maxBackoffDuration=99m",
+        "zeebe.broker.experimental.engine.distribution.redistributionInterval=99s"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDistributionFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getDistribution())
+          .returns(Duration.ofMinutes(10), DistributionCfg::getMaxBackoffDuration)
+          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval);
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -92,23 +92,20 @@ public class ScaleUpPartitionsTest {
             .withBrokerConfig(
                 b ->
                     b.withUnifiedConfig(
-                            cfg -> {
-                              final var backup = cfg.getData().getPrimaryStorage().getBackup();
-                              backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
-                              backup.getFilesystem().setBasePath(backupPath.toString());
+                        cfg -> {
+                          final var backup = cfg.getData().getPrimaryStorage().getBackup();
+                          backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
+                          backup.getFilesystem().setBasePath(backupPath.toString());
 
-                              final var membership = cfg.getCluster().getMembership();
-                              membership.setSyncInterval(Duration.ofSeconds(1));
-                              membership.setGossipInterval(Duration.ofMillis(500));
-                            })
-                        // set distribution via properties because it is not yet supported in
-                        // unified config
-                        .withProperty(
-                            "zeebe.broker.experimental.engine.distribution.maxBackoffDuration",
-                            "1s")
-                        .withProperty(
-                            "zeebe.broker.experimental.engine.distribution.redistributionInterval",
-                            "200ms"))
+                          final var membership = cfg.getCluster().getMembership();
+                          membership.setSyncInterval(Duration.ofSeconds(1));
+                          membership.setGossipInterval(Duration.ofMillis(500));
+
+                          final var distribution =
+                              cfg.getProcessing().getEngine().getDistribution();
+                          distribution.setMaxBackoffDuration(Duration.ofSeconds(1));
+                          distribution.setRedistributionInterval(Duration.ofMillis(200));
+                        }))
             .build();
   }
 


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.processing.engine.distribution to unified configuration.

The legacy properties are:
zeebe.broker.experimental.engine.distribution.maxBackoffDuration
zeebe.broker.experimental.engine.distribution.redistributionInterval

The new properties are:
camunda.processing.engine.distribution.max-backoff-duration
camunda.processing.engine.distribution.redistribution-interval

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code