### PR TITLE
[CPT:DSL] feat: Create basic test scenario DSL schema

### DIFF
--- a/testing/camunda-process-test-dsl/README.md
+++ b/testing/camunda-process-test-dsl/README.md
@@ -1,0 +1,11 @@
+# Camunda-Process-Test - DSL
+
+A DSL to describe test scenarios for Camunda Process Test in a JSON format.
+
+The structure of the DSL is defined in the JSON
+Schema: [test-scenario-dsl.schema.json](src/main/resources/schema/test-scenario-dsl.schema.json).
+
+A test scenario JSON file can be deserialized with [Jackson](https://github.com/FasterXML/jackson)
+into a Java object of the
+type [TestScenario.java](src/main/java/io/camunda/process/test/api/dsl/TestScenario.java).
+

--- a/testing/camunda-process-test-dsl/pom.xml
+++ b/testing/camunda-process-test-dsl/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-testing</artifactId>
+    <version>8.9.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-dsl</artifactId>
+
+  <name>Camunda Process Test DSL</name>
+  <description>DSL to describe test scenarios for Camunda's testing library</description>
+
+  <properties>
+    <version.java>8</version.java>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.networknt</groupId>
+        <artifactId>json-schema-validator</artifactId>
+        <version>1.4.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>javax.annotation:javax.annotation-api</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/testing/camunda-process-test-dsl/revapi.json
+++ b/testing/camunda-process-test-dsl/revapi.json
@@ -1,0 +1,23 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "archives": {
+        "justification": "Ignore everything not included in the module itself",
+        "include": [
+          "io\\.camunda:camunda-process-test-dsl:.*"
+        ]
+      },
+      "elements": {
+        "exclude": [
+          {
+            "justification": "The implementation package is not meant to be used directly, and as such does not need to maintain any backwards compatibility guarantees.",
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.process\\.test\\.impl(\\..*)?/"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCase.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCase.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/** A test case with instructions to validate the business process. */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableTestCase.Builder.class)
+public interface TestCase {
+
+  /**
+   * The name of the test case.
+   *
+   * @return the name
+   */
+  String getName();
+
+  /**
+   * The description of the test case.
+   *
+   * @return the description
+   */
+  Optional<String> getDescription();
+
+  /**
+   * The instructions of the test case.
+   *
+   * @return the instructions
+   */
+  List<TestCaseInstruction> getInstructions();
+}

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstruction.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstruction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruction;
+
+/** An instruction to define an action or an assertion to be performed in a test case. */
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.EXISTING_PROPERTY,
+    property = "type",
+    visible = true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(
+      value = CreateProcessInstanceInstruction.class,
+      name = TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
+})
+public interface TestCaseInstruction {
+
+  /**
+   * The type of the instruction. It should be one of {@link TestCaseInstructionType}.
+   *
+   * @return the type
+   * @see TestCaseInstructionType
+   */
+  String getType();
+}

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstructionType.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstructionType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+/** A collection of supported test case instruction types. */
+public class TestCaseInstructionType {
+
+  public static final String CREATE_PROCESS_INSTANCE = "CREATE_PROCESS_INSTANCE";
+}

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestScenario.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestScenario.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+import org.immutables.value.Value;
+
+/** A test scenario with test cases to validate the business process. */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableTestScenario.Builder.class)
+public interface TestScenario {
+
+  /**
+   * The test cases of the scenario.
+   *
+   * @return the test cases
+   */
+  List<TestCase> getTestCases();
+}

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/CreateProcessInstanceInstruction.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/CreateProcessInstanceInstruction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl.instructions;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.process.test.api.dsl.TestCaseInstruction;
+import java.util.Map;
+import org.immutables.value.Value;
+
+/** An instruction to create a new process instance. */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableCreateProcessInstanceInstruction.Builder.class)
+public interface CreateProcessInstanceInstruction extends TestCaseInstruction {
+
+  /**
+   * The variables to create the process instance with. Optional.
+   *
+   * @return the variables or an empty map if no variables are set
+   */
+  Map<String, Object> getVariables();
+}

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/impl/dsl/TestScenarioReader.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/impl/dsl/TestScenarioReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.camunda.process.test.api.dsl.TestScenario;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/** A reader for test scenarios defined in JSON format. */
+public class TestScenarioReader {
+
+  private static final Supplier<ObjectMapper> DEFAULT_OBJECT_MAPPER_SUPPLIER =
+      () ->
+          new ObjectMapper()
+              .registerModule(new Jdk8Module())
+              .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private final ObjectMapper objectMapper;
+
+  public TestScenarioReader() {
+    objectMapper = DEFAULT_OBJECT_MAPPER_SUPPLIER.get();
+  }
+
+  public TestScenarioReader(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Reads a test scenario from the given input stream.
+   *
+   * @param stream the input stream to read from
+   * @return the test scenario
+   * @throws RuntimeException if reading the test scenario fails
+   */
+  public TestScenario read(final InputStream stream) {
+    Objects.requireNonNull(stream, "stream");
+
+    try {
+      return objectMapper.readValue(stream, TestScenario.class);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to read test scenario from stream", e);
+    }
+  }
+}

--- a/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
+++ b/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://camunda.com/schema/20251202/test-scenario-dsl.schema.json",
+  "title": "Test Scenario DSL",
+  "description": "A test scenario with test cases to validate the business process.",
+  "type": "object",
+  "properties": {
+    "testCases": {
+      "description": "The test cases of the scenario.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TestCase"
+      }
+    }
+  },
+  "required": [
+    "testCases"
+  ],
+  "additionalProperties": true,
+  "definitions": {
+    "TestCase": {
+      "description": "A test case with instructions to validate the business process.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the test case.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The description of the test case.",
+          "type": "string"
+        },
+        "instructions": {
+          "description": "The instructions of the test case.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TestCaseInstruction"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "instructions"
+      ],
+      "additionalProperties": true
+    },
+    "TestCaseInstruction": {
+      "description": "An instruction to define an action or an assertion to be performed in a test case.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/CreateProcessInstanceInstruction"
+        }
+      ]
+    },
+    "CreateProcessInstanceInstruction": {
+      "description": "An instruction to create a new process instance.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of the instruction.",
+          "type": "string",
+          "const": "CREATE_PROCESS_INSTANCE"
+        },
+        "variables": {
+          "description": "The variables to create the process instance with.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": true
+    }
+  }
+}

