### PR TITLE
build: update `lza-java` to `1.8.1`

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -172,6 +172,7 @@
     <version.elasticsearch-test-container>2.0.2</version.elasticsearch-test-container>
     <version.postgres-test-container>2.0.2</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
+    <version.lz4>1.8.1</version.lz4>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
@@ -1957,6 +1958,13 @@
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>
         <version>${version.elasticsearch7}</version>
+      </dependency>
+      <!-- override the transitive dependency from elasticsearch-lz4,
+      once org.elasticsearch:elasticsearch minor or major is bumped up lz4-java direct dependency can be removed -->
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${version.lz4}</version>
       </dependency>
       <dependency>
         <groupId>org.elasticsearch</groupId>


### PR DESCRIPTION
## Description
CVE found `org.lz4:lz4-java`

### Relative dependency tree
```
| +- org.elasticsearch:elasticsearch:jar:7.17.29:compile
| | +- org.elasticsearch:elasticsearch-lz4:jar:7.17.29:compile
| | | \- org.lz4:lz4-java:jar:1.8.0:compile
```

### Note
`org.lz4:lz4-java:1.8.1` is a relocation pom pointing to `at.yawk.lz4:lz4-java:1.8.1`, provided by Sonatype. [ref](https://sites.google.com/sonatype.com/vulnerabilities/cve-2025-12183)

Once `org.elasticsearch:elasticsearch` minor or major version is bumped up `lz4-java` direct dependency can be removed

Elasticsearch, Kibana 7.17.x End of Maintenance Term: April 15, 2025 [ref](https://support.liferay.com/w/elasticsearch-7-17-end-of-life-eol-timeline-and-liferay-dxp-elasticsearch-compatibility-update-faq)
Elasticsearch, Kibana 7.17.x End of Support Term: January 15, 2026

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41872
