### PR TITLE
Process `HistoryDeletion.DELETE` command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionContin
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionFinishProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
 import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor;
+import io.camunda.zeebe.engine.processing.historydeletion.HistoryDeletionProcessors;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
 import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
@@ -353,6 +354,9 @@ public final class EngineProcessors {
 
     UsageMetricsProcessors.addUsageMetricsProcessors(
         typedRecordProcessors, config, clock, processingState, writers, keyGenerator);
+
+    HistoryDeletionProcessors.addHistoryDeletionProcessors(
+        typedRecordProcessors, writers, processingState, authCheckBehavior);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -356,7 +356,7 @@ public final class EngineProcessors {
         typedRecordProcessors, config, clock, processingState, writers, keyGenerator);
 
     HistoryDeletionProcessors.addHistoryDeletionProcessors(
-        typedRecordProcessors, writers, processingState, authCheckBehavior);
+        typedRecordProcessors, writers, processingState);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/DeleteProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/DeleteProcessInstanceBatchOperationExecutor.java
@@ -39,7 +39,6 @@ public class DeleteProcessInstanceBatchOperationExecutor implements BatchOperati
     final var authentication = batchOperation.getAuthentication();
     final var claims = brokerRequestAuthorizationConverter.convert(authentication);
     final var command = new HistoryDeletionRecord();
