### PR TITLE
fix: convert block comments to javadoc in CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -840,7 +840,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   ProcessDefinitionGetRequest newProcessDefinitionGetRequest(long processDefinitionKey);
 
-  /*
+  /**
    * Retrieves the XML representation of a process definition.
    *
    * <pre>
@@ -856,7 +856,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   ProcessDefinitionGetXmlRequest newProcessDefinitionGetXmlRequest(long processDefinitionKey);
 
-  /*
+  /**
    * Retrieves the Form of a process definition.
    *
    * <pre>
@@ -1072,7 +1072,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   DecisionRequirementsSearchRequest newDecisionRequirementsSearchRequest();
 
-  /*
+  /**
    * Executes a search request to query decision definitions.
    *
    * <pre>
@@ -1106,7 +1106,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   DecisionDefinitionGetRequest newDecisionDefinitionGetRequest(long decisionDefinitionKey);
 
-  /*
+  /**
    * Retrieves the XML representation of a decision definition.
    *
    * <pre>
@@ -1156,11 +1156,11 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   DecisionInstanceGetRequest newDecisionInstanceGetRequest(String decisionInstanceId);
 
-  /*
-   * Executes a search request to query decision definitions.
+  /**
+   * Executes a search request to query incidents.
    *
    * <pre>
-   * long decisionDefinitionKey = ...;
+   * long processInstanceKey = ...;
    *
    * camundaClient
    *  .newIncidentSearchRequest()
@@ -1798,7 +1798,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   UpdateMappingRuleCommandStep1 newUpdateMappingRuleCommand(String mappingRuleId);
 
-  /*
+  /**
    * Retrieves the XML representation of a decision requirements.
    *
    * <pre>


### PR DESCRIPTION
## Description

Some actual javadoc was wrapped in generic block comments. This lead to them missing in official javadoc artifacts.

See e.g. https://javadoc.io/static/io.camunda/camunda-client-java/8.8.4/io/camunda/client/CamundaClient.html#newIncidentSearchRequest()

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
