### PR TITLE
fix: use a final class with private ctor instead of an interface

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/metrics/JobHandlerMetrics.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/metrics/JobHandlerMetrics.java
@@ -26,16 +26,17 @@ import java.util.Map;
  * <p>These constants are used for recording and tagging job handler metrics such as invocations,
  * execution times, and job actions (activated, completed, failed, BPMN error).
  */
-@SuppressWarnings("checkstyle:InterfaceIsType")
-public interface JobHandlerMetrics {
-  static CounterMetricsContext counter(final ActivatedJob activatedJob) {
+public final class JobHandlerMetrics {
+  private JobHandlerMetrics() {}
+
+  public static CounterMetricsContext counter(final ActivatedJob activatedJob) {
     return new CounterMetricsContext(
         Name.INVOCATION.asString(),
         Map.ofEntries(Map.entry(Tag.TYPE.asString(), activatedJob.getType())),
         1);
   }
 
-  static TimerMetricsContext timer(final ActivatedJob activatedJob) {
+  public static TimerMetricsContext timer(final ActivatedJob activatedJob) {
     return new TimerMetricsContext(
         Name.EXECUTION_TIME.asString(),
         Map.ofEntries(Map.entry(Tag.TYPE.asString(), activatedJob.getType())));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR makes the `JobHandlerMetrics` a final class with private ctor instead of an interface.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
