### PR TITLE
39202 stop throwing exception when process not yet imported for incident

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -63,8 +63,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of standalone-decisions that have been archived. */
   private final Counter standaloneDecisionsArchived;
 
-  /** Count of incident updates that have been skipped. */
-  private final Counter incidentUpdatesSkipped;
+  /** Count of incident updates that needed retrying. */
+  private final Counter incidentUpdatesRetriesNeeded;
 
   /** Count of incident updates that were processed. */
   private final Counter incidentUpdatesProcessed;
@@ -180,11 +180,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
                 "Duration of how long it takes from resolving to archiving entities, all in all together.")
             .publishPercentileHistogram()
             .register(meterRegistry);
-    incidentUpdatesSkipped =
+    incidentUpdatesRetriesNeeded =
         Counter.builder(meterName("incident.updates"))
-            .tag("action", "skipped")
+            .tag("action", "retry")
             .description(
-                "Count of incidents that have been skipped due to matching process instances not being found.")
+                "Count of incidents that have will need retrying due to matching process instances not being found.")
             .register(meterRegistry);
     incidentUpdatesProcessed =
         Counter.builder(meterName("incident.updates"))
@@ -292,8 +292,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
     standaloneDecisionsArchiving.increment(count);
   }
 
-  public void recordIncidentUpdatesSkipped(final int count) {
-    incidentUpdatesSkipped.increment(count);
+  public void recordIncidentUpdatesRetriesNeeded(final int count) {
+    incidentUpdatesRetriesNeeded.increment(count);
   }
 
   public void recordIncidentUpdatesProcessed(final int count) {
@@ -361,7 +361,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(flushDuration);
     meterRegistry.remove(failedFlush);
     meterRegistry.remove(recordExportDuration);
-    meterRegistry.remove(incidentUpdatesSkipped);
+    meterRegistry.remove(incidentUpdatesRetriesNeeded);
     meterRegistry.remove(incidentUpdatesProcessed);
 
     // Remove custom gauges by their names if needed

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -69,6 +69,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of incident updates that were processed. */
   private final Counter incidentUpdatesProcessed;
 
+  /** Count of document updated when incident updates were processed. */
+  private final Counter incidentUpdatesDocumentsUpdated;
+
   private final Timer archiverSearchTimer;
   private final Timer archiverDeleteTimer;
   private final Timer archiverReindexTimer;
@@ -191,6 +194,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("action", "processed")
             .description("Count of incidents that have been processed.")
             .register(meterRegistry);
+    incidentUpdatesDocumentsUpdated =
+        Counter.builder(meterName("incident.updates.documents"))
+            .tag("action", "updated")
+            .description("Count of documents that were updated when incidents were processed.")
+            .register(meterRegistry);
     bulkSize =
         DistributionSummary.builder(meterName("bulk.size"))
             .description("How many items were exported in one bulk request")
@@ -300,6 +308,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
     incidentUpdatesProcessed.increment(count);
   }
 
+  public void recordIncidentUpdatesDocumentsUpdated(final int count) {
+    incidentUpdatesDocumentsUpdated.increment(count);
+  }
+
   public void recordFlushFailureType(final String failureType) {
     meterRegistry.counter(meterName("flush.failure.type"), "failure_type", failureType).increment();
   }
@@ -363,6 +375,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(recordExportDuration);
     meterRegistry.remove(incidentUpdatesRetriesNeeded);
     meterRegistry.remove(incidentUpdatesProcessed);
+    meterRegistry.remove(incidentUpdatesDocumentsUpdated);
 
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(meterName("since.last.flush.seconds"));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -309,6 +309,7 @@ public final class BackgroundTaskManagerFactory {
             postExport.getBatchSize(),
             executor,
             incidentNotifier,
+            metrics,
             logger),
         1,
         postExport.getDelayBetweenRuns(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -148,7 +148,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       // there was missing data, but this is often transient, so we just skip this batch for now.
       // we return the batch size so it's clear that we want to try again soon (as there was work
       // to do, but we just can't do it ATM)
-      metrics.recordIncidentUpdatesSkipped(incidentCount);
+      metrics.recordIncidentUpdatesRetriesNeeded(incidentCount);
       return CompletableFuture.completedFuture(incidentCount);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -136,7 +136,14 @@ public final class IncidentUpdateTask implements BackgroundTask {
       return CompletableFuture.completedFuture(0);
     }
     logger.trace("Applying the following pending incident updates: {}", batch.newIncidentStates());
-    searchForInstances(data);
+    final var check = searchForInstances(data);
+    if (check != InstancesCheck.OK) {
+      // there was missing data, but this is often transient, so we just skip this batch for now.
+      // we return the batch size so it's clear that we want to try again soon (as there was work
+      // to do, but we just can't do it ATM)
+      return CompletableFuture.completedFuture(batch.newIncidentStates().size());
+    }
+
     data.incidents()
         .forEach(
             (key, incidentDocument) -> {
@@ -163,18 +170,19 @@ public final class IncidentUpdateTask implements BackgroundTask {
             executor);
   }
 
-  private void searchForInstances(final AdditionalData data) {
+  private InstancesCheck searchForInstances(final AdditionalData data) {
     final var incidents = data.incidents().values();
 
-    try {
-      queryData(incidents, data);
-      checkDataAndCollectParentTreePaths(incidents, data, false);
-    } catch (final ExporterException ex) {
+    queryData(incidents, data);
+    if (checkDataAndCollectParentTreePaths(incidents, data, false) != InstancesCheck.OK) {
       // if it failed once we want to give it a chance and to import more data
       // next failure will fail in case ignoring of missing data is not configured
       uncheckedThreadSleep();
       queryData(incidents, data);
-      checkDataAndCollectParentTreePaths(incidents, data, ignoreMissingData);
+      final var check = checkDataAndCollectParentTreePaths(incidents, data, ignoreMissingData);
+      if (check != InstancesCheck.OK) {
+        return check;
+      }
     }
 
     final var flowNodeKeys =
@@ -188,14 +196,15 @@ public final class IncidentUpdateTask implements BackgroundTask {
         .toCompletableFuture()
         .join()
         .forEach(doc -> data.addFlowNodeInstanceInListView(doc.id(), doc.index()));
+
+    return InstancesCheck.OK;
   }
 
-  private void checkDataAndCollectParentTreePaths(
+  private InstancesCheck checkDataAndCollectParentTreePaths(
       final Collection<IncidentDocument> incidents,
       final AdditionalData data,
       final boolean forceIgnoreMissingData) {
 
-    int countMissingInstance = 0;
     final Set<Long> processInstanceKeys =
         incidents.stream()
             .map(IncidentDocument::incident)
@@ -222,14 +231,15 @@ public final class IncidentUpdateTask implements BackgroundTask {
           continue;
         }
         if (!forceIgnoreMissingData) {
-          throw new ExporterException(
+          logger.warn(
               """
-                Process instance %d is not yet imported for incident %s; the update cannot be \
-                correctly applied.
-                """
-                  .formatted(incident.getProcessInstanceKey(), incident.getId()));
+            Process instance {} is not yet imported for incident {}; the update cannot be \
+            correctly applied. Operation will be retried...
+            """,
+              incident.getProcessInstanceKey(),
+              incident.getId());
+          return InstancesCheck.MISSING_DATA;
         } else {
-          countMissingInstance++;
           logger.warn(
               """
                 Process instance {} is not yet imported for incident {}; the update cannot be \
@@ -253,15 +263,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
                   .appendFlowNodeInstance(String.valueOf(incident.getFlowNodeInstanceKey()))
                   .toString());
     }
-
-    if (countMissingInstance > 0 && !ignoreMissingData) {
-      throw new ExporterException(
-          """
-        "%d process instances are not yet imported for incident post processing; operation will \
-        be retried...
-        """
-              .formatted(countMissingInstance));
-    }
+    return InstancesCheck.OK;
   }
 
   private void queryData(final Collection<IncidentDocument> incidents, final AdditionalData data) {
@@ -658,5 +660,10 @@ public final class IncidentUpdateTask implements BackgroundTask {
       Thread.currentThread().interrupt();
       LangUtil.rethrowUnchecked(e);
     }
+  }
+
+  enum InstancesCheck {
+    OK,
+    MISSING_DATA
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -174,6 +174,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
               metadata.setLastIncidentUpdatePosition(batch.highestPosition());
 
               metrics.recordIncidentUpdatesProcessed(incidentCount);
+              metrics.recordIncidentUpdatesDocumentsUpdated(documentsUpdated);
               return CompletableFuture.completedFuture(documentsUpdated);
             },
             executor);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.incident;
 import static io.camunda.search.test.utils.SearchDBExtension.INCIDENT_IDX_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +18,7 @@ import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
@@ -77,7 +79,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -400,7 +401,7 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var executor = Executors.newSingleThreadScheduledExecutor();
 
-      final var incidentNotifier = Mockito.mock(IncidentNotifier.class);
+      final var incidentNotifier = mock(IncidentNotifier.class);
       when(incidentNotifier.notifyAsync(anyList()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
@@ -424,7 +425,14 @@ abstract class IncidentUpdateRepositoryIT {
       // when
       final var incidentUpdateTask =
           new IncidentUpdateTask(
-              metadata, repository, true, 100, executor, incidentNotifier, LOGGER);
+              metadata,
+              repository,
+              true,
+              100,
+              executor,
+              incidentNotifier,
+              mock(CamundaExporterMetrics.class),
+              LOGGER);
 
       incidentUpdateTask.execute().toCompletableFuture().join();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -457,6 +457,7 @@ final class IncidentUpdateTaskTest {
               .setState(IncidentState.PENDING);
       verify(incidentNotifier, times(1)).notifyAsync(List.of(incident));
       verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(7);
     }
 
     @Test
@@ -503,6 +504,7 @@ final class IncidentUpdateTaskTest {
               .setState(IncidentState.PENDING);
       verify(incidentNotifier, times(1)).notifyAsync(List.of(incident));
       verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(7);
     }
 
     @Test
@@ -545,6 +547,7 @@ final class IncidentUpdateTaskTest {
               .setState(IncidentState.PENDING);
       verify(incidentNotifier, times(1)).notifyAsync(List.of(incident));
       verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(7);
     }
 
     @Test
@@ -608,6 +611,7 @@ final class IncidentUpdateTaskTest {
 
       verify(incidentNotifier, times(0)).notifyAsync(any());
       verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(7);
     }
 
     @Test
@@ -670,6 +674,7 @@ final class IncidentUpdateTaskTest {
               "4",
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
       verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(6);
     }
 
     @Test
@@ -699,6 +704,8 @@ final class IncidentUpdateTaskTest {
       assertThat(repository.updated.incidentRequests()).isEmpty();
       assertThat(repository.updated.flowNodeInstanceRequests()).isEmpty();
       verify(incidentNotifier, times(0)).notifyAsync(any());
+      verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(0);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -331,7 +331,7 @@ final class IncidentUpdateTaskTest {
     }
 
     @Test
-    void shouldSkipOnMissingProcessInstance() {
+    void shouldRetryOnMissingProcessInstance() {
       // given
       final var task =
           new IncidentUpdateTask(
@@ -352,7 +352,7 @@ final class IncidentUpdateTaskTest {
       // then
       assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(1);
 
-      verify(metrics).recordIncidentUpdatesSkipped(1);
+      verify(metrics).recordIncidentUpdatesRetriesNeeded(1);
       verify(repository, never()).bulkUpdate(any());
       verify(incidentNotifier, never()).notifyAsync(any());
       assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);


### PR DESCRIPTION
## Description

Previously if the incident update task ran and could not find a matching process instance for an incident it would throw an exception to force retrying later on.  This would lead to a fair bit of log noise.

It's expected that we will have times where this will happen under normal operation and retrying is the correct behaviour.  As it's expected behaviour there is little point raising an exception and thus triggering ERROR level logging.

This PR changes things so we just return early from the task if the process instance is not found.  It does also perform some WARN logging.

In addition metrics have been added to track how often we end up skipping updates like this vs how often we actually perform the updates.  This should let us attach alerts if for some reason we _never_ find the matching process instance.

## Related issues

closes #39202
