### PR TITLE
Add property to pin global listeners configuration in the `USER_TASK` record

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -87,6 +87,9 @@
             },
             "deniedReason": {
               "type": "text"
+            },
+            "listenersConfigKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -87,6 +87,9 @@
             },
             "deniedReason": {
               "type": "text"
+            },
+            "listenersConfigKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -148,9 +148,10 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY, 50);
   private final StringProperty deniedReasonProp = new StringProperty("deniedReason", EMPTY_STRING);
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>("tags", StringValue::new);
+  private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(23);
+    super(24);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -173,7 +174,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(creationTimestampProp)
         .declareProperty(priorityProp)
         .declareProperty(deniedReasonProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(listenersConfigKeyProp);
   }
 
   /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
@@ -201,6 +203,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     priorityProp.setValue(record.getPriority());
     deniedReasonProp.setValue(record.getDeniedReason());
     setTags(record.getTags());
+    listenersConfigKeyProp.setValue(record.getListenersConfigKey());
   }
 
   /**
@@ -428,6 +431,22 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
+  @Override
+  public Set<String> getTags() {
+    return StreamSupport.stream(tagsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .collect(Collectors.toSet());
+  }
+
+  public UserTaskRecord setTags(final Set<String> tags) {
+    tagsProp.reset();
+    if (tags != null) {
+      tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
+    }
+    return this;
+  }
+
   public UserTaskRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -545,6 +564,15 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setUserTaskKey(final long userTaskKey) {
     userTaskKeyProp.setValue(userTaskKey);
+    return this;
+  }
+
+  public long getListenersConfigKey() {
+    return listenersConfigKeyProp.getValue();
+  }
+
+  public UserTaskRecord setListenersConfigKey(final long listenersConfigKey) {
+    listenersConfigKeyProp.setValue(listenersConfigKey);
     return this;
   }
 
@@ -744,22 +772,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord resetChangedAttributes() {
     changedAttributesProp.reset();
-    return this;
-  }
-
-  @Override
-  public Set<String> getTags() {
-    return StreamSupport.stream(tagsProp.spliterator(), false)
-        .map(StringValue::getValue)
-        .map(BufferUtil::bufferAsString)
-        .collect(Collectors.toSet());
-  }
-
-  public UserTaskRecord setTags(final Set<String> tags) {
-    tagsProp.reset();
-    if (tags != null) {
-      tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
-    }
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2691,7 +2691,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "priority": 80,
                   "tags": [],
-                  "deniedReason": "Reason to deny lifecycle transition"
+                  "deniedReason": "Reason to deny lifecycle transition",
+                  "listenersConfigKey": -1
                 }
                 """
       },
@@ -2728,7 +2729,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "priority": 50,
                   "tags": [],
-                  "deniedReason": ""
+                  "deniedReason": "",
+                  "listenersConfigKey": -1
                 }
                 """
       },
@@ -2770,7 +2772,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "priority": 50,
                   "tags": [],
-                  "deniedReason": ""
+                  "deniedReason": "",
+                  "listenersConfigKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2662,7 +2662,8 @@ final class JsonSerializableToJsonTest {
                     .setElementId("activity")
                     .setElementInstanceKey(5678)
                     .setPriority(80)
-                    .setDeniedReason("Reason to deny lifecycle transition"),
+                    .setDeniedReason("Reason to deny lifecycle transition")
+                    .setListenersConfigKey(42L),
         """
                 {
                   "bpmnProcessId": "test-process",
@@ -2692,7 +2693,7 @@ final class JsonSerializableToJsonTest {
                   "priority": 80,
                   "tags": [],
                   "deniedReason": "Reason to deny lifecycle transition",
-                  "listenersConfigKey": -1
+                  "listenersConfigKey": 42
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
@@ -29,6 +29,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -147,9 +148,10 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY, 50);
   private final StringProperty deniedReasonProp = new StringProperty("deniedReason", EMPTY_STRING);
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>("tags", StringValue::new);
+  private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(23);
+    super(24);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -172,7 +174,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(creationTimestampProp)
         .declareProperty(priorityProp)
         .declareProperty(deniedReasonProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(listenersConfigKeyProp);
   }
 
   /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
@@ -200,6 +203,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     priorityProp.setValue(record.getPriority());
     deniedReasonProp.setValue(record.getDeniedReason());
     setTags(record.getTags());
+    listenersConfigKeyProp.setValue(record.getListenersConfigKey());
   }
 
   /**
@@ -544,6 +548,15 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setUserTaskKey(final long userTaskKey) {
     userTaskKeyProp.setValue(userTaskKey);
+    return this;
+  }
+
+  public long getListenersConfigKey() {
+    return listenersConfigKeyProp.getValue();
+  }
+
+  public UserTaskRecord setListenersConfigKey(final long versionKey) {
+    listenersConfigKeyProp.setValue(versionKey);
     return this;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41890
