### PR TITLE
40184 merge optimize release into monorepo release

### DIFF
--- a/.ci/docker/test/optimize-docker-labels.golden.json
+++ b/.ci/docker/test/optimize-docker-labels.golden.json
@@ -17,5 +17,7 @@
   "org.opencontainers.image.title": "Camunda Optimize",
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
+  "io.minimus.images.line": "21"
 }

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -11,6 +11,10 @@ on:
         default: 'main'
         required: false
         type: string
+      includeOptimize:
+        description: 'Whether to include Optimize in the dry run. Defaults to false.'
+        type: boolean
+        default: false
   schedule:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
@@ -36,6 +40,7 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}
       dryRun: true
+      includeOptimize: ${{ inputs.includeOptimize || false }}
 
   notify:
     name: Send Slack notification

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -92,6 +92,8 @@ jobs:
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       PUSH_CHANGES: ${{ !inputs.dryRun }}
+      PROFILE_FLAGS: ${{ inputs.includeOptimize && '' || '-P!include-optimize' }}
+      ARGUMENTS_PROFILE: ${{ inputs.includeOptimize && '' || '-P!include-optimize' }}
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
@@ -180,15 +182,6 @@ jobs:
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
           
-          # Conditionally set profile flags based on includeOptimize input
-          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
-            PROFILE_FLAGS=""
-            ARGUMENTS_PROFILE=""
-          else
-            PROFILE_FLAGS="-P\!include-optimize"
-            ARGUMENTS_PROFILE="-P!include-optimize"
-          fi
-          
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -215,15 +208,6 @@ jobs:
           # -DskipQaBuild=true -P-autoFormat
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
-
-          # Conditionally set profile flags based on includeOptimize input
-          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
-            PROFILE_FLAGS=""
-            ARGUMENTS_PROFILE=""
-          else
-            PROFILE_FLAGS="-P\!include-optimize"
-            ARGUMENTS_PROFILE="-P!include-optimize"
-          fi
 
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -646,6 +646,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ inputs.includeOptimize }}
+    permissions: {}  # GITHUB_TOKEN unused in this job
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
       # registry. As we want to verify the images first before pushing them to dockerhub though,
