### PR TITLE
test: fix asserts and cover new permissions

### DIFF
--- a/qa/http/mapping-rules.http
+++ b/qa/http/mapping-rules.http
@@ -13,7 +13,7 @@ Content-Type: application/x-www-form-urlencoded
 
 > {%
   client.test("Get token should be successful", function () {
-    client.assert(response.status === 200, "Response status is not 201");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.global.set("TOKEN", response.body.access_token)
   });
 %}
@@ -33,7 +33,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule creation should be unsuccessful", function () {
-    client.assert(response.status === 401, "Response status is not 401");
+    client.assert(response.status === 401, "Expected 401, got " + response.status);
   });
 %}
 
@@ -53,7 +53,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule creation should be successful", function () {
-    client.assert(response.status === 201, "Response status is not 201");
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
     client.global.set("MAPPING_ID", response.body.mappingRuleId);
   });
 %}
@@ -73,7 +73,7 @@ Accept: application/json
 
 > {%
   client.test("Tenant creation should be successful", function () {
-    client.assert(response.status === 201, "Response status is not 201");
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
     client.global.set("TENANT_ID", response.body.tenantId);
   });
 %}
@@ -86,7 +86,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule assignment should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -110,7 +110,7 @@ Accept: application/json
 > {%
   client.test("Mapping rule search should be successful", function () {
     let expectedMappingId = client.global.get("MAPPING_ID");
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.assert(response.body.items[0].mappingRuleId === expectedMappingId, "Mapping rule was not found");
   });
 %}
@@ -123,7 +123,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule removal should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -141,7 +141,7 @@ Accept: application/json
 
 > {%
   client.test("Group creation should be successful", function () {
-    client.assert(response.status === 201, "Response status is not 201");
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
     client.global.set("GROUP_ID", response.body.groupId);
   });
 %}
@@ -154,7 +154,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule assignment should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -178,7 +178,7 @@ Accept: application/json
 > {%
   client.test("Mapping search should be successful", function () {
     let expectedMappingId = client.global.get("MAPPING_ID");
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.assert(response.body.items[0].mappingRuleId === expectedMappingId, "Mapping was not found");
   });
 %}
@@ -191,7 +191,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule removal should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -209,7 +209,7 @@ Accept: application/json
 
 > {%
   client.test("Role creation should be successful", function () {
-    client.assert(response.status === 201, "Response status is not 201");
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
     client.global.set("ROLE_ID", response.body.roleId);
   });
 %}
@@ -222,7 +222,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule assignment should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -246,7 +246,7 @@ Accept: application/json
 > {%
   client.test("Mapping rule search should be successful", function () {
     let expectedMappingId = client.global.get("MAPPING_ID");
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.assert(response.body.items[0].mappingRuleId === expectedMappingId, "Mapping rule was not found");
   });
 %}
@@ -263,7 +263,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule removal should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -286,7 +286,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule update should be successful", function () {
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.assert(response.body.name === "mapping31", "Name was not updated correctly.");
     client.assert(response.body.claimName === "test111", "Claim name was not updated correctly.");
   });
@@ -306,7 +306,7 @@ Accept: application/json
   let expectedMappingId = client.global.get("MAPPING_ID");
 
   client.test("Mapping rule retrieval should be successful", function () {
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.assert(response.body.mappingRuleId === expectedMappingId, "mappingId was not found.");
   });
 %}
@@ -332,7 +332,7 @@ Accept: application/json
   let expectedMappingId = client.global.get("MAPPING_ID");
 
   client.test("Mapping rule search should be successful", function () {
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
     client.assert(response.body.items[0].mappingRuleId === expectedMappingId, "Mapping was not found");
   });
 %}
@@ -349,7 +349,9 @@ Accept: application/json
     "CREATE",
     "DELETE_DRD",
     "DELETE_PROCESS",
-    "DELETE_FORM"
+    "DELETE_FORM",
+    "DELETE_RESOURCE",
+    "READ"
   ],
   "ownerType": "MAPPING_RULE",
   "ownerId": "{{MAPPING_ID}}",