--- a/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/DeserializationTest.java
+++ b/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/DeserializationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenario;
+import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruction;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+public class DeserializationTest {
+
+  private static final String EMPTY_TEST_SCENARIO = "/empty-test-scenario.json";
+  private static final String EXAMPLE_TEST_SCENARIO = "/example-test-scenario.json";
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .registerModule(new Jdk8Module());
+
+  @Test
+  void shouldParseEmptyTestScenario() throws IOException {
+    // given
+    final InputStream json = getClass().getResourceAsStream(EMPTY_TEST_SCENARIO);
+
+    // when
+    final TestScenario testScenario = objectMapper.readValue(json, TestScenario.class);
+
+    // then
+    assertThat(testScenario).isNotNull();
+    assertThat(testScenario.getTestCases()).hasSize(1);
+
+    final TestCase testCase = testScenario.getTestCases().get(0);
+    assertThat(testCase.getName()).isEqualTo("Test Case 1");
+    assertThat(testCase.getDescription())
+        .hasValue("A human-readable description of what this test case is verifying.");
+    assertThat(testCase.getInstructions()).isEmpty();
+  }
+
+  @Test
+  void shouldParseExampleTestScenario() throws IOException {
+    // given
+    final InputStream json = getClass().getResourceAsStream(EXAMPLE_TEST_SCENARIO);
+
+    // when
+    final TestScenario testScenario = objectMapper.readValue(json, TestScenario.class);
+
+    // then
+    assertThat(testScenario).isNotNull();
+    assertThat(testScenario.getTestCases()).hasSize(1);
+
+    final TestCase testCase = testScenario.getTestCases().get(0);
+    assertThat(testCase.getName()).isEqualTo("Happy path order processing");
+    assertThat(testCase.getDescription())
+        .hasValue(
+            "The order should be processed successfully from creation to shipping with tracking code received.");
+    assertThat(testCase.getInstructions())
+        .hasSize(1)
+        .satisfies(
+            testCaseInstructions ->
+                assertThat(testCaseInstructions.get(0))
+                    .isInstanceOf(CreateProcessInstanceInstruction.class));
+  }
+}

