### PR TITLE
pg/separate-backup-configs

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Azure.java
+++ b/configuration/src/main/java/io/camunda/configuration/Azure.java
@@ -8,23 +8,44 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Azure {
-  private static final String PREFIX = "camunda.data.backup.azure";
-  private static final Set<String> LEGACY_ENDPOINT_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.endpoint");
-  private static final Set<String> LEGACY_ACCOUNTNAME_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.accountName");
-  private static final Set<String> LEGACY_ACCOUNTKEY_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.accountKey");
-  private static final Set<String> LEGACY_CONNECTIONSTRING_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.connectionString");
-  private static final Set<String> LEGACY_BASEPATH_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.basePath");
-  private static final Set<String> LEGACY_CREATECONTAINER_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.createContainer");
+  private static final String PREFIX = "camunda.data.primary-storage.backup.azure";
+  private static final Set<Set<String>> LEGACY_ENDPOINT_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_ACCOUNTNAME_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_ACCOUNTKEY_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_CONNECTIONSTRING_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_BASEPATH_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_CREATECONTAINER_PROPERTIES = new LinkedHashSet<>(2);
+
+  static {
+    LEGACY_ENDPOINT_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.endpoint"));
+    LEGACY_ENDPOINT_PROPERTIES.add(Set.of("camunda.data.backup.azure.endpoint"));
+
+    LEGACY_ACCOUNTNAME_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.accountName"));
+    LEGACY_ACCOUNTNAME_PROPERTIES.add(Set.of("camunda.data.backup.azure.account-name"));
+
+    LEGACY_ACCOUNTKEY_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.accountKey"));
+    LEGACY_ACCOUNTKEY_PROPERTIES.add(Set.of("camunda.data.backup.azure.account-key"));
+
+    LEGACY_CONNECTIONSTRING_PROPERTIES.add(
+        Set.of("zeebe.broker.data.backup.azure.connectionString"));
+    LEGACY_CONNECTIONSTRING_PROPERTIES.add(Set.of("camunda.data.backup.azure.connection-string"));
+
+    LEGACY_BASEPATH_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.basePath"));
+    LEGACY_BASEPATH_PROPERTIES.add(Set.of("camunda.data.backup.azure.base-path"));
+
+    LEGACY_CREATECONTAINER_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.createContainer"));
+    LEGACY_CREATECONTAINER_PROPERTIES.add(Set.of("camunda.data.backup.azure.create-container"));
+  }
 
   /** Azure endpoint to connect to. Required unless a connection string is specified. */
   private String endpoint;
@@ -70,7 +91,7 @@ public class Azure {
   @NestedConfigurationProperty private SasToken sasToken;
 
   public String getEndpoint() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".endpoint",
         endpoint,
         String.class,
@@ -83,7 +104,7 @@ public class Azure {
   }
 
   public String getAccountName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".account-name",
         accountName,
         String.class,
@@ -96,7 +117,7 @@ public class Azure {
   }
 
   public String getAccountKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".account-key",
         accountKey,
         String.class,
@@ -109,7 +130,7 @@ public class Azure {
   }
 
   public String getConnectionString() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".connection-string",
         connectionString,
         String.class,
@@ -122,7 +143,7 @@ public class Azure {
   }
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".base-path",
         basePath,
         String.class,
@@ -135,7 +156,7 @@ public class Azure {
   }
 
   public boolean isCreateContainer() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".create-container",
         createContainer,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Azure.java
+++ b/configuration/src/main/java/io/camunda/configuration/Azure.java
@@ -88,7 +88,7 @@ public class Azure {
    * runtime error. See more in: <a
    * href="https://learn.microsoft.com/en-us/rest/api/storageservices/delegate-access-with-shared-access-signature">...</a>
    */
-  @NestedConfigurationProperty private SasToken sasToken;
+  @NestedConfigurationProperty private SasToken sasToken = new SasToken();
 
   public String getEndpoint() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(

--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -8,45 +8,13 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
-import java.time.Duration;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Backup implements Cloneable {
   private static final String PREFIX = "camunda.data.backup";
 
-  private static final String LEGACY_OPERATE_SNAPSHOT_TIMEOUT =
-      "camunda.operate.backup.snapshotTimeout";
-  private static final String LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS =
-      "camunda.operate.backup.incompleteCheckTimeoutInSeconds";
-  private static final Set<String> LEGACY_REPOSITORY_NAME_PROPERTIES =
-      Set.of("camunda.tasklist.backup.repositoryName", "camunda.operate.backup.repositoryName");
   private static final String LEGACY_BROKER_STORE = "zeebe.broker.data.backup.store";
-
-  /**
-   * Set the ES / OS snapshot repository name.
-   *
-   * <p>Note: This setting applies to backups of secondary storage.
-   */
-  private String repositoryName;
-
-  /**
-   * A backup of history data consists of multiple Elasticsearch/Opensearch snapshots.
-   * snapshotTimeout controls the maximum time to wait for a snapshot operation to complete during
-   * backup creation. When set to 0, the system will wait indefinitely for snapshots to finish.
-   *
-   * <p>Note: This setting applies to backups of secondary storage.
-   */
-  private int snapshotTimeout = 0;
-
-  /**
-   * Defines the timeout period for determining whether an incomplete backup should be considered as
-   * failed or still in progress. This property helps distinguish between backups that are actively
-   * running versus those that may have stalled or failed silently.
-   *
-   * <p>Note: This setting applies to backups of secondary storage.
-   */
-  private Duration incompleteCheckTimeout = Duration.ofMinutes(5);
 
   /**
    * Set the backup store type. Supported values are [NONE, S3, GCS, AZURE, FILESYSTEM]. Default
@@ -77,48 +45,6 @@ public class Backup implements Cloneable {
 
   /** Configuration for backup store Azure */
   @NestedConfigurationProperty private Azure azure = new Azure();
-
-  public String getRepositoryName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + ".repository-name",
-        repositoryName,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_REPOSITORY_NAME_PROPERTIES);
-  }
-
-  public void setRepositoryName(final String repositoryName) {
-    this.repositoryName = repositoryName;
-  }
-
-  public int getSnapshotTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + ".snapshot-timeout",
-        snapshotTimeout,
-        Integer.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_OPERATE_SNAPSHOT_TIMEOUT));
-  }
-
-  public void setSnapshotTimeout(final int snapshotTimeout) {
-    this.snapshotTimeout = snapshotTimeout;
-  }
-
-  public Duration getIncompleteCheckTimeout() {
-    final long incompleteCheckTimeoutInSeconds =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
-            PREFIX + ".incomplete-check-timeout",
-            incompleteCheckTimeout.getSeconds(),
-            Long.class,
-            BackwardsCompatibilityMode.SUPPORTED,
-            Set.of(LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS));
-
-    return Duration.ofSeconds(incompleteCheckTimeoutInSeconds);
-  }
-
-  public void setIncompleteCheckTimeout(final Duration incompleteCheckTimeout) {
-    this.incompleteCheckTimeout = incompleteCheckTimeout;
-  }
 
   public S3 getS3() {
     return s3;

--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -25,9 +25,6 @@ public class Data {
   /** This section allows to configure primary Zeebe's data storage. */
   @NestedConfigurationProperty private PrimaryStorage primaryStorage = new PrimaryStorage();
 
-  /** This section allows configuring a backup store. */
-  @NestedConfigurationProperty private Backup backup = new Backup();
-
   /** This section allows configuring export. */
   @NestedConfigurationProperty private Export export = new Export();
 
@@ -56,14 +53,6 @@ public class Data {
 
   public void setPrimaryStorage(final PrimaryStorage primaryStorage) {
     this.primaryStorage = primaryStorage;
-  }
-
-  public Backup getBackup() {
-    return backup;
-  }
-
-  public void setBackup(final Backup backup) {
-    this.backup = backup;
   }
 
   public Export getExport() {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageBackup.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageBackup.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class DocumentBasedSecondaryStorageBackup implements Cloneable {
+
+  private static final Set<String> LEGACY_OPERATE_SNAPSHOT_TIMEOUT =
+      Set.of("camunda.operate.backup.snapshotTimeout");
+  private static final Set<String> LEGACY_UNIFIED_CONFIG_SNAPSHOT_TIMEOUT =
+      Set.of("camunda.data.backup.snapshot-timeout");
+  private static final Set<String> LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS =
+      Set.of("camunda.operate.backup.incompleteCheckTimeoutInSeconds");
+  private static final Set<String> LEGACY_UNIFIED_CONFIG_INCOMPLETE_CHECK_TIMEOUT =
+      Set.of("camunda.data.backup.incomplete-check-timeout");
+  private static final Set<String> LEGACY_REPOSITORY_NAME_PROPERTIES =
+      Set.of(
+          "camunda.data.backup.repository-name",
+          "camunda.tasklist.backup.repositoryName",
+          "camunda.operate.backup.repositoryName");
+
+  /**
+   * Set the ES / OS snapshot repository name.
+   *
+   * <p>Note: This setting applies to backups of secondary storage.
+   */
+  private String repositoryName;
+
+  /**
+   * A backup of history data consists of multiple Elasticsearch/Opensearch snapshots.
+   * snapshotTimeout controls the maximum time to wait for a snapshot operation to complete during
+   * backup creation. When set to 0, the system will wait indefinitely for snapshots to finish.
+   *
+   * <p>Note: This setting applies to backups of secondary storage.
+   */
+  private int snapshotTimeout = 0;
+
+  /**
+   * Defines the timeout period for determining whether an incomplete backup should be considered as
+   * failed or still in progress. This property helps distinguish between backups that are actively
+   * running versus those that may have stalled or failed silently.
+   *
+   * <p>Note: This setting applies to backups of secondary storage.
+   */
+  private Duration incompleteCheckTimeout = Duration.ofMinutes(5);
+
+  private final String prefix;
+
+  public DocumentBasedSecondaryStorageBackup(final String databaseName) {
+    prefix = "camunda.data.secondary-storage.%s.backup".formatted(databaseName);
+  }
+
+  public String getRepositoryName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".repository-name",
+        repositoryName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_REPOSITORY_NAME_PROPERTIES);
+  }
+
+  public void setRepositoryName(final String repositoryName) {
+    this.repositoryName = repositoryName;
+  }
+
+  public int getSnapshotTimeout() {
+    final int legacyOperateSnapshotTimeout =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            prefix + ".snapshot-timeout",
+            snapshotTimeout,
+            Integer.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_OPERATE_SNAPSHOT_TIMEOUT);
+
+    final int legacyUnifiedSnapshotTimeout =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            prefix + ".snapshot-timeout",
+            snapshotTimeout,
+            Integer.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_UNIFIED_CONFIG_SNAPSHOT_TIMEOUT);
+
+    // Give precedence to legacy unified configuration value
+    if (legacyUnifiedSnapshotTimeout != snapshotTimeout) {
+      return legacyUnifiedSnapshotTimeout;
+    }
+    return legacyOperateSnapshotTimeout;
+  }
+
+  public void setSnapshotTimeout(final int snapshotTimeout) {
+    this.snapshotTimeout = snapshotTimeout;
+  }
+
+  public Duration getIncompleteCheckTimeout() {
+    final long incompleteCheckTimeoutInSeconds =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            prefix + ".incomplete-check-timeout",
+            incompleteCheckTimeout.getSeconds(),
+            Long.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS);
+
+    final Duration incompleteCheckTimeoutInDuration =
+        UnifiedConfigurationHelper.validateLegacyConfiguration(
+            prefix + ".incomplete-check-timeout",
+            incompleteCheckTimeout,
+            Duration.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            LEGACY_UNIFIED_CONFIG_INCOMPLETE_CHECK_TIMEOUT);
+
+    // Give precedence to legacy unified configuration value
+    if (incompleteCheckTimeoutInDuration.getSeconds() != incompleteCheckTimeout.getSeconds()) {
+      return incompleteCheckTimeoutInDuration;
+    }
+
+    return Duration.ofSeconds(incompleteCheckTimeoutInSeconds);
+  }
+
+  public void setIncompleteCheckTimeout(final Duration incompleteCheckTimeout) {
+    this.incompleteCheckTimeout = incompleteCheckTimeout;
+  }
+
+  @Override
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -81,6 +81,10 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   @NestedConfigurationProperty private Bulk bulk = new Bulk(databaseName());
 
