### PR TITLE
Add command and processor to overwrite key generator

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
 import java.time.InstantSource;
 
@@ -43,8 +44,17 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             context.getPartitionId(),
             zeebeDb,
             zeebeDbContext,
-            () -> {
-              throw new IllegalCallerException("New keys cannot be generated during migration");
+            new KeyGenerator() {
+              @Override
+              public long nextKey() {
+                throw new IllegalCallerException("New keys cannot be generated during migration");
+              }
+
+              @Override
+              public void overwriteNextKey(final long nextKey) {
+                throw new IllegalCallerException(
+                    "KeyGenerator cannot be modified during migration");
+              }
             },
             transientMessageSubscriptionState,
             transientProcessMessageSubscriptionState,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -105,6 +106,7 @@ public class CommandApiRequestReader implements RequestReader {
     RECORDS_BY_TYPE.put(ValueType.HISTORY_DELETION, HistoryDeletionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.CONDITIONAL_SUBSCRIPTION, ConditionalSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.CONDITIONAL_EVALUATION, ConditionalEvaluationRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.KEY_GENERATOR_RESET, KeyGeneratorResetRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.engine.processing.identity.MappingRuleProcessors;
 import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
+import io.camunda.zeebe.engine.processing.keygenerator.KeyGeneratorResetProcessor;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.metrics.UsageMetricsProcessors;
@@ -72,6 +73,7 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
@@ -357,6 +359,11 @@ public final class EngineProcessors {
 
     HistoryDeletionProcessors.addHistoryDeletionProcessors(
         typedRecordProcessors, writers, processingState);
+
+    typedRecordProcessors.onCommand(
+        ValueType.KEY_GENERATOR_RESET,
+        KeyGeneratorResetIntent.RESET,
+        new KeyGeneratorResetProcessor(writers, partitionId));
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/keygenerator/KeyGeneratorResetProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/keygenerator/KeyGeneratorResetProcessor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.keygenerator;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Processes commands to reset the key generator for a partition.
+ *
+ * <p>This is an administrative operation that allows setting a new starting point for key
+ * generation within a partition. The key generator will also accept new values that are lower than
+ * the current key. This can lead to collision with existing or previously completed processes. This
+ * operation must be used with caution and is intended to be used only to recover the cluster from
+ * specific failures.
+ */
+public final class KeyGeneratorResetProcessor
+    implements TypedRecordProcessor<KeyGeneratorResetRecord> {
+
+  private static final String INVALID_PARTITION_ERROR_MESSAGE =
+      "Expected to reset key generator for partition %d, but this command was sent to partition %d";
+  private static final String INVALID_KEY_PARTITION_ERROR_MESSAGE =
+      "Expected new key value to belong to partition %d, but it belongs to partition %d";
+
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final int partitionId;
+
+  public KeyGeneratorResetProcessor(final Writers writers, final int partitionId) {
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<KeyGeneratorResetRecord> command) {
+    // For now, we skip authorization. But can be added later when this operation is supported via
+    // api
+
+    final var record = command.getValue();
+
+    // Validate partition ID matches current partition
+    if (record.getPartitionId() != partitionId) {
+      final var message =
+          INVALID_PARTITION_ERROR_MESSAGE.formatted(record.getPartitionId(), partitionId);
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, message);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, message);
+      return;
+    }
+
+    // Validate the new key value belongs to this partition
+    final var keyPartitionId = Protocol.decodePartitionId(record.getNewKeyValue());
+    if (keyPartitionId != partitionId) {
+      final var message =
+          INVALID_KEY_PARTITION_ERROR_MESSAGE.formatted(partitionId, keyPartitionId);
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, message);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, message);
+      return;
+    }
+
+    // Use -1 as key as we don't need a new key for this specific event
+    stateWriter.appendFollowUpEvent(-1, KeyGeneratorResetIntent.RESET_APPLIED, record);
+
+    // Send response if this was a request
+    if (command.hasRequestMetadata()) {
+      responseWriter.writeEventOnCommand(
+          -1, KeyGeneratorResetIntent.RESET_APPLIED, record, command);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/keygenerator/KeyGeneratorResetProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/keygenerator/KeyGeneratorResetProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.keygenerator;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -27,6 +28,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  * operation must be used with caution and is intended to be used only to recover the cluster from
  * specific failures.
  */
+// We skip authorization checks as this operation will be exposed only via command line debug-tool
+@ExcludeAuthorizationCheck
 public final class KeyGeneratorResetProcessor
     implements TypedRecordProcessor<KeyGeneratorResetRecord> {
 
@@ -49,9 +52,6 @@ public final class KeyGeneratorResetProcessor
 
   @Override
   public void processRecord(final TypedRecord<KeyGeneratorResetRecord> command) {
-    // For now, we skip authorization. But can be added later when this operation is supported via
-    // api
-
     final var record = command.getValue();
 
     // Validate partition ID matches current partition

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -154,6 +155,7 @@ public final class EventAppliers implements EventApplier {
     registerHistoryDeletionAppliers();
     registerConditionalSubscriptionAppliers(state);
     registerConditionalEvaluationAppliers();
+    registerKeyGeneratorResetAppliers(state);
     return this;
   }
 
@@ -720,6 +722,12 @@ public final class EventAppliers implements EventApplier {
 
   private void registerHistoryDeletionAppliers() {
     register(HistoryDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerKeyGeneratorResetAppliers(final MutableProcessingState state) {
+    register(
+        KeyGeneratorResetIntent.RESET_APPLIED,
+        new KeyGeneratorResetAppliedApplier(state.getKeyGenerator()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/KeyGeneratorResetAppliedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/KeyGeneratorResetAppliedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class KeyGeneratorResetAppliedApplier
+    implements TypedEventApplier<KeyGeneratorResetIntent, KeyGeneratorResetRecord> {
+
+  private final KeyGenerator keyGenerator;
+
+  public KeyGeneratorResetAppliedApplier(final KeyGenerator keyGenerator) {
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void applyState(final long key, final KeyGeneratorResetRecord value) {
+    // Apply the reset to the key generator
+    keyGenerator.overwriteNextKey(value.getNewKeyValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -81,9 +82,7 @@ public final class StateQueryService implements QueryService {
               Protocol.DEPLOYMENT_PARTITION,
               zeebeDb,
               zeebeDb.createContext(),
-              () -> {
-                throw new UnsupportedOperationException("Not allowed to generate a new key");
-              },
+              KeyGenerator.IMMUTABLE,
               new TransientPendingSubscriptionState(),
               new TransientPendingSubscriptionState(),
               new EngineConfiguration(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/keygenerator/KeyGeneratorResetTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/keygenerator/KeyGeneratorResetTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.keygenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class KeyGeneratorResetTest {
+
+  private static final int PARTITION_ID = 1;
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Before
+  public void waitForUsageMetricsExport() {
+    // Ensure that the engine has completed its initial usage metrics export cycle. Otherwise it
+    // will generate key in between the tests resulting in non-determinitic results.
+    RecordingExporter.usageMetricsRecords(UsageMetricIntent.EXPORTED)
+        .withPartitionId(PARTITION_ID)
+        .await();
+  }
+
+  @Test
+  public void shouldResetKeyGenerator() {
+    // given
+    final long newKeyValue = Protocol.encodePartitionId(PARTITION_ID, 1000L);
+
+    // when
+    final Record<KeyGeneratorResetRecordValue> resetRecord =
+        engine
+            .keyGeneratorReset()
+            .withPartitionId(PARTITION_ID)
+            .withNewKeyValue(newKeyValue)
+            .reset();
+
+    // then
+    Assertions.assertThat(resetRecord)
+        .hasIntent(KeyGeneratorResetIntent.RESET_APPLIED)
+        .hasPartitionId(PARTITION_ID);
+
+    assertThat(resetRecord.getValue().getPartitionId()).isEqualTo(PARTITION_ID);
+    assertThat(resetRecord.getValue().getNewKeyValue()).isEqualTo(newKeyValue);
+  }
+
+  @Test
+  public void shouldRejectResetWithInvalidPartitionId() {
+    // given
+    final int invalidPartitionId = 2; // Engine is running with partition 1
+    final long newKeyValue = Protocol.encodePartitionId(invalidPartitionId, 1000L);
+
+    // when
+    final Record<KeyGeneratorResetRecordValue> rejectionRecord =
+        engine
+            .keyGeneratorReset()
+            .withPartitionId(invalidPartitionId)
+            .withNewKeyValue(newKeyValue)
+            .expectRejection()
+            .reset();
+
+    // then
+    Assertions.assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to reset key generator for partition 2, but this command was sent to partition 1");
+  }
+
+  @Test
+  public void shouldRejectResetWithKeyFromDifferentPartition() {
+    // given
+    final int differentPartitionId = 3;
+    final long keyFromDifferentPartition = Protocol.encodePartitionId(differentPartitionId, 1000L);
+
+    // when
+    final Record<KeyGeneratorResetRecordValue> rejectionRecord =
+        engine
+            .keyGeneratorReset()
+            .withPartitionId(PARTITION_ID) // Correct partition ID
+            .withNewKeyValue(keyFromDifferentPartition) // But key belongs to partition 3
+            .expectRejection()
+            .reset();
+
+    // then
+    Assertions.assertThat(rejectionRecord)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected new key value to belong to partition 1, but it belongs to partition 3");
+  }
+
+  @Test
+  public void shouldGenerateNextKeyFromResetValue() {
+    // given - reset the key generator to a specific value
+    final long resetKeyValue = Protocol.encodePartitionId(PARTITION_ID, 5000L);
+    engine.keyGeneratorReset().withPartitionId(PARTITION_ID).withNewKeyValue(resetKeyValue).reset();
+
+    // when - trigger an action that generates a new key
+    final var messageKey =
+        engine.message().withCorrelationKey("test").withName("testMessage").publish().getKey();
+
+    // then
+    assertThat(messageKey)
+        .describedAs("The next key generated is equal to the provided key")
+        .isEqualTo(resetKeyValue);
+
+    assertThat(Protocol.decodePartitionId(messageKey)).isEqualTo(PARTITION_ID);
+  }
+
+  @Test
+  public void shouldGenerateMultipleKeysAfterReset() {
+    // given - reset the key generator to a specific value
+    final long resetKeyValue = Protocol.encodePartitionId(PARTITION_ID, 10000L);
+    engine.keyGeneratorReset().withPartitionId(PARTITION_ID).withNewKeyValue(resetKeyValue).reset();
+
+    // when - generate multiple keys
+    final var firstMessageKey =
+        engine.message().withCorrelationKey("test-1").withName("testMessage-1").publish().getKey();
+
+    final var secondMessageKey =
+        engine.message().withCorrelationKey("test-2").withName("testMessage-2").publish().getKey();
+
+    // then
+    assertThat(firstMessageKey)
+        .describedAs("The next key generated is equal to the provided key")
+        .isEqualTo(resetKeyValue);
+    assertThat(secondMessageKey).isEqualTo(firstMessageKey + 1);
+
+    // Verify partition IDs are correct
+    assertThat(Protocol.decodePartitionId(firstMessageKey)).isEqualTo(PARTITION_ID);
+    assertThat(Protocol.decodePartitionId(secondMessageKey)).isEqualTo(PARTITION_ID);
+  }
+
+  @Test
+  public void shouldResetKeyToLowerValue() {
+    // given - reset the key generator to a high value
+    final long initialResetKeyValue = Protocol.encodePartitionId(PARTITION_ID, 20000L);
+    engine
+        .keyGeneratorReset()
+        .withPartitionId(PARTITION_ID)
+        .withNewKeyValue(initialResetKeyValue)
+        .reset();
+    final var firstMessage =
+        engine
+            .message()
+            .withCorrelationKey("test-lower")
+            .withName("testMessage-lower")
+            .publish()
+            .getKey();
+    assertThat(firstMessage)
+        .describedAs("The next key generated is equal to the initial reset key value")
+        .isEqualTo(initialResetKeyValue);
+
+    // when - reset the key generator to a lower value
+    final long lowerResetKeyValue = Protocol.encodePartitionId(PARTITION_ID, 15000L);
+    engine
+        .keyGeneratorReset()
+        .withPartitionId(PARTITION_ID)
+        .withNewKeyValue(lowerResetKeyValue)
+        .reset();
+
+    // then
+    final var messageKey =
+        engine
+            .message()
+            .withCorrelationKey("test-lower")
+            .withName("testMessage-lower")
+            .publish()
+            .getKey();
+
+    assertThat(messageKey)
+        .describedAs("The next key generated is equal to the lower key value")
+        .isEqualTo(lowerResetKeyValue);
+
+    // Verify partition ID is correct
+    assertThat(Protocol.decodePartitionId(messageKey)).isEqualTo(PARTITION_ID);
+  }
+
+  @Test
+  public void shouldRecordResetAppliedEvent() {
+    // given
+    final long newKeyValue = Protocol.encodePartitionId(PARTITION_ID, 2000L);
+
+    // when
+    engine.keyGeneratorReset().withPartitionId(PARTITION_ID).withNewKeyValue(newKeyValue).reset();
+
+    // then - verify the RESET_APPLIED event was recorded
+    final Record<KeyGeneratorResetRecordValue> resetAppliedEvent =
+        RecordingExporter.keyGeneratorResetRecords(KeyGeneratorResetIntent.RESET_APPLIED)
+            .getFirst();
+
+    assertThat(resetAppliedEvent).isNotNull();
+    assertThat(resetAppliedEvent.getValue().getPartitionId()).isEqualTo(PARTITION_ID);
+    assertThat(resetAppliedEvent.getValue().getNewKeyValue()).isEqualTo(newKeyValue);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -93,7 +93,18 @@ public final class EngineErrorHandlingTest {
     streams.createLogStream(STREAM_NAME);
 
     final AtomicLong key = new AtomicLong();
-    keyGenerator = () -> key.getAndIncrement();
+    keyGenerator =
+        new KeyGenerator() {
+          @Override
+          public long nextKey() {
+            return key.getAndIncrement();
+          }
+
+          @Override
+          public void overwriteNextKey(final long nextKey) {
+            throw new UnsupportedOperationException();
+          }
+        };
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.engine.util.client.IdentitySetupClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
 import io.camunda.zeebe.engine.util.client.JobClient;
+import io.camunda.zeebe.engine.util.client.KeyGeneratorResetClient;
 import io.camunda.zeebe.engine.util.client.MappingRuleClient;
 import io.camunda.zeebe.engine.util.client.MessageCorrelationClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
@@ -721,6 +722,10 @@ public final class EngineRule extends ExternalResource {
 
   public ClockClient clock() {
     return new ClockClient(environmentRule);
+  }
+
+  public KeyGeneratorResetClient keyGeneratorReset() {
+    return new KeyGeneratorResetClient(environmentRule);
   }
 
   public ScaleClient scale() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/KeyGeneratorResetClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/KeyGeneratorResetClient.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final class KeyGeneratorResetClient {
+  private static final Function<Long, Record<KeyGeneratorResetRecordValue>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.keyGeneratorResetRecords(KeyGeneratorResetIntent.RESET_APPLIED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+  private static final Function<Long, Record<KeyGeneratorResetRecordValue>> REJECTION_EXPECTATION =
+      (position) ->
+          RecordingExporter.keyGeneratorResetRecords()
+              .onlyCommandRejections()
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final CommandWriter writer;
+  private final KeyGeneratorResetRecord record = new KeyGeneratorResetRecord();
+  private long requestId = -1L;
+  private int requestStreamId = -1;
+  private Function<Long, Record<KeyGeneratorResetRecordValue>> expectation = null;
+
+  public KeyGeneratorResetClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public KeyGeneratorResetClient requestId(final long requestId) {
+    this.requestId = requestId;
+    return this;
+  }
+
+  public KeyGeneratorResetClient requestStreamId(final int requestStreamId) {
+    this.requestStreamId = requestStreamId;
+    return this;
+  }
+
+  public KeyGeneratorResetClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
+    return this;
+  }
+
+  public KeyGeneratorResetClient withPartitionId(final int partitionId) {
+    record.setPartitionId(partitionId);
+    return this;
+  }
+
+  public KeyGeneratorResetClient withNewKeyValue(final long newKeyValue) {
+    record.setNewKeyValue(newKeyValue);
+    return this;
+  }
+
+  public Record<KeyGeneratorResetRecordValue> reset() {
+    final long position = writeCommand(KeyGeneratorResetIntent.RESET);
+    return Objects.requireNonNullElse(expectation, SUCCESS_EXPECTATION).apply(position);
+  }
+
+  public Record<KeyGeneratorResetRecordValue> reset(final String username) {
+    final long position = writeCommand(KeyGeneratorResetIntent.RESET, username);
+    return Objects.requireNonNullElse(expectation, SUCCESS_EXPECTATION).apply(position);
+  }
+
+  private long writeCommand(final KeyGeneratorResetIntent intent) {
+    if (requestId != -1 && requestStreamId != -1) {
+      return writer.writeCommand(requestStreamId, requestId, intent, record);
+    }
+
+    return writer.writeCommand(intent, record);
+  }
+
+  private long writeCommand(final KeyGeneratorResetIntent intent, final String username) {
+    return writer.writeCommand(intent, username, record);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/KeyGeneratorReset_RESET_APPLIED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/KeyGeneratorReset_RESET_APPLIED_v1.golden
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class KeyGeneratorResetAppliedApplier
+    implements TypedEventApplier<KeyGeneratorResetIntent, KeyGeneratorResetRecord> {
+
+  private final KeyGenerator keyGenerator;
+
+  public KeyGeneratorResetAppliedApplier(final KeyGenerator keyGenerator) {
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void applyState(final long key, final KeyGeneratorResetRecord value) {
+    // Apply the reset to the key generator
+    keyGenerator.overwriteNextKey(value.getNewKeyValue());
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -111,6 +111,7 @@ public class ElasticsearchExporterConfiguration {
       case CLUSTER_VARIABLE -> index.clusterVariable;
       case CONDITIONAL_SUBSCRIPTION -> index.conditionalSubscription;
       case CONDITIONAL_EVALUATION -> index.conditionalEvaluation;
+      case KEY_GENERATOR_RESET -> index.keyGeneratorReset;
       default -> false;
     };
   }
@@ -231,6 +232,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean clusterVariable = true;
     public boolean conditionalSubscription = false;
     public boolean conditionalEvaluation = false;
+    public boolean keyGeneratorReset = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -196,6 +196,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.conditionalEvaluation) {
         createValueIndexTemplate(ValueType.CONDITIONAL_EVALUATION, version);
       }
+      if (index.keyGeneratorReset) {
+        createValueIndexTemplate(ValueType.KEY_GENERATOR_RESET, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-key-generator-reset-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-key-generator-reset-template.json
@@ -1,0 +1,33 @@
+{
+  "index_patterns": [
+    "zeebe-record_key-generator-reset_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-key-generator-reset": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "partitionId": {
+              "type": "integer"
+            },
+            "newKeyValue": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -78,6 +78,7 @@ final class TestSupport {
       case CLUSTER_VARIABLE -> config.clusterVariable = value;
       case CONDITIONAL_SUBSCRIPTION -> config.conditionalSubscription = value;
       case CONDITIONAL_EVALUATION -> config.conditionalEvaluation = value;
+      case KEY_GENERATOR_RESET -> config.keyGeneratorReset = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -222,6 +222,7 @@ public class OpensearchExporterConfiguration {
     public boolean clusterVariable = true;
     public boolean conditionalSubscription = false;
     public boolean conditionalEvaluation = false;
+    public boolean keyGeneratorReset = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -171,6 +171,9 @@ public class OpensearchExporterSchemaManager {
       if (index.conditionalEvaluation) {
         createValueIndexTemplate(ValueType.CONDITIONAL_EVALUATION, version);
       }
+      if (index.keyGeneratorReset) {
+        createValueIndexTemplate(ValueType.KEY_GENERATOR_RESET, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-key-generator-reset-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-key-generator-reset-template.json
@@ -1,0 +1,33 @@
+{
+  "index_patterns": [
+    "zeebe-record_key-generator-reset_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-key-generator-reset": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "partitionId": {
+              "type": "integer"
+            },
+            "newKeyValue": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -79,6 +79,7 @@ final class TestSupport {
       case CLUSTER_VARIABLE -> config.clusterVariable = value;
       case CONDITIONAL_SUBSCRIPTION -> config.conditionalSubscription = value;
       case CONDITIONAL_EVALUATION -> config.conditionalEvaluation = value;
+      case KEY_GENERATOR_RESET -> config.keyGeneratorReset = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/keygenerator/KeyGeneratorResetRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/keygenerator/KeyGeneratorResetRecord.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.keygenerator;
+
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
+
+public final class KeyGeneratorResetRecord extends UnifiedRecordValue
+    implements KeyGeneratorResetRecordValue {
+
+  private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId", 0);
+  private final LongProperty newKeyValueProperty = new LongProperty("newKeyValue", 0L);
+
+  public KeyGeneratorResetRecord() {
+    super(2);
+    declareProperty(partitionIdProperty).declareProperty(newKeyValueProperty);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionIdProperty.getValue();
+  }
+
+  public KeyGeneratorResetRecord setPartitionId(final int partitionId) {
+    partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  @Override
+  public long getNewKeyValue() {
+    return newKeyValueProperty.getValue();
+  }
+
+  public KeyGeneratorResetRecord setNewKeyValue(final long newKeyValue) {
+    newKeyValueProperty.setValue(newKeyValue);
+    return this;
+  }
+
+  public KeyGeneratorResetRecord copy() {
+    final KeyGeneratorResetRecord copy = new KeyGeneratorResetRecord();
+    copy.copyFrom(this);
+    return copy;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -52,6 +52,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
@@ -3024,6 +3025,37 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "time": 0
+                }
+                """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// KeyGeneratorResetRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "KeyGeneratorResetRecord (all properties)",
+        (Supplier<KeyGeneratorResetRecord>)
+            () -> new KeyGeneratorResetRecord().setPartitionId(1).setNewKeyValue(2251799813685250L),
+        """
+                {
+                  "partitionId": 1,
+                  "newKeyValue": 2251799813685250
+                }
+                """
+      },
+      {
+        "KeyGeneratorResetRecord (empty)",
+        (Supplier<KeyGeneratorResetRecord>)
+            () -> {
+              final var record = new KeyGeneratorResetRecord();
+              record.reset();
+              return record;
+            },
+        """
+                {
+                  "partitionId": 0,
+                  "newKeyValue": 0
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/KeyGeneratorResetRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/KeyGeneratorResetRecord.golden
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.keygenerator;
+
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
+
+public final class KeyGeneratorResetRecord extends UnifiedRecordValue
+    implements KeyGeneratorResetRecordValue {
+
+  private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId", 0);
+  private final LongProperty newKeyValueProperty = new LongProperty("newKeyValue", 0L);
+
+  public KeyGeneratorResetRecord() {
+    super(2);
+    declareProperty(partitionIdProperty).declareProperty(newKeyValueProperty);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionIdProperty.getValue();
+  }
+
+  public KeyGeneratorResetRecord setPartitionId(final int partitionId) {
+    partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  @Override
+  public long getNewKeyValue() {
+    return newKeyValueProperty.getValue();
+  }
+
+  public KeyGeneratorResetRecord setNewKeyValue(final long newKeyValue) {
+    newKeyValueProperty.setValue(newKeyValue);
+    return this;
+  }
+
+  public KeyGeneratorResetRecord copy() {
+    final KeyGeneratorResetRecord copy = new KeyGeneratorResetRecord();
+    copy.copyFrom(this);
+    return copy;
+  }
+}
+

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
@@ -99,6 +100,7 @@ import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
@@ -341,6 +343,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.CONDITIONAL_EVALUATION,
         new Mapping<>(ConditionalEvaluationRecordValue.class, ConditionalEvaluationIntent.class));
+    mapping.put(
+        ValueType.KEY_GENERATOR_RESET,
+        new Mapping<>(KeyGeneratorResetRecordValue.class, KeyGeneratorResetIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -80,7 +80,8 @@ public interface Intent {
           ClusterVariableIntent.class,
           HistoryDeletionIntent.class,
           ConditionalSubscriptionIntent.class,
-          ConditionalEvaluationIntent.class);
+          ConditionalEvaluationIntent.class,
+          KeyGeneratorResetIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -216,6 +217,8 @@ public interface Intent {
         return ConditionalSubscriptionIntent.from(intent);
       case CONDITIONAL_EVALUATION:
         return ConditionalEvaluationIntent.from(intent);
+      case KEY_GENERATOR_RESET:
+        return KeyGeneratorResetIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -339,6 +342,8 @@ public interface Intent {
         return ConditionalSubscriptionIntent.valueOf(intent);
       case CONDITIONAL_EVALUATION:
         return ConditionalEvaluationIntent.valueOf(intent);
+      case KEY_GENERATOR_RESET:
+        return KeyGeneratorResetIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/KeyGeneratorResetIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/KeyGeneratorResetIntent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum KeyGeneratorResetIntent implements Intent {
+  RESET((short) 0, false),
+  RESET_APPLIED((short) 1, true);
+
+  private final short value;
+  private final boolean isEvent;
+
+  KeyGeneratorResetIntent(final short value, final boolean isEvent) {
+    this.value = value;
+    this.isEvent = isEvent;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return RESET;
+      case 1:
+        return RESET_APPLIED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return isEvent;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/KeyGeneratorResetRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/KeyGeneratorResetRecordValue.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents a command to reset the key generator for a partition.
+ *
+ * <p>This is an administrative operation that allows setting a new starting point for key
+ * generation within a partition. The key generator will only accept new values that are higher than
+ * the current key.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableKeyGeneratorResetRecordValue.Builder.class)
+public interface KeyGeneratorResetRecordValue extends RecordValue {
+
+  /**
+   * @return the partition ID for which the key generator should be reset
+   */
+  int getPartitionId();
+
+  /**
+   * @return the new key value to set. Must be properly encoded with the partition ID.
+   */
+  long getNewKeyValue();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -80,6 +80,7 @@
       <validValue name="HISTORY_DELETION">62</validValue>
       <validValue name="CONDITIONAL_SUBSCRIPTION">63</validValue>
       <validValue name="CONDITIONAL_EVALUATION">64</validValue>
+      <validValue name="KEY_GENERATOR_RESET">65</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/KeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/state/KeyGenerator.java
@@ -8,8 +8,20 @@
 package io.camunda.zeebe.stream.api.state;
 
 /** Generate unique keys. Should be used for records only. */
-@FunctionalInterface
 public interface KeyGenerator {
+
+  KeyGenerator IMMUTABLE =
+      new KeyGenerator() {
+        @Override
+        public long nextKey() {
+          throw new UnsupportedOperationException("KeyGenerator is not supported in this context.");
+        }
+
+        @Override
+        public void overwriteNextKey(final long nextKey) {
+          throw new UnsupportedOperationException("KeyGenerator is not supported in this context.");
+        }
+      };
 
   /**
    * Returns the next key of a record and updates the key generator.
@@ -17,4 +29,11 @@ public interface KeyGenerator {
    * @return the next key for a new record
    */
   long nextKey();
+
+  /**
+   * Overwrite the next key with the given value without any further validations. Use with caution.
+   *
+   * @param nextKey the next key to set
+   */
+  void overwriteNextKey(long nextKey);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.keygenerator.KeyGeneratorResetRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
@@ -149,6 +150,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.HISTORY_DELETION, HistoryDeletionRecord.class);
     registry.put(ValueType.CONDITIONAL_SUBSCRIPTION, ConditionalSubscriptionRecord.class);
     registry.put(ValueType.CONDITIONAL_EVALUATION, ConditionalEvaluationRecord.class);
+    registry.put(ValueType.KEY_GENERATOR_RESET, KeyGeneratorResetRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -62,6 +62,18 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
     return nextKey;
   }
 
+  @Override
+  public void overwriteNextKey(final long nextKey) {
+    if (Protocol.decodePartitionId(nextKey) != partitionId) {
+      throw new UnrecoverableException(
+          new IllegalArgumentException(
+              String.format(
+                  "Provided key %d does not belong to partition %d, it belongs to %d",
+                  nextKey, partitionId, Protocol.decodePartitionId(nextKey))));
+    }
+    nextValueManager.setValue(LATEST_KEY, nextKey - 1);
+  }
+
   /**
    * Retrieve the current key from the state, since it is only used in tests it is not part of the
    * interface.

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -23,6 +23,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.DEPLOYMENT_DISTRIBUTION
 import static io.camunda.zeebe.protocol.record.ValueType.ESCALATION;
 import static io.camunda.zeebe.protocol.record.ValueType.GROUP;
 import static io.camunda.zeebe.protocol.record.ValueType.IDENTITY_SETUP;
+import static io.camunda.zeebe.protocol.record.ValueType.KEY_GENERATOR_RESET;
 import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.ValueType.MULTI_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
@@ -98,6 +99,7 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
@@ -216,6 +218,7 @@ public class CompactRecordLogger {
           entry(CLUSTER_VARIABLE.name(), "CLSTR_VAR"),
           entry(CONDITIONAL_SUBSCRIPTION.name(), "COND_SUB"),
           entry(CONDITIONAL_EVALUATION.name(), "COND_EVAL"),
+          entry(KEY_GENERATOR_RESET.name(), "KEY_RST"),
           entry(IDENTITY_SETUP.name(), "ID"),
           entry(CHECKPOINT.name(), "CHK"));
 
@@ -309,6 +312,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.CHECKPOINT, this::summarizeCheckpoint);
     valueLoggers.put(ValueType.FORM, this::summarizeForm);
     valueLoggers.put(ValueType.HISTORY_DELETION, this::summarizeHistoryDeletion);
+    valueLoggers.put(KEY_GENERATOR_RESET, this::summarizeKeyGeneratorReset);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -1749,6 +1753,12 @@ public class CompactRecordLogger {
     final var value = (CheckpointRecordValue) record.getValue();
     return "checkpoint %s @ #%s"
         .formatted(value.getCheckpointId(), formatPosition(value.getCheckpointPosition()));
+  }
+
+  private String summarizeKeyGeneratorReset(final Record<?> record) {
+    final var value = (KeyGeneratorResetRecordValue) record.getValue();
+    return "Reset keygen p%d @ %s"
+        .formatted(value.getPartitionId(), shortenKey(value.getNewKeyValue()));
   }
 
   private String summarizeHistoryDeletion(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/KeyGeneratorResetRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/KeyGeneratorResetRecordStream.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
+import java.util.stream.Stream;
+
+public final class KeyGeneratorResetRecordStream
+    extends ExporterRecordStream<KeyGeneratorResetRecordValue, KeyGeneratorResetRecordStream> {
+
+  public KeyGeneratorResetRecordStream(
+      final Stream<Record<KeyGeneratorResetRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected KeyGeneratorResetRecordStream supply(
+      final Stream<Record<KeyGeneratorResetRecordValue>> wrappedStream) {
+    return new KeyGeneratorResetRecordStream(wrappedStream);
+  }
+
+  @Override
+  public KeyGeneratorResetRecordStream withPartitionId(final int partitionId) {
+    return valueFilter(v -> v.getPartitionId() == partitionId);
+  }
+
+  public KeyGeneratorResetRecordStream withNewKeyValue(final long newKeyValue) {
+    return valueFilter(v -> v.getNewKeyValue() == newKeyValue);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.KeyGeneratorResetIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
@@ -76,6 +77,7 @@ import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.KeyGeneratorResetRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
@@ -673,6 +675,16 @@ public final class RecordingExporter implements Exporter {
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {
     autoAcknowledge = shouldAcknowledgeRecords;
+  }
+
+  public static KeyGeneratorResetRecordStream keyGeneratorResetRecords() {
+    return new KeyGeneratorResetRecordStream(
+        records(ValueType.KEY_GENERATOR_RESET, KeyGeneratorResetRecordValue.class));
+  }
+
+  public static KeyGeneratorResetRecordStream keyGeneratorResetRecords(
+      final KeyGeneratorResetIntent keyGeneratorResetIntent) {
+    return keyGeneratorResetRecords().withIntent(keyGeneratorResetIntent);
   }
 
   public static class AwaitingRecordIterator implements Iterator<Record<?>> {


### PR DESCRIPTION
## Description

This PR is part of #41871 . 
* Adds a command for resetting the next key in the keygenerator
* Adds processor and event appliers for the same

The processor only validates that the key provided belongs to the specified partition. Addition validations will be added later. There is no authorization check for the command. It can be added if we want to allow this operation via an api. But if we are only allowing this operation via the debug cli tool, then authorization is not necessary.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #41871 
