### PR TITLE
feat: added warning to user about port for Camunda in already use

### DIFF
--- a/c8run/internal/start/startuphandler_test.go
+++ b/c8run/internal/start/startuphandler_test.go
@@ -1,0 +1,29 @@
+package start
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestEnsurePortAvailable(t *testing.T) {
+	inUseListener, err := net.Listen("tcp4", ":0")
+	if err != nil {
+		t.Fatalf("failed to get ephemeral listener: %v", err)
+	}
+
+	port := inUseListener.Addr().(*net.TCPAddr).Port
+
+	if err := ensurePortAvailable(port); err == nil {
+		t.Fatalf("expected error when port %d is already bound", port)
+	}
+
+	if err := inUseListener.Close(); err != nil {
+		t.Fatalf("failed to close temporary listener: %v", err)
+	}
+	time.Sleep(25 * time.Millisecond) // give the OS a moment to release the port
+
+	if err := ensurePortAvailable(port); err != nil {
+		t.Fatalf("expected port %d to be reported as available: %v", port, err)
+	}
+}


### PR DESCRIPTION
## Description

That code change prevents starting Camunda when main port is busy (or informs him to use --port override param as an option).


To test the new port guard, start any service on 8080 (e.g. `npx http-server -p 8080`) and then run the freshly built `c8run`
  (`go run ./cmd/c8run start` or rebuild `./c8run`). The CLI should immediately print `Port 8080 is already in use (tcp4)` and
  exit before spawning Camunda. Stop the http-server and rerun start to confirm it succeeds once the port is free.

  On macOS, `net.Listen("tcp", ":8080")` binds IPv6 (`[::]`) even if the IPv4 endpoint is busy, which is why Tomcat later fails
  when something else holds 127.0.0.1:8080. This guard explicitly probes both `tcp4` and `tcp6`, skipping whichever address
  family isn’t supported, so we correctly detect conflicts for either protocol. 

## Related issues

closes #41743 
