### PR TITLE
Add authorization claims in rejections and process events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -111,7 +111,8 @@ public class DecisionEvaluationEvaluteProcessor
               stateWriter.appendFollowUpEvent(
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),
-                  evaluationRecordTuple.getRight());
+                  evaluationRecordTuple.getRight(),
+                  command.getAuthorizations());
               responseWriter.writeEventOnCommand(
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -115,7 +115,8 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
       return;
     }
 
-    stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
+    stateWriter.appendFollowUpEvent(
+        key, IncidentIntent.RESOLVED, incident, command.getAuthorizations());
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
 
     publishIncidentRelatedJob(jobKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.TagUtil;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
@@ -117,7 +118,7 @@ public final class ProcessInstanceCreationCreateProcessor
         .flatMap(process -> isAuthorized(command, process))
         .flatMap(process -> validateCommand(command.getValue(), process))
         .ifRightOrLeft(
-            process -> createProcessInstance(controller, record, process),
+            process -> createProcessInstance(controller, command, process),
             rejection -> controller.reject(rejection.type(), rejection.reason()));
 
     return true;
@@ -167,16 +168,17 @@ public final class ProcessInstanceCreationCreateProcessor
 
   private void createProcessInstance(
       final CommandControl<ProcessInstanceCreationRecord> controller,
-      final ProcessInstanceCreationRecord record,
+      final TypedRecord<ProcessInstanceCreationRecord> command,
       final DeployedProcess process) {
     final long processInstanceKey = keyGenerator.nextKey();
-
+    final ProcessInstanceCreationRecord record = command.getValue();
     setVariablesFromDocument(
         record,
         process.getKey(),
         processInstanceKey,
         process.getBpmnProcessId(),
-        process.getTenantId());
+        process.getTenantId(),
+        command.getAuthorizations());
 
     final var processInstance =
         initProcessInstanceRecord(process, processInstanceKey, record.getTags());
@@ -410,7 +412,8 @@ public final class ProcessInstanceCreationCreateProcessor
       final long processDefinitionKey,
       final long processInstanceKey,
       final DirectBuffer bpmnProcessId,
-      final String tenantId) {
+      final String tenantId,
+      final Map<String, Object> authorizationClaims) {
 
     variableBehavior.mergeLocalDocument(
         processInstanceKey,
@@ -418,7 +421,8 @@ public final class ProcessInstanceCreationCreateProcessor
         processInstanceKey,
         bpmnProcessId,
         tenantId,
-        record.getVariablesBuffer());
+        record.getVariablesBuffer(),
+        authorizationClaims);
   }
 
   private ProcessInstanceRecord initProcessInstanceRecord(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -194,7 +194,10 @@ public class ProcessInstanceMigrationMigrateProcessor
     }
 
     stateWriter.appendFollowUpEvent(
-        processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
+        processInstanceKey,
+        ProcessInstanceMigrationIntent.MIGRATED,
+        value,
+        command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value, command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -292,7 +292,10 @@ public final class ProcessInstanceModificationModifyProcessor
             });
 
     stateWriter.appendFollowUpEvent(
-        eventKey, ProcessInstanceModificationIntent.MODIFIED, extendedRecord);
+        eventKey,
+        ProcessInstanceModificationIntent.MODIFIED,
+        extendedRecord,
+        command.getAuthorizations());
 
     responseWriter.writeEventOnCommand(
         eventKey, ProcessInstanceModificationIntent.MODIFIED, extendedRecord, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -262,7 +262,8 @@ public final class ProcessInstanceModificationModifyProcessor
                                   scopeKey,
                                   processInstance,
                                   process,
-                                  instruction));
+                                  instruction,
+                                  command.getAuthorizations()));
 
                   extendedRecord.addActivateInstruction(
                       ((ProcessInstanceModificationActivateInstruction) instruction)
@@ -762,7 +763,8 @@ public final class ProcessInstanceModificationModifyProcessor
       final Long scopeKey,
       final ElementInstance processInstance,
       final DeployedProcess process,
-      final ProcessInstanceModificationActivateInstructionValue activate) {
+      final ProcessInstanceModificationActivateInstructionValue activate,
+      final Map<String, Object> authorizationClaims) {
     activate.getVariableInstructions().stream()
         .filter(
             instruction ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -74,7 +74,8 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
     final boolean respond = shouldRespond && command.hasRequestMetadata();
 
     if (isAccepted) {
-      stateWriter.appendFollowUpEvent(entityKey, newState, updatedValue);
+      stateWriter.appendFollowUpEvent(
+          entityKey, newState, updatedValue, command.getAuthorizations());
       wrappedProcessor.afterAccept(commandWriter, stateWriter, entityKey, newState, updatedValue);
       if (respond) {
         responseWriter.writeEventOnCommand(entityKey, newState, updatedValue, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -19,7 +20,10 @@ import java.util.function.Consumer;
  * event).
  */
 public record FollowUpEventMetadata(
-    long operationReference, long batchOperationReference, int recordVersion) {
+    long operationReference,
+    long batchOperationReference,
+    int recordVersion,
+    Map<String, Object> claims) {
 
   public static final int VERSION_NOT_SET = -1;
 
@@ -45,6 +49,10 @@ public record FollowUpEventMetadata(
     return recordVersion;
   }
 
+  public Map<String, Object> getClaims() {
+    return claims;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -54,6 +62,7 @@ public record FollowUpEventMetadata(
     private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
     private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
     private int recordVersion = VERSION_NOT_SET;
+    private Map<String, Object> claims = Map.of();
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;
@@ -70,8 +79,14 @@ public record FollowUpEventMetadata(
       return this;
     }
 
+    public Builder claims(final Map<String, Object> claims) {
+      this.claims = claims;
+      return this;
+    }
+
     public FollowUpEventMetadata build() {
-      return new FollowUpEventMetadata(operationReference, batchOperationReference, recordVersion);
+      return new FollowUpEventMetadata(
+          operationReference, batchOperationReference, recordVersion, claims);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -9,12 +9,14 @@ package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -45,6 +47,15 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
 
   @Override
   public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final Map<String, Object> claims) {
+    appendFollowUpEvent(key, intent, value, m -> m.claims(claims));
+  }
+
+  @Override
+  public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
     appendFollowUpEvent(key, intent, value, m -> m.recordVersion(recordVersion));
   }
@@ -67,6 +78,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
+            .authorization(new AuthInfo().setClaims(metadata.getClaims()))
             .operationReference(metadata.getOperationReference())
             .batchOperationReference(metadata.getBatchOperationReference());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -32,6 +33,7 @@ final class ResultBuilderBackedRejectionWriter extends AbstractResultBuilderBack
         new RecordMetadata()
             .recordType(RecordType.COMMAND_REJECTION)
             .intent(command.getIntent())
+            .authorization(new AuthInfo().setClaims(command.getAuthorizations()))
             .rejectionType(rejectionType)
             .rejectionReason(reason)
             .operationReference(command.getOperationReference());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public interface TypedEventWriter {
@@ -37,6 +38,31 @@ public interface TypedEventWriter {
    * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
    */
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
+
+  /**
+   * Append a follow-up event to the result builder.
+   *
+   * <p>Different versions of event records may be applied by different {@link
+   * io.camunda.zeebe.engine.state.EventApplier EventApplier}s, leading to differing state changes.
+   * This allows fixing bugs in event appliers because every event applier must produce the same
+   * state changes for an event both when writing it and when replaying it, even on newer versions
+   * of Zeebe.
+   *
+   * <p>This method always uses the latest available {@link
+   * io.camunda.zeebe.engine.state.EventApplier}. If a specific version needs to be used, consider
+   * using {@link #appendFollowUpEvent(long, Intent, RecordValue, int)} instead.
+   *
+   * <p>For advanced use cases requiring enriched metadata such as {@code operationReference},
+   * consider using {@link #appendFollowUpEvent(long, Intent, RecordValue, FollowUpEventMetadata)}.
+   *
+   * @param key the key of the event
+   * @param intent the intent of the event
+   * @param value the record of the event
+   * @param claims the authorization claims to set in the event's metadata
+   * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
+   */
+  void appendFollowUpEvent(
+      long key, Intent intent, RecordValue value, final Map<String, Object> claims);
 
   /**
    * Append a specific version of a follow-up event to the result builder.
@@ -108,10 +134,10 @@ public interface TypedEventWriter {
    * @throws ExceededBatchRecordSizeException if the event exceeds batch size
    */
   default void appendFollowUpEvent(
-      long key,
-      Intent intent,
-      RecordValue value,
-      Consumer<FollowUpEventMetadata.Builder> builderConsumer) {
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final Consumer<FollowUpEventMetadata.Builder> builderConsumer) {
     final var builder = FollowUpEventMetadata.builder();
     builderConsumer.accept(builder);
     appendFollowUpEvent(key, intent, value, builder.build());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -157,7 +157,8 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getProcessInstanceKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
-                value.getVariablesBuffer());
+                value.getVariablesBuffer(),
+                record.getAuthorizations());
         case PROPAGATE ->
             variableBehavior.mergeDocument(
                 userTaskRecord.getElementInstanceKey(),
@@ -165,7 +166,8 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getProcessInstanceKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
-                value.getVariablesBuffer());
+                value.getVariablesBuffer(),
+                record.getAuthorizations());
         default ->
             throw new IllegalStateException(
                 "Unexpected variable update semantic: '%s'. Expected either 'LOCAL' or 'PROPAGATE'."
@@ -197,7 +199,8 @@ public final class VariableDocumentUpdateProcessor
             processInstanceKey,
             bpmnProcessId,
             tenantId,
-            value.getVariablesBuffer());
+            value.getVariablesBuffer(),
+            record.getAuthorizations());
       } else {
         variableBehavior.mergeDocument(
             scope.getKey(),
@@ -205,7 +208,8 @@ public final class VariableDocumentUpdateProcessor
             processInstanceKey,
             bpmnProcessId,
             tenantId,
-            value.getVariablesBuffer());
+            value.getVariablesBuffer(),
+            record.getAuthorizations());
       }
     } catch (final MsgpackReaderException e) {
       final String reason =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -304,6 +304,7 @@ public final class EventAppliers implements EventApplier {
     register(
         RuntimeInstructionIntent.INTERRUPTED,
         new RuntimeInstructionInterruptedApplier(elementInstanceState));
+    register(ProcessInstanceIntent.CANCELING, NOOP_EVENT_APPLIER);
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -89,6 +90,8 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
 
     // then
     assertThat(response.getValue().getDecisionOutput()).isEqualTo("\"Sith\"");
+    assertThat(response.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   @Test
@@ -111,6 +114,8 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CREATE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(DECISION_ID));
+    assertThat(rejection.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -97,11 +98,13 @@ public class IncidentResolveAuthorizationTest {
     engine.incident().ofInstance(processInstanceKey).resolve(user.getUsername());
 
     // then
-    assertThat(
-            RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
-                .withProcessInstanceKey(processInstanceKey)
-                .exists())
-        .isTrue();
+    final var record =
+        RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+            .withProcessInstanceKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   @Test
@@ -124,6 +127,8 @@ public class IncidentResolveAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
+    assertThat(rejection.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -200,10 +200,12 @@ public final class CancelProcessInstanceTest {
             .asList();
 
     assertThat(processEvents)
-        .hasSize(10)
+        .hasSize(11)
         .extracting(e -> e.getValue().getElementId(), e -> e.getIntent())
         .containsSubsequence(
             tuple("", ProcessInstanceIntent.CANCEL),
+            tuple("SUB_PROCESS_PROCESS", ProcessInstanceIntent.CANCELING),
+            tuple("SUB_PROCESS_PROCESS", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("SUB_PROCESS_PROCESS", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("subProcess", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("subProcess", ProcessInstanceIntent.ELEMENT_TERMINATING),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
@@ -96,6 +97,14 @@ public class ProcessInstanceCancelAuthorizationTest {
     engine.processInstance().withInstanceKey(processInstanceKey).cancel(user.getUsername());
 
     // then
+    final var record =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCELING)
+            .withProcessInstanceKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -123,6 +132,8 @@ public class ProcessInstanceCancelAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CANCEL_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
+    assertThat(rejection.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
@@ -111,6 +113,15 @@ public class ProcessInstanceCreateAuthorizationTest {
         engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(user.getUsername());
 
     // then
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -138,6 +149,15 @@ public class ProcessInstanceCreateAuthorizationTest {
             .create(user.getUsername());
 
     // then
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Map;
 
 /**
  * A state writer that uses the event applier, to alter the state for each written event.
@@ -37,6 +38,15 @@ public final class EventApplyingStateWriter implements StateWriter {
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final Map<String, Object> claims) {
+    appendFollowUpEvent(key, intent, value, m -> m.claims(claims));
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -10,11 +10,13 @@ package io.camunda.zeebe.engine.processing.variable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -108,6 +110,14 @@ public class VariableDocumentUpdateAuthorizationTest {
         .update(user.getUsername());
 
     // then
+    final var record =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withScopeKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+
     assertThat(
             RecordingExporter.variableDocumentRecords(VariableDocumentIntent.UPDATED)
                 .withScopeKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -31,6 +32,15 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final Map<String, Object> claims) {
+    appendFollowUpEvent(key, intent, value, FollowUpEventMetadata.builder().claims(claims).build());
   }
 
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -29,7 +29,6 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   ELEMENT_COMPLETED((short) 5),
   ELEMENT_TERMINATING((short) 6),
   ELEMENT_TERMINATED((short) 7),
-  SEQUENCE_FLOW_DELETED((short) 15),
 
   ACTIVATE_ELEMENT((short) 8),
   COMPLETE_ELEMENT((short) 9),
@@ -58,7 +57,17 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    * `canceling` task listener was triggered - to resume and finalize the termination of the user
    * task element.
    */
-  CONTINUE_TERMINATING_ELEMENT((short) 14);
+  CONTINUE_TERMINATING_ELEMENT((short) 14),
+
+  SEQUENCE_FLOW_DELETED((short) 15),
+
+  /**
+   * Represents the intent that triggers the cancellation process of a process instance and all of
+   * its child BPMN elements.
+   *
+   * <p>This event is not applied to the state, but is used for auditing reasons.
+   */
+  CANCELING((short) 16);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
@@ -119,6 +128,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return CONTINUE_TERMINATING_ELEMENT;
       case 15:
         return SEQUENCE_FLOW_DELETED;
+      case 16:
+        return CANCELING;
       default:
         return Intent.UNKNOWN;
     }
@@ -142,6 +153,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case ELEMENT_MIGRATED:
       case ANCESTOR_MIGRATED:
       case SEQUENCE_FLOW_DELETED:
+      case CANCELING:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Forward authorization claims from Zeebe command records to Zeebe events and rejections for process-related, user-triggered operations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41940
