### PR TITLE
[Backport stable/8.6] feat: backpressure request limit panel was showing incorrect values

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -20709,7 +20709,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_backpressure_requests_limit{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"})by (partition)",
+              "expr": "sum(zeebe_backpressure_requests_limit{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"} and on(namespace, partition, pod, instance) (atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"} == 3)) by (partition)",
               "hide": false,
               "legendFormat": "Partition: {{partition}}",
               "range": true,


### PR DESCRIPTION
# Description
Backport of #41898 to `stable/8.6`.

relates to 