+  @NestedConfigurationProperty
+  private DocumentBasedSecondaryStorageBackup backup =
+      new DocumentBasedSecondaryStorageBackup(databaseName());
+
   @Override
   public String getUrl() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -351,6 +355,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setTemplatePriority(final Integer templatePriority) {
     this.templatePriority = templatePriority;
+  }
+
+  public DocumentBasedSecondaryStorageBackup getBackup() {
+    return backup;
+  }
+
+  public void setBackup(final DocumentBasedSecondaryStorageBackup backup) {
+    this.backup = backup;
   }
 
   private String prefix() {

--- a/configuration/src/main/java/io/camunda/configuration/Filesystem.java
+++ b/configuration/src/main/java/io/camunda/configuration/Filesystem.java
@@ -8,18 +8,23 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Filesystem {
-  private static final String PREFIX = "camunda.data.backup.filesystem";
-  private static final Set<String> LEGACY_BASE_PATH_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.filesystem.basePath");
+  private static final String PREFIX = "camunda.data.primary-storage.backup.filesystem";
+  private static final Set<Set<String>> LEGACY_BASE_PATH_PROPERTIES = new LinkedHashSet<>(2);
+
+  static {
+    LEGACY_BASE_PATH_PROPERTIES.add(Set.of("zeebe.broker.data.backup.filesystem.basePath"));
+    LEGACY_BASE_PATH_PROPERTIES.add(Set.of("camunda.data.backup.filesystem.base-path"));
+  }
 
   /** Set the base path to store all related backup files in. */
   private String basePath;
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".base-path",
         basePath,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/Gcs.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gcs.java
@@ -8,18 +8,29 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Gcs {
-  private static final String PREFIX = "camunda.data.backup.gcs";
-  private static final Set<String> LEGACY_BUCKETNAME_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.gcs.bucketName");
-  private static final Set<String> LEGACY_BASEPATH_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.gcs.basePath");
-  private static final Set<String> LEGACY_HOST_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.gcs.host");
-  private static final Set<String> LEGACY_AUTH_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.gcs.auth");
+  private static final String PREFIX = "camunda.data.primary-storage.backup.gcs";
+  private static final Set<Set<String>> LEGACY_BUCKETNAME_PROPERTIES = new LinkedHashSet<>(2);
+  private static final Set<Set<String>> LEGACY_BASEPATH_PROPERTIES = new LinkedHashSet<>(2);
+  private static final Set<Set<String>> LEGACY_HOST_PROPERTIES = new LinkedHashSet<>(2);
+  private static final Set<Set<String>> LEGACY_AUTH_PROPERTIES = new LinkedHashSet<>(2);
+
+  static {
+    LEGACY_BUCKETNAME_PROPERTIES.add(Set.of("zeebe.broker.data.backup.gcs.bucketName"));
+    LEGACY_BUCKETNAME_PROPERTIES.add(Set.of("camunda.data.backup.gcs.bucket-name"));
+
+    LEGACY_BASEPATH_PROPERTIES.add(Set.of("zeebe.broker.data.backup.gcs.basePath"));
+    LEGACY_BASEPATH_PROPERTIES.add(Set.of("camunda.data.backup.gcs.base-path"));
+
+    LEGACY_HOST_PROPERTIES.add(Set.of("zeebe.broker.data.backup.gcs.host"));
+    LEGACY_HOST_PROPERTIES.add(Set.of("camunda.data.backup.gcs.host"));
+
+    LEGACY_AUTH_PROPERTIES.add(Set.of("zeebe.broker.data.backup.gcs.auth"));
+    LEGACY_AUTH_PROPERTIES.add(Set.of("camunda.data.backup.gcs.auth"));
+  }
 
   /**
    * Name of the bucket where the backup will be stored. The bucket must already exist. The bucket
@@ -51,7 +62,7 @@ public class Gcs {
   private GcsBackupStoreAuth auth = GcsBackupStoreAuth.AUTO;
 
   public String getBucketName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".bucket-name",
         bucketName,
         String.class,
@@ -64,7 +75,7 @@ public class Gcs {
   }
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".base-path",
         basePath,
         String.class,
@@ -77,7 +88,7 @@ public class Gcs {
   }
 
   public String getHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".host",
         host,
         String.class,
@@ -90,7 +101,7 @@ public class Gcs {
   }
 
   public GcsBackupStoreAuth getAuth() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".auth",
         auth,
         GcsBackupStoreAuth.class,

--- a/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
@@ -37,6 +37,7 @@ public class PrimaryStorage {
   @NestedConfigurationProperty private Disk disk = new Disk();
   @NestedConfigurationProperty private LogStream logStream = new LogStream();
   @NestedConfigurationProperty private RocksDb rocksDb = new RocksDb();
+  @NestedConfigurationProperty private PrimaryStorageBackup backup = new PrimaryStorageBackup();
 
   public String getDirectory() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -86,5 +87,13 @@ public class PrimaryStorage {
 
   public void setRocksDb(final RocksDb rocksDb) {
     this.rocksDb = rocksDb;
+  }
+
+  public PrimaryStorageBackup getBackup() {
+    return backup;
+  }
+
+  public void setBackup(final PrimaryStorageBackup primaryStorageBackup) {
+    backup = primaryStorageBackup;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/PrimaryStorageBackup.java
+++ b/configuration/src/main/java/io/camunda/configuration/PrimaryStorageBackup.java
@@ -11,10 +11,11 @@ import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilit
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-public class Backup implements Cloneable {
-  private static final String PREFIX = "camunda.data.backup";
+public class PrimaryStorageBackup implements Cloneable {
+  private static final String PREFIX = "camunda.data.primary-storage.backup";
 
-  private static final String LEGACY_BROKER_STORE = "zeebe.broker.data.backup.store";
+  private static final Set<String> LEGACY_BROKER_STORE =
+      Set.of("zeebe.broker.data.backup.store", "camunda.data.backup.store");
 
   /**
    * Set the backup store type. Supported values are [NONE, S3, GCS, AZURE, FILESYSTEM]. Default
@@ -84,7 +85,7 @@ public class Backup implements Cloneable {
         store,
         BackupStoreType.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_BROKER_STORE));
+        LEGACY_BROKER_STORE);
   }
 
   public void setStore(final BackupStoreType store) {

--- a/configuration/src/main/java/io/camunda/configuration/S3.java
+++ b/configuration/src/main/java/io/camunda/configuration/S3.java
@@ -9,34 +9,83 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class S3 {
-  private static final String PREFIX = "camunda.data.backup.s3";
-  private static final Set<String> LEGACY_BUCKETNAME_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.bucketName");
-  private static final Set<String> LEGACY_ENDPOINT_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.endpoint");
-  private static final Set<String> LEGACY_REGION_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.region");
-  private static final Set<String> LEGACY_ACCESS_KEY_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.accessKey");
-  private static final Set<String> LEGACY_SECRET_KEY_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.secretKey");
-  private static final Set<String> LEGACY_API_CALL_TIMEOUT_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.apiCallTimeout");
-  private static final Set<String> LEGACY_FORCE_PATH_STYLE_ACCESS_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.forcePathStyleAccess");
-  private static final Set<String> LEGACY_COMPRESSION_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.compression");
-  private static final Set<String> LEGACY_MAX_CONCURRENT_CONNECTIONS_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.maxConcurrentConnections");
-  private static final Set<String> LEGACY_CONNECTION_AQUISITION_TIMEOUT_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.connectionAcquisitionTimeout");
-  private static final Set<String> LEGACY_SUPPPORT_LEGACY_MD5_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.supportLegacyMd5");
-  private static final Set<String> LEGACY_BASEPATH_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.s3.basePath");
+  private static final String PREFIX = "camunda.data.primary-storage.backup.s3";
+
+  private static final Set<Set<String>> LEGACY_BUCKETNAME_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_ENDPOINT_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_REGION_PROPERTIES = new LinkedHashSet<>(2);
+  private static final Set<Set<String>> LEGACY_ACCESS_KEY_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_SECRET_KEY_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_API_CALL_TIMEOUT_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_FORCE_PATH_STYLE_ACCESS_PROPERTIES =
+      new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_COMPRESSION_PROPERTIES = new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_MAX_CONCURRENT_CONNECTIONS_PROPERTIES =
+      new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_CONNECTION_AQUISITION_TIMEOUT_PROPERTIES =
+      new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_SUPPORT_LEGACY_MD5_PROPERTIES =
+      new LinkedHashSet<>(2);
+
+  private static final Set<Set<String>> LEGACY_BASEPATH_PROPERTIES = new LinkedHashSet<>(2);
+
+  static {
+    LEGACY_BUCKETNAME_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.bucketName"));
+    LEGACY_BUCKETNAME_PROPERTIES.add(Set.of("camunda.data.backup.s3.bucket-name"));
+
+    LEGACY_ENDPOINT_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.endpoint"));
+    LEGACY_ENDPOINT_PROPERTIES.add(Set.of("camunda.data.backup.s3.endpoint"));
+
+    LEGACY_REGION_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.region"));
+    LEGACY_REGION_PROPERTIES.add(Set.of("camunda.data.backup.s3.region"));
+
+    LEGACY_ACCESS_KEY_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.accessKey"));
+    LEGACY_ACCESS_KEY_PROPERTIES.add(Set.of("camunda.data.backup.s3.access-key"));
+
+    LEGACY_SECRET_KEY_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.secretKey"));
+    LEGACY_SECRET_KEY_PROPERTIES.add(Set.of("camunda.data.backup.s3.secret-key"));
+
+    LEGACY_API_CALL_TIMEOUT_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.apiCallTimeout"));
+    LEGACY_API_CALL_TIMEOUT_PROPERTIES.add(Set.of("camunda.data.backup.s3.api-call-timeout"));
+
+    LEGACY_FORCE_PATH_STYLE_ACCESS_PROPERTIES.add(
+        Set.of("zeebe.broker.data.backup.s3.forcePathStyleAccess"));
+    LEGACY_FORCE_PATH_STYLE_ACCESS_PROPERTIES.add(
+        Set.of("camunda.data.backup.s3.force-path-style-access"));
+
+    LEGACY_COMPRESSION_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.compression"));
+    LEGACY_COMPRESSION_PROPERTIES.add(Set.of("camunda.data.backup.s3.compression"));
+
+    LEGACY_MAX_CONCURRENT_CONNECTIONS_PROPERTIES.add(
+        Set.of("zeebe.broker.data.backup.s3.maxConcurrentConnections"));
+    LEGACY_MAX_CONCURRENT_CONNECTIONS_PROPERTIES.add(
+        Set.of("camunda.data.backup.s3.max-concurrent-connections"));
+
+    LEGACY_CONNECTION_AQUISITION_TIMEOUT_PROPERTIES.add(
+        Set.of("zeebe.broker.data.backup.s3.connectionAcquisitionTimeout"));
+    LEGACY_CONNECTION_AQUISITION_TIMEOUT_PROPERTIES.add(
+        Set.of("camunda.data.backup.s3.connection-acquisition-timeout"));
+
+    LEGACY_SUPPORT_LEGACY_MD5_PROPERTIES.add(
+        Set.of("zeebe.broker.data.backup.s3.supportLegacyMd5"));
+    LEGACY_SUPPORT_LEGACY_MD5_PROPERTIES.add(Set.of("camunda.data.backup.s3.support-legacy-md5"));
+
+    LEGACY_BASEPATH_PROPERTIES.add(Set.of("zeebe.broker.data.backup.s3.basePath"));
+    LEGACY_BASEPATH_PROPERTIES.add(Set.of("camunda.data.backup.s3.base-path"));
+  }
 
   /**
    * Name of the bucket where the backup will be stored. The bucket must be already created. The
@@ -118,7 +167,7 @@ public class S3 {
   private String basePath;
 
   public String getBucketName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".bucket-name",
         bucketName,
         String.class,
@@ -131,7 +180,7 @@ public class S3 {
   }
 
   public String getEndpoint() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".endpoint",
         endpoint,
         String.class,
@@ -144,7 +193,7 @@ public class S3 {
   }
 
   public String getRegion() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".region",
         region,
         String.class,
@@ -157,7 +206,7 @@ public class S3 {
   }
 
   public String getAccessKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".access-key",
         accessKey,
         String.class,
@@ -170,7 +219,7 @@ public class S3 {
   }
 
   public String getSecretKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".secret-key",
         secretKey,
         String.class,
@@ -183,7 +232,7 @@ public class S3 {
   }
 
   public Duration getApiCallTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".api-call-timeout",
         apiCallTimeout,
         Duration.class,
@@ -196,7 +245,7 @@ public class S3 {
   }
 
   public boolean isForcePathStyleAccess() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".force-path-style-access",
         forcePathStyleAccess,
         Boolean.class,
@@ -209,7 +258,7 @@ public class S3 {
   }
 
   public String getCompression() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".compression",
         compression,
         String.class,
@@ -222,7 +271,7 @@ public class S3 {
   }
 
   public int getMaxConcurrentConnections() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".max-concurrent-connections",
         maxConcurrentConnections,
         Integer.class,
@@ -235,7 +284,7 @@ public class S3 {
   }
 
   public Duration getConnectionAcquisitionTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".connection-acquisition-timeout",
         connectionAcquisitionTimeout,
         Duration.class,
@@ -248,12 +297,12 @@ public class S3 {
   }
 
   public boolean isSupportLegacyMd5() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".support-legacy-md5",
         supportLegacyMd5,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_SUPPPORT_LEGACY_MD5_PROPERTIES);
+        LEGACY_SUPPORT_LEGACY_MD5_PROPERTIES);
   }
 
   public void setSupportLegacyMd5(final boolean supportLegacyMd5) {
@@ -261,7 +310,7 @@ public class S3 {
   }
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".base-path",
         basePath,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/SasToken.java
+++ b/configuration/src/main/java/io/camunda/configuration/SasToken.java
@@ -9,14 +9,21 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import io.camunda.zeebe.backup.azure.SasTokenConfig;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class SasToken {
-  private static final String PREFIX = "camunda.data.backup.azure.sas-token";
-  private static final Set<String> LEGACY_SASTOKEN_TYPE_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.sasToken.type");
-  private static final Set<String> LEGACY_SASTOKEN_VALUE_PROPERTIES =
-      Set.of("zeebe.broker.data.backup.azure.sasToken.value");
+  private static final String PREFIX = "camunda.data.primary-storage.backup.azure.sas-token";
+  private static final Set<Set<String>> LEGACY_SASTOKEN_TYPE_PROPERTIES = new LinkedHashSet<>(2);
+  private static final Set<Set<String>> LEGACY_SASTOKEN_VALUE_PROPERTIES = new LinkedHashSet<>(2);
+
+  static {
+    LEGACY_SASTOKEN_TYPE_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.sasToken.type"));
+    LEGACY_SASTOKEN_TYPE_PROPERTIES.add(Set.of("camunda.data.backup.azure.sas-token.type"));
+
+    LEGACY_SASTOKEN_VALUE_PROPERTIES.add(Set.of("zeebe.broker.data.backup.azure.sasToken.value"));
+    LEGACY_SASTOKEN_VALUE_PROPERTIES.add(Set.of("camunda.data.backup.azure.sas-token.value"));
+  }
 
   /** The SAS token must be of the following types: "delegation", "service" or "account". */
   private SasTokenType type;
@@ -32,7 +39,7 @@ public class SasToken {
   }
 
   public SasTokenType getType() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".type",
         type,
         SasTokenType.class,
@@ -45,7 +52,7 @@ public class SasToken {
   }
 
   public String getValue() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".value",
         value,
         String.class,
@@ -58,6 +65,9 @@ public class SasToken {
   }
 
   public SasTokenConfig toSasTokenConfig() {
+    if (getType() == null || getValue() == null) {
+      return null;
+    }
     return new SasTokenConfig.Builder()
         .withValue(getValue())
         .withTokenType(io.camunda.zeebe.backup.azure.SasTokenType.valueOf(getType().name()))

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -9,7 +9,6 @@ package io.camunda.configuration.beanoverrides;
 
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import io.camunda.configuration.Azure;
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
@@ -27,6 +26,7 @@ import io.camunda.configuration.Membership;
 import io.camunda.configuration.Metrics;
 import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.PrimaryStorage;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.Rdbms;
 import io.camunda.configuration.S3;
@@ -546,9 +546,10 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateFromBackup(final BrokerBasedProperties override) {
-    final Backup backup = unifiedConfiguration.getCamunda().getData().getBackup();
+    final PrimaryStorageBackup primaryStorageBackup =
+        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup();
     final BackupCfg backupCfg = override.getData().getBackup();
-    backupCfg.setStore(BackupStoreType.valueOf(backup.getStore().name()));
+    backupCfg.setStore(BackupStoreType.valueOf(primaryStorageBackup.getStore().name()));
 
     populateFromS3(override);
     populateFromGcs(override);
@@ -559,7 +560,8 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateFromS3(final BrokerBasedProperties override) {
-    final S3 s3 = unifiedConfiguration.getCamunda().getData().getBackup().getS3();
+    final S3 s3 =
+        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getS3();
     final S3BackupStoreConfig s3BackupStoreConfig = override.getData().getBackup().getS3();
     s3BackupStoreConfig.setBucketName(s3.getBucketName());
     s3BackupStoreConfig.setEndpoint(s3.getEndpoint());
@@ -627,7 +629,8 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateFromGcs(final BrokerBasedProperties override) {
-    final Gcs gcs = unifiedConfiguration.getCamunda().getData().getBackup().getGcs();
+    final Gcs gcs =
+        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getGcs();
     final GcsBackupStoreConfig gcsBackupStoreConfig = override.getData().getBackup().getGcs();
     gcsBackupStoreConfig.setBucketName(gcs.getBucketName());
     gcsBackupStoreConfig.setBasePath(gcs.getBasePath());
@@ -638,7 +641,8 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateFromAzure(final BrokerBasedProperties override) {
-    final Azure azure = unifiedConfiguration.getCamunda().getData().getBackup().getAzure();
+    final Azure azure =
+        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getAzure();
     final AzureBackupStoreConfig azureBackupStoreConfig = override.getData().getBackup().getAzure();
     azureBackupStoreConfig.setEndpoint(azure.getEndpoint());
     azureBackupStoreConfig.setAccountName(azure.getAccountName());
@@ -653,7 +657,13 @@ public class BrokerBasedPropertiesOverride {
 
   private void populateFromSasToken(final BrokerBasedProperties override) {
     final SasToken sasToken =
-        unifiedConfiguration.getCamunda().getData().getBackup().getAzure().getSasToken();
+        unifiedConfiguration
+            .getCamunda()
+            .getData()
+            .getPrimaryStorage()
+            .getBackup()
+            .getAzure()
+            .getSasToken();
     final SasTokenConfig sasTokenConfig = override.getData().getBackup().getAzure().getSasToken();
 
     if (sasToken != null) {
@@ -669,7 +679,7 @@ public class BrokerBasedPropertiesOverride {
 
   private void populateFromFilesystem(final BrokerBasedProperties override) {
     final Filesystem filesystem =
-        unifiedConfiguration.getCamunda().getData().getBackup().getFilesystem();
+        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getFilesystem();
     final FilesystemBackupStoreConfig filesystemBackupStoreConfig =
         override.getData().getBackup().getFilesystem();
     filesystemBackupStoreConfig.setBasePath(filesystem.getBasePath());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -52,8 +52,8 @@ import io.camunda.zeebe.broker.system.configuration.backpressure.LimitCfg;
 import io.camunda.zeebe.broker.system.configuration.backpressure.RateLimitCfg;
 import io.camunda.zeebe.broker.system.configuration.backpressure.ThrottleCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
@@ -547,15 +547,15 @@ public class BrokerBasedPropertiesOverride {
 
   private void populateFromBackup(final BrokerBasedProperties override) {
     final Backup backup = unifiedConfiguration.getCamunda().getData().getBackup();
-    final BackupStoreCfg backupStoreCfg = override.getData().getBackup();
-    backupStoreCfg.setStore(BackupStoreType.valueOf(backup.getStore().name()));
+    final BackupCfg backupCfg = override.getData().getBackup();
+    backupCfg.setStore(BackupStoreType.valueOf(backup.getStore().name()));
 
     populateFromS3(override);
     populateFromGcs(override);
     populateFromAzure(override);
     populateFromFilesystem(override);
 
-    override.getData().setBackup(backupStoreCfg);
+    override.getData().setBackup(backupCfg);
   }
 
   private void populateFromS3(final BrokerBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
-import io.camunda.configuration.Backup;
+import io.camunda.configuration.DocumentBasedSecondaryStorageBackup;
 import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -55,27 +55,27 @@ public class OperatePropertiesOverride {
     final OperateProperties override = new OperateProperties();
     BeanUtils.copyProperties(legacyOperateProperties, override);
 
-    populateFromBackup(override);
-
     final SecondaryStorage database =
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
     if (SecondaryStorageType.elasticsearch.equals(database.getType())) {
       populateFromElasticsearch(override, database);
+      populateFromBackup(override, database.getElasticsearch().getBackup());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       populateFromOpensearch(override, database);
+      populateFromBackup(override, database.getOpensearch().getBackup());
     }
 
     return override;
   }
 
-  private void populateFromBackup(final OperateProperties override) {
-    final Backup operateBackup = unifiedConfiguration.getCamunda().getData().getBackup();
+  private void populateFromBackup(
+      final OperateProperties override, final DocumentBasedSecondaryStorageBackup backup) {
     final BackupProperties backupProperties = override.getBackup();
-    backupProperties.setRepositoryName(operateBackup.getRepositoryName());
-    backupProperties.setSnapshotTimeout(operateBackup.getSnapshotTimeout());
+    backupProperties.setRepositoryName(backup.getRepositoryName());
+    backupProperties.setSnapshotTimeout(backup.getSnapshotTimeout());
     backupProperties.setIncompleteCheckTimeoutInSeconds(
-        operateBackup.getIncompleteCheckTimeout().getSeconds());
+        backup.getIncompleteCheckTimeout().getSeconds());
   }
 
   private void populateFromElasticsearch(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -8,7 +8,7 @@
 
 package io.camunda.configuration.beanoverrides;
 
-import io.camunda.configuration.Backup;
+import io.camunda.configuration.DocumentBasedSecondaryStorageBackup;
 import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -54,22 +54,22 @@ public class TasklistPropertiesOverride {
     final TasklistProperties override = new TasklistProperties();
     BeanUtils.copyProperties(legacyTasklistProperties, override);
 
-    populateFromBackup(override);
-
     final SecondaryStorage database =
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
     if (SecondaryStorageType.elasticsearch == database.getType()) {
       populateFromElasticsearch(override, database);
+      populateFromBackup(override, database.getElasticsearch().getBackup());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
       populateFromOpensearch(override, database);
+      populateFromBackup(override, database.getOpensearch().getBackup());
     }
 
     return override;
   }
 
-  private void populateFromBackup(final TasklistProperties override) {
-    final Backup backup = unifiedConfiguration.getCamunda().getData().getBackup();
+  private void populateFromBackup(
+      final TasklistProperties override, final DocumentBasedSecondaryStorageBackup backup) {
     override.getBackup().setRepositoryName(backup.getRepositoryName());
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupAzureSasTokenTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupAzureSasTokenTest.java
@@ -107,4 +107,67 @@ public class DataBackupAzureSasTokenTest {
           .isEqualTo("valueNew");
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.primary-storage.backup.azure.sas-token.type=delegation",
+        "camunda.data.primary-storage.backup.azure.sas-token.value=valueNew",
+        // old unified
+        "camunda.data.backup.azure.sas-token.type=delegation",
+        "camunda.data.backup.azure.sas-token.value=valueOld",
+      })
+  class WithNewAndLegacyUnifiedSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacyUnifiedSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTypeFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getSasToken().type())
+          .isEqualTo(SasTokenType.DELEGATION);
+    }
+
+    @Test
+    void shouldSetValueFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getSasToken().value())
+          .isEqualTo("valueNew");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.primary-storage.backup.azure.sas-token.type=delegation",
+        "camunda.data.primary-storage.backup.azure.sas-token.value=valueNew",
+        // old unified
+        "camunda.data.backup.azure.sas-token.type=delegation",
+        "camunda.data.backup.azure.sas-token.value=valueOld",
+        // legacy
+        "camunda.data.backup.azure.sas-token.type=service",
+        "camunda.data.backup.azure.sas-token.value=valueLegacy",
+      })
+  class WithNewAndBothLegacyUnifiedSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndBothLegacyUnifiedSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTypeFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getSasToken().type())
+          .isEqualTo(SasTokenType.DELEGATION);
+    }
+
+    @Test
+    void shouldSetValueFromNew() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getSasToken().value())
+          .isEqualTo("valueNew");
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupAzureTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupAzureTest.java
@@ -188,4 +188,247 @@ public class DataBackupAzureTest {
       assertThat(brokerCfg.getData().getBackup().getAzure().isCreateContainer()).isFalse();
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.primary-storage.backup.azure.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-name=accountNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-key=accountKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.connection-string=connectionStringPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.create-container=true",
+      })
+  class WithOnlyPrimaryStorageConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyPrimaryStorageConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEndpoint() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountName() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountName())
+          .isEqualTo("accountNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountKey() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountKey())
+          .isEqualTo("accountKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetConnectionString() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getConnectionString())
+          .isEqualTo("connectionStringPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetCreateContainer() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().isCreateContainer()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.azure.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-name=accountNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-key=accountKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.connection-string=connectionStringPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.create-container=true",
+        // backup (unified)
+        "camunda.data.backup.azure.endpoint=endpointNew",
+        "camunda.data.backup.azure.account-name=accountNameNew",
+        "camunda.data.backup.azure.account-key=accountKeyNew",
+        "camunda.data.backup.azure.connection-string=connectionStringNew",
+        "camunda.data.backup.azure.base-path=basePathNew",
+        "camunda.data.backup.azure.create-container=false",
+      })
+  class WithPrimaryStorageAndBackupSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndBackupSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEndpointFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountName())
+          .isEqualTo("accountNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountKey())
+          .isEqualTo("accountKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetConnectionStringFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getConnectionString())
+          .isEqualTo("connectionStringPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetCreateContainerFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().isCreateContainer()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.azure.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-name=accountNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-key=accountKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.connection-string=connectionStringPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.create-container=true",
+        // legacy
+        "zeebe.broker.data.backup.azure.endpoint=endpointLegacy",
+        "zeebe.broker.data.backup.azure.accountName=accountNameLegacy",
+        "zeebe.broker.data.backup.azure.accountKey=accountKeyLegacy",
+        "zeebe.broker.data.backup.azure.connectionString=connectionStringLegacy",
+        "zeebe.broker.data.backup.azure.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.azure.createContainer=false",
+      })
+  class WithPrimaryStorageAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEndpointFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountName())
+          .isEqualTo("accountNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountKey())
+          .isEqualTo("accountKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetConnectionStringFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getConnectionString())
+          .isEqualTo("connectionStringPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetCreateContainerFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().isCreateContainer()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.azure.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-name=accountNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.account-key=accountKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.connection-string=connectionStringPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.azure.create-container=true",
+        // backup (unified)
+        "camunda.data.backup.azure.endpoint=endpointNew",
+        "camunda.data.backup.azure.account-name=accountNameNew",
+        "camunda.data.backup.azure.account-key=accountKeyNew",
+        "camunda.data.backup.azure.connection-string=connectionStringNew",
+        "camunda.data.backup.azure.base-path=basePathNew",
+        "camunda.data.backup.azure.create-container=false",
+        // legacy
+        "zeebe.broker.data.backup.azure.endpoint=endpointLegacy",
+        "zeebe.broker.data.backup.azure.accountName=accountNameLegacy",
+        "zeebe.broker.data.backup.azure.accountKey=accountKeyLegacy",
+        "zeebe.broker.data.backup.azure.connectionString=connectionStringLegacy",
+        "zeebe.broker.data.backup.azure.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.azure.createContainer=false",
+      })
+  class WithAllThreeConfigsSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithAllThreeConfigsSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetEndpointFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountName())
+          .isEqualTo("accountNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccountKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getAccountKey())
+          .isEqualTo("accountKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetConnectionStringFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getConnectionString())
+          .isEqualTo("connectionStringPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetCreateContainerFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getAzure().isCreateContainer()).isTrue();
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupBrokerPropertiesTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupFilesystemTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupFilesystemTest.java
@@ -84,4 +84,91 @@ public class DataBackupFilesystemTest {
           .isEqualTo("basePathNew");
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.primary-storage.backup.filesystem.base-path=basePathPrimaryStorage",
+      })
+  class WithOnlyPrimaryStorageConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyPrimaryStorageConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.filesystem.base-path=basePathPrimaryStorage",
+        // backup (unified)
+        "camunda.data.backup.filesystem.base-path=basePathNew",
+      })
+  class WithPrimaryStorageAndBackupSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndBackupSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.filesystem.base-path=basePathPrimaryStorage",
+        // legacy
+        "zeebe.broker.data.backup.filesystem.basePath=basePathLegacy",
+      })
+  class WithPrimaryStorageAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.filesystem.base-path=basePathPrimaryStorage",
+        // backup (unified)
+        "camunda.data.backup.filesystem.base-path=basePathNew",
+        // legacy
+        "zeebe.broker.data.backup.filesystem.basePath=basePathLegacy",
+      })
+  class WithAllThreeConfigsSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithAllThreeConfigsSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getFilesystem().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
@@ -146,4 +146,187 @@ public class DataBackupGcsTest {
           .isEqualTo(GcsBackupStoreAuth.NONE);
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.primary-storage.backup.gcs.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.host=hostPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.auth=auto",
+      })
+  class WithOnlyPrimaryStorageConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyPrimaryStorageConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketName() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetHost() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost())
+          .isEqualTo("hostPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAuth() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.AUTO);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.gcs.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.host=hostPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.auth=auto",
+        // backup (unified)
+        "camunda.data.backup.gcs.bucket-name=bucketNameNew",
+        "camunda.data.backup.gcs.base-path=basePathNew",
+        "camunda.data.backup.gcs.host=hostNew",
+        "camunda.data.backup.gcs.auth=none",
+      })
+  class WithPrimaryStorageAndBackupSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndBackupSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetHostFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost())
+          .isEqualTo("hostPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAuthFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.AUTO);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.gcs.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.host=hostPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.auth=auto",
+        // legacy
+        "zeebe.broker.data.backup.gcs.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.gcs.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.gcs.host=hostLegacy",
+        "zeebe.broker.data.backup.gcs.auth=none",
+      })
+  class WithPrimaryStorageAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetHostFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost())
+          .isEqualTo("hostPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAuthFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.AUTO);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.gcs.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.host=hostPrimaryStorage",
+        "camunda.data.primary-storage.backup.gcs.auth=auto",
+        // backup (unified)
+        "camunda.data.backup.gcs.bucket-name=bucketNameNew",
+        "camunda.data.backup.gcs.base-path=basePathNew",
+        "camunda.data.backup.gcs.host=hostNew",
+        "camunda.data.backup.gcs.auth=none",
+        // legacy
+        "zeebe.broker.data.backup.gcs.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.gcs.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.gcs.host=hostLegacy",
+        "zeebe.broker.data.backup.gcs.auth=none",
+      })
+  class WithAllThreeConfigsSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithAllThreeConfigsSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetHostFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getHost())
+          .isEqualTo("hostPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAuthFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
+          .isEqualTo(GcsBackupStoreAuth.AUTO);
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
@@ -202,6 +202,94 @@ public class DataBackupOperatePropertiesTest {
             .isEqualTo(180);
       }
     }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // old unified config
