### PR TITLE
fix: Add `JobIntent.YIELD` to the whitelisted commands

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -22,6 +22,7 @@ public class WhiteListedCommands {
       Set.of(
           JobIntent.COMPLETE,
           JobIntent.FAIL,
+          JobIntent.YIELD,
           ProcessInstanceIntent.CANCEL,
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,


### PR DESCRIPTION
## Description
If a cluster is under backpressure, JOB.YIELD may fail. If that happens, then the job will be eventually TIMEOUT when `JobTimeoutChecker` runs.
Once the timeout is fired, the job will be pushed immediately to the workers.
If instead JOB.YIELD is published to the stream, the JOB will not be timedout and it will be available to workers only via the polling mechanism.

Currently, the broker does not have any information if the clients are available to receive new jobs, so it will push job to them even if they are not able to pick them up.
This can create a vicious cycle where the engine itself is generating more load when it's already under pressure.
Whitelisting JOB.YIELD reduce the work the engine need to perform, helping its recovery



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #35074
