### PR TITLE
fix: use BackoffRetryStrategy in ProcessingScheduleServiceImpl

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -12,7 +12,8 @@ import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
+import io.camunda.zeebe.scheduler.retry.BackOffRetryStrategy;
+import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
@@ -45,7 +46,7 @@ public class ProcessingScheduleServiceImpl
   private final PriorityQueue<ScheduledTaskImpl> scheduledTasks = new PriorityQueue<>();
   private LogStreamWriter logStreamWriter;
   private ActorControl actorControl;
-  private AbortableRetryStrategy writeRetryStrategy;
+  private RetryStrategy writeRetryStrategy;
   private CompletableActorFuture<Void> openFuture;
 
   public ProcessingScheduleServiceImpl(
@@ -113,7 +114,8 @@ public class ProcessingScheduleServiceImpl
     }
 
     openFuture = new CompletableActorFuture<>();
-    writeRetryStrategy = new AbortableRetryStrategy(control);
+    writeRetryStrategy =
+        new BackOffRetryStrategy(control, Duration.ofMillis(5), Duration.ofMillis(1));
 
     logStreamWriter = writerSupplier.get();
     actorControl = control;


### PR DESCRIPTION
## Description
AbortableRetryStrategy makes the actor busy sping when it failed to append the event to the log.
This is problematic, because when under load the engine is wasting CPU cycles trying to append new events to the log.
This can slowdown even more the application, because the component that is the current bottleneck is fighting for cpu shares with these jobs.

:question:  Is it really necessary to completely "block" the thread if it's not possible to append the even to the log?

I set the retryInterval to be very small so that it can be retried immediately as failing to append should be a transient problem.

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
relates #35074