+          "camunda.data.backup.incomplete-check-timeout=1m",
+          // legacy configuration operate
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class IncompleteCheckTimeoutOldUnified {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutOldUnified(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromOldUnified() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(60);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // legacy configuration operate
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class IncompleteCheckTimeoutOnlyLegacy {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutOnlyLegacy(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromLegacy() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(90);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.opensearch.backup.incomplete-check-timeout=2m",
+          // legacy configuration operate
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class IncompleteCheckTimeoutFromNewWithLegacy {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutFromNewWithLegacy(
+          @Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(120);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=2m",
+          // old unified config
+          "camunda.data.backup.incomplete-check-timeout=1m",
+        })
+    class IncompleteCheckTimeoutFromNewWithOldUnified {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutFromNewWithOldUnified(
+          @Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(120);
+      }
+    }
   }
 
   @Nested
@@ -351,13 +439,13 @@ public class DataBackupOperatePropertiesTest {
           "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=3m",
           // old unified config
           "camunda.data.backup.repository-name=repositoryName",
-          "camunda.data.backup.snapshot-timeout=5",
-          "camunda.data.backup.incomplete-check-timeout=3m",
+          "camunda.data.backup.snapshot-timeout=2",
+          "camunda.data.backup.incomplete-check-timeout=1m",
           // legacy configuration tasklist
           "camunda.tasklist.backup.repositoryName=repositoryName",
           // legacy configuration operate
           "camunda.operate.backup.repositoryName=repositoryName",
-          "camunda.operate.backup.snapshotTimeout=2",
+          "camunda.operate.backup.snapshotTimeout=1",
           "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
         })
     class WithNewAndLegacySet {
@@ -381,6 +469,94 @@ public class DataBackupOperatePropertiesTest {
       void shouldSetIncompleteCheckTimeoutFromNew() {
         assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
             .isEqualTo(180);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // old unified config
+          "camunda.data.backup.incomplete-check-timeout=1m",
+          // legacy configuration operate
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class IncompleteCheckTimeoutOldUnified {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutOldUnified(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromOldUnified() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(60);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // legacy configuration operate
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class IncompleteCheckTimeoutOnlyLegacy {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutOnlyLegacy(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromLegacy() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(90);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=2m",
+          // legacy configuration operate
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class IncompleteCheckTimeoutFromNewWithLegacy {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutFromNewWithLegacy(
+          @Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(120);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=2m",
+          // old unified config
+          "camunda.data.backup.incomplete-check-timeout=1m",
+        })
+    class IncompleteCheckTimeoutFromNewWithOldUnified {
+      final OperateProperties operateProperties;
+
+      IncompleteCheckTimeoutFromNewWithOldUnified(
+          @Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(120);
       }
     }
   }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
@@ -23,139 +23,365 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   UnifiedConfigurationHelper.class
 })
 public class DataBackupOperatePropertiesTest {
+
   @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.backup.repository-name=repositoryNameNew",
-        "camunda.data.backup.snapshot-timeout=5",
-        "camunda.data.backup.incomplete-check-timeout=3m",
-      })
-  class WithOnlyUnifiedConfigSet {
-    final OperateProperties operateProperties;
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=opensearch"})
+  class Opensearch {
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.secondary-storage.opensearch.backup.repository-name=repositoryNameNew",
+          "camunda.data.secondary-storage.opensearch.backup.snapshot-timeout=5",
+          "camunda.data.secondary-storage.opensearch.backup.incomplete-check-timeout=3m",
+        })
+    class WithOnlyUnifiedConfigSet {
+      final OperateProperties operateProperties;
 
-    WithOnlyUnifiedConfigSet(@Autowired final OperateProperties operateProperties) {
-      this.operateProperties = operateProperties;
+      WithOnlyUnifiedConfigSet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeout() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeout() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
 
-    @Test
-    void shouldSetRepositoryName() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.backup.repository-name=repositoryNameNew",
+          "camunda.data.backup.snapshot-timeout=5",
+          "camunda.data.backup.incomplete-check-timeout=3m",
+        })
+    class WithOnlyOldUnifiedConfigSet {
+      final OperateProperties operateProperties;
+
+      WithOnlyOldUnifiedConfigSet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeout() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeout() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
 
-    @Test
-    void shouldSetSnapshotTimeout() {
-      assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.tasklist.backup.repositoryName=repositoryNameTasklist",
+        })
+    class WithOnlyTasklistLegacySet {
+      final OperateProperties operateProperties;
+
+      WithOnlyTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameFromTasklist() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameTasklist");
+      }
     }
 
-    @Test
-    void shouldSetIncompleteCheckTimeout() {
-      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds()).isEqualTo(180);
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryNameOperate",
+          "camunda.operate.backup.snapshotTimeout=5",
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=180",
+        })
+    class WithOnlyOperateLegacySet {
+      final OperateProperties operateProperties;
+
+      WithOnlyOperateLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameFromLegacyOperate() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameOperate");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeoutFromLegacyOperate() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromLegacyOperate() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryName",
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+        })
+    class WithOperateAndTasklistLegacySet {
+      final OperateProperties operateProperties;
+
+      WithOperateAndTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfLegacyMatch() {
+        assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.opensearch.backup.repository-name=repositoryName",
+          "camunda.data.secondary-storage.opensearch.backup.snapshot-timeout=5",
+          "camunda.data.secondary-storage.opensearch.backup.incomplete-check-timeout=3m",
+          // old unified config
+          "camunda.data.backup.repository-name=repositoryName",
+          "camunda.data.backup.snapshot-timeout=2",
+          "camunda.data.backup.incomplete-check-timeout=3m",
+          // legacy configuration tasklist
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+          // legacy configuration operate
+          "camunda.operate.backup.repositoryName=repositoryName",
+          "camunda.operate.backup.snapshotTimeout=2",
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class WithNewAndLegacySet {
+      final OperateProperties operateProperties;
+
+      WithNewAndLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfNewAndLegacyMatch() {
+        assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
   }
 
   @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.tasklist.backup.repositoryName=repositoryNameTasklist",
-      })
-  class WithOnlyTasklistLegacySet {
-    final OperateProperties operateProperties;
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
+  class Elasticsearch {
 
-    WithOnlyTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
-      this.operateProperties = operateProperties;
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.secondary-storage.elasticsearch.backup.repository-name=repositoryNameNew",
+          "camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout=5",
+          "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=3m",
+        })
+    class WithOnlyUnifiedConfigSet {
+      final OperateProperties operateProperties;
+
+      WithOnlyUnifiedConfigSet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeout() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeout() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
 
-    @Test
-    void shouldSetRepositoryNameFromTasklist() {
-      assertThat(operateProperties.getBackup().getRepositoryName())
-          .isEqualTo("repositoryNameTasklist");
-    }
-  }
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.backup.repository-name=repositoryNameNew",
+          "camunda.data.backup.snapshot-timeout=5",
+          "camunda.data.backup.incomplete-check-timeout=3m",
+        })
+    class WithOnlyOldUnifiedConfigSet {
+      final OperateProperties operateProperties;
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.operate.backup.repositoryName=repositoryNameOperate",
-        "camunda.operate.backup.snapshotTimeout=5",
-        "camunda.operate.backup.incompleteCheckTimeoutInSeconds=180",
-      })
-  class WithOnlyOperateLegacySet {
-    final OperateProperties operateProperties;
+      WithOnlyOldUnifiedConfigSet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
 
-    WithOnlyOperateLegacySet(@Autowired final OperateProperties operateProperties) {
-      this.operateProperties = operateProperties;
-    }
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
 
-    @Test
-    void shouldSetRepositoryNameFromLegacyOperate() {
-      assertThat(operateProperties.getBackup().getRepositoryName())
-          .isEqualTo("repositoryNameOperate");
-    }
+      @Test
+      void shouldSetSnapshotTimeout() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
 
-    @Test
-    void shouldSetSnapshotTimeoutFromLegacyOperate() {
-      assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
-    }
-
-    @Test
-    void shouldSetIncompleteCheckTimeoutFromLegacyOperate() {
-      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds()).isEqualTo(180);
-    }
-  }
-
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.operate.backup.repositoryName=repositoryName",
-        "camunda.tasklist.backup.repositoryName=repositoryName",
-      })
-  class WithOperateAndTasklistLegacySet {
-    final OperateProperties operateProperties;
-
-    WithOperateAndTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
-      this.operateProperties = operateProperties;
+      @Test
+      void shouldSetIncompleteCheckTimeout() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
 
-    @Test
-    void shouldSetRepositoryNameIfLegacyMatch() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
-    }
-  }
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.tasklist.backup.repositoryName=repositoryNameTasklist",
+        })
+    class WithOnlyTasklistLegacySet {
+      final OperateProperties operateProperties;
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        // new
-        "camunda.data.backup.repository-name=repositoryName",
-        "camunda.data.backup.snapshot-timeout=5",
-        "camunda.data.backup.incomplete-check-timeout=3m",
-        // legacy configuration tasklist
-        "camunda.tasklist.backup.repositoryName=repositoryName",
-        // legacy configuration operate
-        "camunda.operate.backup.repositoryName=repositoryName",
-        "camunda.operate.backup.snapshotTimeout=2",
-        "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
-      })
-  class WithNewAndLegacySet {
-    final OperateProperties operateProperties;
+      WithOnlyTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
 
-    WithNewAndLegacySet(@Autowired final OperateProperties operateProperties) {
-      this.operateProperties = operateProperties;
+      @Test
+      void shouldSetRepositoryNameFromTasklist() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameTasklist");
+      }
     }
 