-    command.setBatchOperationKey(batchOperation.getKey());
     command.setResourceKey(itemKey);
     command.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.historydeletion;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -33,18 +32,14 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final AuthorizationCheckBehavior authCheckBehavior;
   private final ElementInstanceState elementInstanceState;
 
   public HistoryDeletionDeleteProcessor(
-      final ProcessingState processingState,
-      final Writers writers,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final ProcessingState processingState, final Writers writers) {
     elementInstanceState = processingState.getElementInstanceState();
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
-    this.authCheckBehavior = authCheckBehavior;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.historydeletion;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -22,6 +23,8 @@ import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 
+// TODO add authorization checks with https://github.com/camunda/camunda/issues/41771
+@ExcludeAuthorizationCheck
 public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<HistoryDeletionRecord> {
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_EXISTS =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.historydeletion;
+
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<HistoryDeletionRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final ElementInstanceState elementInstanceState;
+
+  public HistoryDeletionDeleteProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    elementInstanceState = processingState.getElementInstanceState();
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    this.authCheckBehavior = authCheckBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<HistoryDeletionRecord> record) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionProcessors.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.historydeletion;
 
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -18,11 +17,10 @@ public class HistoryDeletionProcessors {
   public static void addHistoryDeletionProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final ProcessingState processingState) {
     typedRecordProcessors.onCommand(
         ValueType.HISTORY_DELETION,
         HistoryDeletionIntent.DELETE,
-        new HistoryDeletionDeleteProcessor(processingState, writers, authCheckBehavior));
+        new HistoryDeletionDeleteProcessor(processingState, writers));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionProcessors.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.historydeletion;
+
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+
+public class HistoryDeletionProcessors {
+  public static void addHistoryDeletionProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final ProcessingState processingState,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    typedRecordProcessors.onCommand(
+        ValueType.HISTORY_DELETION,
+        HistoryDeletionIntent.DELETE,
+        new HistoryDeletionDeleteProcessor(processingState, writers, authCheckBehavior));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteProcessInstanceHistoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteProcessInstanceHistoryTest.java
@@ -42,7 +42,7 @@ public class DeleteProcessInstanceHistoryTest {
         .await();
 
     // when
-    final var deletedEvent = ENGINE.history().processInstance(processInstanceKey).delete();
+    final var deletedEvent = ENGINE.historyDeletion().processInstance(processInstanceKey).delete();
 
     // then
     assertThat(deletedEvent.getValue())
@@ -63,7 +63,7 @@ public class DeleteProcessInstanceHistoryTest {
 
     // when
     final var rejection =
-        ENGINE.history().processInstance(processInstanceKey).expectRejection().delete();
+        ENGINE.historyDeletion().processInstance(processInstanceKey).expectRejection().delete();
 
     // then
     assertThat(rejection)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteProcessInstanceHistoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteProcessInstanceHistoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.historydeletion;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class DeleteProcessInstanceHistoryTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeleteProcessInstanceHistory() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .await();
+
+    // when
+    final var deletedEvent = ENGINE.history().processInstance(processInstanceKey).delete();
+
+    // then
+    assertThat(deletedEvent.getValue())
+        .hasResourceKey(processInstanceKey)
+        .hasResourceType(HistoryDeletionType.PROCESS_INSTANCE);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.util.client.ClusterVariableClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.GroupClient;
+import io.camunda.zeebe.engine.util.client.HistoryDeletionClient;
 import io.camunda.zeebe.engine.util.client.IdentitySetupClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
@@ -724,6 +725,10 @@ public final class EngineRule extends ExternalResource {
 
   public ScaleClient scale() {
     return new ScaleClient(environmentRule);
+  }
+
+  public HistoryDeletionClient history() {
+    return new HistoryDeletionClient(environmentRule);
   }
 
   public ActorScheduler actorScheduler() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -727,7 +727,7 @@ public final class EngineRule extends ExternalResource {
     return new ScaleClient(environmentRule);
   }
 
-  public HistoryDeletionClient history() {
+  public HistoryDeletionClient historyDeletion() {
     return new HistoryDeletionClient(environmentRule);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Function;
+
+public class HistoryDeletionClient {
+  private static final Function<Long, Record<HistoryDeletionRecordValue>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.historyDeletionRecords(HistoryDeletionIntent.DELETED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+  private static final Function<Long, Record<HistoryDeletionRecordValue>> REJECTION_EXPECTATION =
+      (position) ->
+          RecordingExporter.historyDeletionRecords()
+              .onlyCommandRejections()
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final CommandWriter writer;
+  private final HistoryDeletionRecord record = new HistoryDeletionRecord();
+  private final Function<Long, Record<HistoryDeletionRecordValue>> expectation =
+      SUCCESS_EXPECTATION;
+
+  public HistoryDeletionClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public HistoryDeletionClient processInstance(final long processInstanceKey) {
+    record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
+    record.setResourceKey(processInstanceKey);
+    return this;
+  }
+
+  public Record<HistoryDeletionRecordValue> delete() {
+    final long position = writer.writeCommand(HistoryDeletionIntent.DELETE, record);
+    return expectation.apply(position);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
@@ -30,8 +30,7 @@ public class HistoryDeletionClient {
 
   private final CommandWriter writer;
   private final HistoryDeletionRecord record = new HistoryDeletionRecord();
-  private final Function<Long, Record<HistoryDeletionRecordValue>> expectation =
-      SUCCESS_EXPECTATION;
+  private Function<Long, Record<HistoryDeletionRecordValue>> expectation = SUCCESS_EXPECTATION;
 
   public HistoryDeletionClient(final CommandWriter writer) {
     this.writer = writer;
@@ -46,5 +45,10 @@ public class HistoryDeletionClient {
   public Record<HistoryDeletionRecordValue> delete() {
     final long position = writer.writeCommand(HistoryDeletionIntent.DELETE, record);
     return expectation.apply(position);
+  }
+
+  public HistoryDeletionClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
@@ -19,18 +19,14 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   private static final StringValue RESOURCE_KEY = new StringValue("resourceKey");
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
-  private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
   private final EnumProperty<HistoryDeletionType> resourceTypeProp =
       new EnumProperty<>(RESOURCE_TYPE, HistoryDeletionType.class);
-  private final LongProperty batchOperationKeyProp = new LongProperty(BATCH_OPERATION_KEY);
 
   public HistoryDeletionRecord() {
-    super(3);
-    declareProperty(resourceKeyProp)
-        .declareProperty(resourceTypeProp)
-        .declareProperty(batchOperationKeyProp);
+    super(2);
+    declareProperty(resourceKeyProp).declareProperty(resourceTypeProp);
   }
 
   @Override
@@ -50,16 +46,6 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   public HistoryDeletionRecord setResourceType(final HistoryDeletionType resourceType) {
     resourceTypeProp.setValue(resourceType);
-    return this;
-  }
-
-  @Override
-  public long getBatchOperationKey() {
-    return batchOperationKeyProp.getValue();
-  }
-
-  public HistoryDeletionRecord setBatchOperationKey(final long batchOperationKey) {
-    batchOperationKeyProp.setValue(batchOperationKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3927,13 +3927,11 @@ final class JsonSerializableToJsonTest {
             () ->
                 new HistoryDeletionRecord()
                     .setResourceKey(1L)
-                    .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
-                    .setBatchOperationKey(2L),
+                    .setResourceType(HistoryDeletionType.PROCESS_INSTANCE),
         """
       {
         "resourceKey": 1,
-        "resourceType": "PROCESS_INSTANCE",
-        "batchOperationKey": 2
+        "resourceType": "PROCESS_INSTANCE"
       }
       """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/HistoryDeletionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/HistoryDeletionRecord.golden
@@ -19,18 +19,14 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   private static final StringValue RESOURCE_KEY = new StringValue("resourceKey");
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
-  private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
   private final EnumProperty<HistoryDeletionType> resourceTypeProp =
       new EnumProperty<>(RESOURCE_TYPE, HistoryDeletionType.class);
-  private final LongProperty batchOperationKeyProp = new LongProperty(BATCH_OPERATION_KEY);
 
   public HistoryDeletionRecord() {
-    super(3);
-    declareProperty(resourceKeyProp)
-        .declareProperty(resourceTypeProp)
-        .declareProperty(batchOperationKeyProp);
+    super(2);
+    declareProperty(resourceKeyProp).declareProperty(resourceTypeProp);
   }
 
   @Override
@@ -50,16 +46,6 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   public HistoryDeletionRecord setResourceType(final HistoryDeletionType resourceType) {
     resourceTypeProp.setValue(resourceType);
-    return this;
-  }
-
-  @Override
-  public long getBatchOperationKey() {
-    return batchOperationKeyProp.getValue();
-  }
-
-  public HistoryDeletionRecord setBatchOperationKey(final long batchOperationKey) {
-    batchOperationKeyProp.setValue(batchOperationKey);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -40,7 +40,4 @@ public interface HistoryDeletionRecordValue extends RecordValue {
 
   /** Returns the type of resource to delete. */
   HistoryDeletionType getResourceType();
-
-  /** Returns the key of the batch operation that triggered this history deletion */
-  long getBatchOperationKey();
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1713,9 +1713,7 @@ public class CompactRecordLogger {
     return "Resource key: "
         + shortenKey(value.getResourceKey())
         + ", Resource type: "
-        + value.getResourceType()
-        + ", Batch operation key: "
-        + shortenKey(value.getBatchOperationKey());
+        + value.getResourceType();
   }
 
   private String summarizeForm(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/HistoryDeletionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/HistoryDeletionRecordStream.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import java.util.stream.Stream;
+
+public class HistoryDeletionRecordStream
+    extends ExporterRecordStream<HistoryDeletionRecordValue, HistoryDeletionRecordStream> {
+
+  public HistoryDeletionRecordStream(
+      final Stream<Record<HistoryDeletionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected HistoryDeletionRecordStream supply(
+      final Stream<Record<HistoryDeletionRecordValue>> wrappedStream) {
+    return new HistoryDeletionRecordStream(wrappedStream);
+  }
+
+  public HistoryDeletionRecordStream withResourceKey(final long resourceKey) {
+    return valueFilter(v -> v.getResourceKey() == resourceKey);
+  }
+
+  public HistoryDeletionRecordStream withResourceType(final HistoryDeletionType resourceType) {
+    return valueFilter(v -> v.getResourceType() == resourceType);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -68,6 +69,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -640,6 +642,16 @@ public final class RecordingExporter implements Exporter {
   public static AsyncRequestRecordStream asyncRequestRecords() {
     return new AsyncRequestRecordStream(
         records(ValueType.ASYNC_REQUEST, AsyncRequestRecordValue.class));
+  }
+
+  public static HistoryDeletionRecordStream historyDeletionRecords(
+      final HistoryDeletionIntent intent) {
+    return historyDeletionRecords().withIntent(intent);
+  }
+
+  public static HistoryDeletionRecordStream historyDeletionRecords() {
+    return new HistoryDeletionRecordStream(
+        records(ValueType.HISTORY_DELETION, HistoryDeletionRecordValue.class));
   }
 
   public static BatchOperationPartitionLifecycleRecordStream


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Currently this command processor only deals with deletion of process instances. Later this will be extended. The processor will write the `DELETED` event, which shall be consumed by the exporter. The exporter will take care of the actual data deletion.

There is some validation going on as well. If we know the process instance in primary storage it means the instance is still active. If this is the case we cannot delete it and will reject the command.

Authorization checks have been pulled out of scope. A followup issue is created. See #41771 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41650 
