### PR TITLE
remove zeebe-container from operate ITs

### DIFF
--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -65,9 +65,6 @@ jobs:
     runs-on: ${{ inputs.runner-type }}
     permissions: {}
     if: ${{ !startsWith(inputs.branch, 'fe-') && !(startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')) }}
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe
-      ZEEBE_TEST_DOCKER_IMAGE_TAG: current-test
     services:
       # local registry is used as this job needs to push its docker image to be used by IT
       registry:
@@ -110,15 +107,6 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild
-      - uses: ./.github/actions/build-platform-docker
-        id: build-camunda-docker
-        with:
-          # we use a local registry for pushing
-          repository: ${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          version: ${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }}
-          # push is needed to make accessible for integration tests
-          push: true
 
       # Run integration tests in parallel
       - name: Backend - ${{ inputs.test-type }}

--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -74,8 +74,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -133,6 +133,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.operate.qa.backup;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.operate.util.CollectionUtil.asMap;
 import static io.camunda.webapps.backup.BackupStateDto.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.operate.util.RetryOperation;
 import io.camunda.webapps.backup.GetBackupStateResponseDto;
@@ -66,7 +65,7 @@ public class BackupRestoreTest {
   @Before
   public void setup() {
     testContext = new BackupRestoreTestContext().setIndexPrefix(INDEX_PREFIX);
-    testContext.setConnectionType("elasticsearch");
+    testContext.setDatabaseType(ConnectionTypes.ELASTICSEARCH.getType());
   }
 
   @Test
@@ -138,9 +137,7 @@ public class BackupRestoreTest {
                 new HttpHost(testContext.getExternalElsHost(), testContext.getExternalElsPort()))));
     createSnapshotRepository(testContext);
 
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    testContainerUtil.startZeebe(zeebeVersion, testContext);
+    testContainerUtil.startZeebe(testContext);
 
     operateContainer =
         testContainerUtil

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -81,12 +81,6 @@
 
     <!-- TEST CONTAINERS -->
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-elasticsearch</artifactId>
       <scope>test</scope>
@@ -413,6 +407,11 @@
     <dependency>
       <groupId>org.camunda.bpm.model</groupId>
       <artifactId>camunda-xml-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.operate;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.operate.qa.util.TestContext;
 import org.junit.After;
@@ -49,8 +47,7 @@ public class StartupIT {
     testContext.setDatabaseType("elasticsearch");
     testContainerUtil.startElasticsearch(testContext);
 
-    testContainerUtil.startZeebe(
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME), testContext);
+    testContainerUtil.startZeebe(testContext);
 
     operateContainer =
         testContainerUtil

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.TestContainerUtil.ELS_PORT;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.componentTemplateRequestBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,12 +17,12 @@ import io.camunda.client.api.response.Topology;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
+import io.camunda.operate.qa.util.TestContext;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -48,7 +48,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   @Autowired public OperateProperties operateProperties;
   @Autowired public SearchEngineConfiguration searchEngineConfiguration;
   @Autowired protected RichOpenSearchClient richOpenSearchClient;
-  protected ZeebeContainer zeebeContainer;
+  protected TestStandaloneBroker zeebeBroker;
   @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private TestContainerUtil testContainerUtil;
   @Autowired private IndexPrefixHolder indexPrefixHolder;
@@ -125,20 +125,24 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   @Override
   public void startZeebe() {
 
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    zeebeContainer =
-        testContainerUtil.startZeebe(
-            zeebeVersion,
-            prefix,
-            2,
-            isMultitTenancyEnabled(),
-            ConnectionTypes.OPENSEARCH.getType());
+    final TestContext testContext =
+        new TestContext()
+            .setInternalElsHost("localhost")
+            .setExternalElsHost("localhost")
+            .setInternalElsPort(ELS_PORT)
+            .setExternalElsPort(ELS_PORT)
+            .setIndexPrefix(prefix)
+            .setDatabaseType(ConnectionTypes.OPENSEARCH.getType())
+            .setPartitionCount(2)
+            .setMultitenancyEnabled(isMultitTenancyEnabled());
+
+    zeebeBroker = testContainerUtil.startZeebe(testContext);
 
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .grpcAddress(zeebeContainer.getGrpcAddress())
+            .restAddress(zeebeBroker.restAddress())
+            .grpcAddress(zeebeBroker.grpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 
@@ -161,8 +165,8 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   }
 
   @Override
-  public ZeebeContainer getZeebeContainer() {
-    return zeebeContainer;
+  public TestStandaloneBroker getZeebeBroker() {
+    return zeebeBroker;
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -35,9 +35,9 @@ import io.camunda.operate.webapp.zeebe.operation.process.modify.MoveTokenHandler
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.zeebe.containers.ZeebeContainer;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -159,7 +159,7 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   @Autowired protected OperateProperties operateProperties;
   @Autowired protected OperationExecutor operationExecutor;
   protected OperateTester tester;
-  private ZeebeContainer zeebeContainer;
+  private TestStandaloneBroker zeebeBroker;
   @Autowired private TestSearchRepository testSearchRepository;
   private String workerName;
   @Autowired private MeterRegistry meterRegistry;
@@ -173,8 +173,8 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   public void before() {
     super.before();
 
-    zeebeContainer = zeebeRule.getZeebeContainer();
-    assertThat(zeebeContainer).as("zeebeContainer is not null").isNotNull();
+    zeebeBroker = zeebeRule.getZeebeBroker();
+    assertThat(zeebeBroker).as("zeebeContainer is not null").isNotNull();
 
     camundaClient = getClient();
     operateServicesAdapter =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -174,7 +174,7 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
     super.before();
 
     zeebeBroker = zeebeRule.getZeebeBroker();
-    assertThat(zeebeBroker).as("zeebeContainer is not null").isNotNull();
+    assertThat(zeebeBroker).as("zeebeBroker is not null").isNotNull();
 
     camundaClient = getClient();
     operateServicesAdapter =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRule.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRule.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.util;
 
 import io.camunda.client.CamundaClient;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Instant;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -63,8 +63,8 @@ public class OperateZeebeRule extends TestWatcher {
   //    this.prefix = prefix;
   //  }
   //
-  public ZeebeContainer getZeebeContainer() {
-    return operateZeebeRuleProvider.getZeebeContainer();
+  public TestStandaloneBroker getZeebeBroker() {
+    return operateZeebeRuleProvider.getZeebeBroker();
   }
 
   //  public void setOperateProperties(final OperateProperties operateProperties) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRuleProvider.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.util;
 
 import io.camunda.client.CamundaClient;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Instant;
 import org.junit.runner.Description;
 
@@ -29,7 +29,7 @@ public interface OperateZeebeRuleProvider {
 
   String getPrefix();
 
-  ZeebeContainer getZeebeContainer();
+  TestStandaloneBroker getZeebeBroker();
 
   CamundaClient getClient();
 

--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -64,11 +64,6 @@
 
     <!-- TEST CONTAINERS -->
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-elasticsearch</artifactId>
     </dependency>
@@ -133,10 +128,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-authentication</artifactId>
     </dependency>
@@ -151,6 +142,30 @@
     <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-zeebe</artifactId>
     </dependency>
   </dependencies>
 

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -492,6 +492,9 @@ public class TestContainerUtil {
                     cfg.getAuthorizations().setEnabled(false);
                     final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
                     cfg.getInitialization().setUsers(List.of(user));
+                    if (testContext.isMultitenancyEnabled() != null) {
+                      cfg.getMultiTenancy().setChecksEnabled(testContext.isMultitenancyEnabled());
+                    }
                   });
 
       configureCamundaExporter(testContext);
@@ -500,10 +503,7 @@ public class TestContainerUtil {
         broker.withClusterConfig(
             cluster -> cluster.setPartitionCount(testContext.getPartitionCount()));
       }
-      if (testContext.isMultitenancyEnabled() != null) {
-        broker.withSecurityConfig(
-            cfg -> cfg.getMultiTenancy().setChecksEnabled(testContext.isMultitenancyEnabled()));
-      }
+
       broker.start();
 
       testContext.setInternalZeebeContactPoint(

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -7,15 +7,16 @@
  */
 package io.camunda.operate.qa.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME;
 import static io.camunda.operate.util.ThreadUtil.sleepFor;
 import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
-import static org.testcontainers.images.PullPolicy.alwaysPull;
 
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.exporter.CamundaExporter;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.util.RetryOperation;
-import io.zeebe.containers.ZeebeContainer;
-import io.zeebe.containers.ZeebePort;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.NotFoundException;
 import java.io.File;
@@ -43,7 +44,6 @@ import org.keycloak.admin.client.Keycloak;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -109,7 +109,7 @@ public class TestContainerUtil {
   private GenericContainer identityContainer;
   private GenericContainer keycloakContainer;
   private PostgreSQLContainer postgreSQLContainer;
-  private ZeebeContainer broker;
+  private TestStandaloneBroker broker;
   private GenericContainer operateContainer;
   private Keycloak keycloakClient;
 
@@ -299,7 +299,7 @@ public class TestContainerUtil {
         new ElasticsearchContainer(
                 String.format(
                     "%s:%s", DOCKER_ELASTICSEARCH_IMAGE_NAME, SUPPORTED_ELASTICSEARCH_VERSION))
-            .withNetwork(getNetwork())
+            .withNetwork(Network.SHARED)
             .withEnv("xpack.security.enabled", "false")
             .withEnv("path.repo", "~/")
             .withEnv("action.destructive_requires_name", "false")
@@ -310,7 +310,7 @@ public class TestContainerUtil {
     elsContainer.start();
     elsContainer.followOutput(new Slf4jLogConsumer(LOGGER));
 
-    testContext.setNetwork(getNetwork());
+    testContext.setNetwork(Network.SHARED);
     testContext.setExternalElsHost(elsContainer.getContainerIpAddress());
     testContext.setExternalElsPort(elsContainer.getMappedPort(ELS_PORT));
     testContext.setInternalElsHost(ELS_NETWORK_ALIAS);
@@ -364,6 +364,7 @@ public class TestContainerUtil {
         new GenericContainer<>(String.format("%s:%s", dockerImageName, version))
             .withExposedPorts(8080)
             .withNetwork(testContext.getNetwork())
+            .withExtraHost("host.testcontainers.internal", "host-gateway")
             .withCopyFileToContainer(
                 MountableFile.forHostPath(createConfigurationFile(testContext), 0775),
                 "/usr/local/operate/config/application.properties")
@@ -471,86 +472,44 @@ public class TestContainerUtil {
     return properties;
   }
 
-  public ZeebeContainer startZeebe(
-      final String version,
-      final String prefix,
-      final Integer partitionCount,
-      final boolean multitenancyEnabled,
-      final String connectionType) {
-    final TestContext testContext =
-        new TestContext()
-            .setIndexPrefix(prefix)
-            .setPartitionCount(partitionCount)
-            .setMultitenancyEnabled(multitenancyEnabled)
-            .setConnectionType(connectionType);
-    return startZeebe(version, testContext);
-  }
-
-  public ZeebeContainer startZeebe(final String version, final TestContext testContext) {
+  public TestStandaloneBroker startZeebe(final TestContext testContext) {
     if (broker == null) {
-      final String dockerRepo =
-          ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME);
-      LOGGER.info("************ Starting Zeebe {}:{} ************", dockerRepo, version);
-      final long startTime = System.currentTimeMillis();
-      Testcontainers.exposeHostPorts(ELS_PORT);
       broker =
-          new ZeebeContainer(DockerImageName.parse(String.format("%s:%s", dockerRepo, version)));
-      broker.withLogConsumer(new Slf4jLogConsumer(LOGGER));
-      if (testContext.getNetwork() != null) {
-        broker.withNetwork(testContext.getNetwork());
-      }
-      if (testContext.getZeebeDataFolder() != null) {
-        broker.withFileSystemBind(
-            testContext.getZeebeDataFolder().getPath(), "/usr/local/zeebe/data");
-      }
-      if ("SNAPSHOT".equals(version)) {
-        broker.withImagePullPolicy(alwaysPull());
-      }
-
-      // from 8.3.0 onwards, Zeebe is run with a non-root user in the container;
-      // this user cannot access a mounted volume that is owned by root
-      broker.withCreateContainerCmdModifier(cmd -> cmd.withUser("root"));
+          new TestStandaloneBroker()
+              .withAdditionalProperties(
+                  Map.of(
+                      "zeebe.log.level",
+                      "ERROR",
+                      "atomix.log.level",
+                      "ERROR",
+                      "zeebe.clock.controlled",
+                      "true"))
+              .withGatewayEnabled(true)
+              .withDataConfig(data -> data.setSnapshotPeriod(Duration.ofMinutes(1)))
+              .withSecurityConfig(
+                  cfg -> {
+                    cfg.getAuthentication().setUnprotectedApi(true);
+                    cfg.getAuthorizations().setEnabled(false);
+                    final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
+                    cfg.getInitialization().setUsers(List.of(user));
+                  });
 
       configureCamundaExporter(testContext);
 
-      broker
-          .withEnv("JAVA_OPTS", "-Xss256k -XX:+TieredCompilation -XX:TieredStopAtLevel=1")
-          .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
-          .withEnv("ATOMIX_LOG_LEVEL", "ERROR")
-          .withEnv("ZEEBE_CLOCK_CONTROLLED", "true")
-          .withEnv("ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK", "0.99")
-          .withEnv("ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK", "0.98")
-          .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
-          .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
-          .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
-
-      if (testContext.getDatabaseType() != null) {
-        final String dbType = testContext.getDatabaseType().toLowerCase();
-        broker.withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType);
-      }
-
       if (testContext.getPartitionCount() != null) {
-        broker.withEnv(
-            "ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT",
-            String.valueOf(testContext.getPartitionCount()));
+        broker.withClusterConfig(
+            cluster -> cluster.setPartitionCount(testContext.getPartitionCount()));
       }
       if (testContext.isMultitenancyEnabled() != null) {
-        broker.withEnv(
-            "CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED",
-            String.valueOf(testContext.isMultitenancyEnabled()));
+        broker.withSecurityConfig(
+            cfg -> cfg.getMultiTenancy().setChecksEnabled(testContext.isMultitenancyEnabled()));
       }
       broker.start();
 
-      LOGGER.info(
-          "\n====\nBroker startup time: {}\n====\n", (System.currentTimeMillis() - startTime));
-
       testContext.setInternalZeebeContactPoint(
-          broker.getInternalAddress(ZeebePort.GATEWAY.getPort()));
-      testContext.setZeebeGrpcAddress(broker.getGrpcAddress());
+          String.format(
+              "host.testcontainers.internal:%d", broker.mappedPort(TestZeebePort.GATEWAY)));
+      testContext.setZeebeGrpcAddress(broker.grpcAddress());
     } else {
       throw new IllegalStateException("Broker is already started. Call stopZeebe first.");
     }
@@ -558,43 +517,70 @@ public class TestContainerUtil {
   }
 
   private void configureCamundaExporter(final TestContext testContext) {
-    final String dbType = testContext.getConnectionType();
-    final String dbUrl = getElasticURL(testContext);
+    final String dbType = testContext.getDatabaseType();
 
-    broker
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-            "io.camunda.exporter.CamundaExporter")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY", "1")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1")
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_WAITPERIODBEFOREARCHIVING", "1s")
-        // unified config db type + compatibility vars
-        .withEnv("CAMUNDA_DATABASE_TYPE", dbType)
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType)
-        .withEnv("CAMUNDA_OPERATE_DATABASE", dbType)
-        .withEnv("CAMUNDA_TASKLIST_DATABASE", dbType)
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE", dbType)
-        // unified config db url + compaptibility vars (elasticsearch)
-        .withEnv("CAMUNDA_DATABASE_URL", dbUrl)
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", dbUrl)
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", dbUrl)
-        // unified config db url + compaptibility vars (opensearch)
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_OPERATE_OPENSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_URL", dbUrl);
-    if (testContext.getIndexPrefix() != null && dbType != null) {
-      broker
-          .withEnv(
-              "CAMUNDA_DATA_SECONDARYSTORAGE_" + dbType.toUpperCase() + "_INDEXPREFIX",
-              testContext.getIndexPrefix())
-          .withEnv(
-              "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX",
-              testContext.getIndexPrefix())
-          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testContext.getIndexPrefix());
-    }
+    final String dbUrl =
+        String.format(
+            "http://%s:%s", testContext.getExternalElsHost(), testContext.getExternalElsPort());
+
+    broker.withExporter(
+        CamundaExporter.class.getSimpleName().toLowerCase(),
+        cfg -> {
+          cfg.setClassName(CamundaExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "connect",
+                  Map.of(
+                      "url",
+                      dbUrl,
+                      "type",
+                      dbType,
+                      "indexPrefix",
+                      testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : "",
+                      "index",
+                      Map.of(
+                          "prefix",
+                          testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : ""),
+                      "bulk",
+                      Map.of("size", 1)),
+                  "history",
+                  Map.of("waitPeriodBeforeArchiving", "1s")));
+        });
+
+    final var secondaryStorageType = SecondaryStorageType.valueOf(dbType);
+
+    broker.withUnifiedConfig(
+        cfg -> {
+          cfg.getData().getSecondaryStorage().setType(secondaryStorageType);
+          if (secondaryStorageType.isOpenSearch()) {
+            cfg.getData().getSecondaryStorage().getOpensearch().setUrl(dbUrl);
+            if (testContext.getIndexPrefix() != null) {
+              cfg.getData()
+                  .getSecondaryStorage()
+                  .getOpensearch()
+                  .setIndexPrefix(testContext.getIndexPrefix());
+            }
+          } else {
+            cfg.getData().getSecondaryStorage().getElasticsearch().setUrl(dbUrl);
+            if (testContext.getIndexPrefix() != null) {
+              cfg.getData()
+                  .getSecondaryStorage()
+                  .getElasticsearch()
+                  .setIndexPrefix(testContext.getIndexPrefix());
+            }
+          }
+        });
+
+    broker.withAdditionalProperties(
+        Map.of(
+            "camunda.database.type",
+            dbType,
+            "camunda.operate.database",
+            dbType,
+            "camunda.tasklist.database",
+            dbType,
+            "camunda.database.url",
+            dbUrl));
   }
 
   public void stopZeebeAndOperate(final TestContext testContext) {
@@ -646,7 +632,7 @@ public class TestContainerUtil {
         throw new RuntimeException(e);
       } finally {
         try {
-          broker.shutdownGracefully(Duration.ofSeconds(3));
+          broker.close();
         } catch (final Exception ex) {
           LOGGER.error("broker.shutdownGracefully failed", ex);
           // ignore

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContext.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContext.java
@@ -55,8 +55,9 @@ public class TestContext<T extends TestContext<T>> {
     return databaseType;
   }
 
-  public void setDatabaseType(final String databaseType) {
+  public T setDatabaseType(final String databaseType) {
     this.databaseType = databaseType;
+    return (T) this;
   }
 
   public File getZeebeDataFolder() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Replace the usage of `ZeebeContainer` in Operate IT test suite with the `TestStandaloneBroker`. This will reduce test execution time along with CI preparation builds.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41356
