### PR TITLE
feat: expose clock skew configuration for JWT validation

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/TokenValidatorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/TokenValidatorFactory.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 
 /**
@@ -69,6 +70,10 @@ public class TokenValidatorFactory {
             registrationId);
     final var validators = new LinkedList<OAuth2TokenValidator<Jwt>>();
 
+    validators.add(
+        new JwtTimestampValidator(
+            securityConfiguration.getAuthentication().getOidc().getClockSkew()));
+
     final var validAudiences = oidcAuthenticationConfiguration.getAudiences();
     if (validAudiences != null) {
       validators.add(new AudienceValidator(validAudiences));
@@ -80,9 +85,6 @@ public class TokenValidatorFactory {
       validators.add(new ClusterValidator(securityConfiguration.getSaas().getClusterId()));
     }
 
-    if (!validators.isEmpty()) {
-      return JwtValidators.createDefaultWithValidators(validators);
-    }
-    return JwtValidators.createDefault();
+    return JwtValidators.createDefaultWithValidators(validators);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/OidcFlowTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcFlowTest.java
@@ -53,7 +53,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "camunda.security.authentication.oidc.client-secret=" + OidcFlowTest.CLIENT_SECRET,
       "camunda.security.authentication.oidc.redirect-uri=http://localhost/sso-callback",
       "camunda.security.authentication.oidc.resource=https://api.example.com/app1/, https://api.example.com/app2/",
-      // uncomment to debug the filter chain
+      "camunda.security.authentication.oidc.clock-skew=45s",
+      //       uncomment to debug the filter chain
       //      "logging.level.org.springframework.security=TRACE",
     })
 @ActiveProfiles("consolidated-auth")

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.authentication.config;
 
+import static io.camunda.security.configuration.OidcAuthenticationConfiguration.DEFAULT_CLOCK_SKEW;
+
 import io.camunda.security.configuration.AssertionConfiguration;
 import io.camunda.security.configuration.AssertionConfiguration.KidDigestAlgorithm;
 import io.camunda.security.configuration.AssertionConfiguration.KidEncoding;
@@ -219,6 +221,12 @@ public class OidcAuthenticationConfigurationTest {
                         .build())
                 .build(),
             true),
+        Arguments.of(
+            "clockSkew is set",
+            OidcAuthenticationConfiguration.builder()
+                .clockSkew(DEFAULT_CLOCK_SKEW.plusSeconds(1))
+                .build(),
+            true),
         Arguments.of("default", new OidcAuthenticationConfiguration(), false),
         Arguments.of(
             "default authorizeRequestConfiguration is set",
@@ -243,6 +251,10 @@ public class OidcAuthenticationConfigurationTest {
             OidcAuthenticationConfiguration.builder()
                 .clientAuthenticationMethod("client_secret_basic")
                 .build(),
+            false),
+        Arguments.of(
+            "default clockSkew is set",
+            OidcAuthenticationConfiguration.builder().clockSkew(DEFAULT_CLOCK_SKEW).build(),
             false),
         Arguments.of(
             "AssertionConfiguration values are not set",

--- a/authentication/src/test/resources/camunda-identity-test-realm.json
+++ b/authentication/src/test/resources/camunda-identity-test-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "NONE",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -12,6 +12,7 @@ import io.camunda.security.configuration.AssertionConfiguration.KidDigestAlgorit
 import io.camunda.security.configuration.AssertionConfiguration.KidEncoding;
 import io.camunda.security.configuration.AssertionConfiguration.KidSource;
 import jakarta.annotation.PostConstruct;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -27,6 +28,7 @@ public class OidcAuthenticationConfiguration {
       List.of(
           CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC,
           CLIENT_AUTHENTICATION_METHOD_PRIVATE_KEY_JWT);
+  public static final Duration DEFAULT_CLOCK_SKEW = Duration.ofSeconds(60);
 
   private String issuerUri;
   private String clientName;
@@ -49,6 +51,7 @@ public class OidcAuthenticationConfiguration {
   private List<String> resource;
   private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
   private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
+  private Duration clockSkew = DEFAULT_CLOCK_SKEW;
 
   @PostConstruct
   public void validate() {
@@ -221,6 +224,14 @@ public class OidcAuthenticationConfiguration {
     this.assertionConfiguration = assertionConfiguration;
   }
 
+  public Duration getClockSkew() {
+    return clockSkew;
+  }
+
+  public void setClockSkew(final Duration clockSkew) {
+    this.clockSkew = clockSkew;
+  }
+
   public boolean isSet() {
     return issuerUri != null
         || clientId != null
@@ -248,7 +259,8 @@ public class OidcAuthenticationConfiguration {
         || assertionConfiguration.getKidSource() != KidSource.PUBLIC_KEY
         || assertionConfiguration.getKidDigestAlgorithm() != KidDigestAlgorithm.SHA256
         || assertionConfiguration.getKidEncoding() != KidEncoding.BASE64URL
-        || assertionConfiguration.getKidCase() != null;
+        || assertionConfiguration.getKidCase() != null
+        || !DEFAULT_CLOCK_SKEW.equals(clockSkew);
   }
 
   public static Builder builder() {
@@ -276,6 +288,7 @@ public class OidcAuthenticationConfiguration {
     private String organizationId;
     private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
+    private Duration clockSkew = DEFAULT_CLOCK_SKEW;
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;
@@ -374,6 +387,11 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder clockSkew(final Duration clockSkew) {
+      this.clockSkew = clockSkew;
+      return this;
+    }
+
     public OidcAuthenticationConfiguration build() {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
@@ -395,6 +413,7 @@ public class OidcAuthenticationConfiguration {
       config.setOrganizationId(organizationId);
       config.setClientAuthenticationMethod(clientAuthenticationMethod);
       config.setAssertion(assertionConfiguration);
+      config.setClockSkew(clockSkew);
       return config;
     }
   }


### PR DESCRIPTION
## Description

When creating a JWT validator, Spring injects a `JwtTimestampValidator` with a default clock skew of 60 seconds.
This PR changes the validator creation code to explicitly create a `JwtTimestampValidator` with a duration configured by the user: 
`camunda.security.authentication.oidc.clock-skew=45s`
or the default 60 seconds if no configuration was set.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41620
