### PR TITLE
feat: add support AdHocSubProcess in hasMultipleScopes checks

### DIFF
--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
@@ -176,4 +176,35 @@ describe('hasMultipleScopes', () => {
     );
     expect(result).toBe(false);
   });
+
+  it('should return true if a parent AdHocSubProcess has a scope count greater than 1', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:Process',
+      $parent: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:AdHocSubProcess',
+        $parent: {
+          id: 'node3',
+          name: 'Node 3',
+          $type: 'bpmn:SubProcess',
+          $parent: undefined,
+        },
+      },
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      node1: 0,
+      node2: 2,
+      node3: 0,
+    };
+
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(true);
+  });
 });

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -10,6 +10,8 @@ import type {
   BusinessObject,
   BusinessObjects,
 } from 'bpmn-js/lib/NavigatedViewer';
+import {isAdHocSubProcess} from 'modules/bpmn-js/utils/isAdHocSubProcess';
+import {isSubProcess} from 'modules/bpmn-js/utils/isSubProcess';
 
 const checkScope = (
   parentFlowNode: BusinessObject | undefined,
@@ -26,7 +28,10 @@ const checkScope = (
     return true;
   }
 
-  if (parentFlowNode.$parent?.$type !== 'bpmn:SubProcess') {
+  if (
+    !isSubProcess(parentFlowNode.$parent) &&
+    !isAdHocSubProcess(parentFlowNode.$parent)
+  ) {
     return false;
   }
 


### PR DESCRIPTION
requires merging https://github.com/camunda/camunda/pull/41722 first
## Description
<!-- Describe the goal and purpose of this PR. -->
The `hasMultipleScopes` function is used to determine if a flow node has multiple active scopes in the process hierarchy. This is used to ask the user to select the parent scope to pass it to the modifiction payload. Previously, it only checked for `bpmn:SubProcess` types when recursively walking up the parent chain. This meant that AdHocSubProcess nodes, which can also have multiple scopes, were not being handled correctly.


This PR adds support for AdHocSubProcess in multi-scope detection logic.


### Changes

- Updated `hasMultipleScopes` function to check for both `bpmn:SubProcess` and `bpmn:AdHocSubProcess` parent types when traversing the flow node hierarchy
- Added test case to verify that AdHocSubProcess nodes with multiple running instances are correctly identified as multi-scope scenarios


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40989