-    @Test
-    void shouldSetRepositoryNameIfNewAndLegacyMatch() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryNameOperate",
+          "camunda.operate.backup.snapshotTimeout=5",
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=180",
+        })
+    class WithOnlyOperateLegacySet {
+      final OperateProperties operateProperties;
+
+      WithOnlyOperateLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameFromLegacyOperate() {
+        assertThat(operateProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameOperate");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeoutFromLegacyOperate() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromLegacyOperate() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
 
-    @Test
-    void shouldSetSnapshotTimeoutFromNew() {
-      assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryName",
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+        })
+    class WithOperateAndTasklistLegacySet {
+      final OperateProperties operateProperties;
+
+      WithOperateAndTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfLegacyMatch() {
+        assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
     }
 
-    @Test
-    void shouldSetIncompleteCheckTimeoutFromNew() {
-      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds()).isEqualTo(180);
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.elasticsearch.backup.repository-name=repositoryName",
+          "camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout=5",
+          "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=3m",
+          // old unified config
+          "camunda.data.backup.repository-name=repositoryName",
+          "camunda.data.backup.snapshot-timeout=5",
+          "camunda.data.backup.incomplete-check-timeout=3m",
+          // legacy configuration tasklist
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+          // legacy configuration operate
+          "camunda.operate.backup.repositoryName=repositoryName",
+          "camunda.operate.backup.snapshotTimeout=2",
+          "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
+        })
+    class WithNewAndLegacySet {
+      final OperateProperties operateProperties;
+
+      WithNewAndLegacySet(@Autowired final OperateProperties operateProperties) {
+        this.operateProperties = operateProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfNewAndLegacyMatch() {
+        assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
+
+      @Test
+      void shouldSetSnapshotTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getSnapshotTimeout()).isEqualTo(5);
+      }
+
+      @Test
+      void shouldSetIncompleteCheckTimeoutFromNew() {
+        assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+            .isEqualTo(180);
+      }
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
@@ -272,7 +272,7 @@ public class DataBackupOperatePropertiesTest {
     @TestPropertySource(
         properties = {
           // new
-          "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=2m",
+          "camunda.data.secondary-storage.opensearch.backup.incomplete-check-timeout=2m",
           // old unified config
           "camunda.data.backup.incomplete-check-timeout=1m",
         })

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupS3Test.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupS3Test.java
@@ -308,4 +308,435 @@ public class DataBackupS3Test {
       assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isTrue();
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.primary-storage.backup.s3.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.region=regionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.access-key=accessKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.secret-key=secretKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.api-call-timeout=480s",
+        "camunda.data.primary-storage.backup.s3.force-path-style-access=false",
+        "camunda.data.primary-storage.backup.s3.compression=compressionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.max-concurrent-connections=150",
+        "camunda.data.primary-storage.backup.s3.connection-acquisition-timeout=120s",
+        "camunda.data.primary-storage.backup.s3.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.support-legacy-md5=false",
+      })
+  class WithOnlyPrimaryStorageConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyPrimaryStorageConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketName() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetEndpoint() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetRegion() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion())
+          .isEqualTo("regionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccessKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey())
+          .isEqualTo("accessKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSecretKey() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey())
+          .isEqualTo("secretKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetApiCallTimeout() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(480));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccess() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isFalse();
+    }
+
+    @Test
+    void shouldSetCompression() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnection() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(150);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeout() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(120));
+    }
+
+    @Test
+    void shouldSetBasePath() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isFalse();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.s3.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.region=regionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.access-key=accessKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.secret-key=secretKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.api-call-timeout=480s",
+        "camunda.data.primary-storage.backup.s3.force-path-style-access=false",
+        "camunda.data.primary-storage.backup.s3.compression=compressionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.max-concurrent-connections=150",
+        "camunda.data.primary-storage.backup.s3.connection-acquisition-timeout=120s",
+        "camunda.data.primary-storage.backup.s3.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.support-legacy-md5=false",
+        // backup (unified)
+        "camunda.data.backup.s3.bucket-name=bucketNameNew",
+        "camunda.data.backup.s3.endpoint=endpointNew",
+        "camunda.data.backup.s3.region=regionNew",
+        "camunda.data.backup.s3.access-key=accessKeyNew",
+        "camunda.data.backup.s3.secret-key=secretKeyNew",
+        "camunda.data.backup.s3.api-call-timeout=360s",
+        "camunda.data.backup.s3.force-path-style-access=true",
+        "camunda.data.backup.s3.compression=compressionNew",
+        "camunda.data.backup.s3.max-concurrent-connections=100",
+        "camunda.data.backup.s3.connection-acquisition-timeout=90s",
+        "camunda.data.backup.s3.base-path=basePathNew",
+        "camunda.data.backup.s3.support-legacy-md5=true",
+      })
+  class WithPrimaryStorageAndBackupSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndBackupSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetEndpointFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetRegionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion())
+          .isEqualTo("regionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccessKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey())
+          .isEqualTo("accessKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSecretKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey())
+          .isEqualTo("secretKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetApiCallTimeoutFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(480));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccessFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isFalse();
+    }
+
+    @Test
+    void shouldSetCompressionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnectionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(150);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeoutFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(120));
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5FromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isFalse();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.s3.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.region=regionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.access-key=accessKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.secret-key=secretKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.api-call-timeout=480s",
+        "camunda.data.primary-storage.backup.s3.force-path-style-access=false",
+        "camunda.data.primary-storage.backup.s3.compression=compressionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.max-concurrent-connections=150",
+        "camunda.data.primary-storage.backup.s3.connection-acquisition-timeout=120s",
+        "camunda.data.primary-storage.backup.s3.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.support-legacy-md5=false",
+        // legacy
+        "zeebe.broker.data.backup.s3.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.s3.endpoint=endpointLegacy",
+        "zeebe.broker.data.backup.s3.region=regionLegacy",
+        "zeebe.broker.data.backup.s3.accessKey=accessKeyLegacy",
+        "zeebe.broker.data.backup.s3.secretKey=secretKeyLegacy",
+        "zeebe.broker.data.backup.s3.apiCallTimeout=720s",
+        "zeebe.broker.data.backup.s3.forcePathStyleAccess=true",
+        "zeebe.broker.data.backup.s3.compression=compressionLegacy",
+        "zeebe.broker.data.backup.s3.maxConcurrentConnections=200",
+        "zeebe.broker.data.backup.s3.connectionAcquisitionTimeout=180s",
+        "zeebe.broker.data.backup.s3.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.s3.supportLegacyMd5=true",
+      })
+  class WithPrimaryStorageAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPrimaryStorageAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetEndpointFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetRegionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion())
+          .isEqualTo("regionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccessKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey())
+          .isEqualTo("accessKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSecretKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey())
+          .isEqualTo("secretKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetApiCallTimeoutFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(480));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccessFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isFalse();
+    }
+
+    @Test
+    void shouldSetCompressionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnectionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(150);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeoutFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(120));
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5FromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isFalse();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // primary-storage
+        "camunda.data.primary-storage.backup.s3.bucket-name=bucketNamePrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.endpoint=endpointPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.region=regionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.access-key=accessKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.secret-key=secretKeyPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.api-call-timeout=480s",
+        "camunda.data.primary-storage.backup.s3.force-path-style-access=false",
+        "camunda.data.primary-storage.backup.s3.compression=compressionPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.max-concurrent-connections=150",
+        "camunda.data.primary-storage.backup.s3.connection-acquisition-timeout=120s",
+        "camunda.data.primary-storage.backup.s3.base-path=basePathPrimaryStorage",
+        "camunda.data.primary-storage.backup.s3.support-legacy-md5=false",
+        // backup (unified)
+        "camunda.data.backup.s3.bucket-name=bucketNameNew",
+        "camunda.data.backup.s3.endpoint=endpointNew",
+        "camunda.data.backup.s3.region=regionNew",
+        "camunda.data.backup.s3.access-key=accessKeyNew",
+        "camunda.data.backup.s3.secret-key=secretKeyNew",
+        "camunda.data.backup.s3.api-call-timeout=360s",
+        "camunda.data.backup.s3.force-path-style-access=true",
+        "camunda.data.backup.s3.compression=compressionNew",
+        "camunda.data.backup.s3.max-concurrent-connections=100",
+        "camunda.data.backup.s3.connection-acquisition-timeout=90s",
+        "camunda.data.backup.s3.base-path=basePathNew",
+        "camunda.data.backup.s3.support-legacy-md5=true",
+        // legacy
+        "zeebe.broker.data.backup.s3.bucketName=bucketNameLegacy",
+        "zeebe.broker.data.backup.s3.endpoint=endpointLegacy",
+        "zeebe.broker.data.backup.s3.region=regionLegacy",
+        "zeebe.broker.data.backup.s3.accessKey=accessKeyLegacy",
+        "zeebe.broker.data.backup.s3.secretKey=secretKeyLegacy",
+        "zeebe.broker.data.backup.s3.apiCallTimeout=720s",
+        "zeebe.broker.data.backup.s3.forcePathStyleAccess=true",
+        "zeebe.broker.data.backup.s3.compression=compressionLegacy",
+        "zeebe.broker.data.backup.s3.maxConcurrentConnections=200",
+        "zeebe.broker.data.backup.s3.connectionAcquisitionTimeout=180s",
+        "zeebe.broker.data.backup.s3.basePath=basePathLegacy",
+        "zeebe.broker.data.backup.s3.supportLegacyMd5=true",
+      })
+  class WithAllThreeConfigsSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithAllThreeConfigsSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBucketNameFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBucketName())
+          .isEqualTo("bucketNamePrimaryStorage");
+    }
+
+    @Test
+    void shouldSetEndpointFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getEndpoint())
+          .isEqualTo("endpointPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetRegionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getRegion())
+          .isEqualTo("regionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetAccessKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getAccessKey())
+          .isEqualTo("accessKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSecretKeyFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getSecretKey())
+          .isEqualTo("secretKeyPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetApiCallTimeoutFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getApiCallTimeout())
+          .isEqualTo(Duration.ofSeconds(480));
+    }
+
+    @Test
+    void shouldSetForcePathStyleAccessFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isForcePathStyleAccess()).isFalse();
+    }
+
+    @Test
+    void shouldSetCompressionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getCompression())
+          .isEqualTo("compressionPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetMaxConcurrentConnectionFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getMaxConcurrentConnections())
+          .isEqualTo(150);
+    }
+
+    @Test
+    void shouldSetConnectionAcquisitionTimeoutFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getConnectionAcquisitionTimeout())
+          .isEqualTo(Duration.ofSeconds(120));
+    }
+
+    @Test
+    void shouldSetBasePathFromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().getBasePath())
+          .isEqualTo("basePathPrimaryStorage");
+    }
+
+    @Test
+    void shouldSetSupportLegacyMd5FromPrimaryStorage() {
+      assertThat(brokerCfg.getData().getBackup().getS3().isSupportLegacyMd5()).isFalse();
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
@@ -173,7 +173,10 @@ public class DataBackupTasklistPropertiesTest {
     @Nested
     @TestPropertySource(
         properties = {
-          "camunda.data.secondary-storage.elasticsearch.backup.repository-name=repositoryNameNew",
+          "camunda.data.secondary-storage.elasticsearch.backup.repository-name=repositoryNameNew3",
+          "camunda.data.backup.repository-name=repositoryNameNew2",
+          "camunda.operate.backup.repositoryName=repositoryNameNew",
+          "camunda.tasklist.backup.repositoryName=repositoryNameNew",
         })
     class WithNewUnifiedConfigSet {
       final TasklistProperties tasklistProperties;
@@ -185,7 +188,7 @@ public class DataBackupTasklistPropertiesTest {
       @Test
       void shouldSetRepositoryName() {
         assertThat(tasklistProperties.getBackup().getRepositoryName())
-            .isEqualTo("repositoryNameNew");
+            .isEqualTo("repositoryNameNew3");
       }
     }
 

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
@@ -23,101 +23,252 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   UnifiedConfigurationHelper.class
 })
 public class DataBackupTasklistPropertiesTest {
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.backup.repository-name=repositoryNameNew",
-      })
-  class WithOnlyUnifiedConfigSet {
-    final TasklistProperties tasklistProperties;
 
-    WithOnlyUnifiedConfigSet(@Autowired final TasklistProperties tasklistProperties) {
-      this.tasklistProperties = tasklistProperties;
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=opensearch"})
+  class Opensearch {
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.backup.repository-name=repositoryNameNew",
+        })
+    class WithOldUnifiedConfigSet {
+      final TasklistProperties tasklistProperties;
+
+      WithOldUnifiedConfigSet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
     }
 
-    @Test
-    void shouldSetRepositoryName() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.secondary-storage.opensearch.backup.repository-name=repositoryNameNew",
+        })
+    class WithNewUnifiedConfigSet {
+      final TasklistProperties tasklistProperties;
+
+      WithNewUnifiedConfigSet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryNameOperate",
+        })
+    class WithOnlyOperateLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithOnlyOperateLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameFromOperate() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameOperate");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.tasklist.backup.repositoryName=repositoryNameTasklist",
+        })
+    class WithOnlyTasklistLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithOnlyTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryFromTasklist() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameTasklist");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryName",
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+        })
+    class WithOperateAndTasklistLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithOperateAndTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfLegacyMatch() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.opensearch.backup.repository-name=repositoryName",
+          // old unified configuration
+          "camunda.data.backup.repository-name=repositoryName",
+          // legacy configuration operate
+          "camunda.operate.backup.repositoryName=repositoryName",
+          // legacy configuration tasklist
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+        })
+    class WithNewAndLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithNewAndLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfNewAndLegacyMatch() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
     }
   }
 
   @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.operate.backup.repositoryName=repositoryNameOperate",
