### PR TITLE
feat: backpressure request limit panel was showing incorrect values

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -23449,7 +23449,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_backpressure_requests_limit{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})by (partition)",
+              "expr": "sum(zeebe_backpressure_requests_limit{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"} and on(namespace, partition, pod, instance) (atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"} == 3)) by (partition)",
               "hide": false,
               "legendFormat": "Partition: {{partition}}",
               "range": true,


### PR DESCRIPTION
## Description

The zeebe_backpressure_requests_limit must not be aggregated across pods, because replicas will report the initial value, making the panel reporting the wrong value.

With this query, we match on the atomix_role series, making sure only the metric from the leader is reported

Screenshot from the zeebe benchmark grafana:
<img width="2264" height="1131" alt="image" src="https://github.com/user-attachments/assets/89848369-ec68-4b6e-bd61-773292daa845" />



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Import the dashboard and validate it's working
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
Raised in [SUPPORT-30161](https://jira.camunda.com/browse/SUPPORT-30161?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D)
