### PR TITLE
[Backport stable/8.8] build: update `lza-java` to `1.8.1`

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -171,6 +171,7 @@
     <version.elasticsearch-test-container>2.0.2</version.elasticsearch-test-container>
     <version.postgres-test-container>2.0.2</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
+    <version.lz4>1.8.1</version.lz4>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
@@ -1967,6 +1968,13 @@
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>
         <version>${version.elasticsearch7}</version>
+      </dependency>
+      <!-- override the transitive dependency from elasticsearch-lz4,
+      once org.elasticsearch:elasticsearch minor or major is bumped up lz4-java direct dependency can be removed -->
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${version.lz4}</version>
       </dependency>
       <dependency>
         <groupId>org.elasticsearch</groupId>


### PR DESCRIPTION
# Description
Backport of #41880 to `stable/8.8`.

relates to #41872