### PR TITLE
feat: include debug cli as port of official distribution

### DIFF
--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -112,42 +112,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>build-fatjar</id>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <finalName>cdbg-${project.version}</finalName>
-              <minimizeJar>true</minimizeJar>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>**/*.xsd</exclude>
-                    <exclude>**/*.gif</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Main-Class>io.camunda.debug.cli.Main</Main-Class>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -613,6 +613,11 @@
       <artifactId>netty-transport</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>debug-cli</artifactId>
+    </dependency>
+
     <!-- /end -->
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -826,6 +831,10 @@
               <id>camunda</id>
               <mainClass>io.camunda.application.StandaloneCamunda</mainClass>
             </program>
+            <program>
+              <id>cdbg</id>
+              <mainClass>io.camunda.debug.cli.Main</mainClass>
+            </program>
           </programs>
           <repositoryLayout>flat</repositoryLayout>
           <repositoryName>lib</repositoryName>
@@ -880,6 +889,8 @@
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
+            <!-- Needed for the debug CLI tool -->
+            <dependency>io.camunda:debug-cli</dependency>
 
             <!-- Needed for Spring Actuators, and REST API -->
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>


### PR DESCRIPTION
The debug-cli, short `cdbg` for "camunda debug", is now included in the official distribution which makes it available on all customer deployments, docker image or otherwise.