-      })
-  class WithOnlyOperateLegacySet {
-    final TasklistProperties tasklistProperties;
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
+  class Elasticsearch {
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.backup.repository-name=repositoryNameNew",
+        })
+    class WithOldUnifiedConfigSet {
+      final TasklistProperties tasklistProperties;
 
-    WithOnlyOperateLegacySet(@Autowired final TasklistProperties tasklistProperties) {
-      this.tasklistProperties = tasklistProperties;
+      WithOldUnifiedConfigSet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
     }
 
-    @Test
-    void shouldSetRepositoryNameFromOperate() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName())
-          .isEqualTo("repositoryNameOperate");
-    }
-  }
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.data.secondary-storage.elasticsearch.backup.repository-name=repositoryNameNew",
+        })
+    class WithNewUnifiedConfigSet {
+      final TasklistProperties tasklistProperties;
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.tasklist.backup.repositoryName=repositoryNameTasklist",
-      })
-  class WithOnlyTasklistLegacySet {
-    final TasklistProperties tasklistProperties;
+      WithNewUnifiedConfigSet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
 
-    WithOnlyTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
-      this.tasklistProperties = tasklistProperties;
-    }
-
-    @Test
-    void shouldSetRepositoryFromTasklist() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName())
-          .isEqualTo("repositoryNameTasklist");
-    }
-  }
-
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.operate.backup.repositoryName=repositoryName",
-        "camunda.tasklist.backup.repositoryName=repositoryName",
-      })
-  class WithOperateAndTasklistLegacySet {
-    final TasklistProperties tasklistProperties;
-
-    WithOperateAndTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
-      this.tasklistProperties = tasklistProperties;
+      @Test
+      void shouldSetRepositoryName() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameNew");
+      }
     }
 
