### PR TITLE
Replace Mockito stubs with Instancio for ProcessInstanceEntity test (#41732)

### DIFF
--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -10,6 +10,7 @@ package io.camunda.service;
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_KEY_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -146,9 +148,10 @@ public final class ProcessInstanceServiceTest {
   public void shouldReturnProcessInstanceByKey() {
     // given
     final var key = 123L;
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(key);
-    when(entity.processDefinitionId()).thenReturn("processId");
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), key)
+            .create();
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(entity);
 
     // when
@@ -250,14 +253,16 @@ public final class ProcessInstanceServiceTest {
   @Test
   public void shouldReturnOrderedProcessHierarchy() {
     // given
-    final var childProcess = mock(ProcessInstanceEntity.class);
-    when(childProcess.processInstanceKey()).thenReturn(789L);
-    when(childProcess.treePath()).thenReturn("PI_123/FN_A/FNI_456/PI_789/FN_B/FNI_654");
-    when(childProcess.processDefinitionId()).thenReturn("child_process_id");
+    final var childProcess =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 789L)
+            .set(field(ProcessInstanceEntity::treePath), "PI_123/FN_A/FNI_456/PI_789/FN_B/FNI_654")
+            .create();
 
-    final var parentProcess = mock(ProcessInstanceEntity.class);
-    when(parentProcess.processInstanceKey()).thenReturn(123L);
-    when(parentProcess.processDefinitionId()).thenReturn("parent_process_id");
+    final var parentProcess =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 123L)
+            .create();
 
     when(processInstanceSearchClient.getProcessInstance(eq(789L))).thenReturn(childProcess);
     when(processInstanceSearchClient.searchProcessInstances(any()))
@@ -276,10 +281,11 @@ public final class ProcessInstanceServiceTest {
   @Test
   public void shouldReturnEmptyListForBlankTreePath() {
     // given
-    final var rootInstance = mock(ProcessInstanceEntity.class);
-    when(rootInstance.processInstanceKey()).thenReturn(123L);
-    when(rootInstance.processDefinitionId()).thenReturn("root_process_id");
-    when(rootInstance.treePath()).thenReturn(null); // No treePath
+    final var rootInstance =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 123L)
+            .set(field(ProcessInstanceEntity::treePath), null)
+            .create();
 
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
@@ -293,10 +299,11 @@ public final class ProcessInstanceServiceTest {
   @Test
   public void shouldReturnEmptyListForRootTreePath() {
     // given
-    final var rootInstance = mock(ProcessInstanceEntity.class);
-    when(rootInstance.processInstanceKey()).thenReturn(123L);
-    when(rootInstance.processDefinitionId()).thenReturn("root_process_id");
-    when(rootInstance.treePath()).thenReturn("PI_123"); // Root treePath
+    final var rootInstance =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 123L)
+            .set(field(ProcessInstanceEntity::treePath), "PI_123")
+            .create();
 
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProviderTest.java
@@ -69,11 +69,11 @@ class IncidentItemProviderTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L),
-                    mockProcessInstanceEntity(4L),
-                    mockProcessInstanceEntity(5L)))
+                    createProcessInstanceEntity(1L),
+                    createProcessInstanceEntity(2L),
+                    createProcessInstanceEntity(3L),
+                    createProcessInstanceEntity(4L),
+                    createProcessInstanceEntity(5L)))
             .total(5)
             .build();
     when(searchClientsProxy.searchProcessInstances(piQueryCaptor.capture())).thenReturn(piResult);
@@ -137,11 +137,11 @@ class IncidentItemProviderTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L),
-                    mockProcessInstanceEntity(4L),
-                    mockProcessInstanceEntity(5L)))
+                    createProcessInstanceEntity(1L),
+                    createProcessInstanceEntity(2L),
+                    createProcessInstanceEntity(3L),
+                    createProcessInstanceEntity(4L),
+                    createProcessInstanceEntity(5L)))
             .total(5)
             .build();
     when(searchClientsProxy.searchProcessInstances(piQueryCaptor.capture())).thenReturn(piResult);
@@ -179,16 +179,16 @@ class IncidentItemProviderTest {
     assertThat(resultPage.isLastPage()).isTrue();
   }
 
-  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
-    return entity;
+  private ProcessInstanceEntity createProcessInstanceEntity(final long processInstanceKey) {
+    return Instancio.of(ProcessInstanceEntity.class)
+        .set(field(ProcessInstanceEntity::processInstanceKey), processInstanceKey)
+        .create();
   }
 
   private IncidentEntity mockIncidentEntity(final long incidentKey, final long processInstanceKey) {
-    return Instancio.of(IncidentEntity.class)
-        .set(field(IncidentEntity::incidentKey), incidentKey)
-        .set(field(IncidentEntity::processInstanceKey), processInstanceKey)
-        .create();
+    final var entity = mock(IncidentEntity.class);
+    when(entity.incidentKey()).thenReturn(incidentKey);
+    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
+    return entity;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ProcessInstanceItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ProcessInstanceItemProviderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation.itemprovider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,6 +22,7 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import java.util.List;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -61,11 +63,11 @@ class ProcessInstanceItemProviderTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L),
-                    mockProcessInstanceEntity(4L),
-                    mockProcessInstanceEntity(5L)))
+                    createProcessInstanceEntity(1L),
+                    createProcessInstanceEntity(2L),
+                    createProcessInstanceEntity(3L),
+                    createProcessInstanceEntity(4L),
+                    createProcessInstanceEntity(5L)))
             .total(5)
             .endCursor("5")
             .build();
@@ -111,9 +113,9 @@ class ProcessInstanceItemProviderTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L)))
+                    createProcessInstanceEntity(1L),
+                    createProcessInstanceEntity(2L),
+                    createProcessInstanceEntity(3L)))
             .total(3)
             .endCursor("3")
             .build();
@@ -128,9 +130,9 @@ class ProcessInstanceItemProviderTest {
     assertThat(resultPage.isLastPage()).isTrue();
   }
 
-  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
-    return entity;
+  private ProcessInstanceEntity createProcessInstanceEntity(final long processInstanceKey) {
+    return Instancio.of(ProcessInstanceEntity.class)
+        .set(field(ProcessInstanceEntity::processInstanceKey), processInstanceKey)
+        .create();
   }
 }


### PR DESCRIPTION
## Description

This PR refactors the `ProcessInstanceServiceTest` class to replace
Mockito-based stubbing of `ProcessInstanceEntity` with real instances generated
via Instancio, as requested in issue #41732.

Using Instancio improves the tests by:

- creating real objects instead of Mockito proxies  
- reducing brittleness caused by missing stubs  
- making the tests more maintainable and refactor-friendly  
- clarifying test intent by using mocks only for behavioral cases  
- avoiding Mockito configuration where simple data objects are sufficient  

Only the tests using `ProcessInstanceEntity` as a pure data holder were updated.
Tests that rely on Mockito behavior (e.g. throwing exceptions) continue to use
mocks.

## Checklist

<!-- Boxes will be checked by the reviewer -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41732
