### PR TITLE
Re-enable backup restore tests

### DIFF
--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -31,7 +31,6 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -70,7 +69,6 @@ public class BackupRestoreTest {
     testContext.setConnectionType("elasticsearch");
   }
 
-  @Ignore
   @Test
   public void testBackupRestore() throws Exception {
     startAllApps();

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -29,7 +29,6 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
@@ -73,7 +72,6 @@ public class BackupRestoreTest {
     testContext = new BackupRestoreTestContext().setIndexPrefix(INDEX_PREFIX);
   }
 
-  @Disabled
   @Test
   public void testBackupRestore() throws Exception {
     startAllApps();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The BackupRestoreTests currently test against a SNAPSHOT docker image with main branch code. This logic makes it impossible to make changes to secondary storage schemas, as the Index schema validator marks them as incompatible changes.

Until the issue is fixed, we need to toggle these tests to merge any PR changes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #40543
