### PR TITLE
test: workflow to trigger cross-component-e2e-tests for c8run

### DIFF
--- a/.github/workflows/trigger-c8run-e2e-tests.yml
+++ b/.github/workflows/trigger-c8run-e2e-tests.yml
@@ -1,0 +1,57 @@
+# description: Runs c8-cross-component-e2e-tests on C8Run.
+# test location: https://github.com/camunda/c8-cross-component-e2e-tests/tree/main/tests/c8Run-8.9
+# type: CI
+# owner: @camunda/qa-engineering
+name: Trigger c8-cross-component-e2e-tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited]
+    paths:
+      - "c8run/**"
+
+jobs:
+  trigger-e2e-tests:
+    name: Trigger c8Run E2E Tests in c8-cross-component-e2e-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Generate a GitHub token for camunda/camunda repo
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda,c8-cross-component-e2e-tests
+
+      - name: Trigger repository_dispatch event
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/camunda/c8-cross-component-e2e-tests/dispatches \
+            -d '{"event_type": "run-c8run-tests", "client_payload": {"source_repo": "${{ github.repository }}", "source_sha": "${{ github.sha }}"}}'
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the triggering of cross-component end-to-end (E2E) tests for the `c8run` component. The workflow is designed to run on specific pull request events and ensures that E2E tests are executed in the `c8-cross-component-e2e-tests` repository whenever relevant changes are made.

Key additions in this pull request:

**CI Workflow Automation:**

* Added a new workflow file `.github/workflows/trigger-c8run-e2e-tests.yml` that triggers E2E tests for `c8run` by dispatching an event to the `c8-cross-component-e2e-tests` repository on specific pull request activities.
* The workflow securely generates a GitHub token using secrets stored in Vault, ensuring secure authentication for cross-repository actions.
* It uses a `curl` command to send a `repository_dispatch` event, passing the source repository and commit SHA as payload to initiate the tests in the target repository.
* Includes a step to observe and report the build status, integrating with a custom action for monitoring and error handling.