-    @Test
-    void shouldSetRepositoryNameIfLegacyMatch() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
-    }
-  }
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryNameOperate",
+        })
+    class WithOnlyOperateLegacySet {
+      final TasklistProperties tasklistProperties;
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        // new
-        "camunda.data.backup.repository-name=repositoryName",
-        // legacy configuration operate
-        "camunda.operate.backup.repositoryName=repositoryName",
-        // legacy configuration tasklist
-        "camunda.tasklist.backup.repositoryName=repositoryName",
-      })
-  class WithNewAndLegacySet {
-    final TasklistProperties tasklistProperties;
+      WithOnlyOperateLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
 
-    WithNewAndLegacySet(@Autowired final TasklistProperties tasklistProperties) {
-      this.tasklistProperties = tasklistProperties;
+      @Test
+      void shouldSetRepositoryNameFromOperate() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameOperate");
+      }
     }
 
-    @Test
-    void shouldSetRepositoryNameIfNewAndLegacyMatch() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.tasklist.backup.repositoryName=repositoryNameTasklist",
+        })
+    class WithOnlyTasklistLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithOnlyTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryFromTasklist() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName())
+            .isEqualTo("repositoryNameTasklist");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          "camunda.operate.backup.repositoryName=repositoryName",
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+        })
+    class WithOperateAndTasklistLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithOperateAndTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfLegacyMatch() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
+    }
+
+    @Nested
+    @TestPropertySource(
+        properties = {
+          // new
+          "camunda.data.secondary-storage.elasticsearch.backup.repository-name=repositoryName",
+          // old unified configuration
+          "camunda.data.backup.repository-name=repositoryName",
+          // legacy configuration operate
+          "camunda.operate.backup.repositoryName=repositoryName",
+          // legacy configuration tasklist
+          "camunda.tasklist.backup.repositoryName=repositoryName",
+        })
+    class WithNewAndLegacySet {
+      final TasklistProperties tasklistProperties;
+
+      WithNewAndLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+        this.tasklistProperties = tasklistProperties;
+      }
+
+      @Test
+      void shouldSetRepositoryNameIfNewAndLegacyMatch() {
+        assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      }
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -94,6 +94,10 @@ public class SecondaryStorageElasticsearchTest {
   private static final int EXPECTED_BULK_SIZE = 2_000;
   private static final int EXPECTED_BULK_MEMORY_LIMIT = 50;
 
+  private static final String EXPECTED_BACKUP_REPOSITORY_NAME = "backup-repo";
+  private static final int EXPECTED_BACKUP_SNAPSHOT_TIMEOUT = 10;
+  private static final int EXPECTED_BACKUP_INCOMPLETE_CHECK_TIMEOUT = 10;
+
   @Nested
   @TestPropertySource(
       properties = {
@@ -161,7 +165,12 @@ public class SecondaryStorageElasticsearchTest {
             + EXPECTED_BATCH_OPERATION_EXPORT_ITEMS_ON_CREATION,
         "camunda.data.secondary-storage.elasticsearch.bulk.delay=10s",
         "camunda.data.secondary-storage.elasticsearch.bulk.size=" + EXPECTED_BULK_SIZE,
-        "camunda.data.secondary-storage.elasticsearch.bulk.memory-limit=50MB"
+        "camunda.data.secondary-storage.elasticsearch.bulk.memory-limit=50MB",
+        "camunda.data.secondary-storage.elasticsearch.backup.repository-name="
+            + EXPECTED_BACKUP_REPOSITORY_NAME,
+        "camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout="
+            + EXPECTED_BACKUP_SNAPSHOT_TIMEOUT,
+        "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=PT10S",
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -203,6 +212,12 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(operateProperties.getElasticsearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(operateProperties.getBackup().getSnapshotTimeout())
+          .isEqualTo(EXPECTED_BACKUP_SNAPSHOT_TIMEOUT);
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+          .isEqualTo(EXPECTED_BACKUP_INCOMPLETE_CHECK_TIMEOUT);
     }
 
     @Test
@@ -225,6 +240,8 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(tasklistProperties.getElasticsearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(tasklistProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
     }
 
     @Test
@@ -491,6 +508,16 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.database.index.replicasByIndexName.my-index=3",
         "camunda.data.secondary-storage.elasticsearch.number-of-shards-per-index.my-index=2",
         "camunda.database.index.shardsByIndexName.my-index=2",
+
+        // backup configuration
+        "camunda.data.secondary-storage.elasticsearch.backup.repository-name="
+            + EXPECTED_BACKUP_REPOSITORY_NAME,
+        "camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout="
+            + EXPECTED_BACKUP_SNAPSHOT_TIMEOUT,
+        "camunda.data.secondary-storage.elasticsearch.backup.incomplete-check-timeout=10s",
+        "camunda.operate.backup.repositoryName=" + EXPECTED_BACKUP_REPOSITORY_NAME,
+        "camunda.operate.backup.snapshotTimeout=" + EXPECTED_BACKUP_SNAPSHOT_TIMEOUT,
+        "camunda.operate.backup.incompleteCheckTimeoutInSeconds=10",
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -532,6 +559,12 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(operateProperties.getElasticsearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(operateProperties.getBackup().getSnapshotTimeout())
+          .isEqualTo(EXPECTED_BACKUP_SNAPSHOT_TIMEOUT);
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+          .isEqualTo(EXPECTED_BACKUP_INCOMPLETE_CHECK_TIMEOUT);
     }
 
     @Test
@@ -554,6 +587,8 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(tasklistProperties.getElasticsearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(tasklistProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -93,6 +93,10 @@ public class SecondaryStorageOpensearchTest {
   private static final int EXPECTED_BULK_SIZE = 2_000;
   private static final int EXPECTED_BULK_MEMORY_LIMIT = 50;
 
+  private static final String EXPECTED_BACKUP_REPOSITORY_NAME = "backup-repo";
+  private static final int EXPECTED_BACKUP_SNAPSHOT_TIMEOUT = 10;
+  private static final int EXPECTED_BACKUP_INCOMPLETE_CHECK_TIMEOUT = 10;
+
   @Nested
   @TestPropertySource(
       properties = {
@@ -156,7 +160,12 @@ public class SecondaryStorageOpensearchTest {
             + EXPECTED_BATCH_OPERATION_EXPORT_ITEMS_ON_CREATION,
         "camunda.data.secondary-storage.opensearch.bulk.delay=10s",
         "camunda.data.secondary-storage.opensearch.bulk.size=" + EXPECTED_BULK_SIZE,
-        "camunda.data.secondary-storage.opensearch.bulk.memory-limit=50MB"
+        "camunda.data.secondary-storage.opensearch.bulk.memory-limit=50MB",
+        "camunda.data.secondary-storage.opensearch.backup.repository-name="
+            + EXPECTED_BACKUP_REPOSITORY_NAME,
+        "camunda.data.secondary-storage.opensearch.backup.snapshot-timeout="
+            + EXPECTED_BACKUP_SNAPSHOT_TIMEOUT,
+        "camunda.data.secondary-storage.opensearch.backup.incomplete-check-timeout=PT10S",
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -197,6 +206,12 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(operateProperties.getOpensearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(operateProperties.getBackup().getSnapshotTimeout())
+          .isEqualTo(EXPECTED_BACKUP_SNAPSHOT_TIMEOUT);
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+          .isEqualTo(EXPECTED_BACKUP_INCOMPLETE_CHECK_TIMEOUT);
     }
 
     @Test
@@ -480,6 +495,16 @@ public class SecondaryStorageOpensearchTest {
         "camunda.database.index.replicasByIndexName.my-index=3",
         "camunda.data.secondary-storage.opensearch.number-of-shards-per-index.my-index=2",
         "camunda.database.index.shardsByIndexName.my-index=2",
+
+        // backup configuration
+        "camunda.data.secondary-storage.opensearch.backup.repository-name="
+            + EXPECTED_BACKUP_REPOSITORY_NAME,
+        "camunda.data.secondary-storage.opensearch.backup.snapshot-timeout="
+            + EXPECTED_BACKUP_SNAPSHOT_TIMEOUT,
+        "camunda.data.secondary-storage.opensearch.backup.incomplete-check-timeout=10s",
+        "camunda.operate.backup.repositoryName=" + EXPECTED_BACKUP_REPOSITORY_NAME,
+        "camunda.operate.backup.snapshotTimeout=" + EXPECTED_BACKUP_SNAPSHOT_TIMEOUT,
+        "camunda.operate.backup.incompleteCheckTimeoutInSeconds=10",
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -520,6 +545,12 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(operateProperties.getOpensearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(operateProperties.getBackup().getSnapshotTimeout())
+          .isEqualTo(EXPECTED_BACKUP_SNAPSHOT_TIMEOUT);
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
+      assertThat(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+          .isEqualTo(EXPECTED_BACKUP_INCOMPLETE_CHECK_TIMEOUT);
     }
 
     @Test
@@ -542,6 +573,8 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(tasklistProperties.getOpenSearch().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(tasklistProperties.getBackup().getRepositoryName())
+          .isEqualTo(EXPECTED_BACKUP_REPOSITORY_NAME);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
@@ -16,8 +16,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.Environment;
 
@@ -27,6 +29,13 @@ class UnifiedConfigurationHelperTest {
   private static final Set<String> SINGLE_LEGACY_PROPERTY = Set.of("legacy.prop1");
   private static final Set<String> MULTIPLE_LEGACY_PROPERTIES =
       Set.of("legacy.prop1", "legacy.prop2");
+  private static final Set<Set<String>> LEGACY_ORDERED_PROPERTIES = new LinkedHashSet<>(3);
+
+  static {
+    LEGACY_ORDERED_PROPERTIES.add(Set.of("legacy.prop1"));
+    LEGACY_ORDERED_PROPERTIES.add(Set.of("legacy.prop21", "legacy.prop22"));
+    LEGACY_ORDERED_PROPERTIES.add(Set.of("legacy.prop3"));
+  }
 
   Environment mockEnvironment;
 
@@ -254,5 +263,136 @@ class UnifiedConfigurationHelperTest {
         UnifiedConfigurationHelper.validateLegacyConfiguration(
             NEW_PROPERTY, defaultValue, String.class, mode, SINGLE_LEGACY_PROPERTY);
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Nested
+  class MultiLevelTest {
+
+    @Test
+    void multiLevelPropertyChainSetNew() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+      setPropertyValues("legacy.prop21", "legacyValue2");
+      setPropertyValues("legacy.prop22", "legacyValue2");
+      setPropertyValues("legacy.prop3", "legacyValue3");
+      setPropertyValues(NEW_PROPERTY, defaultValue);
+
+      final String expected = "newValue";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void multiLevelPropertyChainOneLevelLower() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+      setPropertyValues("legacy.prop21", "legacyValue2");
+      setPropertyValues("legacy.prop22", "legacyValue2");
+      setPropertyValues("legacy.prop3", "legacyValue3");
+
+      final String expected = "legacyValue3";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void multiLevelPropertyChainTwoLevelsLower() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+      setPropertyValues("legacy.prop21", "legacyValue2");
+      setPropertyValues("legacy.prop22", "legacyValue2");
+
+      final String expected = "legacyValue2";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void multiLevelPropertyChainThreeLevelsLower() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+
+      final String expected = "legacyValue";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void multiLevelPropertyChainWithMissingHigherOrdered() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+      setPropertyValues("legacy.prop21", "legacyValue2");
+      setPropertyValues("legacy.prop22", "legacyValue2");
+      setPropertyValues(NEW_PROPERTY, defaultValue);
+
+      final String expected = "newValue";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void multiLevelPropertyChainWithGap() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+      setPropertyValues("legacy.prop3", "legacyValue3");
+      setPropertyValues(NEW_PROPERTY, defaultValue);
+
+      final String expected = "newValue";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void multiLevelPropertyChainWithGaps() {
+      // given
+      final String defaultValue = "newValue";
+      final BackwardsCompatibilityMode mode = SUPPORTED;
+
+      // when
+      setPropertyValues("legacy.prop1", "legacyValue");
+      setPropertyValues(NEW_PROPERTY, defaultValue);
+
+      final String expected = "newValue";
+      final String actual =
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+              NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
+      assertThat(actual).isEqualTo(expected);
+    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
@@ -10,8 +10,9 @@ package io.camunda.application.commons.backup;
 import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.elasticsearch;
 import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.opensearch;
 
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.DocumentBasedSecondaryStorageBackup;
+import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.BackupRepositoryPropsRecord;
@@ -26,7 +27,8 @@ public class BackupConfig {
 
   @Bean
   public BackupRepositoryProps backupRepositoryProps(final Camunda camunda) {
-    return props(VersionUtil.getVersion(), camunda.getData().getBackup());
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    return props(VersionUtil.getVersion(), backupConfig(secondaryStorage));
   }
 
   @Bean("backupThreadPoolExecutor")
@@ -42,11 +44,19 @@ public class BackupConfig {
     return executor;
   }
 
-  public static BackupRepositoryProps props(final String version, final Backup backupConfig) {
+  public static BackupRepositoryProps props(
+      final String version, final DocumentBasedSecondaryStorageBackup backupConfig) {
     return new BackupRepositoryPropsRecord(
         version,
         backupConfig.getRepositoryName(),
         backupConfig.getSnapshotTimeout(),
         backupConfig.getIncompleteCheckTimeout().getSeconds());
+  }
+
+  private DocumentBasedSecondaryStorageBackup backupConfig(
+      final SecondaryStorage secondaryStorage) {
+    return elasticsearch.equals(secondaryStorage.getType())
+        ? secondaryStorage.getElasticsearch().getBackup()
+        : secondaryStorage.getOpensearch().getBackup();
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
@@ -37,7 +37,7 @@ final class BackupStoreComponent {
     return buildBackupStore(brokerCfg.getData().getBackup());
   }
 
-  private BackupStore buildBackupStore(final BackupStoreCfg backupCfg) {
+  private BackupStore buildBackupStore(final BackupCfg backupCfg) {
     final var store = backupCfg.getStore();
     return switch (store) {
       case S3 -> buildS3BackupStore(backupCfg);
@@ -50,24 +50,23 @@ final class BackupStoreComponent {
     };
   }
 
-  private static BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupStoreCfg.getS3());
+  private static BackupStore buildS3BackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
     return S3BackupStore.of(storeConfig);
   }
 
-  private static BackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = GcsBackupStoreConfig.toStoreConfig(backupStoreCfg.getGcs());
+  private static BackupStore buildGcsBackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = GcsBackupStoreConfig.toStoreConfig(backupCfg.getGcs());
     return GcsBackupStore.of(storeConfig);
   }
 
-  private static BackupStore buildAzureBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = AzureBackupStoreConfig.toStoreConfig(backupStoreCfg.getAzure());
+  private static BackupStore buildAzureBackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = AzureBackupStoreConfig.toStoreConfig(backupCfg.getAzure());
     return AzureBackupStore.of(storeConfig);
   }
 
-  private static BackupStore buildFilesystemBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig =
-        FilesystemBackupStoreConfig.toStoreConfig(backupStoreCfg.getFilesystem());
+  private static BackupStore buildFilesystemBackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = FilesystemBackupStoreConfig.toStoreConfig(backupCfg.getFilesystem());
     return FilesystemBackupStore.of(storeConfig);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -14,9 +14,9 @@ import feign.FeignException.NotFound;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
-import io.camunda.configuration.Backup;
-import io.camunda.configuration.Backup.BackupStoreType;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
 import io.camunda.it.document.DocumentClient;
 import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupHistoryResponse;
@@ -240,7 +240,7 @@ public class BackupRestoreIT {
   }
 
   private void configureZeebeBackupStore(final Camunda cfg, final DatabaseType databaseType) {
-    final var backup = cfg.getData().getBackup();
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
     final var azure = backup.getAzure();
 
     backup.setStore(BackupStoreType.AZURE);
@@ -264,9 +264,9 @@ public class BackupRestoreIT {
 
   private void restoreZeebe() {
     final var unifiedRestoreConfig = new Camunda();
-    final var backup = unifiedRestoreConfig.getData().getBackup();
+    final var backup = unifiedRestoreConfig.getData().getPrimaryStorage().getBackup();
 
-    backup.setStore(Backup.BackupStoreType.AZURE); // We are configuring Azure always
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.AZURE); // We are configuring Azure always
     backup.getAzure().setBasePath(containerName);
     backup.getAzure().setConnectionString(AZURITE_CONTAINER.getConnectString());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -29,7 +29,7 @@ import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
@@ -364,7 +364,7 @@ public final class SystemContext {
     }
   }
 
-  private void validateBackupCfg(final BackupStoreCfg backup) {
+  private void validateBackupCfg(final BackupCfg backup) {
     try {
       switch (backup.getStore()) {
         case NONE -> LOG.warn("No backup store is configured. Backups will not be taken");

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import java.io.File;
 import java.time.Duration;
 import java.util.Optional;
@@ -37,7 +37,7 @@ public final class DataCfg implements ConfigurationEntry {
   private Double diskUsageCommandWatermark;
   private Duration diskUsageMonitoringInterval;
   private DiskCfg disk = new DiskCfg();
-  private BackupStoreCfg backup = new BackupStoreCfg();
+  private BackupCfg backup = new BackupCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -156,11 +156,11 @@ public final class DataCfg implements ConfigurationEntry {
     this.disk = disk;
   }
 
-  public BackupStoreCfg getBackup() {
+  public BackupCfg getBackup() {
     return backup;
   }
 
-  public void setBackup(final BackupStoreCfg backup) {
+  public void setBackup(final BackupCfg backup) {
     this.backup = backup;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupCfg.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.system.configuration.backup;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 
-public class BackupStoreCfg implements ConfigurationEntry {
+public class BackupCfg implements ConfigurationEntry {
 
   private BackupStoreType store = BackupStoreType.NONE;
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.backup.filesystem.FilesystemBackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
@@ -82,7 +82,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
 
   private static void installS3Store(
       final PartitionTransitionContext context,
-      final BackupStoreCfg backupCfg,
+      final BackupCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
       final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
@@ -96,7 +96,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
 
   private static void installGcsStore(
       final PartitionTransitionContext context,
-      final BackupStoreCfg backupCfg,
+      final BackupCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
       final var brokerGcsConfig = backupCfg.getGcs();
@@ -111,7 +111,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
 
   private static void installAzureStore(
       final PartitionTransitionContext context,
-      final BackupStoreCfg backupCfg,
+      final BackupCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
       final var brokerAzureConfig = backupCfg.getAzure();
@@ -126,7 +126,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
 
   private static void installFilesystemStore(
       final PartitionTransitionContext context,
-      final BackupStoreCfg backupCfg,
+      final BackupCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
       final var brokerFilesystemConfig = backupCfg.getFilesystem();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenerCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import java.util.HashMap;
@@ -83,7 +83,7 @@ final class BackupStoreCfgTest {
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("backup-cfg", new HashMap<>());
-    final BackupStoreCfg backup = cfg.getData().getBackup();
+    final BackupCfg backup = cfg.getData().getBackup();
 
     // then
     assertThat(backup.getStore()).isEqualTo(BackupStoreType.S3);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
@@ -16,8 +16,8 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
@@ -153,7 +153,7 @@ class BackupStoreTransitionStepTest {
   }
 
   private void configureStore(final BackupStoreType type, final S3BackupStoreConfig s3Config) {
-    final var backupCfg = new BackupStoreCfg();
+    final var backupCfg = new BackupCfg();
     backupCfg.setStore(type);
     backupCfg.setS3(s3Config);
     when(brokerCfg.getData()).thenReturn(dataCfg);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureBackupAcceptanceIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
-import io.camunda.configuration.Backup;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.azure.AzureBackupConfig;
 import io.camunda.zeebe.backup.azure.AzureBackupStore;
@@ -89,10 +89,10 @@ final class AzureBackupAcceptanceIT implements BackupAcceptance {
   private void configureBroker(final TestStandaloneBroker broker) {
     broker.withUnifiedConfig(
         cfg -> {
-          final var backup = cfg.getData().getBackup();
+          final var backup = cfg.getData().getPrimaryStorage().getBackup();
           final var azure = backup.getAzure();
 
-          backup.setStore(Backup.BackupStoreType.AZURE);
+          backup.setStore(PrimaryStorageBackup.BackupStoreType.AZURE);
           azure.setBasePath(CONTAINER_NAME);
           azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
         });

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureRestoreAcceptanceIT.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.it.cluster.backup;
 import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.testcontainers.junit.jupiter.Container;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureRestoreAcceptanceIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.it.cluster.backup;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
@@ -33,8 +34,8 @@ final class AzureRestoreAcceptanceIT implements RestoreAcceptance {
 
   @Override
   public void configureBackupStore(final Camunda cfg) {
-    final var backup = cfg.getData().getBackup();
-    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.AZURE);
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.AZURE);
     final var azure = backup.getAzure();
     azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
     azure.setBasePath(CONTAINER_NAME);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupErrorResponseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupErrorResponseTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.it.cluster.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.shared.management.BackupEndpoint;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -11,8 +11,8 @@ import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.configuration.Backup.BackupStoreType;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup.BackupStoreType;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
@@ -96,7 +96,7 @@ class BackupMultiPartitionTest {
 
   private void configureBackupStore(final Camunda config) {
 
-    final var backupConfig = config.getData().getBackup();
+    final var backupConfig = config.getData().getPrimaryStorage().getBackup();
     backupConfig.setStore(BackupStoreType.S3);
 
     final var s3Config = backupConfig.getS3();
@@ -246,10 +246,11 @@ class BackupMultiPartitionTest {
     unifiedRestoreConfig.getCluster().setSize(broker.unifiedConfig().getCluster().getSize());
 
     // backup config s3
-    final var backupConfig = unifiedRestoreConfig.getData().getBackup();
+    final var backupConfig = unifiedRestoreConfig.getData().getPrimaryStorage().getBackup();
     backupConfig.setStore(BackupStoreType.S3);
     final var s3Config = backupConfig.getS3();
-    final var legacyBackupConfig = broker.unifiedConfig().getData().getBackup().getS3();
+    final var legacyBackupConfig =
+        broker.unifiedConfig().getData().getPrimaryStorage().getBackup().getS3();
     s3Config.setBucketName(legacyBackupConfig.getBucketName());
     s3Config.setEndpoint(legacyBackupConfig.getEndpoint());
     s3Config.setRegion(legacyBackupConfig.getRegion());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.gateway.admin.backup.BackupRequestHandler;
 import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
 import io.camunda.zeebe.gateway.admin.backup.State;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
@@ -11,9 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import com.google.cloud.storage.BucketInfo;
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Gcs;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.management.backups.BackupInfo;
 import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
@@ -128,14 +128,14 @@ public class ClusteredBackupRestoreTest {
   }
 
   private static void configureBackupStore(final Camunda config) {
-    final var backup = config.getData().getBackup();
+    final var backup = config.getData().getPrimaryStorage().getBackup();
 
     final var storeConfig = new Gcs();
     storeConfig.setAuth(Gcs.GcsBackupStoreAuth.NONE);
     storeConfig.setBucketName(BUCKET_NAME);
     storeConfig.setHost(GCS.externalEndpoint());
 
-    backup.setStore(Backup.BackupStoreType.GCS);
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.GCS);
     backup.setGcs(storeConfig);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
@@ -20,7 +20,7 @@ import io.camunda.management.backups.TakeBackupRuntimeResponse;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ConcurrentBackupScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ConcurrentBackupScalingIT.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import feign.FeignException;
 import io.atomix.cluster.MemberId;
-import io.camunda.configuration.Backup;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
@@ -117,8 +117,12 @@ final class ConcurrentBackupScalingIT {
   private void configureBackup(final TestStandaloneBroker broker) {
     broker.withUnifiedConfig(
         cfg -> {
-          cfg.getData().getBackup().setStore(Backup.BackupStoreType.FILESYSTEM);
           cfg.getData()
+              .getPrimaryStorage()
+              .getBackup()
+              .setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
+          cfg.getData()
+              .getPrimaryStorage()
               .getBackup()
               .getFilesystem()
               .setBasePath(backupBasePath.toAbsolutePath().toString());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
@@ -13,9 +13,9 @@ import static org.awaitility.Awaitility.await;
 
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.client.CamundaClient;
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Gcs;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.management.backups.StateCode;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
@@ -257,8 +257,11 @@ final class ContinuousBackupIT {
     gcsConfig.setBasePath(basePath);
     gcsConfig.setBucketName(BUCKET_NAME);
     gcsConfig.setHost(GCS.externalEndpoint());
-    cfg.getData().getBackup().setGcs(gcsConfig);
-    cfg.getData().getBackup().setStore(Backup.BackupStoreType.GCS);
+    cfg.getData().getPrimaryStorage().getBackup().setGcs(gcsConfig);
+    cfg.getData()
+        .getPrimaryStorage()
+        .getBackup()
+        .setStore(PrimaryStorageBackup.BackupStoreType.GCS);
     cfg.getData().getPrimaryStorage().getLogStream().setLogSegmentSize(DataSize.ofMegabytes(1));
     cfg.getCluster().getNetwork().setMaxMessageSize(DataSize.ofKilobytes(500));
     cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
@@ -270,7 +273,10 @@ final class ContinuousBackupIT {
     gcsConfig.setBasePath(basePath);
     gcsConfig.setBucketName(BUCKET_NAME);
     gcsConfig.setHost(GCS.externalEndpoint());
-    cfg.getData().getBackup().setGcs(gcsConfig);
-    cfg.getData().getBackup().setStore(Backup.BackupStoreType.GCS);
+    cfg.getData().getPrimaryStorage().getBackup().setGcs(gcsConfig);
+    cfg.getData()
+        .getPrimaryStorage()
+        .getBackup()
+        .setStore(PrimaryStorageBackup.BackupStoreType.GCS);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupAcceptanceIT.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.it.cluster.backup;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -55,11 +55,14 @@ final class FilesystemBackupAcceptanceIT implements BackupAcceptance {
   private void configureBroker(final TestStandaloneBroker broker) {
     broker.withUnifiedConfig(
         cfg -> {
-          cfg.getData().getBackup().setStore(Backup.BackupStoreType.FILESYSTEM);
+          cfg.getData()
+              .getPrimaryStorage()
+              .getBackup()
+              .setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
 
           final var config = new Filesystem();
           config.setBasePath(basePath.toAbsolutePath().toString());
-          cfg.getData().getBackup().setFilesystem(config);
+          cfg.getData().getPrimaryStorage().getBackup().setFilesystem(config);
         });
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemRestoreAcceptanceIT.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.cluster.backup;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import java.nio.file.Path;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemRestoreAcceptanceIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.it.cluster.backup;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
@@ -36,8 +37,8 @@ final class FilesystemRestoreAcceptanceIT implements RestoreAcceptance {
 
   @Override
   public void configureBackupStore(final Camunda cfg) {
-    final var backup = cfg.getData().getBackup();
-    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.FILESYSTEM);
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
 
     final var config = backup.getFilesystem();
     config.setBasePath(basePath.toAbsolutePath().toString());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupAcceptanceIT.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.it.cluster.backup;
 
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.client.CamundaClient;
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.Gcs;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
@@ -88,14 +88,17 @@ final class GcsBackupAcceptanceIT implements BackupAcceptance {
   private void configureBroker(final TestStandaloneBroker broker) {
     broker.withUnifiedConfig(
         cfg -> {
-          cfg.getData().getBackup().setStore(Backup.BackupStoreType.GCS);
+          cfg.getData()
+              .getPrimaryStorage()
+              .getBackup()
+              .setStore(PrimaryStorageBackup.BackupStoreType.GCS);
 
           final var config = new Gcs();
           config.setAuth(Gcs.GcsBackupStoreAuth.NONE);
           config.setBasePath(basePath);
           config.setBucketName(BUCKET_NAME);
           config.setHost(GCS.externalEndpoint());
-          cfg.getData().getBackup().setGcs(config);
+          cfg.getData().getPrimaryStorage().getBackup().setGcs(config);
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsRestoreAcceptanceIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.cluster.backup;
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Gcs;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -56,8 +57,8 @@ final class GcsRestoreAcceptanceIT implements RestoreAcceptance {
 
   @Override
   public void configureBackupStore(final Camunda cfg) {
-    final var backup = cfg.getData().getBackup();
-    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.GCS);
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.GCS);
 
     final var config = backup.getGcs();
     config.setAuth(Gcs.GcsBackupStoreAuth.NONE);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsRestoreAcceptanceIT.java
@@ -13,7 +13,7 @@ import io.camunda.configuration.Gcs;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.test.testcontainers.GcsContainer;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupAcceptanceIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
-import io.camunda.configuration.Backup;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
@@ -108,10 +108,10 @@ final class S3BackupAcceptanceIT implements BackupAcceptance {
   private void configureBroker(final TestStandaloneBroker broker) {
     broker.withUnifiedConfig(
         cfg -> {
-          final var backup = cfg.getData().getBackup();
+          final var backup = cfg.getData().getPrimaryStorage().getBackup();
           final var s3 = backup.getS3();
 
-          backup.setStore(Backup.BackupStoreType.S3);
+          backup.setStore(PrimaryStorageBackup.BackupStoreType.S3);
           s3.setBucketName(bucketName);
           s3.setEndpoint(minio.externalEndpoint());
           s3.setRegion(minio.region());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3RestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3RestoreAcceptanceIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.it.cluster.backup;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -61,8 +62,8 @@ final class S3RestoreAcceptanceIT implements RestoreAcceptance {
 
   @Override
   public void configureBackupStore(final Camunda cfg) {
-    final var backup = cfg.getData().getBackup();
-    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.S3);
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.S3);
 
     final var s3 = backup.getS3();
     s3.setRegion(MINIO.region());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3RestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3RestoreAcceptanceIT.java
@@ -11,7 +11,7 @@ import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.test.testcontainers.MinioContainer;
 import java.time.Duration;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -18,9 +18,9 @@ import static org.assertj.core.api.Assertions.fail;
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.CreateGroupResponse;
-import io.camunda.configuration.Backup;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.management.backups.StateCode;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationUtil;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
@@ -93,8 +93,8 @@ public class ScaleUpPartitionsTest {
                 b ->
                     b.withUnifiedConfig(
                             cfg -> {
-                              final var backup = cfg.getData().getBackup();
-                              backup.setStore(Backup.BackupStoreType.FILESYSTEM);
+                              final var backup = cfg.getData().getPrimaryStorage().getBackup();
+                              backup.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
                               backup.getFilesystem().setBasePath(backupPath.toString());
 
                               final var membership = cfg.getCluster().getMembership();
@@ -133,10 +133,11 @@ public class ScaleUpPartitionsTest {
         .setReplicationFactor(brokerCfg.getCluster().getReplicationFactor());
     unifiedRestoreConfig.getCluster().setSize(brokerCfg.getCluster().getSize());
 
-    final var backupConfig = unifiedRestoreConfig.getData().getBackup();
-    backupConfig.setStore(Backup.BackupStoreType.FILESYSTEM);
+    final var backupConfig = unifiedRestoreConfig.getData().getPrimaryStorage().getBackup();
+    backupConfig.setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
     final var filesystem = new Filesystem();
-    filesystem.setBasePath(brokerCfg.getData().getBackup().getFilesystem().getBasePath());
+    filesystem.setBasePath(
+        brokerCfg.getData().getPrimaryStorage().getBackup().getFilesystem().getBasePath());
     backupConfig.setFilesystem(filesystem);
     return unifiedRestoreConfig;
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Separate primary and secondary storage backup configurations. To support this change while maintaining backwards compatibility a new parser for the unified configuration was required that would support ordering in the properties.

To do so, you can now supply a `LinkedHashSet<Set<String>>` of properties to validate against. The last value always has precedence in the configuration, apart from the value directly specified in the Unified Config. The `LinkedHashSet` is required to maintain insertion order for the properties. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41968