@@ -671,8 +672,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/optimize/ci/optimize REGISTRY_HUB_DOCKER_COM_USR;
-            secret/data/products/optimize/ci/optimize REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_PSW;
             secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -725,7 +726,7 @@ jobs:
           command: |
             docker -D buildx imagetools create \
               --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-              ${{ env.LOCAL_DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
+              ${{ steps.build-optimize-docker.outputs.image }}
       - name: Sync Latest Optimize Docker Image to DockerHub
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
@@ -738,7 +739,7 @@ jobs:
           command: |
             docker -D buildx imagetools create \
               --tag ${{ env.DOCKER_IMAGE }}:latest \
-              ${{ env.LOCAL_DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
+              ${{ steps.build-optimize-docker.outputs.image }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -183,6 +183,8 @@ jobs:
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
           
+          # shellcheck disable=SC2086 
+          # TODO: remove hellcheck disable=SC2086 when includeOptimize is no longer required
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -210,7 +212,8 @@ jobs:
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
 
-          # shellcheck disable=SC2016
+          # shellcheck disable=SC2016,SC2086 
+          # TODO: remove SC2086 when includeOptimize is no longer required
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -183,8 +183,6 @@ jobs:
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
           
-          # shellcheck disable=SC2086 
-          # TODO: remove hellcheck disable=SC2086 when includeOptimize is no longer required
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -212,8 +210,7 @@ jobs:
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
 
-          # shellcheck disable=SC2016,SC2086 
-          # TODO: remove SC2086 when includeOptimize is no longer required
+          # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -93,8 +93,6 @@ jobs:
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       PUSH_CHANGES: ${{ !inputs.dryRun }}
-      PROFILE_FLAGS: ${{ inputs.includeOptimize && '' || '-P!include-optimize' }}
-      ARGUMENTS_PROFILE: ${{ inputs.includeOptimize && '' || '-P!include-optimize' }}
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
@@ -183,6 +181,15 @@ jobs:
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
           
+          # Conditionally set profile flags based on includeOptimize input
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            PROFILE_FLAGS=""
+            ARGUMENTS_PROFILE=""
+          else
+            PROFILE_FLAGS="-P\!include-optimize"
+            ARGUMENTS_PROFILE="-P!include-optimize"
+          fi
+          
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -209,6 +216,15 @@ jobs:
           # -DskipQaBuild=true -P-autoFormat
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
+
+          # Conditionally set profile flags based on includeOptimize input
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            PROFILE_FLAGS=""
+            ARGUMENTS_PROFILE=""
+          else
+            PROFILE_FLAGS="-P\!include-optimize"
+            ARGUMENTS_PROFILE="-P!include-optimize"
+          fi
 
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -32,6 +32,10 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      includeOptimize:
+        description: 'Whether to include Optimize in the release process. When true, Optimize is included in Maven prepare/perform steps. Defaults to false for backward compatibility.'
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -58,6 +62,10 @@ on:
         default: true
       releaseProcessDryRun:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
+        type: boolean
+        default: false
+      includeOptimize:
+        description: 'Whether to include Optimize in the release process. When true, Optimize is included in Maven prepare/perform steps. Defaults to false for backward compatibility.'
         type: boolean
         default: false
 defaults:
@@ -171,6 +179,16 @@ jobs:
           #   Additional arguments to pass to the Maven executions, separated by spaces.
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
+          
+          # Conditionally set profile flags based on includeOptimize input
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            PROFILE_FLAGS=""
+            ARGUMENTS_PROFILE=""
+          else
+            PROFILE_FLAGS="-P\!include-optimize"
+            ARGUMENTS_PROFILE="-P!include-optimize"
+          fi
+          
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -181,8 +199,8 @@ jobs:
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
             -DpreparationGoals="" \
-            -P\!include-optimize \
-            -Darguments='-P!include-optimize'
+            ${PROFILE_FLAGS} \
+            -Darguments="${ARGUMENTS_PROFILE}"
 
       - name: Maven Perform Release
         id: maven-perform-release
@@ -198,6 +216,15 @@ jobs:
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
 
+          # Conditionally set profile flags based on includeOptimize input
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            PROFILE_FLAGS=""
+            ARGUMENTS_PROFILE=""
+          else
+            PROFILE_FLAGS="-P\!include-optimize"
+            ARGUMENTS_PROFILE="-P!include-optimize"
+          fi
+
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
@@ -205,8 +232,8 @@ jobs:
             -DlocalCheckout="${{ inputs.dryRun }}" \
             -DskipQaBuild=true \
             -P-autoFormat \
-            -P\!include-optimize \
-            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -P!include-optimize -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            ${PROFILE_FLAGS} \
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
@@ -215,6 +242,19 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
+      - name: Debug Optimize Versions
+        if: ${{ inputs.includeOptimize && inputs.dryRun }}
+        run: |
+          echo "=== Optimize Version Information ==="
+          echo "Optimize project.version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout || echo "Failed to get Optimize version"
+          echo ""
+          echo "Zeebe version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=zeebe.version -q -DforceStdout || echo "Failed to get Zeebe version"
+          echo ""
+          echo "Identity version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=identity.version -q -DforceStdout || echo "Failed to get Identity version"
+          echo ""
       - name: Collect Release artifacts
         id: release-artifacts
         run: |

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -77,6 +77,7 @@ env:
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
   RELEASE_TAG: ${{ inputs.releaseProcessDryRun && format('dryrun-{0}', inputs.releaseVersion) || inputs.releaseVersion }}
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
+  PLATFORMS: "linux/amd64,linux/arm64"
 jobs:
   # Release job performs Maven prepare and perform release operations, managing release artifacts and repository changes.
   # Flags impact:
@@ -318,7 +319,6 @@ jobs:
         ports:
           - 5000:5000
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
       DOCKER_IMAGE: camunda/zeebe
     steps:
@@ -424,7 +424,6 @@ jobs:
         ports:
           - 5000:5000
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/operate
       DOCKER_IMAGE: camunda/operate
     steps:
@@ -533,7 +532,6 @@ jobs:
         ports:
           - 5000:5000
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       DOCKER_IMAGE: camunda/tasklist
     steps:
@@ -643,7 +641,6 @@ jobs:
         ports:
           - 5000:5000
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/optimize
       DOCKER_IMAGE: camunda/optimize
     steps:
@@ -752,7 +749,6 @@ jobs:
         ports:
           - 5000:5000
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
       DOCKER_IMAGE: camunda/camunda
     steps:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -324,6 +324,7 @@ jobs:
     name: Zeebe docker Image Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
       # registry. As we want to verify the images first before pushing them to dockerhub though,
@@ -429,6 +430,7 @@ jobs:
     name: Operate Docker Image Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
       # registry. As we want to verify the images first before pushing them to dockerhub though,
@@ -537,6 +539,7 @@ jobs:
     name: Tasklist Docker Image Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
       # registry. As we want to verify the images first before pushing them to dockerhub though,
@@ -755,6 +758,7 @@ jobs:
     name: Camunda Docker Image Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
       # registry. As we want to verify the images first before pushing them to dockerhub though,

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -253,7 +253,7 @@ jobs:
           ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=zeebe.version -q -DforceStdout || echo "Failed to get Zeebe version"
           echo ""
           echo "Identity version:"
-          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=identity.version -q -DforceStdout || echo "Failed to get Identity version"
+          ./mvnw help:effective-pom -pl optimize -DforceStdout | grep -oPm1 "(?<=<version.identity>)[^<]+" || echo "Failed to get Identity version"
           echo ""
       - name: Collect Release artifacts
         id: release-artifacts
@@ -262,6 +262,12 @@ jobs:
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".tar.gz "${ARTIFACT_DIR}/"
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
           cp target/checkout/db/rdbms-schema/target/camunda-db-rdbms-schema-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
+          
+          # Include Optimize artifacts if Optimize is included in the release
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            cp target/checkout/optimize-distro/target/camunda-optimize-"${RELEASE_VERSION}"-production.tar.gz "${ARTIFACT_DIR}/"
+          fi
+          
           echo "dir=${ARTIFACT_DIR}" >> "$GITHUB_OUTPUT"
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v4
@@ -634,6 +640,115 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  optimize-docker:
+    needs: release
+    name: Optimize Docker Image Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ inputs.includeOptimize }}
+    services:
+      # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
+      # registry. As we want to verify the images first before pushing them to dockerhub though,
+      # a local registry is used and if verification passes images are pushed to the remote registry.
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
+    env:
+      PLATFORMS: "linux/amd64,linux/arm64"
+      LOCAL_DOCKER_IMAGE: localhost:5000/camunda/optimize
+      DOCKER_IMAGE: camunda/optimize
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/optimize/ci/optimize REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/optimize/ci/optimize REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
+          password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts-${{ inputs.releaseVersion }}
+      - name: Build Optimize Docker Image
+        uses: ./.github/actions/build-platform-docker
+        id: build-optimize-docker
+        with:
+          repository: ${{ env.LOCAL_DOCKER_IMAGE }}
+          version: ${{ inputs.releaseVersion }}
+          revision: ${{ needs.release.outputs.releaseTagRevision }}
+          # pushes to local registry for verification prior pushing to remote
+          push: true
+          distball: camunda-optimize-${{ inputs.releaseVersion }}-production.tar.gz
+          platforms: ${{ env.PLATFORMS }}
+          dockerfile: optimize.Dockerfile
+          # turns on BuildKit debug logging
+          debug: 'true'
+      - name: Verify Optimize Docker image
+        uses: ./.github/actions/verify-platform-docker
+        with:
+          imageName: ${{ env.LOCAL_DOCKER_IMAGE }}
+          date: ${{ steps.build-optimize-docker.outputs.date }}
+          revision: ${{ needs.release.outputs.releaseTagRevision }}
+          version: ${{ inputs.releaseVersion }}
+          platforms: ${{ env.PLATFORMS }}
+          dockerfile: optimize.Dockerfile
+          goldenfile: optimize-docker-labels.golden.json
+      - name: Sync Optimize Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ env.LOCAL_DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
+      - name: Sync Latest Optimize Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ env.LOCAL_DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   camunda-docker:
     needs: release
     name: Camunda Docker Image Release
@@ -777,7 +892,7 @@ jobs:
   # - Uses RELEASE_TAG for versioning (prefixed with 'dryrun-' when releaseProcessDryRun=true)
   # The job generates changelog, checksums artifacts, and determines pre-release status
   github:
-    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
+    needs: [release, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
     name: Github Release
     runs-on: ubuntu-latest
     # Minor releases take more time since a lot of issues are included in the changelog
@@ -905,7 +1020,7 @@ jobs:
   fossa-release:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -965,7 +1080,7 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk, fossa-release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release succeeded
     if: ${{ always() && (
@@ -974,6 +1089,7 @@ jobs:
       needs.zeebe-docker.result == 'success' &&
       needs.operate-docker.result == 'success' &&
       needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
       needs.camunda-docker.result == 'success' &&
       (needs.snyk.result == 'success' || needs.snyk.result == 'skipped') &&
       (needs.fossa-release.result == 'success' || needs.fossa-release.result == 'skipped')
@@ -1015,7 +1131,7 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk, fossa-release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
     if: ${{ always() && (
@@ -1024,6 +1140,7 @@ jobs:
         needs.zeebe-docker.result == 'failure' ||
         needs.operate-docker.result == 'failure' ||
         needs.tasklist-docker.result == 'failure' ||
+        needs.optimize-docker.result == 'failure' ||
         needs.camunda-docker.result == 'failure' ||
         needs.snyk.result == 'failure' ||
         needs.fossa-release.result == 'failure'

--- a/.github/workflows/optimize-create-release-branch.yml
+++ b/.github/workflows/optimize-create-release-branch.yml
@@ -1,4 +1,5 @@
 # type: Release
+# DEPRECATED: This workflow is deprecated and should be removed when 8.7 reaches EOL in favor of Monorepo Release Process camunda/40184.
 name: Optimize Create Release Branch
 on:
   workflow_dispatch:

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -1,4 +1,5 @@
 # type: Release
+# DEPRECATED: This workflow is deprecated and should be removed when 8.7 reaches EOL in favor of Monorepo Release Process camunda/40184.
 name: Optimize Release Camunda Optimize C8
 
 on:
@@ -348,7 +349,7 @@ jobs:
           DATE="$(date +%FT%TZ)"
           export DATE
           export REVISION="${REVISION}"
-          export BASE_IMAGE=docker.io/library/alpine:3.22.0
+          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
 
           # if CI (GHA) export the variables for pushing in a later step
           if [ "${CI}" = "true" ]; then
@@ -362,12 +363,17 @@ jobs:
               --build-arg VERSION="${RELEASE_VERSION}" \
               --build-arg DATE="${DATE}" \
               --build-arg REVISION="${REVISION}" \
+              --build-arg BASE_IMAGE="${BASE_IMAGE}" \
               --provenance false \
               --load \
               -f optimize.Dockerfile \
               .
 
-          ./optimize/docker/test/verify.sh "${tags[@]}"
+          echo "Docker build completed. Running verification..."
+          echo "Verifying with VERSION=${VERSION}, REVISION=${REVISION}, DATE=${DATE}, BASE_IMAGE=${BASE_IMAGE}"
+          
+          # Verify using the most reliable tag (DockerHub)
+          ./optimize/docker/test/verify.sh "${DOCKER_IMAGE_DOCKER_HUB}:${RELEASE_VERSION}"
 
       - name: Start Smoketest
         uses: ./.github/actions/compose

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -42,7 +42,7 @@ ARG BASE_IMAGE
 ARG BASE_DIGEST
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="optimize@camunda.com"

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /
 ARG VERSION=""
 ARG DISTRO=production
 ARG ARTIFACT_PATH=./optimize-distro/target
+ARG DISTBALL=""
 
 ENV TMP_DIR=/tmp/optimize \
     BUILD_DIR=/tmp/build
@@ -20,9 +21,10 @@ ENV TMP_DIR=/tmp/optimize \
 RUN mkdir -p ${TMP_DIR} && \
     mkdir -p ${BUILD_DIR}
 
-COPY ${ARTIFACT_PATH}/camunda-optimize-${VERSION}-${DISTRO}.tar.gz ${BUILD_DIR}
-RUN tar -xzf ${BUILD_DIR}/camunda-optimize-${VERSION}-${DISTRO}.tar.gz -C ${BUILD_DIR} && \
-    rm ${BUILD_DIR}/camunda-optimize-${VERSION}-${DISTRO}.tar.gz
+# Support both legacy path and monorepo DISTBALL pattern
+COPY ${DISTBALL:-${ARTIFACT_PATH}/camunda-optimize-${VERSION}-${DISTRO}.tar.gz} ${BUILD_DIR}/optimize-distro.tar.gz
+RUN tar -xzf ${BUILD_DIR}/optimize-distro.tar.gz -C ${BUILD_DIR} && \
+    rm ${BUILD_DIR}/optimize-distro.tar.gz
 COPY ./optimize/docker/bin/optimize.sh ${BUILD_DIR}/optimize.sh
 # Prevent environment-config.yaml from overriding service-config.yaml since the
 # service-config.yaml allows usage of OPTIMIZE_ environment variables

--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -19,5 +19,6 @@
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
   "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "21",
+  "io.minimus.images.version": "21.0.9-dev"
 }

--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -1,16 +1,13 @@
 {
   "io.k8s.description": "Provides business activity monitoring for workflows and uses BPMN-based analysis to uncover process bottlenecks",
-  "io-minimus, images-galleryURL": "https://images.minimus.io/gallery/images/1212/openj re-base",
-  "io-minimus, images.line": "21",
-  "io.minimus. images.version": "21.0.9-dev",
-  "io.openshift.min-cpu",: "1",
+  "io.openshift.min-cpu": "1",
   "io.openshift.min-memory": "2Gi",
   "io.openshift.non-scalable": "false",
   "io.openshift.wants": "zeebe,elasticsearch,identity,keycloak,opensearch",
   "io.openshift.tags": "bpmn,optimization,camunda",
   "org.opencontainers.image.authors": "optimize@camunda.com",
   "org.opencontainers.image.base.digest": $BASEDIGEST,
-  "org. opencontainers. image.base.name": "docker.io/library/reg.mini.dev/1212/openjre-base:21-dev",
+  "org.opencontainers.image.base.name": $BASE_IMAGE,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Provides business activity monitoring for workflows and uses BPMN-based analysis to uncover process bottlenecks",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/optimize-deployment/install-and-start/",
@@ -20,5 +17,7 @@
   "org.opencontainers.image.title": "Camunda Optimize",
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
-  "org.opencontainers.image.version": $VERSION
+  "org.opencontainers.image.version": $VERSION,
+  "io.minimus.images.galleryURL": "https://images.minimus.io/gallery/images/1212/openjre-base",
+  "io.minimus.images.line": "21"
 }

--- a/optimize/docker/test/verify.sh
+++ b/optimize/docker/test/verify.sh
@@ -29,36 +29,42 @@ if [ -z "${VERSION}" ]; then
   echo >&2 "No VERSION was given; make sure to pass a semantic version, e.g. VERSION=3.9.0"
   exit 1
 fi
+echo "[INFO] VERSION=${VERSION}"
 
 if [ -z "${REVISION}" ]; then
   echo >&2 "No REVISION was given; make sure to pass the Git commit sha, e.g. REVISION=2941d620f08d9729632b2b1222123edcbe3532c8"
   exit 1
 fi
+echo "[INFO] REVISION=${REVISION}"
 
 if [ -z "${DATE}" ]; then
   echo >&2 "No DATE was given; make sure to pass an ISO8601 date, e.g. DATE='2001-01-01T00:00:00Z'"
   exit 1
 fi
+echo "[INFO] DATE=${DATE}"
 
 if [ -z "${BASE_IMAGE}" ]; then
   echo >&2 "No BASE_IMAGE was given; make sure to pass a valid base image name, e.g. docker.io/library/alpine:3.22.0"
   exit 1
 fi
+echo "[INFO] BASE_IMAGE=${BASE_IMAGE}"
 
 # Check that the base image exists
 if ! baseImageInfo="$(docker manifest inspect "${BASE_IMAGE}")"; then
   echo >&2 "No known Docker base image ${BASE_IMAGE} exists; did you pass the right name?"
   exit 1
 fi
+echo "[INFO] Base image ${BASE_IMAGE} exists and is accessible"
 
 SCRIPT_DIR=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
 DOCKERFILE_PATH="${SCRIPT_DIR}/../../../optimize.Dockerfile"
-DIGEST=$(cat "$DOCKERFILE_PATH" | grep -o 'sha256: [a-f0-9]\{64\}' | head -n 1)
+
+echo "[INFO] Looking for digest in Dockerfile: ${DOCKERFILE_PATH}"
+DIGEST=$(cat "$DOCKERFILE_PATH" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n 1)
 if [[ -z "$DIGEST" ]]; then
     echo >&2 "Docker image digest can not be found in the Dockerfile (with name $DOCKERFILE_PATH)"
     exit 1
 fi
-
 echo "Digest found: $DIGEST"
 
 imageName="${1}"
@@ -70,6 +76,7 @@ for imageName in "$@"; do
     echo >&2 "No known Docker image ${imageName} exists; did you pass the right name?"
     exit 1
   fi
+  echo "[INFO] Docker image ${imageName} found successfully"
 
   # Extract the actual labels from the info - make sure to sort keys so we always have the same
   # ordering for maps to compare things properly
@@ -81,19 +88,24 @@ for imageName in "$@"; do
     echo >&2 "Are there any labels in the above? If so, the JSON query may need to be changed."
     exit 1
   fi
+  echo "[INFO] Successfully extracted $(echo "${actualLabels}" | jq 'length') labels from image"
 
     # Generate the expected labels files with the dynamic properties substituted
     labelsGoldenFile="${BASH_SOURCE%/*}/docker-labels.golden.json"
+    echo "[INFO] Generating expected labels from golden file: ${labelsGoldenFile}"
+    echo "[INFO] Substituting: VERSION=${VERSION}, REVISION=${REVISION}, DATE=${DATE}, BASEDIGEST=${DIGEST}, BASE_IMAGE=${BASE_IMAGE}"
     expectedLabels=$(
       jq --sort-keys -n \
         --arg VERSION "${VERSION}" \
         --arg REVISION "${REVISION}" \
         --arg DATE "${DATE}" \
         --arg BASEDIGEST "${DIGEST}" \
+        --arg BASE_IMAGE "${BASE_IMAGE}" \
         "$(cat "${labelsGoldenFile}")"
     )
 
   # Compare and output
+  echo "[INFO] Comparing expected vs actual labels..."
   if ! diff <(echo "${expectedLabels}") <(echo "${actualLabels}"); then
     echo >&2 "Expected label values (marked by '<') do not match actual label values (marked by '>'); if you think this is wrong, update the golden file at ${labelsGoldenFile}"
     exit 1

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.9.0-SNAPSHOT</version>
+    <version>8.9.0-SNAPSHOT</version> #this
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -46,9 +46,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.previousVersion>8.8.0</project.previousVersion>
 
-    <zeebe.version>8.8.5</zeebe.version>
+    <zeebe.version>${project.version}</zeebe.version>
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <identity.version>8.8.2</identity.version>
+    <version.identity>${version.identity}</version.identity>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.9.0-SNAPSHOT</version> #this
+    <version>8.9.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -47,8 +47,6 @@
     <project.previousVersion>8.8.0</project.previousVersion>
 
     <zeebe.version>${project.version}</zeebe.version>
-    <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <version.identity>${version.identity}</version.identity>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

This pull request introduces support for optionally including Optimize in the Camunda Platform release and dry run workflows, as the first step to complete https://github.com/camunda/camunda/issues/40184.

 It adds new workflow inputs, conditional logic, and a dedicated job for building and publishing the Optimize Docker image. There are also improvements to artifact handling, Dockerfile flexibility, and OCI image labeling.

**Release workflow enhancements:**

* Added `includeOptimize` boolean input to both `camunda-platform-release.yml` and `camunda-platform-release-main-dry-run.yml` workflows, allowing users to control whether Optimize is included in the release or dry run process. [[1]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R35-R38) [[2]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R67-R70) [[3]](diffhunk://#diff-6435569638e89471eb604f5f02638ffb7163b0f832dd0771a405c52485bdddb2R14-R17)
* Updated Maven release steps to conditionally include or exclude Optimize using profile flags based on the new input. [[1]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R182-R191) [[2]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L184-R203) [[3]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R219-R236)
* Enhanced artifact collection to include Optimize distribution files when relevant.
* Added a debug step to print Optimize and dependency versions during dry runs for troubleshooting.

**Optimize Docker image release:**

* Introduced a new `optimize-docker` job to build, verify, and publish the Optimize Docker image when `includeOptimize` is true, including integration with DockerHub and Minimus, and local registry verification.
* Updated downstream jobs and notification logic to depend on the new `optimize-docker` job, ensuring correct release sequencing and Slack notifications. [[1]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L740-R896) [[2]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L868-R1024) [[3]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L928-R1084) [[4]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R1093) [[5]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L978-R1135) [[6]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R1144)

**Dockerfile and image metadata improvements:**

* Made `optimize.Dockerfile` more flexible by supporting both legacy and monorepo artifact naming via the `DISTBALL` build argument, and improved handling of the base image label. [[1]](diffhunk://#diff-b6b6a44be0d263e530e17b154a30f9788cd07d806d93e46e90462c145e13ef6aR16-R27) [[2]](diffhunk://#diff-b6b6a44be0d263e530e17b154a30f9788cd07d806d93e46e90462c145e13ef6aL43-R45)
* Updated OCI image labels in the golden file to include Minimus gallery metadata. (.ci/docker/test/optimize-docker-labels.golden.json)

**Dependency management:**

* Changed `optimize/pom.xml` to set `zeebe.version` to match the project version, simplifying version alignment.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

> [!WARNING]
> Backport will be triggered only after the whole Optimize alpha release, via Monorepo, is stable. 

## Related issues

closes #
