### PR TITLE
fix: backup and restore do not create indices from tasklist

### DIFF
--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -106,6 +106,7 @@ public class BackupRestoreTest {
         testContainerUtil
             .createTasklistContainer(testContext)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+            .withEnv("CAMUNDA_DATABASE_SCHEMA_MANAGER_CREATE_SCHEMA", "false")
             // Unified Configuration: DB type + compatibility
             .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType)
             .withEnv("CAMUNDA_TASKLIST_DATABASE", dbType)

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -501,6 +501,7 @@ public class TestContainerUtil {
                   });
       LOGGER.info("************ Starting StandaloneBroker ************");
       addConfig(broker, testContext);
+      broker.withCreateSchema(testContext.isCreateSchema());
       broker.start();
       LOGGER.info("************ StandaloneBroker started  ************");
 
@@ -571,6 +572,8 @@ public class TestContainerUtil {
 
     zeebeBroker.withAdditionalProperties(
         Map.of(
+            "camunda.data.secondary-storage.type",
+            type,
             "camunda.database.type",
             type,
             "camunda.operate.database",

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContext.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContext.java
@@ -49,6 +49,7 @@ public class TestContext<T extends TestContext<T>> {
   private Integer externalTasklistPort;
   private Integer externalTasklistMgmtPort;
   private String externalTasklistContextPath = "/";
+  private boolean createSchema = true;
 
   private List<String> processesToAssert = new ArrayList<>();
 
@@ -342,5 +343,14 @@ public class TestContext<T extends TestContext<T>> {
 
   public String getExternalIdentityBaseUrl() {
     return String.format("http://%s:%d", externalIdentityHost, externalIdentityPort);
+  }
+
+  public boolean isCreateSchema() {
+    return createSchema;
+  }
+
+  public TestContext<T> setCreateSchema(final boolean createSchema) {
+    this.createSchema = createSchema;
+    return this;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Create the indices from the spring `TestStandaloneBroker` instead of the `camunda/tasklist:SNAPSHOT` container

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
