### PR TITLE
feat: setting min supported OS version

### DIFF
--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,7 +12,7 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.11.1@sha256:68039e76c8c60c0488b8906945b2efd5179bb29a9ae8d71ec64981ab5772b796}
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.17.0@sha256:7b9517dff561f54456fad947f11820fa595a340fd1034fc63d57b77f724b3f8f}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:
       - fixsysctl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
     secrets: inherit
     with:
       database-type: "opensearch"
-      database-image-version: "2.19.3"
+      database-image-version: "2.17.0"
       it-database-type: "os"
 
   rdbms-h2-integration-tests:

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.3}
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.17.0}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/docs/testing/acceptance.md
+++ b/docs/testing/acceptance.md
@@ -229,7 +229,7 @@ docker run -d -p 9200:9200 \
               -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!" \
               -e "OPENSEARCH_PASSWORD=changeme" \
               -e "DISABLE_SECURITY_PLUGIN=true" \
-              opensearchproject/opensearch:latest
+              opensearchproject/opensearch:2.17.0
 ```
 
 To run with OpenSearch from your IDE, you have two options:

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -3,7 +3,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:2.17.0
     depends_on:
       - opensearch-init
     container_name: opensearch

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:2.17.0
     container_name: opensearch
     environment:
       - cluster.name=opensearch

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     command: [ "sysctl", "-w", "vm.max_map_count=262144" ]
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:2.17.0
     container_name: opensearch
     depends_on:
       - opensearch-init

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
@@ -11,6 +11,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -30,7 +32,6 @@ import java.util.Map;
 import net.bytebuddy.ByteBuddy;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.testcontainers.OpenSearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,13 +48,21 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       DatabaseInfo.class,
-      OperatePropertiesOverride.class
+      OperatePropertiesOverride.class,
+      UnifiedConfiguration.class,
+      UnifiedConfigurationHelper.class
     },
-    properties = "camunda.data.secondary-storage.type=opensearch")
+    properties = {
+      "camunda.data.secondary-storage.type=opensearch",
+      "zeebe.broker.exporters.camundaexporter.args.connect.type=opensearch",
+      "camunda.operate.database=opensearch",
+      "camunda.tasklist.database=opensearch",
+      "camunda.database.type=opensearch"
+    })
 public class OpensearchConnectorIT extends OperateAbstractIT {
 
   private static final OpenSearchContainer<?> OPENSEARCH_CONTAINER =
-      new OpenSearchContainer<>("opensearchproject/opensearch")
+      new OpenSearchContainer<>("opensearchproject/opensearch:2.17.0")
           .withEnv(Map.of())
           .withExposedPorts(9200, 9205);
 
@@ -68,19 +77,18 @@ public class OpensearchConnectorIT extends OperateAbstractIT {
 
   @BeforeClass
   public static void beforeAll() {
-    // OpensearchOperateAbstractIT.beforeClass();
     OPENSEARCH_CONTAINER.start();
     WIRE_MOCK_SERVER.start();
   }
 
   @AfterClass
   public static void afterAll() throws IOException {
+    OPENSEARCH_CONTAINER.stop();
     FileUtil.deleteFolderIfExists(TEMP_DIR);
     WIRE_MOCK_SERVER.stop();
   }
 
   @Test
-  @Ignore
   public void shouldSetCustomHeaderOnAllOpensearchClientRequests() throws IOException {
     // given
     final var client = connector.operateOpenSearchClient();
@@ -118,8 +126,7 @@ public class OpensearchConnectorIT extends OperateAbstractIT {
 
     setPluginConfig(registry, OperateProperties.PREFIX + ".openSearch", plugin);
     setPluginConfig(registry, OperateProperties.PREFIX + ".zeebeOpenSearch", plugin);
-    registry.add(OperateProperties.PREFIX + ".opensearch.url", WIRE_MOCK_SERVER::baseUrl);
-    registry.add(OperateProperties.PREFIX + ".zeebeopensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.data.secondary-storage.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
   }
 
   private static void setPluginConfig(

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,6 +1,6 @@
 testcontainers:
   elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.6"
-  opensearch: "opensearchproject/opensearch:2.5.0"
+  opensearch: "opensearchproject/opensearch:2.17.0"
 
 # Unified Configuration
 camunda:

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -67,7 +67,7 @@
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->
     <elasticsearch.log4j.version>2.24.2</elasticsearch.log4j.version>
     <!-- OpenSearch-->
-    <opensearch.client.version>2.10.4</opensearch.client.version>
+    <opensearch.client.version>2.26.0</opensearch.client.version>
     <!-- The least supported opensearch version we should test against-->
     <opensearch.test.version>2.17.0</opensearch.test.version>
     <!-- the opensearch version of the previous Optimize version -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,7 +79,7 @@
     <version.netty>4.1.127.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.17.0</version.opensearch>
-    <version.opensearch-java>2.19.0</version.opensearch-java>
+    <version.opensearch-java>2.26.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.0</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.31.1</version.protobuf>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:2.17.0
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -167,30 +167,47 @@ public class ElasticsearchConnector {
 
   private KeyStore loadCustomTrustStore(final SslProperties sslConfig) {
     try {
-      final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-      trustStore.load(null);
-      // load custom es server certificate if configured
-      final String serverCertificate = sslConfig.getCertificatePath();
-      if (serverCertificate != null) {
-        setCertificateInTrustStore(trustStore, serverCertificate);
+      final String certificatePath = sslConfig.getCertificatePath();
+      if (certificatePath != null) {
+        // Check if it's a PKCS12 keystore
+        if (certificatePath.endsWith(".p12") || certificatePath.endsWith(".pfx")) {
+          return loadPKCS12KeyStore(certificatePath);
+        } else {
+          // Load as X.509 certificate
+          return loadX509KeyStore(certificatePath);
+        }
+      } else {
+        final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null);
+        return trustStore;
       }
-      return trustStore;
     } catch (final Exception e) {
-      final String message =
-          "Could not create certificate trustStore for the secured Elasticsearch Connection!";
-      throw new TasklistRuntimeException(message, e);
+      throw new TasklistRuntimeException(
+          "Could not create certificate trustStore for the secured Elasticsearch Connection!", e);
     }
   }
 
-  private void setCertificateInTrustStore(
-      final KeyStore trustStore, final String serverCertificate) {
-    try {
-      final Certificate cert = loadCertificateFromPath(serverCertificate);
-      trustStore.setCertificateEntry("elasticsearch-host", cert);
+  private KeyStore loadPKCS12KeyStore(final String certificatePath) {
+    try (final FileInputStream fis = new FileInputStream(certificatePath)) {
+      final KeyStore keyStore = KeyStore.getInstance("PKCS12");
+      keyStore.load(fis, null); // No password for the test keystore
+      return keyStore;
     } catch (final Exception e) {
-      final String message =
-          "Could not load configured server certificate for the secured Elasticsearch Connection!";
-      throw new TasklistRuntimeException(message, e);
+      throw new TasklistRuntimeException(
+          "Could not load PKCS12 certificate from path: " + certificatePath, e);
+    }
+  }
+
+  private KeyStore loadX509KeyStore(final String certificatePath) {
+    try {
+      final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      trustStore.load(null);
+      final Certificate cert = loadCertificateFromPath(certificatePath);
+      trustStore.setCertificateEntry("elasticsearch-host", cert);
+      return trustStore;
+    } catch (final Exception e) {
+      throw new TasklistRuntimeException(
+          "Could not load X.509 certificate from path: " + certificatePath, e);
     }
   }
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -73,7 +73,6 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 public class OpenSearchConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchConnector.class);
-  private static final String AWS_OPENSEARCH_SERVICE_NAME = "es";
 
   private PluginRepository osClientRepository = new PluginRepository();
   @Autowired private TasklistProperties tasklistProperties;

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:2.17.0
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
@@ -21,6 +21,7 @@ import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
 import java.util.Map;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,28 +51,23 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 @ContextConfiguration(initializers = {ElasticsearchConnectorBasicAuthIT.ElasticsearchStarter.class})
 public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
-  static ElasticsearchContainer elasticsearch =
+  private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER =
       new ElasticsearchContainer(
               "docker.elastic.co/elasticsearch/elasticsearch:" + SUPPORTED_ELASTICSEARCH_VERSION)
-          .withEnv(
-              Map.of(
-                  "xpack.security.enabled", "true",
-                  "ELASTIC_PASSWORD", "changeme"
-                  //        "xpack.security.transport.ssl.enabled","true",
-                  //        "xpack.security.http.ssl.enabled", "true",
-                  //        "xpack.security.transport.ssl.verification_mode","none",//"certificate",
-                  //        "xpack.security.transport.ssl.keystore.path",
-                  // "elastic-certificates.p12",
-                  //        "xpack.security.transport.ssl.truststore.path",
-                  // "elastic-certificates.p12"
-                  ))
+          .withEnv(Map.of("xpack.security.enabled", "true"))
+          .withPassword("elastic")
           .withExposedPorts(9200);
 
   @Autowired RestHighLevelClient tasklistEsClient;
 
   @BeforeAll
-  public static void beforeClass() {
+  static void beforeAll() {
     assumeTrue(TestUtil.isElasticSearch());
+  }
+
+  @AfterAll
+  static void afterAll() {
+    ELASTICSEARCH_CONTAINER.stop();
   }
 
   @Test
@@ -84,15 +80,24 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
     @Override
     public void initialize(final ConfigurableApplicationContext applicationContext) {
-      elasticsearch.start();
-      final String elsUrl = String.format("http://%s", elasticsearch.getHttpHostAddress());
+      ELASTICSEARCH_CONTAINER.start();
+
+      final String elsUrl =
+          String.format("http://%s", ELASTICSEARCH_CONTAINER.getHttpHostAddress());
+
       TestPropertyValues.of(
-              // "camunda.tasklist.elasticsearch.host="+elasticsearch.getHost(),
-              // "camunda.tasklist.elasticsearch.port="+elasticsearch.getFirstMappedPort(),
-              "camunda.data.secondary-storage.elasticsearch.url=" + elsUrl,
+              "camunda.database.type=elasticsearch",
               "camunda.data.secondary-storage.type=elasticsearch",
+              "camunda.operate.database=elasticsearch",
+              "camunda.tasklist.database=elasticsearch",
+              "zeebe.broker.exporters.camundaexporter.args.connect.type=elasticsearch",
+              "camunda.data.secondary-storage.elasticsearch.url=" + elsUrl,
+              "camunda.database.url=" + elsUrl,
+              "camunda.operate.elasticsearch.url=" + elsUrl,
+              "camunda.tasklist.elasticsearch.url=" + elsUrl,
+              "zeebe.broker.exporters.camundaexporter.args.connect.url=" + elsUrl,
               "camunda.data.secondary-storage.elasticsearch.username=elastic",
-              "camunda.data.secondary-storage.elasticsearch.password=changeme")
+              "camunda.data.secondary-storage.elasticsearch.password=elastic")
           .applyTo(applicationContext.getEnvironment());
     }
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -68,13 +68,15 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
 
   private static final String ES_ADMIN_USER = "elastic";
   private static final String ES_ADMIN_PASSWORD = "changeme";
-  static ElasticsearchContainer elasticsearch =
+  private static final String TASKLIST_ES_USER = "tasklist_user";
+  private static final String TASKLIST_ES_PASSWORD = "tasklist_pwd";
+
+  private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER =
       new ElasticsearchContainer(
               "docker.elastic.co/elasticsearch/elasticsearch:" + SUPPORTED_ELASTICSEARCH_VERSION)
           .withEnv(Map.of("xpack.security.enabled", "true", "ELASTIC_PASSWORD", ES_ADMIN_PASSWORD))
           .withExposedPorts(9200);
-  private static final String TASKLIST_ES_USER = "tasklist_user";
-  private static final String TASKLIST_ES_PASSWORD = "tasklist_pwd";
+
   @Autowired RestHighLevelClient tasklistEsClient;
 
   @Autowired private TestRestTemplate testRestTemplate;
@@ -82,7 +84,7 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
   @LocalManagementPort private int managementPort;
 
   @BeforeAll
-  public static void beforeClass() {
+  static void beforeAll() {
     assumeTrue(TestUtil.isElasticSearch());
   }
 
@@ -101,14 +103,24 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
 
     @Override
     public void initialize(final ConfigurableApplicationContext applicationContext) {
-      elasticsearch.start();
+      ELASTICSEARCH_CONTAINER.start();
 
       createElasticsearchRoleAndUser();
 
-      final String elsUrl = String.format("http://%s", elasticsearch.getHttpHostAddress());
+      final String elsUrl =
+          String.format("http://%s", ELASTICSEARCH_CONTAINER.getHttpHostAddress());
+
       TestPropertyValues.of(
-              "camunda.data.secondary-storage.elasticsearch.url=" + elsUrl,
+              "camunda.database.type=elasticsearch",
               "camunda.data.secondary-storage.type=elasticsearch",
+              "camunda.operate.database=elasticsearch",
+              "camunda.tasklist.database=elasticsearch",
+              "zeebe.broker.exporters.camundaexporter.args.connect.type=elasticsearch",
+              "camunda.database.url=" + elsUrl,
+              "camunda.data.secondary-storage.elasticsearch.url=" + elsUrl,
+              "camunda.operate.elasticsearch.url=" + elsUrl,
+              "camunda.tasklist.elasticsearch.url=" + elsUrl,
+              "zeebe.broker.exporters.camundaexporter.args.connect.url=" + elsUrl,
               "camunda.data.secondary-storage.elasticsearch.username=" + TASKLIST_ES_USER,
               "camunda.data.secondary-storage.elasticsearch.password=" + TASKLIST_ES_PASSWORD,
               // Disable health check as tasklist ES client has no cluster privileges
@@ -156,7 +168,7 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
       final var credentialProvider = new BasicCredentialsProvider();
       credentialProvider.setCredentials(
           AuthScope.ANY, new UsernamePasswordCredentials(ES_ADMIN_USER, ES_ADMIN_PASSWORD));
-      final URI uri = new URI("http://" + elasticsearch.getHttpHostAddress());
+      final URI uri = new URI("http://" + ELASTICSEARCH_CONTAINER.getHttpHostAddress());
       return new ElasticsearchClient(
           new RestClientTransport(
               RestClient.builder(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()))

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
@@ -53,7 +53,7 @@ import org.testcontainers.utility.DockerImageName;
 public class ElasticsearchConnectorIT {
 
   @Container
-  static ElasticsearchContainer elasticsearch =
+  private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER =
       new ElasticsearchContainer(
               DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
                   .withTag(SUPPORTED_ELASTICSEARCH_VERSION))
@@ -115,11 +115,17 @@ public class ElasticsearchConnectorIT {
     WIRE_MOCK_SERVER.stubFor(
         WireMock.any(WireMock.anyUrl())
             .willReturn(
-                WireMock.aResponse().proxiedFrom("http://" + elasticsearch.getHttpHostAddress())));
+                WireMock.aResponse()
+                    .proxiedFrom("http://" + ELASTICSEARCH_CONTAINER.getHttpHostAddress())));
 
     setPluginConfig(registry, TasklistProperties.PREFIX + ".elasticsearch", plugin);
     // URL
+    registry.add("camunda.database.url", WIRE_MOCK_SERVER::baseUrl);
     registry.add("camunda.data.secondary-storage.elasticsearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.operate.elasticsearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.tasklist.elasticsearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add(
+        "zeebe.broker.exporters.camundaexporter.args.connect.url", WIRE_MOCK_SERVER::baseUrl);
   }
 
   private static void setPluginConfig(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -18,11 +18,9 @@ import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
-import java.io.File;
 import java.util.Map;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,19 +44,16 @@ import org.testcontainers.utility.MountableFile;
       UnifiedConfigurationHelper.class
     })
 @ContextConfiguration(initializers = {ElasticsearchConnectorSSLAuthIT.ElasticsearchStarter.class})
-@Disabled
 public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
 
-  static String certDir = new File("src/test/resources/certs").getAbsolutePath();
+  private static final String CERTIFICATE_RESOURCE_PATH = "certs/elastic-stack-ca.p12";
 
-  static ElasticsearchContainer elasticsearch =
+  private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER =
       new ElasticsearchContainer(
               "docker.elastic.co/elasticsearch/elasticsearch:" + SUPPORTED_ELASTICSEARCH_VERSION)
           .withCopyFileToContainer(
-              MountableFile.forHostPath("src/test/resources/certs/elastic-stack-ca.p12"),
+              MountableFile.forClasspathResource(CERTIFICATE_RESOURCE_PATH),
               "/usr/share/elasticsearch/config/certs/elastic-stack-ca.p12")
-          // .withCopyFileToContainer(MountableFile.forClasspathResource("/certs/elastic-stack-ca.p12"),"/usr/share/elasticsearch/config/certs/elastic-stack-ca.p12")
-          .withPassword("elastic")
           .withEnv(
               Map.of(
                   "xpack.security.enabled",
@@ -68,16 +63,17 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
                   "xpack.security.http.ssl.keystore.path",
                   "/usr/share/elasticsearch/config/certs/elastic-stack-ca.p12"))
           .withExposedPorts(9200)
-          .waitingFor(Wait.forHttps("/").withBasicCredentials("elastic", "elastic"));
+          .withPassword("elastic")
+          .waitingFor(
+              Wait.forHttps("/").allowInsecure().withBasicCredentials("elastic", "elastic"));
 
   @Autowired RestHighLevelClient tasklistEsClient;
 
   @BeforeAll
-  public static void beforeClass() {
+  static void beforeAll() {
     assumeTrue(TestUtil.isElasticSearch());
   }
 
-  @Disabled("Can be tested manually")
   @Test
   public void canConnect() {
     assertThat(tasklistEsClient).isNotNull();
@@ -88,20 +84,30 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
 
     @Override
     public void initialize(final ConfigurableApplicationContext applicationContext) {
-      elasticsearch.start();
+      ELASTICSEARCH_CONTAINER.start();
 
       final String elsUrl =
           String.format(
-              "https://%s:%d/", elasticsearch.getHost(), elasticsearch.getFirstMappedPort());
+              "https://%s:%d/",
+              ELASTICSEARCH_CONTAINER.getHost(), ELASTICSEARCH_CONTAINER.getFirstMappedPort());
+
       TestPropertyValues.of(
               "camunda.data.secondary-storage.type=elasticsearch",
+              "camunda.database.type=elasticsearch",
+              "camunda.tasklist.database=elasticsearch",
+              "camunda.operate.database=elasticsearch",
+              "zeebe.broker.exporters.camundaexporter.args.connect.type=elasticsearch",
+              "camunda.database.url=" + elsUrl,
               "camunda.data.secondary-storage.elasticsearch.url=" + elsUrl,
+              "camunda.operate.elasticsearch.url=" + elsUrl,
+              "camunda.tasklist.elasticsearch.url=" + elsUrl,
+              "zeebe.broker.exporters.camundaexporter.args.connect.url=" + elsUrl,
               "camunda.data.secondary-storage.elasticsearch.username=elastic",
-              "camunda.data.secondary-storage.elasticsearch.password=elastic"
-              // "camunda.tasklist.elasticsearch.ssl.certificatePath="+certDir+"/elastic-stack-ca.p12",
-              // "camunda.tasklist.elasticsearch.ssl.selfSigned=true",
-              // "camunda.tasklist.elasticsearch.ssl.verifyHostname=true",
-              )
+              "camunda.data.secondary-storage.elasticsearch.password=elastic",
+              "camunda.data.secondary-storage.elasticsearch.security.certificate-path="
+                  + getClass().getClassLoader().getResource(CERTIFICATE_RESOURCE_PATH).getPath(),
+              "camunda.data.secondary-storage.elasticsearch.security.self-signed=true",
+              "camunda.data.secondary-storage.elasticsearch.security.verify-hostname=false")
           .applyTo(applicationContext.getEnvironment());
     }
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -18,11 +18,13 @@ import io.camunda.tasklist.qa.util.TestOpenSearchSchemaManager;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
-import java.util.Map;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.testcontainers.OpenSearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -50,37 +52,27 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(initializers = {OpenSearchConnectorBasicAuthIT.OpenSearchStarter.class})
 public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
-  static OpenSearchContainer opensearch =
-      (OpenSearchContainer)
-          new OpenSearchContainer("opensearchproject/opensearch:2.17.0")
-              .withEnv(
-                  Map.of(
-                      // "plugins.security.disabled", "false",
-                      "OPENSEARCH_PASSWORD", "changeme",
-                      "plugins.security.allow_unsafe_democertificates", "true"
-                      //        "xpack.security.transport.ssl.enabled","true",
-                      //        "xpack.security.http.ssl.enabled", "true",
-                      //
-                      // "xpack.security.transport.ssl.verification_mode","none",//"certificate",
-                      //        "xpack.security.transport.ssl.keystore.path",
-                      // "elastic-certificates.p12",
-                      //        "xpack.security.transport.ssl.truststore.path",
-                      // "elastic-certificates.p12"
-                      ))
-              .withExposedPorts(9200, 9200);
+  private static final OpenSearchContainer OPENSEARCH_CONTAINER =
+      new OpenSearchContainer("opensearchproject/opensearch:2.17.0");
 
   @Autowired
   @Qualifier("tasklistOsClient")
   OpenSearchClient openSearchClient;
 
   @BeforeAll
-  public static void beforeClass() {
+  static void beforeAll() {
     assumeTrue(TestUtil.isOpenSearch());
   }
 
+  @AfterAll
+  static void afterAll() {
+    OPENSEARCH_CONTAINER.stop();
+  }
+
   @Test
-  public void canConnect() {
+  public void canConnect() throws IOException {
     assertThat(openSearchClient).isNotNull();
+    assertThat(openSearchClient.cluster().health().status()).isSameAs(HealthStatus.Green);
   }
 
   static class OpenSearchStarter
@@ -88,16 +80,26 @@ public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
     @Override
     public void initialize(final ConfigurableApplicationContext applicationContext) {
-      opensearch.start();
+      OPENSEARCH_CONTAINER.start();
 
       final String osUrl =
-          String.format("http://%s:%s", opensearch.getHost(), opensearch.getMappedPort(9200));
+          String.format(
+              "http://%s:%s",
+              OPENSEARCH_CONTAINER.getHost(), OPENSEARCH_CONTAINER.getMappedPort(9200));
+
       TestPropertyValues.of(
+              "camunda.database.type=opensearch",
               "camunda.data.secondary-storage.type=opensearch",
+              "camunda.operate.database=opensearch",
+              "camunda.tasklist.database=opensearch",
+              "zeebe.broker.exporters.camundaexporter.args.connect.type=opensearch",
+              "camunda.database.url=" + osUrl,
               "camunda.data.secondary-storage.opensearch.url=" + osUrl,
-              "camunda.data.secondary-storage.opensearch.cluster-name=docker-cluster",
-              "camunda.data.secondary-storage.opensearch.username=opensearch",
-              "camunda.data.secondary-storage.opensearch.password=changeme")
+              "camunda.operate.opensearch.url=" + osUrl,
+              "camunda.tasklist.opensearch.url=" + osUrl,
+              "camunda.database.opensearch.username=" + OPENSEARCH_CONTAINER.getUsername(),
+              "camunda.database.opensearch.password=" + OPENSEARCH_CONTAINER.getPassword(),
+              "camunda.data.secondary-storage.opensearch.cluster-name=docker-cluster")
           .applyTo(applicationContext.getEnvironment());
     }
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -8,14 +8,16 @@
 package io.camunda.tasklist.os;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
-import java.io.File;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +32,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
 
 @ExtendWith(SpringExtension.class)
@@ -47,28 +48,40 @@ import org.testcontainers.utility.MountableFile;
 @Disabled
 public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
 
-  static String certDir = new File("src/test/resources/certs").getAbsolutePath();
+  private static final String CERTIFICATE_RESOURCE_PATH = "certs/elastic-stack-ca.p12";
 
   static OpenSearchContainer opensearch =
       (OpenSearchContainer)
           new OpenSearchContainer("opensearchproject/opensearch:2.17.0")
+              // .withSecurityEnabled() // this should be uncommented to test SSL
               .withCopyFileToContainer(
-                  MountableFile.forHostPath("src/test/resources/certs/elastic-stack-ca.p12"),
-                  "/usr/share/elasticsearch/config/certs/elastic-stack-ca.p12")
-              // .withCopyFileToContainer(MountableFile.forClasspathResource("/certs/elastic-stack-ca.p12"),"/usr/share/elasticsearch/config/certs/elastic-stack-ca.p12")
-              // .withPassword("elastic")
+                  MountableFile.forClasspathResource(CERTIFICATE_RESOURCE_PATH),
+                  "/usr/share/opensearch/config/certs/opensearch-ca.p12")
               .withEnv(
                   Map.of(
-                      "xpack.security.http.ssl.keystore.path",
-                      "/usr/share/elasticsearch/config/certs/elastic-stack-ca.p12"))
-              .withExposedPorts(9200)
-              .waitingFor(Wait.forHttps("/").withBasicCredentials("elastic", "elastic"));
+                      "plugins.security.allow_unsafe_democertificates",
+                      "true",
+                      "plugins.security.ssl.http.enabled",
+                      "true",
+                      "plugins.security.ssl.http.keystore_type",
+                      "PKCS12",
+                      "plugins.security.ssl.http.keystore_filepath",
+                      "opensearch.keystore",
+                      "plugins.security.ssl.transport.keystore_type",
+                      "PKCS12",
+                      "plugins.security.ssl.transport.keystore_filepath",
+                      "opensearch.keystore"));
 
   @Autowired
   @Qualifier("tasklistOsClient")
-  OpenSearchClient openSearchClient;
+  private OpenSearchClient openSearchClient;
 
-  @Disabled("Can be tested manually")
+  @BeforeAll
+  static void beforeAll() {
+    assumeTrue(TestUtil.isOpenSearch());
+  }
+
+  @Disabled("SSL configuration not working - need investigation")
   @Test
   public void canConnect() {
     assertThat(openSearchClient).isNotNull();
@@ -80,16 +93,26 @@ public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
     @Override
     public void initialize(final ConfigurableApplicationContext applicationContext) {
       opensearch.start();
+      final boolean isSecurityEnabled = opensearch.isSecurityEnabled();
+      final String protocol = isSecurityEnabled ? "https" : "http";
+      final String osUrl =
+          String.format(
+              "%s://%s:%d/", protocol, opensearch.getHost(), opensearch.getFirstMappedPort());
 
-      final String elsUrl =
-          String.format("https://%s:%d/", opensearch.getHost(), opensearch.getFirstMappedPort());
       TestPropertyValues.of(
-              "camunda.tasklist.opensearch.url=" + elsUrl,
-              "camunda.tasklist.opensearch.username=elastic",
-              "camunda.tasklist.opensearch.password=elastic",
-              "camunda.tasklist.opensearch.clusterName=docker-cluster",
-              "camunda.data.secondary-storage.opensearch.username=elastic",
-              "camunda.data.secondary-storage.opensearch.password=elastic")
+              "camunda.data.secondary-storage.type=opensearch",
+              "camunda.database.url=" + osUrl,
+              "camunda.data.secondary-storage.opensearch.url=" + osUrl,
+              "camunda.database.opensearch.username=" + opensearch.getUsername(),
+              "camunda.database.opensearch.password=" + opensearch.getPassword(),
+              "camunda.data.secondary-storage.opensearch.ssl.enabled=" + isSecurityEnabled,
+              "camunda.data.secondary-storage.opensearch.ssl.self-signed=true",
+              "camunda.data.secondary-storage.opensearch.ssl.verify-hostname=false",
+              "camunda.database.opensearch.ssl.enabled=" + isSecurityEnabled,
+              "camunda.database.opensearch.ssl.self-signed=true",
+              "camunda.database.opensearch.ssl.verify-hostname=false",
+              "camunda.data.secondary-storage.opensearch.security.certificate-path="
+                  + getClass().getClassLoader().getResource(CERTIFICATE_RESOURCE_PATH).getPath())
           .applyTo(applicationContext.getEnvironment());
     }
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
@@ -49,11 +50,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     },
     properties = {
       "camunda.data.secondary-storage.type=opensearch",
+      "camunda.database.type=opensearch",
+      "camunda.tasklist.database=opensearch",
+      "camunda.operate.database=opensearch",
+      "zeebe.broker.exporters.camundaexporter.args.connect.type=opensearch",
     })
 public class OpensearchConnectorIT {
 
+  @Container
   private static final OpenSearchContainer<?> OPENSEARCH_CONTAINER =
-      new OpenSearchContainer<>("opensearchproject/opensearch")
+      new OpenSearchContainer<>("opensearchproject/opensearch:2.17.0")
           .withEnv(Map.of())
           .withExposedPorts(9200, 9205);
 
@@ -69,7 +75,6 @@ public class OpensearchConnectorIT {
   @BeforeAll
   static void beforeAll() {
     assumeTrue(TestUtil.isOpenSearch());
-    OPENSEARCH_CONTAINER.start();
     WIRE_MOCK_SERVER.start();
   }
 
@@ -117,7 +122,12 @@ public class OpensearchConnectorIT {
 
     setPluginConfig(registry, TasklistProperties.PREFIX + ".openSearch", plugin);
     // Unified configuration: db url + compatibility
+    registry.add("camunda.database.url", WIRE_MOCK_SERVER::baseUrl);
     registry.add("camunda.data.secondary-storage.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.operate.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add("camunda.tasklist.opensearch.url", WIRE_MOCK_SERVER::baseUrl);
+    registry.add(
+        "zeebe.broker.exporters.camundaexporter.args.connect.url", WIRE_MOCK_SERVER::baseUrl);
   }
 
   private static void setPluginConfig(

--- a/zeebe/exporters/opensearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/opensearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:2.17.0
     container_name: opensearch
     environment:
       - "discovery.type=single-node"


### PR DESCRIPTION


## Description

Set the current min OpenSearch supported version as 2.17.0 everywhere and refactor tests. We will bump this up soon to 2.19, but for the time being ensuring the whole stack works with the min version we support.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40612
