### PR TITLE
ci: reduce zeebe disk requirements

### DIFF
--- a/dist/src/test/java/io/camunda/application/AbstractCamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/AbstractCamundaDockerIT.java
@@ -122,6 +122,8 @@ public abstract class AbstractCamundaDockerIT {
                 .withReadTimeout(Duration.ofSeconds(120)))
         .withStartupTimeout(Duration.ofSeconds(300))
         // Unified Configuration
+        .withEnv("CAMUNDA_DATA_PRIMARYSTORAGE_DISK_FREESPACE_PROCESSING", "512MB")
+        .withEnv("CAMUNDA_DATA_PRIMARYSTORAGE_DISK_FREESPACE_REPLICATION", "200MB")
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DATABASE_TYPE)
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", elasticsearchUrl())
         // ---
@@ -143,6 +145,8 @@ public abstract class AbstractCamundaDockerIT {
                 .withReadTimeout(Duration.ofSeconds(120)))
         .withStartupTimeout(Duration.ofSeconds(300))
         // Unified Configuration
+        .withEnv("CAMUNDA_DATA_PRIMARYSTORAGE_DISK_FREESPACE_PROCESSING", "512MB")
+        .withEnv("CAMUNDA_DATA_PRIMARYSTORAGE_DISK_FREESPACE_REPLICATION", "200MB")
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", "rdbms")
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_URL", url)
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_USERNAME", "camunda")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Reduce Zeebe's storage requirements for Docker startup tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
