### PR TITLE
feat: improved logging in case of mapping rule conflicts

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/MigrationHandler.java
@@ -28,10 +28,18 @@ public abstract class MigrationHandler<T> {
   }
 
   protected boolean isConflictError(final Throwable e) {
+    return isErrorWithStatus(e, Status.ALREADY_EXISTS);
+  }
+
+  protected boolean isNotFoundError(final Throwable e) {
+    return isErrorWithStatus(e, Status.NOT_FOUND);
+  }
+
+  private boolean isErrorWithStatus(final Throwable e, final Status status) {
     return (e instanceof final CompletionException completionException
-            && isConflictError(completionException.getCause()))
+            && isErrorWithStatus(completionException.getCause(), status))
         || (e instanceof final ServiceException serviceException
-            && serviceException.getStatus() == Status.ALREADY_EXISTS);
+            && serviceException.getStatus() == status);
   }
 
   protected boolean isNotImplementedError(final Throwable e) {


### PR DESCRIPTION
## Description

This adds a more helpful log message for an edge-case where a statical setup mapping rule in the Orchestration Cluster
conflicts with a mapping rule to be creates as part of the identity migration.
The particular conflict would be the same claimName and value pair but a different id.
The message provides guidance on how to resolve this conflict.

Note: As this is mostly about improved logging, while general behavior in terms of throwing a MigrationException is unchanged, I did not add a test case for this. I locally ran a Test case that provokes the conflict to compare the log output.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #38405 (does not close it, as the conflict still blocks the migration, see the decision [here](https://github.com/camunda/camunda/issues/38405#issuecomment-3455463062))
