### PR TITLE
refactor: move resolve incident callbacks into hook scope

### DIFF
--- a/operate/client/src/modules/components/IncidentOperation/index.tsx
+++ b/operate/client/src/modules/components/IncidentOperation/index.tsx
@@ -21,25 +21,24 @@ type IncidentOperationProps = {
 };
 
 const IncidentOperation: React.FC<IncidentOperationProps> = (props) => {
-  const {isPending, mutate} = useResolveIncident(
-    props.incidentKey,
-    props.jobKey,
-  );
+  const {isPending, mutate: resolveIncident} = useResolveIncident({
+    incidentKey: props.incidentKey,
+    jobKey: props.jobKey,
+    onError: (error) => {
+      handleOperationError(error.status);
+    },
+    onSuccess: () => {
+      tracking.track({
+        eventName: 'single-operation',
+        operationType: 'RESOLVE_INCIDENT',
+        source: 'incident-table',
+      });
+    },
+  });
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     e.stopPropagation();
-    mutate(undefined, {
-      onError: (error) => {
-        handleOperationError(error.status);
-      },
-      onSuccess: () => {
-        tracking.track({
-          eventName: 'single-operation',
-          operationType: 'RESOLVE_INCIDENT',
-          source: 'incident-table',
-        });
-      },
-    });
+    resolveIncident();
   };
 
   return (

--- a/operate/client/src/modules/mutations/incidents/useResolveIncident.ts
+++ b/operate/client/src/modules/mutations/incidents/useResolveIncident.ts
@@ -12,15 +12,28 @@ import {fetchIncident} from 'modules/api/v2/incidents/fetchIncident';
 import {updateJob} from 'modules/api/v2/jobs/updateJob';
 import {queryKeys} from 'modules/queries/queryKeys';
 
-function useResolveIncident(incidentKey: string, jobKey?: string) {
+type ResolveIncidentOptions = {
+  incidentKey: string;
+  jobKey?: string;
+  onSuccess?: () => void | Promise<void>;
+  onError?: (error: {status: number; statusText: string}) => void;
+};
+
+function useResolveIncident(options: ResolveIncidentOptions) {
   const queryClient = useQueryClient();
 
   return useMutation<void, {status: number; statusText: string}>({
-    scope: {id: incidentKey},
+    scope: {id: options.incidentKey},
+    onError: (error) => {
+      return options.onError?.(error);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: queryKeys.incidents.search()});
+      return options.onSuccess?.();
     },
     mutationFn: async () => {
+      const {incidentKey, jobKey} = options;
+
       if (jobKey) {
         const response = await updateJob(jobKey, {retries: 1});
         if (!response.ok) {

--- a/operate/client/src/modules/mutations/incidents/useResolveIncident.ts
+++ b/operate/client/src/modules/mutations/incidents/useResolveIncident.ts
@@ -15,8 +15,11 @@ import {queryKeys} from 'modules/queries/queryKeys';
 type ResolveIncidentOptions = {
   incidentKey: string;
   jobKey?: string;
-  onSuccess?: () => void | Promise<void>;
-  onError?: (error: {status: number; statusText: string}) => void;
+  onSuccess?: () => Promise<unknown> | unknown;
+  onError?: (error: {
+    status: number;
+    statusText: string;
+  }) => Promise<unknown> | unknown;
 };
 
 function useResolveIncident(options: ResolveIncidentOptions) {


### PR DESCRIPTION
## Description

This PR adjust the `useResolveIncident` mutation hook to provide success/error callbacks to the hook options instead of mutation options. This aligns the implementation with #41430.