@@ -359,7 +361,7 @@ Accept: application/json
 
 > {%
   client.test("Authorization creation should be successful", function () {
-    client.assert(response.status === 201, "Response status is not 201");
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
   });
 
   client.test("Response should be JSON", function () {
@@ -385,7 +387,7 @@ Accept: application/json
 
 > {%
   client.test("Authorization update should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
     client.assert(response.body === "" || response.body === null, "Response body is not empty");
   });
 %}
@@ -420,7 +422,7 @@ Accept: application/json
 
 > {%
   client.test("Authorization search should be successful", function () {
-    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
   });
 
   client.test("Response should be JSON", function () {
@@ -451,7 +453,7 @@ Accept: application/json
 
 > {%
   client.test("Mapping rule deletion should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -467,7 +469,7 @@ Accept: application/json
 
 > {%
   client.test("Tenant deletion should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -483,7 +485,7 @@ Accept: application/json
 
 > {%
   client.test("Group deletion should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 
@@ -499,6 +501,6 @@ Accept: application/json
 
 > {%
   client.test("Role deletion should be successful", function () {
-    client.assert(response.status === 204, "Response status is not 204");
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}

--- a/qa/http/user-authorizations-tests.http
+++ b/qa/http/user-authorizations-tests.http
@@ -217,7 +217,7 @@ Accept: application/json
 %}
 
 ###
-# @name create-authorization-positive
+# @name create-process-definition-authorization-positive
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authorizations
 Authorization: Basic {{BASIC_AUTH_TOKEN}}
 Content-Type: application/json
@@ -255,6 +255,136 @@ Accept: application/json
 %}
 
 ###
+# @name create-decision-requirements-definition-authorization-positive
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authorizations
+Authorization: Basic {{BASIC_AUTH_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "permissionTypes": [
+    "READ"
+  ],
+  "ownerType": "USER",
+  "ownerId": "{{USERNAME}}",
+  "resourceType": "DECISION_REQUIREMENTS_DEFINITION",
+  "resourceId": "test-decision-requirements-definition"
+}
+
+> {%
+  client.test("Authorization creation should be successful", function () {
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Authorization key should not be empty", function () {
+    client.assert(response.body.authorizationKey !== "", "Authorization key is empty");
+  });
+%}
+
+###
+# @name create-decision-requirements-definition-authorization-negative
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authorizations
+Authorization: Basic {{BASIC_AUTH_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "permissionTypes": [
+    "READ",
+    "DELETE",
+    "UPDATE"
+  ],
+  "ownerType": "USER",
+  "ownerId": "{{USERNAME}}",
+  "resourceType": "DECISION_REQUIREMENTS_DEFINITION",
+  "resourceId": "test-resource"
+}
+
+> {%
+  client.test("Authorization creation should be successful", function () {
+    client.assert(response.status === 400, "Expected 400, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/problem+json"), "Response is not problem+json");
+  });
+%}
+
+###
+# @name create-resource-authorization-positive
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authorizations
+Authorization: Basic {{BASIC_AUTH_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "permissionTypes": [
+    "CREATE",
+    "DELETE_DRD",
+    "DELETE_PROCESS",
+    "DELETE_FORM",
+    "DELETE_RESOURCE",
+    "READ"
+  ],
+  "ownerType": "USER",
+  "ownerId": "{{USERNAME}}",
+  "resourceType": "RESOURCE",
+  "resourceId": "*"
+}
+
+> {%
+  client.test("Authorization creation should be successful", function () {
+    client.assert(response.status === 201, "Response status is not 201");
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Authorization key should not be empty", function () {
+    client.assert(response.body.authorizationKey !== "", "Authorization key is empty");
+  });
+%}
+
+###
+# @name create-resource-authorization-negative
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authorizations
+Authorization: Basic {{BASIC_AUTH_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "permissionTypes": [
+    "CREATE",
+    "DELETE_DRD",
+    "DELETE_PROCESS",
+    "DELETE_FORM",
+    "DELETE_RESOURCE",
+    "READ",
+    "UPDATE",
+    "DELETE"
+  ],
+  "ownerType": "USER",
+  "ownerId": "{{USERNAME}}",
+  "resourceType": "RESOURCE",
+  "resourceId": "*"
+}
+
+> {%
+  client.test("Authorization creation should be successful", function () {
+    client.assert(response.status === 400, "Response status is not 400");
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/problem+json"), "Response is not problem+json");
+  });
+%}
+
+###
 # @name create-authorization-missing-fields
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authorizations
 Authorization: Basic {{BASIC_AUTH_TOKEN}}
@@ -268,7 +398,7 @@ Accept: application/json
 > {%
   client.test("Authorization creation should fail due to missing fields", function () {
     client.assert(response.status === 400, "Expected 400, got " + response.status);
-    client.assert(response.body.detail === "No ownerType provided. No resourceId provided. No resourceType provided. No permissionTypes provided.");
+    client.assert(response.body.detail === "At least one of [resourceId, resourcePropertyName] is required");
   });
 %}
 


### PR DESCRIPTION
This pull request enhances the test coverage and improves error messaging in the HTTP API tests for mapping rules and user authorizations. The main changes include making test assertions more descriptive, expanding the set of permissions for resource authorizations, and adding comprehensive positive and negative test cases for new authorization types.

**Test assertion improvements:**

* Updated all status code assertions in `qa/http/mapping-rules.http` to display the expected and actual status codes for easier debugging. [[1]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L16-R16) [[2]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L36-R36) [[3]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L56-R56) [[4]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L76-R76) [[5]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L89-R89) [[6]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L113-R113) [[7]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L126-R126) [[8]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L144-R144) [[9]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L157-R157) [[10]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L181-R181) [[11]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L194-R194) [[12]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L212-R212) [[13]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L225-R225) [[14]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L249-R249) [[15]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L266-R266) [[16]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L289-R289) [[17]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L309-R309) [[18]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L335-R335) [[19]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L362-R364) [[20]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L388-R390) [[21]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L423-R425) [[22]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L454-R456) [[23]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L470-R472) [[24]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L486-R488) [[25]](diffhunk://#diff-f5490929862719391b048677739ac9fb22e9a63e05433e23560d89453f4e2129L502-R504)

**Authorization and permissions testing:**

* Added new permissions (`DELETE_RESOURCE`, `READ`) to the `permissionTypes` array for resource authorizations in `qa/http/mapping-rules.http` to reflect updated API capabilities.
* Added new positive and negative test cases for `DECISION_REQUIREMENTS_DEFINITION` and `RESOURCE` authorizations in `qa/http/user-authorizations-tests.http`, including checks for correct status codes, content types, and authorization key presence.
* Renamed an existing test for clarity (`create-authorization-positive` to `create-process-definition-authorization-positive`).

**Error handling and messaging:**

* Improved the error message assertion for missing fields in authorization creation to match the updated API response.

These changes make the tests more robust, easier to debug, and ensure better coverage for new and updated authorization scenarios.