### PR TITLE
Track command distribution latency

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -184,7 +184,8 @@ public final class EngineProcessors {
             typedRecordProcessorContext.getPartitionId(),
             routingInfo,
             interPartitionCommandSender,
-            distributionMetrics);
+            distributionMetrics,
+            clock);
 
     final var deploymentDistributionCommandSender =
         new DeploymentDistributionCommandSender(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionDistributingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionDistributingApplier.java
@@ -24,6 +24,6 @@ public final class CommandDistributionDistributingApplier
   @Override
   public void applyState(final long key, final CommandDistributionRecord value) {
     distributionState.addPendingDistribution(key, value.getPartitionId());
-    distributionState.addRetriableDistribution(key, value.getPartitionId());
+    distributionState.addRetriableDistribution(key, value.getPartitionId(), value.getStartTime());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionDistributingApplierV2.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionDistributingApplierV2.java
@@ -12,18 +12,19 @@ import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 
-public final class CommandDistributionDistributingApplier
+public final class CommandDistributionDistributingApplierV2
     implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
 
   private final MutableDistributionState distributionState;
 
-  public CommandDistributionDistributingApplier(final MutableDistributionState distributionState) {
+  public CommandDistributionDistributingApplierV2(
+      final MutableDistributionState distributionState) {
     this.distributionState = distributionState;
   }
 
   @Override
   public void applyState(final long key, final CommandDistributionRecord value) {
     distributionState.addPendingDistribution(key, value.getPartitionId());
-    distributionState.addRetriableDistribution(key, value.getPartitionId());
+    distributionState.addRetriableDistribution(key, value.getPartitionId(), value.getStartTime());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -696,7 +696,12 @@ public final class EventAppliers implements EventApplier {
         new CommandDistributionStartedApplier(distributionState));
     register(
         CommandDistributionIntent.DISTRIBUTING,
+        1,
         new CommandDistributionDistributingApplier(distributionState));
+    register(
+        CommandDistributionIntent.DISTRIBUTING,
+        2,
+        new CommandDistributionDistributingApplierV2(distributionState));
     register(
         CommandDistributionIntent.ACKNOWLEDGED,
         new CommandDistributionAcknowledgedApplier(distributionState));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -127,6 +127,13 @@ public class DbDistributionState implements MutableDistributionState {
 
   @Override
   public void addRetriableDistribution(final long distributionKey, final int partition) {
+    addRetriableDistribution(distributionKey, partition, -1L);
+  }
+
+  @Override
+  public void addRetriableDistribution(
+      final long distributionKey, final int partition, final long startTime) {
+    // TODO: include start time in the retriableDistributiin CF or another mechanism
     this.distributionKey.wrapLong(distributionKey);
     partitionKey.wrapInt(partition);
     retriableDistributionColumnFamily.insert(distributionPartitionKey, DbNil.INSTANCE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -45,6 +45,10 @@ public class DbDistributionState implements MutableDistributionState {
   private final ColumnFamily<DbLong, PersistedCommandDistribution>
       commandDistributionRecordColumnFamily;
 
+  /** [distribution key | partition id] => [DistributionMetadata] */
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DistributionMetadata>
+      distributionMetadataColumnFamily;
+
   /** [queue id | partition id | distribution key ] => [] */
   private final ColumnFamily<
           DbCompositeKey<DbString, DbCompositeKey<DbInt, DbForeignKey<DbLong>>>, DbNil>
@@ -90,6 +94,13 @@ public class DbDistributionState implements MutableDistributionState {
             distributionPartitionKey,
             DbNil.INSTANCE);
 
+    distributionMetadataColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.COMMAND_DISTRIBUTION_METADATA,
+            transactionContext,
+            distributionPartitionKey,
+            new DistributionMetadata());
+
     queueId = new DbString();
     queuePerPartitionKey = new DbCompositeKey<>(queueId, partitionKey);
     queuedDistributionKey =
@@ -133,10 +144,13 @@ public class DbDistributionState implements MutableDistributionState {
   @Override
   public void addRetriableDistribution(
       final long distributionKey, final int partition, final long startTime) {
-    // TODO: include start time in the retriableDistributiin CF or another mechanism
     this.distributionKey.wrapLong(distributionKey);
     partitionKey.wrapInt(partition);
     retriableDistributionColumnFamily.insert(distributionPartitionKey, DbNil.INSTANCE);
+    if (startTime > -1L) {
+      distributionMetadataColumnFamily.insert(
+          distributionPartitionKey, new DistributionMetadata().setStartTime(startTime));
+    }
   }
 
   @Override
@@ -144,6 +158,7 @@ public class DbDistributionState implements MutableDistributionState {
     this.distributionKey.wrapLong(distributionKey);
     partitionKey.wrapInt(partition);
     retriableDistributionColumnFamily.deleteExisting(distributionPartitionKey);
+    distributionMetadataColumnFamily.deleteIfExists(distributionPartitionKey);
   }
 
   @Override
@@ -268,6 +283,15 @@ public class DbDistributionState implements MutableDistributionState {
         .setIntent(persistedDistribution.getIntent())
         .setCommandValue(persistedDistribution.getCommandValue())
         .setAuthInfo(persistedDistribution.getAuthInfo());
+  }
+
+  @Override
+  public Optional<DistributionMetadata> getDistributionMetadata(
+      final long distributionKey, final int partition) {
+    this.distributionKey.wrapLong(distributionKey);
+    partitionKey.wrapInt(partition);
+    return Optional.ofNullable(distributionMetadataColumnFamily.get(distributionPartitionKey))
+        .map(metadata -> new DistributionMetadata().setStartTime(metadata.getStartTime()));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionMetadata.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.distribution;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+
+public class DistributionMetadata extends UnpackedObject implements DbValue {
+
+  private static final StringValue START_TIME = new StringValue("startTime");
+
+  private final LongProperty startTimeProp = new LongProperty(START_TIME, -1L);
+
+  public DistributionMetadata() {
+    super(1);
+    declareProperty(startTimeProp);
+  }
+
+  public long getStartTime() {
+    return startTimeProp.getValue();
+  }
+
+  public DistributionMetadata setStartTime(final long startTime) {
+    startTimeProp.setValue(startTime);
+    return this;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.state.distribution.DistributionMetadata;
 import io.camunda.zeebe.engine.state.distribution.PersistedCommandDistribution;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import java.util.Optional;
@@ -68,6 +69,18 @@ public interface DistributionState {
    * @return an new instance of the {@link CommandDistributionRecord}
    */
   CommandDistributionRecord getCommandDistributionRecord(long distributionKey, int partition);
+
+  /**
+   * Returns the {@link DistributionMetadata} persisted for a specific distribution and target
+   * partition. Metadata is written by {@link
+   * io.camunda.zeebe.engine.state.mutable.MutableDistributionState#addRetriableDistribution(long,
+   * int, long)} (the 3-arg variant) and removed when the retriable entry is removed.
+   *
+   * @param distributionKey the key of the distribution
+   * @param partition the target partition of the distribution
+   * @return an {@link Optional} containing the metadata if present, otherwise empty
+   */
+  Optional<DistributionMetadata> getDistributionMetadata(long distributionKey, int partition);
 
   /**
    * Visits each persisted command distribution {@link PersistedCommandDistribution}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -73,8 +73,8 @@ public interface DistributionState {
   /**
    * Returns the {@link DistributionMetadata} persisted for a specific distribution and target
    * partition. Metadata is written by {@link
-   * io.camunda.zeebe.engine.state.mutable.MutableDistributionState#addRetriableDistribution(long,
-   * int, long)} (the 3-arg variant) and removed when the retriable entry is removed.
+   * io.camunda.zeebe.engine.state.mutable.MutableDistributionState} and removed when the retriable
+   * entry is removed.
    *
    * @param distributionKey the key of the distribution
    * @param partition the target partition of the distribution

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -37,6 +37,16 @@ public interface MutableDistributionState extends DistributionState {
   void addRetriableDistribution(final long distributionKey, final int partition);
 
   /**
+   * Adds a retriable distribution to the state
+   *
+   * @param distributionKey the key of the distribution
+   * @param partition the partition for which the distribution is retriable
+   * @param startTime the start time of the distribution
+   */
+  void addRetriableDistribution(
+      final long distributionKey, final int partition, final long startTime);
+
+  /**
    * Removes a retriable distribution from the state
    *
    * @param distributionKey the key of the retriable distribution that will be removed

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Map;
 import java.util.Optional;
@@ -64,6 +65,7 @@ class CommandDistributionBehaviorTest {
   private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
   private InterPartitionCommandSender mockInterpartitionCommandSender;
   private Writers writers;
+  private ControllableStreamClock clock;
 
   private KeyGenerator keyGenerator;
   private ValueType valueType;
@@ -78,6 +80,7 @@ class CommandDistributionBehaviorTest {
     fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
     writers = new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+    clock = mock(ControllableStreamClock.class);
     keyGenerator = new AtomicKeyGenerator(PARTITION_ID);
     writers.setKeyValidator(keyGenerator);
 
@@ -106,7 +109,8 @@ class CommandDistributionBehaviorTest {
             1,
             RoutingInfo.forStaticPartitions(1),
             mockInterpartitionCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     // when distributing to all partitions
     behavior.withKey(keyGenerator.nextKey()).unordered().distribute(command);
@@ -129,7 +133,8 @@ class CommandDistributionBehaviorTest {
             1,
             RoutingInfo.forStaticPartitions(3),
             mockInterpartitionCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     // when distributing to all partitions
     final var key = keyGenerator.nextKey();
@@ -167,7 +172,8 @@ class CommandDistributionBehaviorTest {
             2,
             RoutingInfo.forStaticPartitions(4),
             mockInterpartitionCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     // when distributing to partitions 1 and 3
     final var key = keyGenerator.nextKey();
@@ -205,7 +211,8 @@ class CommandDistributionBehaviorTest {
             1,
             RoutingInfo.forStaticPartitions(3),
             mockInterpartitionCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     // given command with auth info
     final var authInfo =
@@ -256,7 +263,8 @@ class CommandDistributionBehaviorTest {
             1,
             RoutingInfo.forStaticPartitions(3),
             mockInterpartitionCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     // when distributing first command in queue to all partitions
     final var key = keyGenerator.nextKey();
@@ -292,7 +300,8 @@ class CommandDistributionBehaviorTest {
             1,
             RoutingInfo.forStaticPartitions(3),
             mockInterpartitionCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     final var firstKey = keyGenerator.nextKey();
     final var secondKey = keyGenerator.nextKey();
@@ -340,7 +349,8 @@ class CommandDistributionBehaviorTest {
               PARTITION_ID,
               RoutingInfo.forStaticPartitions(2),
               mockInterpartitionCommandSender,
-              mockDistributionMetrics);
+              mockDistributionMetrics,
+              clock);
     }
 
     @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
@@ -91,7 +92,8 @@ public class CommandDistributionScalingTest {
             1,
             RoutingInfo.dynamic(state.getRoutingState(), RoutingInfo.forStaticPartitions(2)),
             mockInterpartitionCommandSender,
-            mock(DistributionMetrics.class));
+            mock(DistributionMetrics.class),
+            mock(ControllableStreamClock.class));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributionSchedulerTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import java.time.Duration;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +52,7 @@ public class CommandRedistributionSchedulerTest {
   @Mock private DistributionMetrics mockDistributionMetrics;
   @Mock private InterPartitionCommandSender mockCommandSender;
   @Mock private ReadonlyStreamProcessorContext mockContext;
+  @Mock private ControllableStreamClock clock;
 
   private CommandRedistributionScheduler commandRedistributor;
   private long distributionKey;
@@ -141,7 +143,8 @@ public class CommandRedistributionSchedulerTest {
             1,
             routingInfo,
             mockCommandSender,
-            mockDistributionMetrics);
+            mockDistributionMetrics,
+            clock);
 
     final var config =
         new EngineConfiguration()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -45,6 +45,8 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
@@ -90,7 +92,8 @@ public final class MessageStreamProcessorTest {
                 PARTITION_ID,
                 routingInfo,
                 mockInterpartitionCommandSender,
-                mock(DistributionMetrics.class)));
+                mock(DistributionMetrics.class),
+                mock(ControllableStreamClock.class)));
 
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -46,7 +46,6 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -92,6 +92,92 @@ public final class DistributionStateTest {
   }
 
   @Test
+  public void shouldNotPersistMetadataWhenAddRetriableDistributionWithoutStartTime() {
+    // given
+    final var distributionKey = 10L;
+    final var partition = 1;
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
+
+    // when
+    distributionState.addRetriableDistribution(distributionKey, partition);
+
+    // then
+    assertThat(distributionState.getDistributionMetadata(distributionKey, partition)).isEmpty();
+  }
+
+  @Test
+  public void shouldPersistMetadataWhenAddRetriableDistributionWithStartTime() {
+    // given
+    final var distributionKey = 10L;
+    final var partition = 1;
+    final var startTime = 1234567890L;
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
+
+    // when
+    distributionState.addRetriableDistribution(distributionKey, partition, startTime);
+
+    // then
+    assertThat(distributionState.getDistributionMetadata(distributionKey, partition))
+        .hasValueSatisfying(metadata -> assertThat(metadata.getStartTime()).isEqualTo(startTime));
+  }
+
+  @Test
+  public void shouldPersistMetadataPerPartition() {
+    // given
+    final var distributionKey = 10L;
+    final var partitionA = 1;
+    final var partitionB = 2;
+    final var startTimeA = 1111L;
+    final var startTimeB = 2222L;
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
+
+    // when
+    distributionState.addRetriableDistribution(distributionKey, partitionA, startTimeA);
+    distributionState.addRetriableDistribution(distributionKey, partitionB, startTimeB);
+
+    // then
+    assertThat(distributionState.getDistributionMetadata(distributionKey, partitionA))
+        .hasValueSatisfying(metadata -> assertThat(metadata.getStartTime()).isEqualTo(startTimeA));
+    assertThat(distributionState.getDistributionMetadata(distributionKey, partitionB))
+        .hasValueSatisfying(metadata -> assertThat(metadata.getStartTime()).isEqualTo(startTimeB));
+  }
+
+  @Test
+  public void shouldRemoveMetadataWhenRemoveRetriableDistribution() {
+    // given
+    final var distributionKey = 10L;
+    final var partition = 1;
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
+    distributionState.addRetriableDistribution(distributionKey, partition, 1234567890L);
+
+    // when
+    distributionState.removeRetriableDistribution(distributionKey, partition);
+
+    // then
+    assertThat(distributionState.getDistributionMetadata(distributionKey, partition)).isEmpty();
+  }
+
+  @Test
+  public void shouldRemoveRetriableDistributionWhenNoMetadataPresent() {
+    // given
+    final var distributionKey = 10L;
+    final var partition = 1;
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
+    distributionState.addRetriableDistribution(distributionKey, partition);
+
+    // when / then — no metadata was written, removal must still succeed
+    distributionState.removeRetriableDistribution(distributionKey, partition);
+    assertThat(distributionState.hasRetriableDistribution(distributionKey, partition)).isFalse();
+    assertThat(distributionState.getDistributionMetadata(distributionKey, partition)).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnEmptyMetadataWhenNothingStored() {
+    // when / then
+    assertThat(distributionState.getDistributionMetadata(10L, 1)).isEmpty();
+  }
+
+  @Test
   public void shouldReturnFalseOnEmptyStateForHasPendingCheck() {
     // when
     final var hasPending = distributionState.hasPendingDistribution(10L);

--- a/zeebe/engine/src/test/resources/state/appliers/golden/CommandDistribution_DISTRIBUTING_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/CommandDistribution_DISTRIBUTING_v2.golden
@@ -12,18 +12,19 @@ import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 
-public final class CommandDistributionDistributingApplier
+public final class CommandDistributionDistributingApplierV2
     implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
 
   private final MutableDistributionState distributionState;
 
-  public CommandDistributionDistributingApplier(final MutableDistributionState distributionState) {
+  public CommandDistributionDistributingApplierV2(
+      final MutableDistributionState distributionState) {
     this.distributionState = distributionState;
   }
 
   @Override
   public void applyState(final long key, final CommandDistributionRecord value) {
     distributionState.addPendingDistribution(key, value.getPartitionId());
-    distributionState.addRetriableDistribution(key, value.getPartitionId());
+    distributionState.addRetriableDistribution(key, value.getPartitionId(), value.getStartTime());
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -33,6 +33,9 @@
             },
             "commandValue": {
               "enabled": false
+            },
+            "startTime": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -39,6 +39,9 @@
             },
             "commandValue": {
               "enabled": false
+            },
+            "startTime": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -106,7 +106,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final LongProperty startTimeProperty = new LongProperty(START_TIME_KEY, -1L);
 
   public CommandDistributionRecord() {
-    super(5);
+    super(7);
     declareProperty(partitionIdProperty)
         .declareProperty(queueIdProperty)
         .declareProperty(valueTypeProperty)

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.distribution;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
@@ -63,6 +64,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
   private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
+  private static final StringValue START_TIME_KEY = new StringValue("timestamp");
 
   // You'll need to register any of the records value's that you want to distribute
   static {
@@ -101,6 +103,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
       new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
+  private final LongProperty startTimeProperty = new LongProperty(START_TIME_KEY, -1L);
 
   public CommandDistributionRecord() {
     super(5);
@@ -109,7 +112,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(commandValueProperty)
-        .declareProperty(authInfoProperty);
+        .declareProperty(authInfoProperty)
+        .declareProperty(startTimeProperty);
   }
 
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
@@ -220,6 +224,15 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  public long getStartTime() {
+    return startTimeProperty.getValue();
+  }
+
+  public CommandDistributionRecord setStartTime(final long startTimeProperty) {
+    this.startTimeProperty.setValue(startTimeProperty);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -64,7 +64,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
   private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
-  private static final StringValue START_TIME_KEY = new StringValue("timestamp");
+  private static final StringValue START_TIME_KEY = new StringValue("startTime");
 
   // You'll need to register any of the records value's that you want to distribute
   static {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2712,10 +2712,12 @@ final class JsonSerializableToJsonTest {
                   .setValueType(ValueType.DEPLOYMENT)
                   .setIntent(DeploymentIntent.CREATE)
                   .setCommandValue(deploymentRecord)
-                  .setAuthInfo(new AuthInfo().setClaims(Map.of("claim-a", "foo")));
+                  .setAuthInfo(new AuthInfo().setClaims(Map.of("claim-a", "foo")))
+                  .setStartTime(123L);
             },
         """
                 {
+                  "startTime": 123,
                   "partitionId": 1,
                   "queueId": "totally-random-queue-id",
                   "valueType": "DEPLOYMENT",
@@ -2758,6 +2760,7 @@ final class JsonSerializableToJsonTest {
         (Supplier<UnifiedRecordValue>) () -> new CommandDistributionRecord().setPartitionId(1),
         """
                 {
+                  "startTime": -1,
                   "partitionId": 1,
                   "queueId": null,
                   "valueType": "NULL_VAL",

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.distribution;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
@@ -61,6 +62,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
   private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
+  private static final StringValue START_TIME_KEY = new StringValue("timestamp");
 
   // You'll need to register any of the records value's that you want to distribute
   static {
@@ -97,6 +99,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
       new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
+  private final LongProperty startTimeProperty = new LongProperty(START_TIME_KEY, -1L);
 
   public CommandDistributionRecord() {
     super(5);
@@ -105,7 +108,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(commandValueProperty)
-        .declareProperty(authInfoProperty);
+        .declareProperty(authInfoProperty)
+        .declareProperty(startTimeProperty);
   }
 
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
@@ -216,6 +220,15 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  public long getStartTime() {
+    return startTimeProperty.getValue();
+  }
+
+  public CommandDistributionRecord setStartTime(final long startTimeProperty) {
+    this.startTimeProperty.setValue(startTimeProperty);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -28,6 +28,8 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
@@ -86,6 +88,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(
         ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE, BatchOperationPartitionLifecycleRecord::new);
     RECORDS_BY_TYPE.put(ValueType.CLUSTER_VARIABLE, ClusterVariableRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.GLOBAL_LISTENER_BATCH, GlobalListenerBatchRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.GLOBAL_LISTENER, GlobalListenerRecord::new);
   }
 
   private final IntegerProperty partitionIdProperty = new IntegerProperty(PARTITION_ID_KEY);
@@ -102,7 +106,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final LongProperty startTimeProperty = new LongProperty(START_TIME_KEY, -1L);
 
   public CommandDistributionRecord() {
-    super(5);
+    super(7);
     declareProperty(partitionIdProperty)
         .declareProperty(queueIdProperty)
         .declareProperty(valueTypeProperty)

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -62,7 +62,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
   private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
-  private static final StringValue START_TIME_KEY = new StringValue("timestamp");
+  private static final StringValue START_TIME_KEY = new StringValue("startTime");
 
   // You'll need to register any of the records value's that you want to distribute
   static {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -279,7 +279,10 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   ACTIVE_PROCESS_INSTANCE_COUNT(142, PARTITION_LOCAL),
 
   // agent instances (scoped to a process instance, which lives on a single partition)
-  AGENT_INSTANCES(143, PARTITION_LOCAL);
+  AGENT_INSTANCES(143, PARTITION_LOCAL),
+
+  // metadata in a command distribuation record
+  COMMAND_DISTRIBUTION_METADATA(144, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Track the latency of each distribution of a command between two partitions, to be able to better detect cluster issues, i.e., high load or distribution failures.

The approach of this PR is to include a `startTime` property in the `CommandDistributionRecord`, to be used when a command is successfully distributed, and calculate the time it took for a command to be distributed between the `source` and `target` partitions.

ℹ️ This PR was created as part of the Core Bravo team mob-programmign session.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40360
