### PR TITLE
build: optimize 8.6.21 release update base image version in docker

### DIFF
--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch,identity,keycloak",
   "io.openshift.tags": "bpmn,optimization,camunda",
   "org.opencontainers.image.authors": "optimize@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.21.3",
+  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.22.2",
   "org.opencontainers.image.base.digest": $BASEDIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Provides business activity monitoring for workflows and uses BPMN-based analysis to uncover process bottlenecks",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The optimize 8.6.21 release job [here](https://github.com/camunda/camunda/actions/runs/19890209748/job/57006908812) failed due to alpine verision mismatch in the docker test golden file

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
