### PR TITLE
test: Consider only instances created by the test

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -504,14 +504,17 @@ public class ProcessInstanceSearchIT {
             .newProcessInstanceSearchRequest()
             .filter(
                 f ->
-                    f.endDate(d -> d.exists(false)).orFilters(List.of(f2 -> f2.hasIncident(false))))
+                    f.processDefinitionId(pid -> pid.eq("service_tasks_v1"))
+                        .orFilters(List.of(f2 -> f2.hasIncident(false))))
             .send()
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(3);
-    assertThat(result.items()).filteredOn(pi -> pi.getEndDate() == null).hasSize(3);
-    assertThat(result.items()).filteredOn(pi -> !pi.getHasIncident()).hasSize(3);
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items())
+        .filteredOn(pi -> pi.getProcessDefinitionId().equals("service_tasks_v1"))
+        .hasSize(2);
+    assertThat(result.items()).filteredOn(pi -> !pi.getHasIncident()).hasSize(2);
   }
 
   @Test


### PR DESCRIPTION
## Description

* When testet against Aurora, this test might be flaky, because ProcessInstanceSearch might find instances created by other test cases. Now the result is filtered for instances created by this test when the filter was not specific enough.
