### PR TITLE
feat: Poc for cluster variable resolution via API

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariableresolver.ClusterVariableResolverRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditionalevaluation.ConditionalEvaluationRecord;
@@ -73,6 +74,7 @@ public class CommandApiRequestReader implements RequestReader {
     RECORDS_BY_TYPE.put(ValueType.INCIDENT, IncidentRecord::new);
     RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord::new);
     RECORDS_BY_TYPE.put(ValueType.CLUSTER_VARIABLE, ClusterVariableRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.CLUSTER_VARIABLE_RESOLVER, ClusterVariableResolverRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord::new);
     RECORDS_BY_TYPE.put(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableBehavior.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+
+/**
+ * Behavior for resolving cluster variable references using FEEL expressions. Provides utilities for
+ * evaluating FEEL expressions against cluster variable state in a specific tenant context.
+ */
+public final class ClusterVariableBehavior {
+
+  private final ExpressionProcessor expressionProcessor;
+  private final ExpressionLanguage expressionLanguage;
+
+  public ClusterVariableBehavior(
+      final ExpressionProcessor expressionProcessor, final ExpressionLanguage expressionLanguage) {
+    this.expressionProcessor = expressionProcessor;
+    this.expressionLanguage = expressionLanguage;
+  }
+
+  /**
+   * Resolves a cluster variable reference (FEEL expression) for a specific tenant.
+   *
+   * @param reference the FEEL expression to evaluate (e.g., "camunda.vars.tenant.MY_KEY")
+   * @param tenantId the tenant ID in which to resolve the variables
+   * @return Either a success with the resolved value as a String, or a failure with an error
+   *     message
+   */
+  public Either<Rejection, String> resolveReference(final String reference, final String tenantId) {
+    try {
+      final var expression = expressionLanguage.parseExpression(reference);
+      final var result = expressionProcessor.evaluateStringExpression(expression, -1, tenantId);
+      return result
+          .mapLeft(
+              failure ->
+                  new Rejection(
+                      RejectionType.PROCESSING_ERROR,
+                      String.format(
+                          "Failed to evaluate expression '%s': %s",
+                          reference, failure.getMessage())))
+          .map(resolvedValue -> resolvedValue);
+    } catch (final Exception e) {
+      final String errorMessage =
+          String.format("Error resolving reference '%s': %s", reference, e.getMessage());
+      return Either.left(new Rejection(RejectionType.PROCESSING_ERROR, errorMessage));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableResolverProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableResolverProcessor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariableresolver.ClusterVariableResolverRecord;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableResolverIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+/**
+ * Processor for handling cluster variable resolution commands. Evaluates FEEL expressions
+ * containing references to cluster variables and returns the resolved values.
+ */
+public class ClusterVariableResolverProcessor
+    implements TypedRecordProcessor<ClusterVariableResolverRecord> {
+
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final StateWriter stateWriter;
+  private final ClusterVariableBehavior clusterVariableBehavior;
+  private final KeyGenerator keyGenerator;
+  private final AuthorizationCheckBehavior authorizationCheckBehavior;
+
+  public ClusterVariableResolverProcessor(
+      final Writers writers,
+      final ClusterVariableBehavior clusterVariableBehavior,
+      final KeyGenerator keyGenerator,
+      final AuthorizationCheckBehavior authorizationCheckBehavior) {
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    stateWriter = writers.state();
+    this.clusterVariableBehavior = clusterVariableBehavior;
+    this.keyGenerator = keyGenerator;
+    this.authorizationCheckBehavior = authorizationCheckBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ClusterVariableResolverRecord> command) {
+    final var record = command.getValue();
+    final var tenantId = record.getTenantId();
+
+    clusterVariableBehavior
+        .resolveReference(record.getReference(), tenantId)
+        .ifRightOrLeft(
+            resolvedValue -> acceptCommand(command, resolvedValue),
+            rejection -> rejectCommand(command, rejection));
+  }
+
+  private void rejectCommand(
+      final TypedRecord<ClusterVariableResolverRecord> command, final Rejection rejection) {
+    rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+    responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+  }
+
+  private void acceptCommand(
+      final TypedRecord<ClusterVariableResolverRecord> command, final String resolvedValue) {
+    final var key = keyGenerator.nextKey();
+    final var responseRecord = new ClusterVariableResolverRecord();
+    responseRecord.setTenantId(command.getValue().getTenantId()).setResolvedValue(resolvedValue);
+    stateWriter.appendFollowUpEvent(key, ClusterVariableResolverIntent.RESOLVED, responseRecord);
+    responseWriter.writeEventOnCommand(
+        key, ClusterVariableResolverIntent.RESOLVED, responseRecord, command);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -36,7 +36,6 @@ public final class ExpressionProcessor {
   private static final List<ResultType> NULLABLE_DATE_TIME_RESULT_TYPES =
       List.of(ResultType.NULL, ResultType.DATE_TIME, ResultType.STRING);
 
-  private static final EvaluationContext EMPTY_EVALUATION_CONTEXT = x -> Either.left(null);
   private final DirectBuffer resultView = new UnsafeBuffer();
 
   private final ExpressionLanguage expressionLanguage;
@@ -422,7 +421,7 @@ public final class ExpressionProcessor {
 
     final EvaluationContext context;
     if (variableScopeKey < 0) {
-      context = EMPTY_EVALUATION_CONTEXT;
+      context = scopedEvaluationContext.tenantScoped(tenantId);
     } else {
       context = scopedEvaluationContext.processScoped(variableScopeKey).tenantScoped(tenantId);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableResolverIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
@@ -154,6 +155,7 @@ public final class EventAppliers implements EventApplier {
     registerHistoryDeletionAppliers();
     registerConditionalSubscriptionAppliers(state);
     registerConditionalEvaluationAppliers();
+    registerClusterVariableResolutionEventAppliers();
     return this;
   }
 
@@ -161,6 +163,10 @@ public final class EventAppliers implements EventApplier {
     register(ConditionalSubscriptionIntent.CREATED, NOOP_EVENT_APPLIER);
     register(ConditionalSubscriptionIntent.TRIGGERED, NOOP_EVENT_APPLIER);
     register(ConditionalSubscriptionIntent.DELETED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerClusterVariableResolutionEventAppliers() {
+    register(ClusterVariableResolverIntent.RESOLVED, NOOP_EVENT_APPLIER);
   }
 
   private void registerClusterVariableEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ResolveClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/ResolveClusterVariableTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableResolverIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ResolveClusterVariableTest {
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void createGlobalScopedClusterVariable() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_1")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .create();
+
+    // when
+    final var record2 =
+        ENGINE_RULE.clusterResolutionVariables().withReference("=camunda.vars.env.KEY_1").resolve();
+
+    // then
+    Assertions.assertThat(record2)
+        .hasIntent(ClusterVariableResolverIntent.RESOLVED)
+        .hasRecordType(RecordType.EVENT);
+
+    final var record = record2.getValue();
+    Assertions.assertThat(record).hasResolvedValue("VALUE");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.util.client.AuthorizationClient;
 import io.camunda.zeebe.engine.util.client.BatchOperationClient;
 import io.camunda.zeebe.engine.util.client.ClockClient;
 import io.camunda.zeebe.engine.util.client.ClusterVariableClient;
+import io.camunda.zeebe.engine.util.client.ClusterVariableResolutionClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.GroupClient;
@@ -491,6 +492,10 @@ public final class EngineRule extends ExternalResource {
 
   public ClusterVariableClient clusterVariables() {
     return new ClusterVariableClient(environmentRule);
+  }
+
+  public ClusterVariableResolutionClient clusterResolutionVariables() {
+    return new ClusterVariableResolutionClient(environmentRule);
   }
 
   public JobActivationClient jobs() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableResolutionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableResolutionClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.clustervariableresolver.ClusterVariableResolverRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableResolverIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableResolverRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Random;
+import java.util.function.LongFunction;
+
+public final class ClusterVariableResolutionClient {
+
+  private static final long DEFAULT_KEY = -1;
+
+  private static final LongFunction<Record<ClusterVariableResolverRecordValue>> SUCCESS_SUPPLIER =
+      (sourceRecordPosition) ->
+          RecordingExporter.clusterVariableResolutionRecords()
+              .onlyEvents()
+              .withSourceRecordPosition(sourceRecordPosition)
+              .getFirst();
+  private static final LongFunction<Record<ClusterVariableResolverRecordValue>> REJECTION_SUPPLIER =
+      (sourceRecordPosition) ->
+          RecordingExporter.clusterVariableResolutionRecords()
+              .onlyCommandRejections()
+              .withSourceRecordPosition(sourceRecordPosition)
+              .getFirst();
+
+  private final long requestId = new Random().nextLong();
+  private final int requestStreamId = new Random().nextInt();
+
+  private final ClusterVariableResolverRecord clusterVariableResolverRecord;
+  private final CommandWriter writer;
+  private LongFunction<Record<ClusterVariableResolverRecordValue>> expectation = SUCCESS_SUPPLIER;
+
+  public ClusterVariableResolutionClient(final CommandWriter writer) {
+    clusterVariableResolverRecord = new ClusterVariableResolverRecord();
+    this.writer = writer;
+  }
+
+  public ClusterVariableResolutionClient withReference(final String reference) {
+    clusterVariableResolverRecord.setReference(reference);
+    return this;
+  }
+
+  public ClusterVariableResolutionClient withTenantId(final String tenantId) {
+    clusterVariableResolverRecord.setTenantId(tenantId);
+    return this;
+  }
+
+  public ClusterVariableResolutionClient expectRejection() {
+    expectation = REJECTION_SUPPLIER;
+    return this;
+  }
+
+  public Record<ClusterVariableResolverRecordValue> resolve() {
+    final long position =
+        writer.writeCommand(
+            DEFAULT_KEY,
+            requestStreamId,
+            requestId,
+            ClusterVariableResolverIntent.RESOLVE,
+            clusterVariableResolverRecord);
+    return expectation.apply(position);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariableresolver/ClusterVariableResolverRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariableresolver/ClusterVariableResolverRecord.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.clustervariableresolver;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableResolverRecordValue;
+import org.agrona.DirectBuffer;
+
+public class ClusterVariableResolverRecord extends UnifiedRecordValue
+    implements ClusterVariableResolverRecordValue {
+
+  private final StringProperty referenceProp = new StringProperty("reference", "");
+  private final StringProperty resolvedValueProp = new StringProperty("resolvedValue", "");
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+
+  public ClusterVariableResolverRecord() {
+    super(3);
+    declareProperty(referenceProp).declareProperty(resolvedValueProp).declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public String getReference() {
+    return bufferAsString(referenceProp.getValue());
+  }
+
+  public ClusterVariableResolverRecord setReference(final String reference) {
+    referenceProp.setValue(reference);
+    return this;
+  }
+
+  @Override
+  public String getResolvedValue() {
+    final String value = bufferAsString(resolvedValueProp.getValue());
+    return value.isEmpty() ? null : value;
+  }
+
+  public ClusterVariableResolverRecord setResolvedValue(final String resolvedValue) {
+    resolvedValueProp.setValue(resolvedValue != null ? resolvedValue : "");
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getReferenceBuffer() {
+    return referenceProp.getValue();
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ClusterVariableResolverRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getTenantIdBuffer() {
+    return tenantIdProp.getValue();
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationMoveInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariableresolver.ClusterVariableResolverRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditionalevaluation.ConditionalEvaluationRecord;
@@ -4037,6 +4038,45 @@ final class JsonSerializableToJsonTest {
                 "processDefinitionKey":-1,
                 "variables":{},
                 "tenantId":"<default>"
+                }
+                """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// ClusterVariableResolverRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // //////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ClusterVariableResolverRecord",
+        (Supplier<ClusterVariableResolverRecord>)
+            () ->
+                new ClusterVariableResolverRecord()
+                    .setReference("camunda.vars.tenant.MY_KEY")
+                    .setResolvedValue("resolvedValue")
+                    .setTenantId("tenant123"),
+        """
+                {
+                  "reference": "camunda.vars.tenant.MY_KEY",
+                  "resolvedValue": "resolvedValue",
+                  "errorMessage": null,
+                  "tenantId": "tenant123"
+                }
+                """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// Empty ClusterVariableResolverRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // //////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ClusterVariableResolverRecord",
+        (Supplier<ClusterVariableResolverRecord>) ClusterVariableResolverRecord::new,
+        """
+                {
+                  "reference": "",
+                  "resolvedValue": null,
+                  "errorMessage": null,
+                  "tenantId": ""
                 }
                 """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableResolverIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
@@ -84,6 +85,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementR
 import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableResolverRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ConditionalEvaluationRecordValue;
@@ -341,6 +343,10 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.CONDITIONAL_EVALUATION,
         new Mapping<>(ConditionalEvaluationRecordValue.class, ConditionalEvaluationIntent.class));
+    mapping.put(
+        ValueType.CLUSTER_VARIABLE_RESOLVER,
+        new Mapping<>(
+            ClusterVariableResolverRecordValue.class, ClusterVariableResolverIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClusterVariableResolverIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClusterVariableResolverIntent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ClusterVariableResolverIntent implements Intent {
+  RESOLVE((short) 0),
+  RESOLVED((short) 1);
+
+  private final short value;
+
+  ClusterVariableResolverIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case RESOLVED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return RESOLVE;
+      case 1:
+        return RESOLVED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -78,6 +78,7 @@ public interface Intent {
           MultiInstanceIntent.class,
           RuntimeInstructionIntent.class,
           ClusterVariableIntent.class,
+          ClusterVariableResolverIntent.class,
           HistoryDeletionIntent.class,
           ConditionalSubscriptionIntent.class,
           ConditionalEvaluationIntent.class);
@@ -216,6 +217,8 @@ public interface Intent {
         return ConditionalSubscriptionIntent.from(intent);
       case CONDITIONAL_EVALUATION:
         return ConditionalEvaluationIntent.from(intent);
+      case CLUSTER_VARIABLE_RESOLVER:
+        return ClusterVariableResolverIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -339,6 +342,8 @@ public interface Intent {
         return ConditionalSubscriptionIntent.valueOf(intent);
       case CONDITIONAL_EVALUATION:
         return ConditionalEvaluationIntent.valueOf(intent);
+      case CLUSTER_VARIABLE_RESOLVER:
+        return ClusterVariableResolverIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableResolverRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableResolverRecordValue.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents a cluster variable resolver record that evaluates a FEEL expression containing a
+ * reference to a cluster variable. This is a read-only operation used by inbound connectors to
+ * resolve variable references from raw BPMN properties.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableClusterVariableResolverRecordValue.Builder.class)
+public interface ClusterVariableResolverRecordValue extends RecordValue, TenantOwned {
+
+  /**
+   * The reference string containing the FEEL expression to be resolved (e.g.,
+   * "camunda.vars.tenant.MY_KEY")
+   *
+   * @return the reference string
+   */
+  String getReference();
+
+  /**
+   * The resolved value after evaluating the FEEL expression. This will be null if the resolution is
+   * still pending or if there was an error.
+   *
+   * @return the resolved value as a String, or null
+   */
+  String getResolvedValue();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -80,6 +80,7 @@
       <validValue name="HISTORY_DELETION">62</validValue>
       <validValue name="CONDITIONAL_SUBSCRIPTION">63</validValue>
       <validValue name="CONDITIONAL_EVALUATION">64</validValue>
+      <validValue name="CLUSTER_VARIABLE_RESOLVER">65</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariableresolver.ClusterVariableResolverRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditionalevaluation.ConditionalEvaluationRecord;
@@ -97,6 +98,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.VARIABLE, VariableRecord.class);
     registry.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
     registry.put(ValueType.CLUSTER_VARIABLE, ClusterVariableRecord.class);
+    registry.put(ValueType.CLUSTER_VARIABLE_RESOLVER, ClusterVariableResolverRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord.class);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ClusterVariableResolverRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ClusterVariableResolverRecordStream.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableResolverRecordValue;
+import java.util.stream.Stream;
+
+public final class ClusterVariableResolverRecordStream
+    extends ExporterRecordStream<
+        ClusterVariableResolverRecordValue, ClusterVariableResolverRecordStream> {
+
+  public ClusterVariableResolverRecordStream(
+      final Stream<Record<ClusterVariableResolverRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ClusterVariableResolverRecordStream supply(
+      final Stream<Record<ClusterVariableResolverRecordValue>> wrappedStream) {
+    return new ClusterVariableResolverRecordStream(wrappedStream);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.ASYNC_REQUEST;
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.CHECKPOINT;
 import static io.camunda.zeebe.protocol.record.ValueType.CLUSTER_VARIABLE;
+import static io.camunda.zeebe.protocol.record.ValueType.CLUSTER_VARIABLE_RESOLVER;
 import static io.camunda.zeebe.protocol.record.ValueType.COMMAND_DISTRIBUTION;
 import static io.camunda.zeebe.protocol.record.ValueType.COMPENSATION_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.CONDITIONAL_EVALUATION;
@@ -82,6 +83,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementR
 import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableResolverRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ConditionalEvaluationRecordValue;
@@ -216,6 +218,7 @@ public class CompactRecordLogger {
           entry(CLUSTER_VARIABLE.name(), "CLSTR_VAR"),
           entry(CONDITIONAL_SUBSCRIPTION.name(), "COND_SUB"),
           entry(CONDITIONAL_EVALUATION.name(), "COND_EVAL"),
+          entry(CLUSTER_VARIABLE_RESOLVER.name(), "CLSTR_VAR_RES"),
           entry(IDENTITY_SETUP.name(), "ID"),
           entry(CHECKPOINT.name(), "CHK"));
 
@@ -302,6 +305,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.ESCALATION, this::summarizeEscalation);
     valueLoggers.put(ValueType.PROCESS_INSTANCE_MIGRATION, this::summarizeProcessInstanceMigration);
     valueLoggers.put(CLUSTER_VARIABLE, this::summarizeClusterVariable);
+    valueLoggers.put(CLUSTER_VARIABLE_RESOLVER, this::summarizeClusterVariableResolver);
     valueLoggers.put(ValueType.CONDITIONAL_SUBSCRIPTION, this::summarizeConditionalSubscription);
     valueLoggers.put(CONDITIONAL_EVALUATION, this::summarizeConditionalEvaluation);
     valueLoggers.put(ValueType.IDENTITY_SETUP, this::summarizeIdentitySetup);
@@ -995,6 +999,12 @@ public class CompactRecordLogger {
     result.append(formatVariables(value)).append(formatTenant(value));
 
     return result.toString();
+  }
+
+  private String summarizeClusterVariableResolver(final Record<?> record) {
+    final var value = (ClusterVariableResolverRecordValue) record.getValue();
+    final String result = value.getResolvedValue() != null ? "resolved" : "error";
+    return "%s->%s%s".formatted(value.getReference(), result, formatTenant(value));
   }
 
   private StringBuilder summarizeRejection(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -62,6 +62,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementR
 import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableResolverRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
@@ -379,6 +380,11 @@ public final class RecordingExporter implements Exporter {
   public static ClusterVariableRecordStream clusterVariableRecords() {
     return new ClusterVariableRecordStream(
         records(ValueType.CLUSTER_VARIABLE, ClusterVariableRecordValue.class));
+  }
+
+  public static ClusterVariableResolverRecordStream clusterVariableResolutionRecords() {
+    return new ClusterVariableResolverRecordStream(
+        records(ValueType.CLUSTER_VARIABLE_RESOLVER, ClusterVariableResolverRecordValue.class));
   }
 
   public static VariableRecordStream variableRecords(final VariableIntent intent) {


### PR DESCRIPTION
This pull request introduces a new feature for resolving cluster variable references using FEEL expressions, adds supporting processors and behaviors, and updates the engine to handle these new commands. It also includes a test for the new functionality. The changes are grouped below by theme:

**Cluster Variable Resolution Feature:**

* Added `ClusterVariableBehavior` to encapsulate logic for resolving cluster variable references via FEEL expressions in a tenant context.
* Introduced `ClusterVariableResolverProcessor`, which handles commands to resolve cluster variable references, evaluates the FEEL expression, and writes the resolved value as an event.
* Registered the new processor and intent (`CLUSTER_VARIABLE_RESOLVER` and `RESOLVE`) in `ClusterVariableProcessors` and the engine, wiring in the necessary dependencies for FEEL evaluation. [[1]](diffhunk://#diff-f8c976e75ff9c83cd84085f7eb4e0cd9e824b75be4ba9620eb70fded44d030c2R10-R19) [[2]](diffhunk://#diff-f8c976e75ff9c83cd84085f7eb4e0cd9e824b75be4ba9620eb70fded44d030c2L26-R31) [[3]](diffhunk://#diff-f8c976e75ff9c83cd84085f7eb4e0cd9e824b75be4ba9620eb70fded44d030c2R42-R50) [[4]](diffhunk://#diff-e4a1127d09b06b9c48c96b07dbc647bee1c3d47eafe6472668fb73e42a83fdb6R26) [[5]](diffhunk://#diff-e4a1127d09b06b9c48c96b07dbc647bee1c3d47eafe6472668fb73e42a83fdb6R77) [[6]](diffhunk://#diff-54653cd8c67cd91fe5aba63bd7e7b723c0b8178340c3fbf63a60699ab52db5e5R15) [[7]](diffhunk://#diff-54653cd8c67cd91fe5aba63bd7e7b723c0b8178340c3fbf63a60699ab52db5e5R25-R29) [[8]](diffhunk://#diff-54653cd8c67cd91fe5aba63bd7e7b723c0b8178340c3fbf63a60699ab52db5e5R41-R44) [[9]](diffhunk://#diff-54653cd8c67cd91fe5aba63bd7e7b723c0b8178340c3fbf63a60699ab52db5e5R354-R395)

**Engine and State Integration:**

* Updated event appliers to recognize and handle the new `ClusterVariableResolverIntent.RESOLVED` event type, using a no-op applier. [[1]](diffhunk://#diff-4b8a1009b92b413ddffe7be870fe9fc8caabcf7d1f9aaf0cae2208ec60b6e403R29) [[2]](diffhunk://#diff-4b8a1009b92b413ddffe7be870fe9fc8caabcf7d1f9aaf0cae2208ec60b6e403R158) [[3]](diffhunk://#diff-4b8a1009b92b413ddffe7be870fe9fc8caabcf7d1f9aaf0cae2208ec60b6e403R168-R171)
* Modified `ExpressionProcessor` to use the correct evaluation context for tenant-scoped variable resolution, enabling FEEL expressions to access cluster variables. [[1]](diffhunk://#diff-adbf061608f1aa519954f97da23b1172b341fdfecaff5860c43f6fac067e4255L39) [[2]](diffhunk://#diff-adbf061608f1aa519954f97da23b1172b341fdfecaff5860c43f6fac067e4255L425-R424)

**Testing and Utilities:**

* Added `ResolveClusterVariableTest` to verify that cluster variable resolution works as expected and produces the correct event and value.
* Extended `EngineRule` with a new `ClusterVariableResolutionClient` to support test scenarios for resolving cluster variables. [[1]](diffhunk://#diff-26c635cad708d973b6dde99414a33760ea3c474fb24e697326b3aa09035bed20R33) [[2]](diffhunk://#diff-26c635cad708d973b6dde99414a33760ea3c474fb24e697326b3aa09035bed20R497-R500)