### PR TITLE
feat: add useProcessInstanceElementSelection hook

### DIFF
--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -19,6 +19,10 @@ import {useProcessInstance} from 'modules/queries/processInstance/useProcessInst
 import {getFlowNodeName} from 'modules/utils/flowNodes';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useHasPendingCancelOrMoveModification = () => {
   const willAllFlowNodesBeCanceled = useWillAllFlowNodesBeCanceled();
   const modificationsByFlowNode = useModificationsByFlowNode();
@@ -49,6 +53,10 @@ const useHasPendingCancelOrMoveModification = () => {
   );
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useHasRunningOrFinishedTokens = () => {
   const {data: statistics} = useFlownodeInstancesStatistics();
   const currentFlowNodeSelection = flowNodeSelectionStore.state.selection;
@@ -61,6 +69,10 @@ const useHasRunningOrFinishedTokens = () => {
   );
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useIsRootNodeSelected = () => {
   const {data: processInstance} = useProcessInstance();
 
@@ -70,6 +82,10 @@ const useIsRootNodeSelected = () => {
   );
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useNewTokenCountForSelectedNode = () => {
   const modificationsByFlowNode = useModificationsByFlowNode();
   const currentFlowNodeSelection = flowNodeSelectionStore.state.selection;
@@ -89,6 +105,10 @@ const useNewTokenCountForSelectedNode = () => {
   );
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useIsPlaceholderSelected = () => {
   const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
@@ -99,6 +119,10 @@ const useIsPlaceholderSelected = () => {
   );
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useRootNode = () => {
   const {data: processInstance} = useProcessInstance();
 
@@ -108,6 +132,10 @@ const useRootNode = () => {
   };
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const useSelectedFlowNodeName = () => {
   const {data: processInstance} = useProcessInstance();
   const {data: businessObjects} = useBusinessObjects();

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
@@ -1,0 +1,328 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor, act} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {MemoryRouter, Route, Routes, useLocation} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockElementInstance: ElementInstance = {
+  elementInstanceKey: '2251799813699889',
+  elementId: 'service-task-1',
+  elementName: 'Service Task',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  processDefinitionId: 'process-def-1',
+  processInstanceKey: '123',
+  processDefinitionKey: '2',
+  hasIncident: false,
+  tenantId: '<default>',
+};
+
+const mockElementInstance2: ElementInstance = {
+  elementInstanceKey: '2251799813699890',
+  elementId: 'service-task-2',
+  elementName: 'Service Task 2',
+  type: 'SERVICE_TASK',
+  state: 'COMPLETED',
+  startDate: '2018-06-21',
+  endDate: '2018-06-22',
+  processDefinitionId: 'process-def-1',
+  processInstanceKey: '123',
+  processDefinitionKey: '2',
+  hasIncident: false,
+  tenantId: '<default>',
+};
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('123')],
+) => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('useProcessInstanceElementSelection', () => {
+  describe('Initial state', () => {
+    it('should return null for selectedElementInstance when no selection', () => {
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper(),
+      });
+
+      expect(result.current.selectedElementInstance).toBeNull();
+      expect(result.current.selectedElementId).toBeNull();
+      expect(result.current.isFetchingElement).toBe(false);
+    });
+  });
+
+  describe('selectElement', () => {
+    it('should update URL with elementId only', () => {
+      mockSearchElementInstances().withSuccess({
+        items: [mockElementInstance],
+        page: {totalItems: 1},
+      });
+
+      const {result} = renderHook(
+        () => {
+          const location = useLocation();
+          const hook = useProcessInstanceElementSelection();
+          return {...hook, location};
+        },
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      act(() => {
+        result.current.selectElement('service-task-1');
+      });
+
+      expect(result.current.selectedElementId).toBe('service-task-1');
+      expect(result.current.location.search).toContain(
+        'elementId=service-task-1',
+      );
+      expect(result.current.location.search).not.toContain(
+        'elementInstanceKey',
+      );
+    });
+
+    it('should fetch element instances when only elementId is provided', async () => {
+      mockSearchElementInstances().withSuccess({
+        items: [mockElementInstance],
+        page: {totalItems: 1},
+      });
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1`,
+        ]),
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedElementInstance).toEqual(
+          mockElementInstance,
+        ),
+      );
+      expect(result.current.selectedElementId).toBe('service-task-1');
+      expect(result.current.isFetchingElement).toBe(false);
+    });
+
+    it('should return null when search returns multiple element instances', async () => {
+      mockSearchElementInstances().withSuccess({
+        items: [mockElementInstance, mockElementInstance2],
+        page: {totalItems: 2},
+      });
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1`,
+        ]),
+      });
+
+      await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
+
+      expect(result.current.selectedElementInstance).toBeNull();
+    });
+
+    it('should return null when search returns no element instances', async () => {
+      mockSearchElementInstances().withSuccess({
+        items: [],
+        page: {totalItems: 0},
+      });
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1`,
+        ]),
+      });
+
+      await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
+
+      expect(result.current.selectedElementInstance).toBeNull();
+    });
+
+    it('should handle network error when searching element instances', async () => {
+      mockSearchElementInstances().withNetworkError();
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1`,
+        ]),
+      });
+
+      await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
+
+      expect(result.current.selectedElementInstance).toBeNull();
+    });
+  });
+
+  describe('selectElementInstance', () => {
+    it('should update URL with both elementId and elementInstanceKey', () => {
+      mockFetchElementInstance('2251799813699889').withSuccess(
+        mockElementInstance,
+      );
+
+      const {result} = renderHook(
+        () => {
+          const location = useLocation();
+          const hook = useProcessInstanceElementSelection();
+          return {...hook, location};
+        },
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      act(() => {
+        result.current.selectElementInstance(
+          'service-task-1',
+          '2251799813699889',
+        );
+      });
+
+      expect(result.current.selectedElementId).toBe('service-task-1');
+      expect(result.current.location.search).toContain(
+        'elementId=service-task-1',
+      );
+      expect(result.current.location.search).toContain(
+        'elementInstanceKey=2251799813699889',
+      );
+    });
+
+    it('should fetch element instance by key when elementInstanceKey is provided', async () => {
+      mockFetchElementInstance('2251799813699889').withSuccess(
+        mockElementInstance,
+      );
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
+        ]),
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedElementInstance).toEqual(
+          mockElementInstance,
+        ),
+      );
+      expect(result.current.selectedElementId).toBe('service-task-1');
+      expect(result.current.isFetchingElement).toBe(false);
+    });
+
+    it('should handle network error when fetching element instance by key', async () => {
+      mockFetchElementInstance('2251799813699889').withNetworkError();
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
+        ]),
+      });
+
+      await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
+
+      expect(result.current.selectedElementInstance).toBeNull();
+    });
+
+    it('should prefer elementInstanceKey over elementId search', async () => {
+      mockFetchElementInstance('2251799813699889').withSuccess(
+        mockElementInstance,
+      );
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
+        ]),
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedElementInstance).toEqual(
+          mockElementInstance,
+        ),
+      );
+
+      // searchElementInstances should not be called
+      expect(result.current.selectedElementInstance).toEqual(
+        mockElementInstance,
+      );
+    });
+  });
+
+  describe('clearSelection', () => {
+    it('should remove elementId and elementInstanceKey from URL', () => {
+      mockFetchElementInstance('2251799813699889').withSuccess(
+        mockElementInstance,
+      );
+
+      const {result} = renderHook(
+        () => {
+          const location = useLocation();
+          const hook = useProcessInstanceElementSelection();
+          return {...hook, location};
+        },
+        {
+          wrapper: getWrapper([
+            `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
+          ]),
+        },
+      );
+
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selectedElementId).toBeNull();
+      expect(result.current.location.search).not.toContain('elementId');
+      expect(result.current.location.search).not.toContain(
+        'elementInstanceKey',
+      );
+    });
+
+    it('should clear selectedElementInstance when clearing selection', async () => {
+      mockFetchElementInstance('2251799813699889').withSuccess(
+        mockElementInstance,
+      );
+
+      const {result} = renderHook(() => useProcessInstanceElementSelection(), {
+        wrapper: getWrapper([
+          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
+        ]),
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedElementInstance).toEqual(
+          mockElementInstance,
+        ),
+      );
+
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      await waitFor(() =>
+        expect(result.current.selectedElementInstance).toBeNull(),
+      );
+    });
+  });
+});

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
@@ -45,15 +45,22 @@ const mockElementInstance2: ElementInstance = {
   tenantId: '<default>',
 };
 
-const getWrapper = (
-  initialEntries: React.ComponentProps<
-    typeof MemoryRouter
-  >['initialEntries'] = [Paths.processInstance('123')],
-) => {
+const getWrapper = (initialSearchParams?: {[key: string]: string}) => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
+    const searchParams = new URLSearchParams();
+    if (initialSearchParams) {
+      Object.entries(initialSearchParams).forEach(([key, value]) => {
+        searchParams.set(key, value);
+      });
+    }
+
     return (
       <QueryClientProvider client={getMockQueryClient()}>
-        <MemoryRouter initialEntries={initialEntries}>
+        <MemoryRouter
+          initialEntries={[
+            `${Paths.processInstance('123')}?${searchParams.toString()}`,
+          ]}
+        >
           <Routes>
             <Route path={Paths.processInstance()} element={children} />
           </Routes>
@@ -115,9 +122,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1`,
-        ]),
+        wrapper: getWrapper({elementId: 'service-task-1'}),
       });
 
       await waitFor(() =>
@@ -136,9 +141,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1`,
-        ]),
+        wrapper: getWrapper({elementId: 'service-task-1'}),
       });
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
@@ -153,9 +156,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1`,
-        ]),
+        wrapper: getWrapper({elementId: 'service-task-1'}),
       });
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
@@ -167,9 +168,7 @@ describe('useProcessInstanceElementSelection', () => {
       mockSearchElementInstances().withNetworkError();
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1`,
-        ]),
+        wrapper: getWrapper({elementId: 'service-task-1'}),
       });
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
@@ -217,9 +216,10 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
-        ]),
+        wrapper: getWrapper({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+        }),
       });
 
       await waitFor(() =>
@@ -235,9 +235,10 @@ describe('useProcessInstanceElementSelection', () => {
       mockFetchElementInstance('2251799813699889').withNetworkError();
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
-        ]),
+        wrapper: getWrapper({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+        }),
       });
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
@@ -251,20 +252,16 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
-        ]),
+        wrapper: getWrapper({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+        }),
       });
 
       await waitFor(() =>
         expect(result.current.selectedElementInstance).toEqual(
           mockElementInstance,
         ),
-      );
-
-      // searchElementInstances should not be called
-      expect(result.current.selectedElementInstance).toEqual(
-        mockElementInstance,
       );
     });
   });
@@ -282,9 +279,10 @@ describe('useProcessInstanceElementSelection', () => {
           return {...hook, location};
         },
         {
-          wrapper: getWrapper([
-            `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
-          ]),
+          wrapper: getWrapper({
+            elementId: 'service-task-1',
+            elementInstanceKey: '2251799813699889',
+          }),
         },
       );
 
