### PR TITLE
Retrieve process instances from secondary storage for deletion batch operation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
@@ -13,9 +13,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
-import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
-import java.util.List;
 
 public class ItemProviderFactory {
 
@@ -50,7 +48,10 @@ public class ItemProviderFactory {
           forResolveIncident(
               batchOperation.getEntityFilter(ProcessInstanceFilter.class),
               batchOperation.getAuthentication());
-      case DELETE_PROCESS_INSTANCE -> (cursor, pageSize) -> new ItemPage(List.of(), null, 0, true);
+      case DELETE_PROCESS_INSTANCE ->
+          forDeleteProcessInstance(
+              batchOperation.getEntityFilter(ProcessInstanceFilter.class),
+              batchOperation.getAuthentication());
     };
   }
 
@@ -100,6 +101,15 @@ public class ItemProviderFactory {
             .partitionId(partitionId)
             .states(ProcessInstanceState.ACTIVE.name())
             .build(),
+        authentication);
+  }
+
+  private ProcessInstanceItemProvider forDeleteProcessInstance(
+      final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
+    return new ProcessInstanceItemProvider(
+        searchClientsProxy,
+        metrics,
+        filter.toBuilder().partitionId(partitionId).build(),
         authentication);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
@@ -8,7 +8,8 @@
 package io.camunda.zeebe.engine.processing.batchoperation.itemprovider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.filter.Operation;
@@ -106,6 +107,26 @@ class ItemProviderFactoryTest {
     final var usedFilter = ((IncidentItemProvider) itemProvider).getFilter();
     assertThat(usedFilter.parentProcessInstanceKeyOperations()).isEmpty();
     assertThat(usedFilter.stateOperations()).contains(Operation.eq("ACTIVE"));
+    assertThat(usedFilter.partitionId()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSetFiltersForDeleteProcessInstance() {
+    // Arrange
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var batchOperation = mock(PersistedBatchOperation.class);
+    when(batchOperation.getBatchOperationType())
+        .thenReturn(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
+
+    // Act
+    final var itemProvider = factory.fromBatchOperation(batchOperation);
+
+    // Assert
+    assertThat(itemProvider).isNotNull();
+    assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
+
+    final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
     assertThat(usedFilter.partitionId()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## Description

On Batch Operation `DELETE_PROCESS_INSTANCE`, query process instance according to the user provided filter

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41011