--- a/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/PojoCompatibilityTest.java
+++ b/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/PojoCompatibilityTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import io.camunda.process.test.api.dsl.ImmutableTestCase;
+import io.camunda.process.test.api.dsl.ImmutableTestScenario;
+import io.camunda.process.test.api.dsl.TestCaseInstructionType;
+import io.camunda.process.test.api.dsl.TestScenario;
+import io.camunda.process.test.api.dsl.instructions.ImmutableCreateProcessInstanceInstruction;
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class PojoCompatibilityTest {
+
+  private static final String DSL_SCHEMA = "/schema/test-scenario-dsl.schema.json";
+
+  private static JsonSchema jsonSchema;
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+          .registerModule(new Jdk8Module());
+
+  @BeforeAll
+  static void setup() {
+    final JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
+    jsonSchema = factory.getSchema(PojoCompatibilityTest.class.getResourceAsStream(DSL_SCHEMA));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("testScenarios")
+  void shouldBeValidScenario(final String name, final TestScenario testScenario) {
+    // given
+    final JsonNode json = objectMapper.valueToTree(testScenario);
+
+    // when
+    final Set<ValidationMessage> errors = jsonSchema.validate(json);
+
+    // then
+    assertThat(errors)
+        .describedAs("Scenario '%s' should have no validation errors", name)
+        .isEmpty();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("testScenarios")
+  void shouldDeserializeScenario(final String name, final TestScenario testScenario)
+      throws IOException {
+    // given
+    final String json = objectMapper.writeValueAsString(testScenario);
+
+    // when
+    final TestScenario deserializedObject = objectMapper.readValue(json, TestScenario.class);
+
+    // then
+    assertThat(deserializedObject)
+        .describedAs("Scenario '%s' should deserialize correctly", name)
+        .isEqualTo(testScenario);
+  }
+
+  static Stream<Arguments> testScenarios() {
+    return Stream.of(
+        Arguments.of("no test cases", ImmutableTestScenario.builder().build()),
+        Arguments.of(
+            "test case: minimal",
+            ImmutableTestScenario.builder()
+                .addTestCases(ImmutableTestCase.builder().name("test case 1").build())
+                .build()),
+        Arguments.of(
+            "test case: full",
+            ImmutableTestScenario.builder()
+                .addTestCases(
+                    ImmutableTestCase.builder()
+                        .name("test case 1")
+                        .description("My first test case")
+                        .build())
+                .build()),
+        Arguments.of(
+            "create process instance: minimal",
+            ImmutableTestScenario.builder()
+                .addTestCases(
+                    ImmutableTestCase.builder()
+                        .name("test case 1")
+                        .addInstructions(
+                            ImmutableCreateProcessInstanceInstruction.builder()
+                                .type(TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
+                                .build())
+                        .build())
+                .build()),
+        Arguments.of(
+            "create process instance: full",
+            ImmutableTestScenario.builder()
+                .addTestCases(
+                    ImmutableTestCase.builder()
+                        .name("test case 1")
+                        .addInstructions(
+                            ImmutableCreateProcessInstanceInstruction.builder()
+                                .type(TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
+                                .putVariables("orderId", 12345)
+                                .build())
+                        .build())
+                .build()));
+  }
+}

--- a/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/SchemaValidationTest.java
+++ b/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/SchemaValidationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.ValidationMessage;
+import java.io.IOException;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class SchemaValidationTest {
+
+  private static final String DSL_SCHEMA = "/schema/test-scenario-dsl.schema.json";
+
+  private static JsonSchema jsonSchema;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeAll
+  static void setup() {
+    final JsonSchemaFactory factory = JsonSchemaFactory.getInstance(VersionFlag.V7);
+    jsonSchema = factory.getSchema(SchemaValidationTest.class.getResourceAsStream(DSL_SCHEMA));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/empty-test-scenario.json", "/example-test-scenario.json"})
+  void shouldValidateScenario(final String filePath) throws IOException {
+    // given
+    final JsonNode jsonNode = objectMapper.readTree(getClass().getResourceAsStream(filePath));
+
+    // when
+    final Set<ValidationMessage> errors = jsonSchema.validate(jsonNode);
+
+    // then
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  void shouldReportValidationErrors() throws IOException {
+    // given
+    final JsonNode jsonNode =
+        objectMapper.readTree(getClass().getResourceAsStream("/invalid-test-scenario.json"));
+
+    // when
+    final Set<ValidationMessage> errors = jsonSchema.validate(jsonNode);
+
+    // then
+    assertThat(errors)
+        .isNotEmpty()
+        .extracting(ValidationMessage::getMessage)
+        .contains(
+            "$.testCases[0].instructions[0]: must be valid to one and only one schema, but 0 are valid");
+  }
+}

--- a/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/TestScenarioReaderTest.java
+++ b/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/TestScenarioReaderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenario;
+import io.camunda.process.test.impl.dsl.TestScenarioReader;
+import org.junit.jupiter.api.Test;
+
+public class TestScenarioReaderTest {
+
+  private static final String EXAMPLE_TEST_SCENARIO = "/example-test-scenario.json";
+  private static final String INVALID_TEST_SCENARIO = "/invalid-test-scenario.json";
+
+  @Test
+  void shouldReadTestScenario() {
+    // given
+    final TestScenarioReader reader = new TestScenarioReader();
+
+    // when
+    final TestScenario testScenario =
+        reader.read(getClass().getResourceAsStream(EXAMPLE_TEST_SCENARIO));
+
+    // then
+    assertThat(testScenario).isNotNull();
+    assertThat(testScenario.getTestCases()).hasSize(1);
+
+    final TestCase testCase = testScenario.getTestCases().get(0);
+    assertThat(testCase.getName()).isEqualTo("Happy path order processing");
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidTestScenario() {
+    // given
+    final TestScenarioReader reader = new TestScenarioReader();
+
+    // when / then
+    assertThatThrownBy(() -> reader.read(getClass().getResourceAsStream(INVALID_TEST_SCENARIO)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Failed to read test scenario from stream")
+        .rootCause()
+        .hasMessageStartingWith("Could not resolve type id 'unknown type'");
+  }
+}

--- a/testing/camunda-process-test-dsl/src/test/resources/empty-test-scenario.json
+++ b/testing/camunda-process-test-dsl/src/test/resources/empty-test-scenario.json
@@ -1,0 +1,9 @@
+{
+  "testCases": [
+    {
+      "name": "Test Case 1",
+      "description": "A human-readable description of what this test case is verifying.",
+      "instructions": []
+    }
+  ]
+}

--- a/testing/camunda-process-test-dsl/src/test/resources/example-test-scenario.json
+++ b/testing/camunda-process-test-dsl/src/test/resources/example-test-scenario.json
@@ -1,0 +1,17 @@
+{
+  "testCases": [
+    {
+      "name": "Happy path order processing",
+      "description": "The order should be processed successfully from creation to shipping with tracking code received.",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-dsl/src/test/resources/full-test-scenario.json
+++ b/testing/camunda-process-test-dsl/src/test/resources/full-test-scenario.json
@@ -1,0 +1,64 @@
+{
+  "testCases": [
+    {
+      "name": "Happy path order processing",
+      "description": "The order should be processed successfully from creation to shipping with tracking code received.",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        },
+        {
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "selector": {
+            "processDefinitionId": "order-process",
+            "elementNames": [
+              "Received tracking code"
+            ]
+          },
+          "state": "IS_ACTIVE"
+        },
+        {
+          "type": "ASSERT_VARIABLES",
+          "selector": {
+            "processDefinitionId": "order-process"
+          },
+          "variables": {
+            "shipping_id": "shipping-1"
+          }
+        },
+        {
+          "type": "PUBLISH_MESSAGE",
+          "messageName": "Received tracking code",
+          "correlationKey": "shipping-1",
+          "variables": {
+            "tracking_code": "tracking-1"
+          }
+        },
+        {
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "selector": {
+            "processDefinitionId": "order-process",
+            "elementNames": [
+              "Collect money",
+              "Fetch items",
+              "Ship parcel",
+              "Received tracking code"
+            ]
+          },
+          "state": "IS_COMPLETED"
+        },
+        {
+          "type": "ASSERT_PROCESS_INSTANCE",
+          "selector": {
+            "processDefinitionId": "order-process"
+          },
+          "state": "IS_COMPLETED"
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-dsl/src/test/resources/invalid-test-scenario.json
+++ b/testing/camunda-process-test-dsl/src/test/resources/invalid-test-scenario.json
@@ -1,0 +1,13 @@
+{
+  "testCases": [
+    {
+      "name": "An invalid test case",
+      "instructions": [
+        {
+          "type": "unknown type",
+          "isValid": false
+        }
+      ]
+    }
+  ]
+}

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -24,6 +24,7 @@
     <module>camunda-process-test-java</module>
     <module>camunda-process-test-spring</module>
     <module>camunda-process-test-example</module>
+    <module>camunda-process-test-dsl</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
## Description

Create a new CPT module for the test scenario DSL.

- Add a basic JSON schema for the DSL.
- Add Java interfaces for the DSL. Generate the Java classes with the Immutables library.
- Use Jackson annotations to deserialize a JSON file into the DSL.
- Add test cases to verify the compatibility between the schema and the Java classes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41203 
