### PR TITLE
feat: implement a full backup index

### DIFF
--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -32,6 +32,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>

--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -59,6 +59,39 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!--  Ensure non-jqwik junit5 tests can be run -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>net.jqwik:jqwik</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
@@ -117,12 +117,8 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
    */
   @Override
   public Stream<IndexedBackup> all() {
-    try {
-      final var spliterator = new EntrySpliterator(buffer.duplicate().position(HEADER_SIZE));
-      return StreamSupport.stream(spliterator, true);
-    } catch (final Exception e) {
-      throw new RuntimeException("Failed to acquire read lock for backup index", e);
-    }
+    final var spliterator = new EntrySpliterator(buffer.duplicate().position(HEADER_SIZE));
+    return StreamSupport.stream(spliterator, true);
   }
 
   /**

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
@@ -137,10 +137,6 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
     } else {
       spliceNewEntry(newEntry);
     }
-
-    // Update the entry count. Use the initially read count because `insertNewEntry` overwrites
-    // it for crash safety.
-    setEntries(initialEntries + 1);
   }
 
   @Override
@@ -387,6 +383,7 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
     // Move to the insertion point
     // Then write the new entry
     writeEntry(newEntry);
+    setEntries(getEntries() + 1);
   }
 
   private void spliceNewEntry(final IndexedBackup newEntry) {

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
@@ -196,8 +196,10 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
       final var mismatch = Arrays.mismatch(chunk, zeros);
       if (mismatch != -1) {
         throw new PartialIndexCorruption(
-            "Corrupt backup index: non-zero byte %d found at position %d"
-                .formatted(chunk[mismatch], buffer.position() - chunkSize + mismatch),
+            "Corrupt backup index: non-zero byte %s found at position %d"
+                .formatted(
+                    String.format("0x%02X", chunk[mismatch]),
+                    buffer.position() - chunkSize + mismatch),
             lastValidEntry);
       }
     }

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
@@ -1,0 +1,581 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.index;
+
+import io.camunda.zeebe.backup.api.BackupIndex;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.agrona.IoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A compact backup index that stores backup entries in a memory-mapped file. The index is sorted by
+ * checkpoint id to allow efficient searching.
+ *
+ * <p>The index file format is as follows:
+ *
+ * <ul>
+ *   <li>Header:
+ *       <ul>
+ *         <li>4 bytes: version (int)
+ *         <li>4 bytes: number of entries (int)
+ *       </ul>
+ *   <li>Entries (each entry is 24 bytes):
+ *       <ul>
+ *         <li>8 bytes: checkpoint id (long)
+ *         <li>8 bytes: first log position (long)
+ *         <li>8 bytes: last log position (long)
+ *       </ul>
+ * </ul>
+ *
+ * The stored entries can be read via the {@link #all()} method which returns a stream of all
+ * entries.
+ *
+ * <p><b>Concurrent modifications</b> are not supported. The index should be modified by a single
+ * writer at a time. Readers can read concurrently while modifications are being made, but they will
+ * only see a consistent snapshot of the index as of the time they called {@link #all()}.
+ *
+ * @apiNote Changes to the index are not automatically flushed to disk. Users should call {@link
+ *     #flush()} to ensure changes are persisted. Changes are automatically flushed on {@link
+ *     #close()}.
+ * @implNote Appending a new entry to the end of the index is efficient. Inserting entries in the
+ *     middle of the index or removing entries requires rewriting the index file, which is done in a
+ *     crash-safe manner using a temporary file. The index file is preallocated to avoid frequent
+ *     remapping when adding new entries.
+ * @see BackupIndex
+ */
+final class CompactBackupIndex implements BackupIndex, AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(CompactBackupIndex.class);
+
+  /**
+   * Number of entries to preallocate space for when creating the initial mapping. This avoids
+   * frequent remapping when adding new entries.
+   */
+  private static final int PREALLOCATED_ENTRIES = 1024;
+
+  private static final int HEADER_SIZE =
+      Integer.BYTES // version
+          + Integer.BYTES; // entries;
+  private static final int ENTRY_SIZE =
+      Long.BYTES // checkpointId
+          + Long.BYTES // firstLogPosition
+          + Long.BYTES; // lastLogPosition
+
+  private static final int VERSION = 1;
+
+  private final Path path;
+
+  /** The file channel for the index file. Might be replaced when rewriting the index. */
+  private FileChannel file;
+
+  /** The memory-mapped buffer for the index file. Might be replaced when remapping or rewriting */
+  private MappedByteBuffer buffer;
+
+  private CompactBackupIndex(final Path path, final FileChannel file)
+      throws IndexCorruption, PartialIndexCorruption {
+    this.path = path;
+    this.file = file;
+    createInitialMapping(file);
+    validate();
+  }
+
+  public static CompactBackupIndex open(final Path path)
+      throws IOException, IndexCorruption, PartialIndexCorruption {
+    return new CompactBackupIndex(
+        path,
+        FileChannel.open(
+            path, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE));
+  }
+
+  public void flush() {
+    buffer.force();
+  }
+
+  /**
+   * Returns a stream of all backup entries in the index. The stream supports parallel processing
+   * and reflects the state of the index at the time of calling this method. Concurrent
+   * modifications to the index done through {@link #add(IndexedBackup)} and {@link
+   * #remove(IndexedBackup)} are not reflected in the returned stream.
+   */
+  @Override
+  public Stream<IndexedBackup> all() {
+    try {
+      final var spliterator = new EntrySpliterator(buffer.duplicate().position(HEADER_SIZE));
+      return StreamSupport.stream(spliterator, true);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to acquire read lock for backup index", e);
+    }
+  }
+
+  /**
+   * Adds a new backup entry to the index. The index is sorted so the entry will be written at the
+   * correct position.
+   */
+  @Override
+  public void add(final IndexedBackup newEntry) {
+    final var initialEntries = getEntries();
+    if (initialEntries == Integer.MAX_VALUE) {
+      throw new IllegalStateException(
+          "Backup index is full, can't contain more than " + Integer.MAX_VALUE + " entries");
+    }
+    final var existingEntry = byCheckpointId(newEntry.checkpointId());
+    if (existingEntry != null) {
+      return;
+    }
+    remapIfNeeded();
+    if (buffer.position() == buffer.limit()) {
+      appendNewEntry(newEntry);
+    } else {
+      spliceNewEntry(newEntry);
+    }
+
+    // Update the entry count. Use the initially read count because `insertNewEntry` overwrites
+    // it for crash safety.
+    setEntries(initialEntries + 1);
+  }
+
+  @Override
+  public void remove(final IndexedBackup entryToRemove) {
+    final var existingEntry = byCheckpointId(entryToRemove.checkpointId());
+    if (existingEntry == null) {
+      return;
+    }
+    if (buffer.position() == buffer.limit()) {
+      removeLastEntry();
+    } else {
+      removeMiddleEntry();
+    }
+  }
+
+  /**
+   * Validates the index file format and checks for corruption. Does not hold any locks, because it
+   * is only called during initialization.
+   *
+   * @throws IndexCorruption if the index is corrupted and cannot be used
+   * @throws PartialIndexCorruption if the index is partially corrupted, but some entries can be
+   *     recovered.
+   */
+  private void validate() throws IndexCorruption, PartialIndexCorruption {
+    final var version = getVersion();
+    if (version != VERSION) {
+      throw new IndexCorruption("Unsupported backup index version: " + version);
+    }
+
+    final var entries = getEntries();
+    if (entries < 0) {
+      throw new IllegalStateException(
+          "Corrupt backup index: negative number of entries: " + entries);
+    }
+    if (buffer.capacity() < HEADER_SIZE + entries * ENTRY_SIZE) {
+      throw new IndexCorruption(
+          "Corrupt backup index: expected size for "
+              + entries
+              + " entries, but file is too small: "
+              + buffer.capacity());
+    }
+    seek(entries - 1);
+    final IndexedBackup lastValidEntry;
+    if (entries > 0) {
+      lastValidEntry = readEntry();
+    } else {
+      lastValidEntry = null;
+    }
+    buffer.position(HEADER_SIZE + (entries) * ENTRY_SIZE);
+    // Check that remaining bytes are zeroed out
+    final var chunkSize = 1024;
+    //noinspection MismatchedReadAndWriteOfArray, only used for comparison
+    final var zeros = new byte[chunkSize];
+    final var chunk = new byte[chunkSize];
+    while (buffer.remaining() >= chunkSize) {
+      buffer.get(chunk);
+      final var mismatch = Arrays.mismatch(chunk, zeros);
+      if (mismatch != -1) {
+        throw new PartialIndexCorruption(
+            "Corrupt backup index: non-zero byte %d found at position %d"
+                .formatted(chunk[mismatch], buffer.position() - chunkSize + mismatch),
+            lastValidEntry);
+      }
+    }
+    // Check the remaining bytes one by one
+    while (buffer.hasRemaining()) {
+      if (buffer.get() != 0) {
+        throw new PartialIndexCorruption(
+            "Corrupt backup index: non-zero bytes found at %d after last valid entry"
+                .formatted(buffer.position()),
+            lastValidEntry);
+      }
+    }
+    buffer.limit(HEADER_SIZE + getEntries() * ENTRY_SIZE);
+
+    if (Files.exists(resolveTemporaryIndexCopy())) {
+      LOG.warn(
+          "Found temporary backup index copy file. This indicates that a previous modification of the backup index did not complete successfully. The temporary file will be deleted.");
+      try {
+        Files.delete(resolveTemporaryIndexCopy());
+      } catch (final IOException e) {
+        LOG.error(
+            "Failed to delete temporary backup index copy file at {}",
+            resolveTemporaryIndexCopy(),
+            e);
+      }
+    }
+  }
+
+  private int getVersion() {
+    return buffer.getInt(0);
+  }
+
+  private void setVersion() {
+    buffer.putInt(0, VERSION);
+  }
+
+  private int getEntries() {
+    return buffer.getInt(Integer.BYTES);
+  }
+
+  private void setEntries(final int entries) {
+    buffer.putInt(Integer.BYTES, entries);
+  }
+
+  private void createInitialMapping(final FileChannel file) {
+    try {
+      // Preallocate for at least 1024 entries
+      final var minCapacity = PREALLOCATED_ENTRIES * ENTRY_SIZE + HEADER_SIZE;
+      final var fileSize = file.size();
+      final var mappingCapacity = Math.max(fileSize, minCapacity);
+      buffer = file.map(MapMode.READ_WRITE, 0, mappingCapacity);
+      if (fileSize == 0) {
+        // Initialize header;
+        setVersion();
+        setEntries(0);
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to map backup index", e);
+    }
+  }
+
+  /**
+   * Remaps the buffer if needed to ensure it has enough capacity for at least one more entry. The
+   * new buffer capacity is increased by 50% to avoid frequent remapping.
+   */
+  private void remapIfNeeded() {
+    final var entries = getEntries();
+    final var requiredCapacity = (long) (entries + 1) * ENTRY_SIZE + HEADER_SIZE;
+    if (buffer.capacity() < requiredCapacity) {
+      try {
+        final var position = buffer.position();
+        final var limit = buffer.limit();
+        // Increase capacity by 50%
+        final var newCapacity = (long) (entries * 1.5) * ENTRY_SIZE + HEADER_SIZE;
+        // Remap with the new capacity but keep the current position and limit.
+        // The previous buffer is intentionally not unmapped here so that existing streams can still
+        // read from it.
+        buffer = file.map(MapMode.READ_WRITE, 0, newCapacity).position(position).limit(limit);
+      } catch (final IOException e) {
+        throw new UncheckedIOException("Failed to remap backup index", e);
+      }
+    }
+  }
+
+  /**
+   * Searches for a backup entry by checkpoint id. If the entry is not found, the buffer position is
+   * set to the insertion point.
+   *
+   * @param checkpointId the checkpoint id to search for
+   * @return the found entry, or null if not found
+   */
+  public IndexedBackup byCheckpointId(final long checkpointId) {
+    return searchFor(entry -> Long.compare(entry.checkpointId(), checkpointId));
+  }
+
+  /**
+   * Searches for an entry using binary search. The buffer position is set to the beginning of the
+   * found entry or to the insertion point if not found.
+   *
+   * @param search the search comparator. Should return 0 if the entry is found, negative if the
+   *     entry is greater than the searched entry, and positive if the entry is less than the
+   *     searched entry.
+   * @return the found entry, or null if not found.
+   */
+  private IndexedBackup searchFor(final SearchComparator search) {
+    // binary search
+    int left = 0;
+    int right = getEntries() - 1;
+    // fast path for appending at the end
+    seek(right);
+    final var lastEntry = readEntry();
+    if (lastEntry == null || search.test(lastEntry) < 0) {
+      return null;
+    }
+    while (left <= right) {
+      final int mid = left + (right - left) / 2;
+      seek(mid);
+      final var entry = readEntry();
+      final var comparison = search.test(entry);
+      if (comparison == 0) {
+        // Seek back to the found entry
+        seek(mid);
+        return entry;
+      } else if (comparison < 0) {
+        left = mid + 1;
+      } else {
+        right = mid - 1;
+      }
+    }
+    // Entry not found, position at insertion point
+    seek(left);
+    return null;
+  }
+
+  /**
+   * Seeks to the entry at the given index. If the index is negative, the position is set to the
+   * start of the first entry. If the index is greater than the number of entries, the position is
+   * set to the end of the last entry, i.e. the position where the next entry can be written.
+   */
+  private void seek(final int index) {
+    buffer.position(HEADER_SIZE + Math.clamp(0, index, getEntries()) * ENTRY_SIZE);
+  }
+
+  private void removeMiddleEntry() {
+    onTemporaryCopy(
+        (original, copy) -> {
+          try {
+            copy.position(0);
+            file.transferTo(0, buffer.position(), copy);
+            file.transferTo(buffer.position() + ENTRY_SIZE, buffer.capacity(), copy);
+            return -1;
+          } catch (final IOException e) {
+            throw new UncheckedIOException("Could not create new backup index", e);
+          }
+        });
+  }
+
+  void removeLastEntry() {
+    final IndexedBackup entry = new IndexedBackup(0, 0, 0);
+    buffer.putLong(entry.checkpointId());
+    buffer.putLong(entry.firstLogPosition());
+    buffer.putLong(entry.lastLogPosition());
+    setEntries(getEntries() - 1);
+    buffer.limit(buffer.position());
+  }
+
+  /** Appends a new entry at the end of the buffer. */
+  private void appendNewEntry(final IndexedBackup newEntry) {
+    // Move to the end of the buffer
+    buffer.position(buffer.limit());
+    // Extend the limit to make space for the new entry
+    buffer.limit(buffer.limit() + ENTRY_SIZE);
+    // Move to the insertion point
+    // Then write the new entry
+    writeEntry(newEntry);
+  }
+
+  private void spliceNewEntry(final IndexedBackup newEntry) {
+    onTemporaryCopy(
+        (original, copy) -> {
+          try {
+            copy.position(0);
+            original.transferTo(0, buffer.position(), copy);
+            copy.position(buffer.position() + ENTRY_SIZE);
+            original.transferTo(buffer.position(), buffer.capacity(), copy);
+            writeEntry(newEntry);
+            return 1;
+          } catch (final IOException e) {
+            throw new UncheckedIOException("Could not create new backup index", e);
+          }
+        });
+  }
+
+  /**
+   * Creates a temporary copy of the index file, applies the given action, and replaces the index.
+   * The action should return the number of added or removed entries. The buffer is remapped to the
+   * new file before the action is run.
+   */
+  void onTemporaryCopy(final CopyAction action) {
+    final var tempPath = resolveTemporaryIndexCopy();
+    try {
+      final var copy =
+          FileChannel.open(
+              tempPath,
+              StandardOpenOption.READ,
+              StandardOpenOption.WRITE,
+              StandardOpenOption.CREATE);
+      final var originalCapacity = buffer.capacity();
+      final var originalPosition = buffer.position();
+      final var originalLimit = buffer.limit();
+      // Immediately remap the buffer to the temporary file so that the action has access to it.
+      // The original buffer is intentionally not unmapped here so that existing streams can still
+      // read from it.
+      buffer =
+          copy.map(MapMode.READ_WRITE, 0, originalCapacity)
+              .position(originalPosition)
+              .limit(originalLimit);
+      final int addedOrRemovedEntries;
+      try {
+        addedOrRemovedEntries = action.update(file, copy);
+      } catch (final IOException e) {
+        throw new UncheckedIOException("Could not modify the copied backup index", e);
+      }
+
+      final var newEntries = getEntries() + addedOrRemovedEntries;
+      buffer.limit(HEADER_SIZE + newEntries * ENTRY_SIZE);
+      setEntries(newEntries);
+
+      Files.move(tempPath, path, StandardCopyOption.ATOMIC_MOVE);
+      file.close();
+      file = copy;
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to modify backup index in temporary copy", e);
+    }
+  }
+
+  private Path resolveTemporaryIndexCopy() {
+    return path.getParent().resolve(path.getFileName() + ".tmp");
+  }
+
+  /** Writes an entry at the current buffer position and advances the position. */
+  private void writeEntry(final IndexedBackup entry) {
+    buffer.putLong(entry.checkpointId());
+    buffer.putLong(entry.firstLogPosition());
+    buffer.putLong(entry.lastLogPosition());
+  }
+
+  private IndexedBackup readEntry() {
+    if (buffer.remaining() < ENTRY_SIZE) {
+      return null;
+    }
+    return readEntry(buffer);
+  }
+
+  private static IndexedBackup readEntry(final ByteBuffer buffer) {
+    return new IndexedBackup(buffer.getLong(), buffer.getLong(), buffer.getLong());
+  }
+
+  @Override
+  public void close() throws IOException {
+    flush();
+    IoUtil.unmap(buffer);
+    file.close();
+  }
+
+  public static final class IndexCorruption extends Exception {
+    private IndexCorruption(final String message) {
+      super(message);
+    }
+  }
+
+  public static final class PartialIndexCorruption extends Exception {
+    private final IndexedBackup lastValidEntry;
+
+    private PartialIndexCorruption(final String message, final IndexedBackup lastValidEntry) {
+      super(
+          message
+              + (lastValidEntry != null
+                  ? ", last valid entry: " + lastValidEntry
+                  : ", no valid entries found."));
+      this.lastValidEntry = lastValidEntry;
+    }
+
+    public IndexedBackup getLastValidEntry() {
+      return lastValidEntry;
+    }
+  }
+
+  /**
+   * A spliterator over backup index entries. This spliterator supports splitting for parallel
+   * processing. The underlying buffer is frozen on creating a new instance which guarantees that
+   * modification done through {@link CompactBackupIndex#add(IndexedBackup)} and {@link
+   * CompactBackupIndex#remove(IndexedBackup)} after this spliterator is opened are not reflected.
+   */
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class EntrySpliterator implements Spliterator<IndexedBackup> {
+    private final MappedByteBuffer buffer;
+
+    public EntrySpliterator(final MappedByteBuffer buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override
+    public boolean tryAdvance(final java.util.function.Consumer<? super IndexedBackup> action) {
+      if (buffer.remaining() >= ENTRY_SIZE) {
+        action.accept(readEntry(buffer));
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public Spliterator<IndexedBackup> trySplit() {
+      // Don't split if there are less than 1024 entries remaining to avoid overhead from too many
+      // small splits.
+      if (buffer.remaining() < ENTRY_SIZE * 1024) {
+        return null;
+      }
+      // Split in the middle. We can't just divide by 2, because we need to ensure we split at an
+      // entry boundary.
+      final var availableEntries = buffer.remaining() / ENTRY_SIZE;
+      final var mid = buffer.position() + (availableEntries / 2) * ENTRY_SIZE;
+      // The new buffer starts in the first half. That's the contract for `trySplit` with the
+      // `Spliterator.ORDERED` characteristic.
+      final var splitBuffer = buffer.duplicate().position(buffer.position()).limit(mid);
+      // We continue with the second half.
+      buffer.position(mid);
+      return new EntrySpliterator(splitBuffer);
+    }
+
+    @Override
+    public long estimateSize() {
+      return buffer.remaining() / ENTRY_SIZE;
+    }
+
+    @Override
+    public int characteristics() {
+      return Spliterator.SUBSIZED
+          | Spliterator.IMMUTABLE
+          | Spliterator.ORDERED
+          | Spliterator.NONNULL;
+    }
+  }
+
+  public interface SearchComparator {
+    int test(IndexedBackup entry);
+  }
+
+  /**
+   * An action that can copy from the original index file to a temporary copy in order to modify it.
+   * On completion, the temporary copy will replace the original index file.
+   */
+  private interface CopyAction {
+
+    /**
+     * Applies the action on the temporary copy of the index file. By the time this method is
+     * called, the buffer has already been remapped to the temporary file, all reads of the original
+     * index must be done through {@link CompactBackupIndex#file}.
+     *
+     * @param copy the file channel for the temporary copy of the index file. The channel is
+     *     positioned at the beginning.
+     * @return The number of added (positive) or removed (negative) entries.
+     * @throws IOException if an I/O error occurs during this operation.
+     */
+    int update(FileChannel original, FileChannel copy) throws IOException;
+  }
+}

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/index/CompactBackupIndex.java
@@ -299,7 +299,7 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
    * @param checkpointId the checkpoint id to search for
    * @return the found entry, or null if not found
    */
-  public IndexedBackup byCheckpointId(final long checkpointId) {
+  IndexedBackup byCheckpointId(final long checkpointId) {
     return searchFor(entry -> Long.compare(entry.checkpointId(), checkpointId));
   }
 
@@ -366,10 +366,10 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
   }
 
   void removeLastEntry() {
-    final IndexedBackup entry = new IndexedBackup(0, 0, 0);
-    buffer.putLong(entry.checkpointId());
-    buffer.putLong(entry.firstLogPosition());
-    buffer.putLong(entry.lastLogPosition());
+    // Directly write zeros to remove the last entry for clarity and efficiency
+    buffer.putLong(0L);
+    buffer.putLong(0L);
+    buffer.putLong(0L);
     setEntries(getEntries() - 1);
     buffer.limit(buffer.position());
   }
@@ -380,7 +380,7 @@ final class CompactBackupIndex implements BackupIndex, AutoCloseable {
     buffer.position(buffer.limit());
     // Extend the limit to make space for the new entry
     buffer.limit(buffer.limit() + ENTRY_SIZE);
-    // Move to the insertion point
+
     // Then write the new entry
     writeEntry(newEntry);
     setEntries(getEntries() + 1);

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/BackupIndexPropertyTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/BackupIndexPropertyTest.java
@@ -5,13 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
- */
+
 package io.camunda.zeebe.backup.index;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -57,7 +51,6 @@ public class BackupIndexPropertyTest {
                       .as("The compact backup index should match the in-memory set")
                       .containsExactlyElementsOf(inMemoryBackups);
                 })
-            .withInvariant(index -> {})
             .run();
 
     resultingModel.close();
@@ -85,13 +78,13 @@ public class BackupIndexPropertyTest {
                     .lessOrEqual(backupId - 1)
                     .withoutEdgeCases()
                     .flatMap(
-                        previousBackupId ->
+                        firstLogPosition ->
                             Arbitraries.longs()
                                 .greaterOrEqual(backupId + 1)
                                 .withoutEdgeCases()
                                 .map(
-                                    nextBackupId ->
-                                        Tuple.of(backupId, previousBackupId, nextBackupId))));
+                                    lastLogPosition ->
+                                        Tuple.of(backupId, firstLogPosition, lastLogPosition))));
   }
 
   static final class RemoveAction implements Action.Dependent<TestModel> {

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/BackupIndexPropertyTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/BackupIndexPropertyTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.index;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.zeebe.backup.api.BackupIndex.IndexedBackup;
+import io.camunda.zeebe.backup.index.CompactBackupIndex.IndexCorruption;
+import io.camunda.zeebe.backup.index.CompactBackupIndex.PartialIndexCorruption;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.Tuple;
+import net.jqwik.api.Tuple.Tuple3;
+import net.jqwik.api.state.Action;
+import net.jqwik.api.state.ActionChain;
+import net.jqwik.api.state.Transformer;
+
+public class BackupIndexPropertyTest {
+
+  /**
+   * Verifies that an in-memory sorted set and the compact backup index maintain identical indexes
+   * throughout a series of add and remove operations.
+   */
+  @Property(tries = 10, shrinking = ShrinkingMode.FULL)
+  void shouldMaintainIdenticalIndexes(@ForAll("indexActions") final ActionChain<TestModel> chain) {
+    final var resultingModel =
+        chain
+            .withInvariant(
+                model -> {
+                  final var inMemoryBackups = model.getInMemorySet().toList();
+                  final var indexBackups = model.getCompactBackupIndex().toList();
+
+                  assertThat(indexBackups)
+                      .as("The compact backup index should match the in-memory set")
+                      .containsExactlyElementsOf(inMemoryBackups);
+                })
+            .withInvariant(index -> {})
+            .run();
+
+    resultingModel.close();
+  }
+
+  @Provide
+  Arbitrary<ActionChain<TestModel>> indexActions() {
+    return ActionChain.startWith(TestModel::new)
+        // Generate many transformations to exercise remapping of the indexes
+        .withMaxTransformations(2048)
+        // Generate more add actions than remove actions to avoid empty indexes
+        .withAction(50, new AddAction())
+        .withAction(5, new RemoveAction())
+        // Occasionally reopen the index to verify persistence
+        .withAction(1, new ReopenAction());
+  }
+
+  static Arbitrary<Tuple3<Long, Long, Long>> arbitraryEntry() {
+    return Arbitraries.longs()
+        .greaterOrEqual(1)
+        .withoutEdgeCases()
+        .flatMap(
+            backupId ->
+                Arbitraries.longs()
+                    .lessOrEqual(backupId - 1)
+                    .withoutEdgeCases()
+                    .flatMap(
+                        previousBackupId ->
+                            Arbitraries.longs()
+                                .greaterOrEqual(backupId + 1)
+                                .withoutEdgeCases()
+                                .map(
+                                    nextBackupId ->
+                                        Tuple.of(backupId, previousBackupId, nextBackupId))));
+  }
+
+  static final class RemoveAction implements Action.Dependent<TestModel> {
+
+    @Override
+    public Arbitrary<Transformer<TestModel>> transformer(final TestModel state) {
+      return arbitraryEntry()
+          .map(
+              backup -> {
+                final var checkpointId = backup.get1();
+                final var firstLogIndex = backup.get2();
+                final var lastLogIndex = backup.get3();
+                return Transformer.transform(
+                    "Remove %s[%s,%s]".formatted(checkpointId, firstLogIndex, lastLogIndex),
+                    mutableState -> {
+                      state.removeBackup(
+                          new IndexedBackup(checkpointId, firstLogIndex, lastLogIndex));
+                      return state;
+                    });
+              });
+    }
+  }
+
+  static final class AddAction implements Action.Dependent<TestModel> {
+    @Override
+    public Arbitrary<Transformer<TestModel>> transformer(final TestModel state) {
+      return arbitraryEntry()
+          .map(
+              backup -> {
+                final var checkpointId = backup.get1();
+                final var firstLogIndex = backup.get2();
+                final var lastLogIndex = backup.get3();
+                return Transformer.transform(
+                    "Add %s[%s,%s]".formatted(checkpointId, firstLogIndex, lastLogIndex),
+                    mutableState -> {
+                      state.addBackup(new IndexedBackup(checkpointId, firstLogIndex, lastLogIndex));
+                      return state;
+                    });
+              });
+    }
+  }
+
+  static final class ReopenAction implements Action.Dependent<TestModel> {
+    @Override
+    public Arbitrary<Transformer<TestModel>> transformer(final TestModel state) {
+      return Arbitraries.just(
+          Transformer.transform(
+              "Reopen Index",
+              mutableState -> {
+                try {
+                  mutableState.compactBackupIndex.close();
+                  mutableState.compactBackupIndex = CompactBackupIndex.open(mutableState.indexPath);
+                } catch (final IOException | IndexCorruption | PartialIndexCorruption e) {
+                  throw new RuntimeException(e);
+                }
+                return mutableState;
+              }));
+    }
+  }
+
+  static final class TestModel implements AutoCloseable {
+    Path indexPath;
+    SortedSet<IndexedBackup> inMemorySet =
+        new TreeSet<>(Comparator.comparing(IndexedBackup::checkpointId));
+    CompactBackupIndex compactBackupIndex;
+
+    TestModel() {
+      try {
+        indexPath = Files.createTempFile("backup", ".index");
+        compactBackupIndex = CompactBackupIndex.open(indexPath);
+      } catch (final IOException | IndexCorruption | PartialIndexCorruption e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    void addBackup(final IndexedBackup backup) {
+      inMemorySet.add(backup);
+      compactBackupIndex.add(backup);
+    }
+
+    void removeBackup(final IndexedBackup backup) {
+      inMemorySet.remove(backup);
+      compactBackupIndex.remove(backup);
+    }
+
+    Stream<IndexedBackup> getInMemorySet() {
+      return inMemorySet.stream();
+    }
+
+    Stream<IndexedBackup> getCompactBackupIndex() {
+      return compactBackupIndex.all();
+    }
+
+    @Override
+    public void close() {
+      try {
+        compactBackupIndex.close();
+        Files.delete(indexPath);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/CompactBackupIndexTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/CompactBackupIndexTest.java
@@ -775,7 +775,7 @@ final class CompactBackupIndexTest {
       try (final var channel = Files.newByteChannel(indexFile, StandardOpenOption.WRITE)) {
         channel.position(4); // Skip version field
         final var buffer = ByteBuffer.allocate(4);
-        buffer.putInt(5000); // Claim we have 1000 entries but file is too small
+        buffer.putInt(5000); // Claim we have 5000 entries but file is too small
         buffer.flip();
         channel.write(buffer);
       }

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/CompactBackupIndexTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/CompactBackupIndexTest.java
@@ -41,7 +41,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldCreateNewIndexFile() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -55,7 +55,7 @@ final class CompactBackupIndexTest {
     void shouldOpenExistingIndexFile() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
       final var backup = createBackup(1, 100L, 200L);
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       try (final var index = CompactBackupIndex.open(indexFile)) {
         index.add(backup);
       }
@@ -71,7 +71,7 @@ final class CompactBackupIndexTest {
     void shouldReturnEmptyStreamWhenNoBackups()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -87,7 +87,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldAddSingleBackup() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup = createBackup(1, 100L, 200L);
 
       // when
@@ -103,7 +103,7 @@ final class CompactBackupIndexTest {
     void shouldAddMultipleBackupsInOrder()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -123,7 +123,7 @@ final class CompactBackupIndexTest {
     void shouldAddBackupsOutOfOrderAndMaintainSorting()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -146,7 +146,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldNotAddDuplicateBackup() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -168,7 +168,7 @@ final class CompactBackupIndexTest {
     void shouldHandleInsertionAtBeginning()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup5 = createBackup(5, 500L, 600L);
       final var backup10 = createBackup(10, 1000L, 1100L);
@@ -191,7 +191,7 @@ final class CompactBackupIndexTest {
     void shouldHandleInsertionInMiddle()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup10 = createBackup(10, 1000L, 1100L);
       final var backup20 = createBackup(20, 2000L, 2100L);
@@ -213,7 +213,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldHandleInsertionAtEnd() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup5 = createBackup(5, 500L, 600L);
       final var backup10 = createBackup(10, 1000L, 1100L);
@@ -240,7 +240,7 @@ final class CompactBackupIndexTest {
     void shouldFindBackupByCheckpointId()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -260,7 +260,7 @@ final class CompactBackupIndexTest {
     void shouldReturnNullWhenBackupNotFound()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup3 = createBackup(3, 300L, 400L);
 
@@ -278,7 +278,7 @@ final class CompactBackupIndexTest {
     void shouldReturnNullForEmptyIndex()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -291,7 +291,7 @@ final class CompactBackupIndexTest {
     void shouldHandleEdgeCaseWithSingleEntry()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup = createBackup(5, 500L, 600L);
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -316,7 +316,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldRemoveSingleEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup = createBackup(1, 100L, 200L);
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -335,7 +335,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldRemoveLastEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -357,7 +357,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldRemoveFirstEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -379,7 +379,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldRemoveMiddleEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -402,7 +402,7 @@ final class CompactBackupIndexTest {
     void shouldHandleRemovalFromEmptyIndex()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup = createBackup(1, 100L, 200L);
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -418,7 +418,7 @@ final class CompactBackupIndexTest {
     void shouldHandleRemovalOfNonExistentEntry()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -440,7 +440,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldRemoveMultipleEntries() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -468,7 +468,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldRemoveAllEntries() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -492,7 +492,7 @@ final class CompactBackupIndexTest {
     void shouldRemoveEntryWithSameCheckpointIdButDifferentData()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
 
@@ -513,7 +513,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldHandleAddAfterRemoval() throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -544,7 +544,7 @@ final class CompactBackupIndexTest {
     void shouldPersistDataAcrossReopens()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // Add initial backups
       final var backup1 = createBackup(1, 100L, 200L);
@@ -570,7 +570,7 @@ final class CompactBackupIndexTest {
     void shouldPersistRemovalAcrossReopens()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -598,12 +598,12 @@ final class CompactBackupIndexTest {
     void shouldHandleLargeNumberOfBackups()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
-      final int numBackups = 1000;
+      final var indexFile = tempDir.resolve("backup.index");
+      final var numBackups = 1000;
 
       // when
       try (final var index = CompactBackupIndex.open(indexFile)) {
-        for (int i = numBackups; i > 0; i--) { // Insert in reverse order
+        for (var i = numBackups; i > 0; i--) { // Insert in reverse order
           index.add(createBackup(i, (long) i * 100, (long) i * 200));
         }
 
@@ -612,7 +612,7 @@ final class CompactBackupIndexTest {
         assertThat(allBackups).hasSize(numBackups);
 
         // Verify sorted order
-        for (int i = 0; i < numBackups; i++) {
+        for (var i = 0; i < numBackups; i++) {
           assertThat(allBackups.get(i).checkpointId()).isEqualTo(i + 1);
         }
 
@@ -627,17 +627,17 @@ final class CompactBackupIndexTest {
     void shouldHandleLargeNumberOfRemovals()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
-      final int numBackups = 1000;
+      final var indexFile = tempDir.resolve("backup.index");
+      final var numBackups = 1000;
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
         // Add many backups
-        for (int i = 1; i <= numBackups; i++) {
+        for (var i = 1; i <= numBackups; i++) {
           index.add(createBackup(i, (long) i * 100, (long) i * 200));
         }
 
         // when - remove every other backup
-        for (int i = 2; i <= numBackups; i += 2) {
+        for (var i = 2; i <= numBackups; i += 2) {
           index.remove(createBackup(i, 0, 0)); // Data doesn't matter
         }
 
@@ -646,14 +646,14 @@ final class CompactBackupIndexTest {
           final var allBackups = entries.collect(Collectors.toList());
           assertThat(allBackups).hasSize(numBackups / 2);
 
-          for (int i = 0; i < allBackups.size(); i++) {
-            final long expectedCheckpointId = (long) (i * 2 + 1);
+          for (var i = 0; i < allBackups.size(); i++) {
+            final var expectedCheckpointId = (long) (i * 2 + 1);
             assertThat(allBackups.get(i).checkpointId()).isEqualTo(expectedCheckpointId);
           }
         }
 
         // Verify removed entries are not found
-        for (int i = 2; i <= numBackups; i += 2) {
+        for (var i = 2; i <= numBackups; i += 2) {
           assertThat(index.byCheckpointId(i)).isNull();
         }
       }
@@ -663,11 +663,11 @@ final class CompactBackupIndexTest {
     void shouldIterateThroughHugeIndex()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
-      final int numBackups = 10_000_000;
+      final var indexFile = tempDir.resolve("backup.index");
+      final var numBackups = 10_000_000;
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
-        for (int i = 1; i <= numBackups; i++) {
+        for (var i = 1; i <= numBackups; i++) {
           index.add(createBackup(i, (long) i * 100, (long) i * 200));
         }
         index.flush();
@@ -677,7 +677,7 @@ final class CompactBackupIndexTest {
           final var sum = entries.parallel().mapToLong(IndexedBackup::checkpointId).sum();
 
           // then
-          final long expectedSum = (long) numBackups * (numBackups + 1) / 2; // Sum of 1..n
+          final var expectedSum = (long) numBackups * (numBackups + 1) / 2; // Sum of 1..n
           assertThat(sum).isEqualTo(expectedSum);
         }
       }
@@ -687,7 +687,7 @@ final class CompactBackupIndexTest {
     void iterationCanHandleConcurrentModification()
         throws IndexCorruption, IOException, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
         final var backup1 = createBackup(1, 100L, 200L);
@@ -718,7 +718,7 @@ final class CompactBackupIndexTest {
     void shouldThrowIndexCorruptionForUnsupportedVersion()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       try (final var index = CompactBackupIndex.open(indexFile)) {
         index.add(createBackup(1, 100L, 200L));
       }
@@ -741,7 +741,7 @@ final class CompactBackupIndexTest {
     void shouldThrowIllegalStateExceptionForNegativeEntryCount()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       try (final var index = CompactBackupIndex.open(indexFile)) {
         index.add(createBackup(1, 100L, 200L));
       }
@@ -765,7 +765,7 @@ final class CompactBackupIndexTest {
     void shouldThrowIndexCorruptionForFileTooSmall()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       try (final var index = CompactBackupIndex.open(indexFile)) {
         index.add(createBackup(1, 100L, 200L));
         index.add(createBackup(2, 200L, 300L));
@@ -791,7 +791,7 @@ final class CompactBackupIndexTest {
     void shouldThrowPartialIndexCorruptionForNonZeroBytesInRemainder()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
@@ -799,7 +799,7 @@ final class CompactBackupIndexTest {
       }
 
       // Corrupt by writing non-zero byte in the remainder area (last few bytes)
-      final long fileSize = Files.size(indexFile);
+      final var fileSize = Files.size(indexFile);
       try (final var channel =
           Files.newByteChannel(indexFile, StandardOpenOption.WRITE, StandardOpenOption.READ)) {
         channel.position(fileSize - 1); // Last byte
@@ -820,8 +820,8 @@ final class CompactBackupIndexTest {
     void shouldDeleteTemporaryIndexFileOnOpen()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
-      final Path tempFile = tempDir.resolve("backup.index.tmp");
+      final var indexFile = tempDir.resolve("backup.index");
+      final var tempFile = tempDir.resolve("backup.index.tmp");
 
       try (final var index = CompactBackupIndex.open(indexFile)) {
         index.add(createBackup(1, 100L, 200L));
@@ -843,7 +843,7 @@ final class CompactBackupIndexTest {
     void shouldReturnLastValidEntryInPartialCorruption()
         throws IOException, IndexCorruption, PartialIndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
       final var backup1 = createBackup(1, 100L, 200L);
       final var backup2 = createBackup(2, 200L, 300L);
       final var backup3 = createBackup(3, 300L, 400L);
@@ -876,7 +876,7 @@ final class CompactBackupIndexTest {
     @Test
     void shouldHandlePartialCorruptionWithNoValidEntries() throws IOException, IndexCorruption {
       // given
-      final Path indexFile = tempDir.resolve("backup.index");
+      final var indexFile = tempDir.resolve("backup.index");
 
       // Create an index with header but claim we have entries and corrupt the data area
       try (final var channel =
@@ -907,7 +907,7 @@ final class CompactBackupIndexTest {
           .isInstanceOf(PartialIndexCorruption.class)
           .satisfies(
               ex -> {
-                final PartialIndexCorruption pic = (PartialIndexCorruption) ex;
+                final var pic = (PartialIndexCorruption) ex;
                 assertThat(pic.getLastValidEntry()).isNull();
                 assertThat(pic.getMessage()).contains("no valid entries found");
               });

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/CompactBackupIndexTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/index/CompactBackupIndexTest.java
@@ -1,0 +1,916 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.backup.api.BackupIndex.IndexedBackup;
+import io.camunda.zeebe.backup.index.CompactBackupIndex.IndexCorruption;
+import io.camunda.zeebe.backup.index.CompactBackupIndex.PartialIndexCorruption;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class CompactBackupIndexTest {
+
+  @TempDir private Path tempDir;
+
+  private IndexedBackup createBackup(
+      final long checkpointId, final long firstLogPos, final long checkpointPosition) {
+    return new IndexedBackup(checkpointId, firstLogPos, checkpointPosition);
+  }
+
+  @Nested
+  class BasicOperations {
+
+    @Test
+    void shouldCreateNewIndexFile() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // then
+        assertThat(indexFile).exists();
+        assertThat(Files.size(indexFile)).isGreaterThan(8); // Header size (2*Integer.BYTES)
+      }
+    }
+
+    @Test
+    void shouldOpenExistingIndexFile() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final var backup = createBackup(1, 100L, 200L);
+      final Path indexFile = tempDir.resolve("backup.index");
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup);
+      }
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // then
+        assertThat(index.all()).singleElement().isEqualTo(backup);
+      }
+    }
+
+    @Test
+    void shouldReturnEmptyStreamWhenNoBackups()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // then
+        assertThat(index.all()).isEmpty();
+      }
+    }
+  }
+
+  @Nested
+  class AddingBackups {
+
+    @Test
+    void shouldAddSingleBackup() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup = createBackup(1, 100L, 200L);
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup);
+
+        // then
+        assertThat(index.all()).singleElement().isEqualTo(backup);
+      }
+    }
+
+    @Test
+    void shouldAddMultipleBackupsInOrder()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        final var backup1 = createBackup(1, 100L, 200L);
+        final var backup2 = createBackup(2, 200L, 300L);
+        final var backup3 = createBackup(3, 300L, 400L);
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup2, backup3);
+      }
+    }
+
+    @Test
+    void shouldAddBackupsOutOfOrderAndMaintainSorting()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        final var backup3 = createBackup(3, 300L, 400L);
+        final var backup1 = createBackup(1, 100L, 200L);
+        final var backup5 = createBackup(5, 500L, 600L);
+        final var backup2 = createBackup(2, 200L, 300L);
+        final var backup4 = createBackup(4, 400L, 500L);
+        index.add(backup3);
+        index.add(backup1);
+        index.add(backup5);
+        index.add(backup2);
+        index.add(backup4);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup2, backup3, backup4, backup5);
+      }
+    }
+
+    @Test
+    void shouldNotAddDuplicateBackup() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        final var backup1 = createBackup(1, 100L, 200L);
+        final var duplicate1 = createBackup(1, 100L, 200L); // Same as backup1
+        final var duplicate2 = createBackup(1, 999L, 999L); // Different descriptor
+        index.add(backup1);
+        index.add(duplicate1);
+        index.add(duplicate2);
+
+        // then
+        assertThat(index.all())
+            .singleElement()
+            .isEqualTo(backup1); // Original values, duplicate not added
+      }
+    }
+
+    @Test
+    void shouldHandleInsertionAtBeginning()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup5 = createBackup(5, 500L, 600L);
+      final var backup10 = createBackup(10, 1000L, 1100L);
+      final var backup15 = createBackup(15, 1500L, 1600L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup5);
+        index.add(backup10);
+        index.add(backup15);
+
+        // when - insert at the beginning
+        index.add(backup1);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup5, backup10, backup15);
+      }
+    }
+
+    @Test
+    void shouldHandleInsertionInMiddle()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup10 = createBackup(10, 1000L, 1100L);
+      final var backup20 = createBackup(20, 2000L, 2100L);
+      final var backup5 = createBackup(5, 500L, 600L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup10);
+        index.add(backup20);
+
+        // when - insert in the middle
+        index.add(backup5);
+
+        // then
+        assertThat(index.all().map(IndexedBackup::checkpointId)).containsExactly(1L, 5L, 10L, 20L);
+      }
+    }
+
+    @Test
+    void shouldHandleInsertionAtEnd() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup5 = createBackup(5, 500L, 600L);
+      final var backup10 = createBackup(10, 1000L, 1100L);
+      final var backup20 = createBackup(20, 2000L, 2100L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup5);
+        index.add(backup10);
+
+        // when - insert at the end
+        index.add(backup20);
+
+        // then
+        assertThat(index.all()).hasSize(4).element(3).isEqualTo(backup20);
+      }
+    }
+  }
+
+  @Nested
+  class FindingBackups {
+
+    @Test
+    void shouldFindBackupByCheckpointId()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        final var backup1 = createBackup(1, 100L, 200L);
+        final var backup2 = createBackup(2, 200L, 300L);
+        final var backup3 = createBackup(3, 300L, 400L);
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // then
+        assertThat(index.byCheckpointId(2L)).isEqualTo(backup2);
+      }
+    }
+
+    @Test
+    void shouldReturnNullWhenBackupNotFound()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup3);
+
+        // then
+        assertThat(index.byCheckpointId(2L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldReturnNullForEmptyIndex()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // then
+        assertThat(index.byCheckpointId(1L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldHandleEdgeCaseWithSingleEntry()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup = createBackup(5, 500L, 600L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup);
+
+        // when - searching for entries before and after
+        final var foundExact = index.byCheckpointId(5L);
+        final var foundBefore = index.byCheckpointId(4L);
+        final var foundAfter = index.byCheckpointId(6L);
+
+        // then
+        assertThat(foundExact).extracting(IndexedBackup::checkpointId).isEqualTo(5L);
+        assertThat(foundBefore).isNull();
+        assertThat(foundAfter).isNull();
+      }
+    }
+  }
+
+  @Nested
+  class RemovingBackups {
+
+    @Test
+    void shouldRemoveSingleEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup = createBackup(1, 100L, 200L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup);
+        assertThat(index.all()).hasSize(1);
+
+        // when
+        index.remove(backup);
+
+        // then
+        assertThat(index.all()).isEmpty();
+        assertThat(index.byCheckpointId(1L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldRemoveLastEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // when
+        index.remove(backup3);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup2);
+        assertThat(index.byCheckpointId(3L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldRemoveFirstEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // when
+        index.remove(backup1);
+
+        // then
+        assertThat(index.all()).containsExactly(backup2, backup3);
+        assertThat(index.byCheckpointId(1L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldRemoveMiddleEntry() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // when
+        index.remove(backup2);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup3);
+        assertThat(index.byCheckpointId(2L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldHandleRemovalFromEmptyIndex()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup = createBackup(1, 100L, 200L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // when - try to remove from empty index
+        index.remove(backup);
+
+        // then - should be no-op
+        assertThat(index.all()).isEmpty();
+      }
+    }
+
+    @Test
+    void shouldHandleRemovalOfNonExistentEntry()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+      final var nonExistent = createBackup(5, 500L, 600L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // when - try to remove non-existent entry
+        index.remove(nonExistent);
+
+        // then - should be no-op
+        assertThat(index.all()).containsExactly(backup1, backup2, backup3);
+      }
+    }
+
+    @Test
+    void shouldRemoveMultipleEntries() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+      final var backup4 = createBackup(4, 400L, 500L);
+      final var backup5 = createBackup(5, 500L, 600L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+        index.add(backup4);
+        index.add(backup5);
+
+        // when - remove multiple entries
+        index.remove(backup2);
+        index.remove(backup4);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup3, backup5);
+        assertThat(index.byCheckpointId(2L)).isNull();
+        assertThat(index.byCheckpointId(4L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldRemoveAllEntries() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+
+        // when - remove all entries
+        index.remove(backup1);
+        index.remove(backup2);
+        index.remove(backup3);
+
+        // then
+        assertThat(index.all()).isEmpty();
+      }
+    }
+
+    @Test
+    void shouldRemoveEntryWithSameCheckpointIdButDifferentData()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+
+        // when - try to remove with same checkpoint id but different data
+        final var backup2Different = createBackup(2, 999L, 999L);
+        index.remove(backup2Different);
+
+        // then - should still remove based on checkpoint id
+        assertThat(index.all()).containsExactly(backup1);
+        assertThat(index.byCheckpointId(2L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldHandleAddAfterRemoval() throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+      final var backup4 = createBackup(4, 400L, 500L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup3);
+        index.add(backup4);
+
+        // when - remove middle entry and add it back
+        index.remove(backup3);
+        assertThat(index.all()).containsExactly(backup1, backup4);
+
+        // Add backup2 in the gap
+        index.add(backup2);
+
+        // then
+        assertThat(index.all()).containsExactly(backup1, backup2, backup4);
+      }
+    }
+  }
+
+  @Nested
+  class PersistenceAndPerformance {
+
+    @Test
+    void shouldPersistDataAcrossReopens()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // Add initial backups
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+      }
+
+      // Reopen and add more
+      final var backup3 = createBackup(3, 300L, 400L);
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup3);
+      }
+
+      // Reopen and verify all backups are present
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        assertThat(index.all()).containsExactly(backup1, backup2, backup3);
+      }
+    }
+
+    @Test
+    void shouldPersistRemovalAcrossReopens()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      // Add backups
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+      }
+
+      // Reopen and remove backup2
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.remove(backup2);
+      }
+
+      // Reopen and verify backup2 is gone
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        assertThat(index.all()).containsExactly(backup1, backup3);
+        assertThat(index.byCheckpointId(2L)).isNull();
+      }
+    }
+
+    @Test
+    void shouldHandleLargeNumberOfBackups()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final int numBackups = 1000;
+
+      // when
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        for (int i = numBackups; i > 0; i--) { // Insert in reverse order
+          index.add(createBackup(i, (long) i * 100, (long) i * 200));
+        }
+
+        // then
+        final var allBackups = index.all().collect(Collectors.toList());
+        assertThat(allBackups).hasSize(numBackups);
+
+        // Verify sorted order
+        for (int i = 0; i < numBackups; i++) {
+          assertThat(allBackups.get(i).checkpointId()).isEqualTo(i + 1);
+        }
+
+        // Verify binary search works
+        for (long i = 1; i <= numBackups; i++) {
+          assertThat(index.byCheckpointId(i)).extracting(IndexedBackup::checkpointId).isEqualTo(i);
+        }
+      }
+    }
+
+    @Test
+    void shouldHandleLargeNumberOfRemovals()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final int numBackups = 1000;
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // Add many backups
+        for (int i = 1; i <= numBackups; i++) {
+          index.add(createBackup(i, (long) i * 100, (long) i * 200));
+        }
+
+        // when - remove every other backup
+        for (int i = 2; i <= numBackups; i += 2) {
+          index.remove(createBackup(i, 0, 0)); // Data doesn't matter
+        }
+
+        // then - verify only odd-numbered backups remain
+        try (final var entries = index.all()) {
+          final var allBackups = entries.collect(Collectors.toList());
+          assertThat(allBackups).hasSize(numBackups / 2);
+
+          for (int i = 0; i < allBackups.size(); i++) {
+            final long expectedCheckpointId = (long) (i * 2 + 1);
+            assertThat(allBackups.get(i).checkpointId()).isEqualTo(expectedCheckpointId);
+          }
+        }
+
+        // Verify removed entries are not found
+        for (int i = 2; i <= numBackups; i += 2) {
+          assertThat(index.byCheckpointId(i)).isNull();
+        }
+      }
+    }
+
+    @Test
+    void shouldIterateThroughHugeIndex()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final int numBackups = 10_000_000;
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        for (int i = 1; i <= numBackups; i++) {
+          index.add(createBackup(i, (long) i * 100, (long) i * 200));
+        }
+        index.flush();
+
+        // when
+        try (final var entries = index.all()) {
+          final var sum = entries.parallel().mapToLong(IndexedBackup::checkpointId).sum();
+
+          // then
+          final long expectedSum = (long) numBackups * (numBackups + 1) / 2; // Sum of 1..n
+          assertThat(sum).isEqualTo(expectedSum);
+        }
+      }
+    }
+
+    @Test
+    void iterationCanHandleConcurrentModification()
+        throws IndexCorruption, IOException, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        final var backup1 = createBackup(1, 100L, 200L);
+        final var backup2 = createBackup(2, 200L, 300L);
+        final var backup3 = createBackup(3, 300L, 400L);
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+        final var openStream = index.all();
+
+        // when - modify after opening the stream
+        for (var i = 4; i <= 10_000; i++) {
+          index.add(createBackup(i, i * 100L, (i + 1) * 100L));
+        }
+
+        // then - stream only shows entries as of time of opening
+        assertThat(openStream).containsExactly(backup1, backup2, backup3);
+      }
+    }
+  }
+
+  // Helper methods
+
+  @Nested
+  class CorruptionHandling {
+
+    @Test
+    void shouldThrowIndexCorruptionForUnsupportedVersion()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(createBackup(1, 100L, 200L));
+      }
+
+      // Corrupt the version field
+      try (final var channel = Files.newByteChannel(indexFile, StandardOpenOption.WRITE)) {
+        final var buffer = ByteBuffer.allocate(4);
+        buffer.putInt(999); // Invalid version
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // when/then
+      assertThatThrownBy(() -> CompactBackupIndex.open(indexFile))
+          .isInstanceOf(IndexCorruption.class)
+          .hasMessageContaining("Unsupported backup index version: 999");
+    }
+
+    @Test
+    void shouldThrowIllegalStateExceptionForNegativeEntryCount()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(createBackup(1, 100L, 200L));
+      }
+
+      // Corrupt the entry count field
+      try (final var channel = Files.newByteChannel(indexFile, StandardOpenOption.WRITE)) {
+        channel.position(4); // Skip version field
+        final var buffer = ByteBuffer.allocate(4);
+        buffer.putInt(-1); // Negative entry count
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // when/then
+      assertThatThrownBy(() -> CompactBackupIndex.open(indexFile))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Corrupt backup index: negative number of entries: -1");
+    }
+
+    @Test
+    void shouldThrowIndexCorruptionForFileTooSmall()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(createBackup(1, 100L, 200L));
+        index.add(createBackup(2, 200L, 300L));
+      }
+
+      // Corrupt by increasing entry count but not file size
+      try (final var channel = Files.newByteChannel(indexFile, StandardOpenOption.WRITE)) {
+        channel.position(4); // Skip version field
+        final var buffer = ByteBuffer.allocate(4);
+        buffer.putInt(5000); // Claim we have 1000 entries but file is too small
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // when/then
+      assertThatThrownBy(() -> CompactBackupIndex.open(indexFile))
+          .isInstanceOf(IndexCorruption.class)
+          .hasMessageContaining(
+              "Corrupt backup index: expected size for 5000 entries, but file is too small");
+    }
+
+    @Test
+    void shouldThrowPartialIndexCorruptionForNonZeroBytesInRemainder()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+      }
+
+      // Corrupt by writing non-zero byte in the remainder area (last few bytes)
+      final long fileSize = Files.size(indexFile);
+      try (final var channel =
+          Files.newByteChannel(indexFile, StandardOpenOption.WRITE, StandardOpenOption.READ)) {
+        channel.position(fileSize - 1); // Last byte
+        final var buffer = ByteBuffer.allocate(1);
+        buffer.put((byte) 0xFF); // Non-zero byte
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // when/then
+      assertThatThrownBy(() -> CompactBackupIndex.open(indexFile))
+          .isInstanceOf(PartialIndexCorruption.class)
+          .hasMessageContaining("Corrupt backup index: non-zero bytes found at")
+          .hasMessageContaining("after last valid entry");
+    }
+
+    @Test
+    void shouldDeleteTemporaryIndexFileOnOpen()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final Path tempFile = tempDir.resolve("backup.index.tmp");
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(createBackup(1, 100L, 200L));
+      }
+
+      // Create a temporary file
+      Files.writeString(tempFile, "leftover temp file");
+      assertThat(tempFile).exists();
+
+      // when - open index again
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        // then - temporary file should be deleted
+        assertThat(tempFile).doesNotExist();
+        assertThat(index.all()).hasSize(1);
+      }
+    }
+
+    @Test
+    void shouldReturnLastValidEntryInPartialCorruption()
+        throws IOException, IndexCorruption, PartialIndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+      final var backup1 = createBackup(1, 100L, 200L);
+      final var backup2 = createBackup(2, 200L, 300L);
+      final var backup3 = createBackup(3, 300L, 400L);
+
+      try (final var index = CompactBackupIndex.open(indexFile)) {
+        index.add(backup1);
+        index.add(backup2);
+        index.add(backup3);
+      }
+
+      // Corrupt by writing non-zero byte after entries
+      final long corruptPosition = 8 + (3 * 24) + 50;
+      try (final var channel =
+          Files.newByteChannel(indexFile, StandardOpenOption.WRITE, StandardOpenOption.READ)) {
+        channel.position(corruptPosition);
+        final var buffer = ByteBuffer.allocate(1);
+        buffer.put((byte) 0xff);
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // then
+      assertThatThrownBy(() -> CompactBackupIndex.open(indexFile))
+          .isInstanceOf(PartialIndexCorruption.class)
+          .extracting(ex -> ((PartialIndexCorruption) ex).getLastValidEntry())
+          .extracting(IndexedBackup::checkpointId)
+          .isEqualTo(3L);
+    }
+
+    @Test
+    void shouldHandlePartialCorruptionWithNoValidEntries() throws IOException, IndexCorruption {
+      // given
+      final Path indexFile = tempDir.resolve("backup.index");
+
+      // Create an index with header but claim we have entries and corrupt the data area
+      try (final var channel =
+          Files.newByteChannel(indexFile, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+        final var buffer = ByteBuffer.allocate(8 + 1024);
+        buffer.putInt(1); // version
+        buffer.putInt(0); // 0 entries
+        // Fill with zeros initially
+        while (buffer.hasRemaining()) {
+          buffer.put((byte) 0);
+        }
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // Corrupt by writing non-zero byte in preallocated area
+      try (final var channel =
+          Files.newByteChannel(indexFile, StandardOpenOption.WRITE, StandardOpenOption.READ)) {
+        channel.position(100);
+        final var buffer = ByteBuffer.allocate(1);
+        buffer.put((byte) 0xAA);
+        buffer.flip();
+        channel.write(buffer);
+      }
+
+      // when/then
+      assertThatThrownBy(() -> CompactBackupIndex.open(indexFile))
+          .isInstanceOf(PartialIndexCorruption.class)
+          .satisfies(
+              ex -> {
+                final PartialIndexCorruption pic = (PartialIndexCorruption) ex;
+                assertThat(pic.getLastValidEntry()).isNull();
+                assertThat(pic.getMessage()).contains("no valid entries found");
+              });
+    }
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIndex.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIndex.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.util.stream.Stream;
+
+public interface BackupIndex {
+  Stream<IndexedBackup> all();
+
+  void add(IndexedBackup backup);
+
+  void remove(IndexedBackup backup);
+
+  record IndexedBackup(long checkpointId, long firstLogPosition, long lastLogPosition) {}
+}


### PR DESCRIPTION
This introduces an API and implementation for a full backup index, suitable to be stored on any backup store.

The implementation uses a memory-mapped file and stores entries in a compact custom binary format. Writes must be serialized but reads can be concurrent, thanks to the use of memory mapped files.

Searching through the index is efficient because we store entries in sorted order and can do a quick binary search on it.
Readers can open a parallel stream to work on a snapshot of the entries, taken when the stream is first opened. More details on the exact behavior can be found in the JavaDocs.

The implementation is covered with unit tests as well as a property tests that asserts that this behaves just like an in-memory sorted set.

Relates to #42368