### PR TITLE
fix: Improve ISM policy checks for IT

### DIFF
--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
@@ -305,9 +305,15 @@ public class SearchAndCreateTaskMigrationIT extends UserTaskMigrationHelper {
       final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
       final JsonNode jsonResponse = OBJECT_MAPPER.readTree(response.body());
       assertThat(jsonResponse.get(datedIndex)).isNotNull();
-      assertThat(jsonResponse.get(datedIndex).get("index.plugins.index_state_management.policy_id"))
-          .isNotNull();
-      assertThat(jsonResponse.get(datedIndex).get("policy_id")).isNotNull();
+      final var indexNode = jsonResponse.get(datedIndex);
+      final var deprecatedPolicyId =
+          indexNode.get("index.plugins.index_state_management.policy_id");
+      final var policyId = indexNode.get("policy_id");
+      assertThat(deprecatedPolicyId != null || policyId != null)
+          .as(
+              "Expected ISM policy to be applied to index '%s', but neither 'index.plugins.index_state_management.policy_id' nor 'policy_id' were found",
+              datedIndex)
+          .isTrue();
     } catch (final Exception e) {
       fail("Failed to get ISM policy for index: " + datedIndex, e);
     }


### PR DESCRIPTION
## Description

See [Slack thread](https://camunda.slack.com/archives/C08F5RD5X8B/p1764249720875789?thread_ts=1764242989.371109&cid=C08F5RD5X8B) for observed flakiness

This PR attempts to fix flakiness observed in CI checks. Examples of flakiness: [[1](https://github.com/camunda/camunda/actions/runs/19768005772/job/56645445159)], [[2](https://github.com/camunda/camunda/actions/runs/19759185640/job/56617105360)], [[3](https://github.com/camunda/camunda/actions/runs/19732161675/job/56535608264)]

In all cases we see

```
Expecting actual not to be null
	at io.camunda.it.migration.usertask.SearchAndCreateTaskMigrationIT.assertIndexHasIsmPolicy(SearchAndCreateTaskMigrationIT.java:310)
```

[This corresponds to the check](https://github.com/camunda/camunda/blob/0814cf786bd80f10775a7b5d69204e4a5f7eb741/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java#L310)

```java
assertThat(jsonResponse.get(datedIndex).get("policy_id")).isNotNull();
```

This check is similar to the check above it:

```java
assertThat(jsonResponse.get(datedIndex).get("index.plugins.index_state_management.policy_id"))
    .isNotNull();
```

According to the [explain-index documentation](https://docs.opensearch.org/2.19/im-plugin/ism/api/)

> The plugins.index_state_management.policy_id setting is deprecated starting from ODFE version 1.13.0. We retain this field in the response API for consistency.

So `policy_id` and `plugins.index_state_management.policy_id` can be used for the same check, but the latter is deprecated.

I cannot reproduce the CI behaviour locally and could not find anything online for 2.19.x that would explain why we sometimes see

```
policy_id == null
plugins.index_state_management.policy_id != null
```

In the `GET /_plugins/_ism/explain/` response for an index with a newly applied ISM policy.

Given the above, I thought it might be worth to change the checks

```
OLD - plugins.index_state_management.policy_id != null && policy_id != null
NEW - plugins.index_state_management.policy_id || null && policy_id != null
```

Another thing we can try is use Awaitility to give this check a bit more time before considering it false. However, I did not want to increase the current duration of tests even more and I do not have any evidence to support a specific await duration that could work.

I ran the CI checks with these PR changes [a few times](https://github.com/camunda/camunda/actions/runs/19822029251/job/56801119081?pr=41834) and could not reproduce the issue

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