@@ -305,9 +303,10 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
-        wrapper: getWrapper([
-          `${Paths.processInstance('123')}?elementId=service-task-1&elementInstanceKey=2251799813699889`,
-        ]),
+        wrapper: getWrapper({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+        }),
       });
 
       await waitFor(() =>

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
@@ -47,12 +47,7 @@ const mockElementInstance2: ElementInstance = {
 
 const getWrapper = (initialSearchParams?: {[key: string]: string}) => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
-    const searchParams = new URLSearchParams();
-    if (initialSearchParams) {
-      Object.entries(initialSearchParams).forEach(([key, value]) => {
-        searchParams.set(key, value);
-      });
-    }
+    const searchParams = new URLSearchParams(initialSearchParams);
 
     return (
       <QueryClientProvider client={getMockQueryClient()}>

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -24,8 +24,9 @@ const useProcessInstanceElementSelection = () => {
 
   const selectElement = useCallback(
     (elementId: string) => {
-      setSearchParams({
-        [ELEMENT_ID]: elementId,
+      setSearchParams((params) => {
+        params.set(ELEMENT_ID, elementId);
+        return params;
       });
     },
     [setSearchParams],
@@ -33,9 +34,10 @@ const useProcessInstanceElementSelection = () => {
 
   const selectElementInstance = useCallback(
     (elementId: string, elementInstanceKey: string) => {
-      setSearchParams({
-        [ELEMENT_ID]: elementId,
-        [ELEMENT_INSTANCE_KEY]: elementInstanceKey,
+      setSearchParams((params) => {
+        params.set(ELEMENT_ID, elementId);
+        params.set(ELEMENT_INSTANCE_KEY, elementInstanceKey);
+        return params;
       });
     },
     [setSearchParams],

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -17,7 +17,8 @@ const ELEMENT_INSTANCE_KEY = 'elementInstanceKey';
 
 const useProcessInstanceElementSelection = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const {processInstanceId} = useProcessInstancePageParams();
+  const {processInstanceId: processInstanceKey} =
+    useProcessInstancePageParams();
   const elementInstanceKey = searchParams.get(ELEMENT_INSTANCE_KEY);
   const elementId = searchParams.get(ELEMENT_ID);
 
@@ -61,10 +62,10 @@ const useProcessInstanceElementSelection = () => {
   const {data: searchResult, isFetching: isFetchingElementInstancesSearch} =
     useElementInstancesSearch(
       elementId ?? '',
-      processInstanceId ?? '',
+      processInstanceKey ?? '',
       undefined,
       {
-        enabled: !!elementId && !elementInstanceKey && !!processInstanceId,
+        enabled: !!elementId && !elementInstanceKey && !!processInstanceKey,
       },
     );
 

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useSearchParams} from 'react-router-dom';
+import {useCallback} from 'react';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useElementInstance} from 'modules/queries/elementInstances/useElementInstance';
+import {useElementInstancesSearch} from 'modules/queries/elementInstances/useElementInstancesSearch';
+
+const ELEMENT_ID = 'elementId';
+const ELEMENT_INSTANCE_KEY = 'elementInstanceKey';
+
+const useProcessInstanceElementSelection = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const {processInstanceId} = useProcessInstancePageParams();
+  const elementInstanceKey = searchParams.get(ELEMENT_INSTANCE_KEY);
+  const elementId = searchParams.get(ELEMENT_ID);
+
+  const selectElement = useCallback(
+    (elementId: string) => {
+      setSearchParams({
+        [ELEMENT_ID]: elementId,
+      });
+    },
+    [setSearchParams],
+  );
+
+  const selectElementInstance = useCallback(
+    (elementId: string, elementInstanceKey: string) => {
+      setSearchParams({
+        [ELEMENT_ID]: elementId,
+        [ELEMENT_INSTANCE_KEY]: elementInstanceKey,
+      });
+    },
+    [setSearchParams],
+  );
+
+  const clearSelection = useCallback(() => {
+    setSearchParams((prevParams) => {
+      const newParams = new URLSearchParams(prevParams);
+      newParams.delete(ELEMENT_ID);
+      newParams.delete(ELEMENT_INSTANCE_KEY);
+      return newParams;
+    });
+  }, [setSearchParams]);
+
+  // If elementInstanceKey is in URL, fetch element instance by key
+  const {
+    data: elementInstanceByKey,
+    isFetching: isFetchingElementInstanceByKey,
+  } = useElementInstance(elementInstanceKey ?? '', {
+    enabled: !!elementInstanceKey,
+  });
+
+  // If only elementId is in URL, search for all instances
+  const {data: searchResult, isFetching: isFetchingElementInstancesSearch} =
+    useElementInstancesSearch(
+      elementId ?? '',
+      processInstanceId ?? '',
+      undefined,
+      {
+        enabled: !!elementId && !elementInstanceKey && !!processInstanceId,
+      },
+    );
+
+  const selectedElementInstance =
+    elementInstanceByKey ??
+    (searchResult?.page.totalItems === 1 ? searchResult?.items[0] : null);
+
+  return {
+    selectElement,
+    selectElementInstance,
+    clearSelection,
+    selectedElementInstance,
+    selectedElementId: elementId,
+    isFetchingElement:
+      isFetchingElementInstanceByKey || isFetchingElementInstancesSearch,
+  };
+};
+
+export {useProcessInstanceElementSelection};

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -44,11 +44,10 @@ const useProcessInstanceElementSelection = () => {
   );
 
   const clearSelection = useCallback(() => {
-    setSearchParams((prevParams) => {
-      const newParams = new URLSearchParams(prevParams);
-      newParams.delete(ELEMENT_ID);
-      newParams.delete(ELEMENT_INSTANCE_KEY);
-      return newParams;
+    setSearchParams((params) => {
+      params.delete(ELEMENT_ID);
+      params.delete(ELEMENT_INSTANCE_KEY);
+      return params;
     });
   }, [setSearchParams]);
 

--- a/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
@@ -12,28 +12,28 @@ import type {
   QueryElementInstancesRequestBody,
   ElementInstance,
 } from '@camunda/camunda-api-zod-schemas/8.8';
-
-const ELEMENT_INSTANCES_SEARCH_QUERY_KEY = 'elementInstancesSearch';
+import {queryKeys} from '../queryKeys';
 
 const useElementInstancesSearch = (
   elementId: string,
   processInstanceKey: string,
-  elementType: ElementInstance['type'],
+  elementType?: ElementInstance['type'],
   options: {enabled: boolean} = {enabled: true},
 ) => {
   return useQuery({
     queryKey: [
-      ELEMENT_INSTANCES_SEARCH_QUERY_KEY,
-      elementId,
-      processInstanceKey,
-      elementType,
+      queryKeys.elementInstances.search({
+        elementId,
+        processInstanceKey,
+        elementType,
+      }),
     ],
     queryFn: async () => {
       const payload: QueryElementInstancesRequestBody = {
         filter: {
           elementId,
           processInstanceKey,
-          type: elementType ?? undefined,
+          type: elementType,
         },
         page: {limit: 1},
       };

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -113,17 +113,15 @@ const queryKeys = {
     search: (payload: {
       elementId: string;
       processInstanceKey: string;
-      elementType: ElementInstance['type'];
-      pageSize: number;
+      elementType?: ElementInstance['type'];
     }) => {
-      const {elementId, processInstanceKey, elementType, pageSize} = payload;
+      const {elementId, processInstanceKey, elementType} = payload;
 
       return [
         'elementInstancesSearch',
         elementId,
         processInstanceKey,
         elementType,
-        pageSize,
       ];
     },
     searchByScope: (

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -40,6 +40,10 @@ class FlowNodeSelection {
     makeAutoObservable(this, {init: false, selectFlowNode: false});
   }
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   init = () => {
     this.rootNodeSelectionDisposer = when(
       () => processInstanceDetailsStore.state.processInstance?.id !== undefined,
@@ -96,14 +100,26 @@ class FlowNodeSelection {
     );
   };
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   setSelection = (selection: Selection | null) => {
     this.state.selection = selection;
   };
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   clearSelection = () => {
     this.setSelection(this.rootNode);
   };
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   selectFlowNode = (selection: Selection) => {
     if (
       selection.flowNodeId === undefined ||
@@ -115,6 +131,10 @@ class FlowNodeSelection {
     }
   };
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   get areMultipleInstancesSelected(): boolean {
     if (this.state.selection === null) {
       return false;
@@ -124,6 +144,10 @@ class FlowNodeSelection {
     return flowNodeId !== undefined && flowNodeInstanceId === undefined;
   }
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   get rootNode() {
     return {
       flowNodeInstanceId: processInstanceDetailsStore.state.processInstance?.id,
@@ -131,6 +155,10 @@ class FlowNodeSelection {
     };
   }
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   get isRootNodeSelected() {
     return (
       this.state.selection?.flowNodeInstanceId ===
@@ -138,10 +166,18 @@ class FlowNodeSelection {
     );
   }
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   get selectedFlowNodeId() {
     return this.state.selection?.flowNodeId;
   }
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   get selectedFlowNodeInstanceId() {
     return (
       this.state.selection?.flowNodeInstanceId ??
@@ -149,6 +185,10 @@ class FlowNodeSelection {
     );
   }
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   isSelected = ({
     flowNodeId,
     flowNodeInstanceId,
@@ -175,6 +215,10 @@ class FlowNodeSelection {
     return selection.flowNodeInstanceId === flowNodeInstanceId;
   };
 
+  /**
+   * @deprecated
+   * will be migrated to useProcessInstanceElementSelection
+   */
   reset = () => {
     this.state = {...DEFAULT_STATE};
     this.rootNodeSelectionDisposer?.();

--- a/operate/client/src/modules/utils/flowNodeSelection.ts
+++ b/operate/client/src/modules/utils/flowNodeSelection.ts
@@ -20,6 +20,10 @@ import {
   type FlowNodeInstance,
 } from 'modules/stores/flowNodeInstance';
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const init = (
   rootNode: Selection | null,
   processInstanceKey?: string,
@@ -80,10 +84,18 @@ const init = (
   );
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const clearSelection = (rootNode: Selection | null) => {
   flowNodeSelectionStore.setSelection(rootNode);
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const selectFlowNode = (rootNode: Selection, selection: Selection) => {
   if (
     selection.flowNodeId === undefined ||
@@ -96,6 +108,10 @@ const selectFlowNode = (rootNode: Selection, selection: Selection) => {
   }
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const selectAdHocSubProcessInnerInstance = (
   rootNode: Selection,
   flowNodeInstance: FlowNodeInstance,
@@ -144,6 +160,10 @@ const selectAdHocSubProcessInnerInstance = (
   }
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const getSelectedRunningInstanceCount = ({
   totalRunningInstancesForFlowNode,
   isRootNodeSelected,
@@ -172,6 +192,10 @@ const getSelectedRunningInstanceCount = ({
   return totalRunningInstancesForFlowNode;
 };
 
+/**
+ * @deprecated
+ * will be migrated to useProcessInstanceElementSelection
+ */
 const getSelectedFlowNodeName = ({
   businessObjects,
   processDefinitionName,


### PR DESCRIPTION
## Description

- add useProcessInstanceElementSelection hook
- add unit test coverage
- mark existing flowNodeSelection functions as deprecated

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41817
