### PR TITLE
fix: add treePath to copy function of processInstanceDbModel

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -51,6 +51,7 @@ public record ProcessInstanceDbModel(
                 .tenantId(tenantId)
                 .version(version)
                 .partitionId(partitionId)
+                .treePath(treePath)
                 .historyCleanupDate(historyCleanupDate)
                 .tags(tags))
         .build();


### PR DESCRIPTION
## Description

Add the treePath to the copy function of ProcessInstanceDbModel to fix a vanished treePath in random cases, when queue items are merged before flush.
