### PR TITLE
fix: refactor permission deletion to consider overlapping authorizations

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -21,8 +21,10 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DbAuthorizationState implements MutableAuthorizationState {
 
@@ -126,35 +128,70 @@ public class DbAuthorizationState implements MutableAuthorizationState {
   @Override
   public void delete(final long authorizationKey) {
     this.authorizationKey.wrapLong(authorizationKey);
-    final var persistedAuthorization =
-        authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
+    final var authorizationToDelete =
+        authorizationByAuthorizationKeyColumnFamily.get(
+            this.authorizationKey, PersistedAuthorization::new);
 
-    // remove the old permissions
-    persistedAuthorization
+    ownerId.wrapString(authorizationToDelete.getOwnerId());
+    ownerType.wrapString(authorizationToDelete.getOwnerType().name());
+
+    final var overlappingAuthorizationKeys =
+        authorizationKeysByOwnerColumnFamily.get(ownerTypeAndOwnerId);
+
+    // For each authorization key get the authorization and check if it matches the persisted
+    // Authorization ResourceType and ResourceMatcher, collecting the matching authorization
+    // permissions in a set.
+    final var sharedPermissionTypes =
+        overlappingAuthorizationKeys.getAuthorizationKeys().stream()
+            .filter(overlappingKey -> overlappingKey != authorizationToDelete.getAuthorizationKey())
+            .map(
+                key -> {
+                  this.authorizationKey.wrapLong(key);
+                  return authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
+                })
+            .filter(
+                storedAuthorization ->
+                    filterMatchingAuthorization(authorizationToDelete, storedAuthorization))
+            .flatMap(
+                overlappingAuthorization -> overlappingAuthorization.getPermissionTypes().stream())
+            .collect(Collectors.toSet());
+
+    authorizationToDelete
         .getPermissionTypes()
         .forEach(
             permissionType -> {
+              if (sharedPermissionTypes.contains(permissionType)) {
+                return;
+              }
+
               removePermission(
-                  persistedAuthorization.getOwnerType(),
-                  persistedAuthorization.getOwnerId(),
-                  persistedAuthorization.getResourceType(),
+                  authorizationToDelete.getOwnerType(),
+                  authorizationToDelete.getOwnerId(),
+                  authorizationToDelete.getResourceType(),
                   permissionType,
                   Set.of(
                       new AuthorizationScope(
-                          persistedAuthorization.getResourceMatcher(),
-                          persistedAuthorization.getResourceId(),
-                          persistedAuthorization.getResourcePropertyName())));
+                          authorizationToDelete.getResourceMatcher(),
+                          authorizationToDelete.getResourceId(),
+                          authorizationToDelete.getResourcePropertyName())));
             });
 
     // delete the old authorization record
+    this.authorizationKey.wrapLong(authorizationToDelete.getAuthorizationKey());
     authorizationByAuthorizationKeyColumnFamily.deleteExisting(this.authorizationKey);
 
     // remove authorization key from owner
-    ownerId.wrapString(persistedAuthorization.getOwnerId());
-    ownerType.wrapString(persistedAuthorization.getOwnerType().name());
     final var keys = authorizationKeysByOwnerColumnFamily.get(ownerTypeAndOwnerId);
     keys.removeAuthorizationKey(authorizationKey);
     authorizationKeysByOwnerColumnFamily.update(ownerTypeAndOwnerId, keys);
+  }
+
+  private boolean filterMatchingAuthorization(
+      final PersistedAuthorization candidateAuthorization,
+      final PersistedAuthorization storedAuthorization) {
+    return candidateAuthorization.getResourceType() == storedAuthorization.getResourceType()
+        && Objects.equals(
+            candidateAuthorization.getResourceId(), storedAuthorization.getResourceId());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -135,19 +135,20 @@ public class DbAuthorizationState implements MutableAuthorizationState {
     ownerId.wrapString(authorizationToDelete.getOwnerId());
     ownerType.wrapString(authorizationToDelete.getOwnerType().name());
 
-    final var overlappingAuthorizationKeys =
-        authorizationKeysByOwnerColumnFamily.get(ownerTypeAndOwnerId);
+    final var authorizationKeysForOwnerTypeAndOwnerId =
+        authorizationKeysByOwnerColumnFamily.get(ownerTypeAndOwnerId, AuthorizationKeys::new);
+    authorizationKeysForOwnerTypeAndOwnerId.removeAuthorizationKey(authorizationKey);
 
     // For each authorization key get the authorization and check if it matches the persisted
     // Authorization ResourceType and ResourceMatcher, collecting the matching authorization
     // permissions in a set.
     final var sharedPermissionTypes =
-        overlappingAuthorizationKeys.getAuthorizationKeys().stream()
-            .filter(overlappingKey -> overlappingKey != authorizationToDelete.getAuthorizationKey())
+        authorizationKeysForOwnerTypeAndOwnerId.getAuthorizationKeys().stream()
             .map(
                 key -> {
                   this.authorizationKey.wrapLong(key);
-                  return authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
+                  return authorizationByAuthorizationKeyColumnFamily.get(
+                      this.authorizationKey, PersistedAuthorization::new);
                 })
             .filter(Objects::nonNull)
             .filter(
@@ -180,9 +181,8 @@ public class DbAuthorizationState implements MutableAuthorizationState {
     this.authorizationKey.wrapLong(authorizationToDelete.getAuthorizationKey());
     authorizationByAuthorizationKeyColumnFamily.deleteExisting(this.authorizationKey);
 
-    final var keys = authorizationKeysByOwnerColumnFamily.get(ownerTypeAndOwnerId);
-    keys.removeAuthorizationKey(authorizationKey);
-    authorizationKeysByOwnerColumnFamily.update(ownerTypeAndOwnerId, keys);
+    authorizationKeysByOwnerColumnFamily.update(
+        ownerTypeAndOwnerId, authorizationKeysForOwnerTypeAndOwnerId);
   }
 
   private boolean filterMatchingAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -149,6 +149,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
                   this.authorizationKey.wrapLong(key);
                   return authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
                 })
+            .filter(Objects::nonNull)
             .filter(
                 storedAuthorization ->
                     filterMatchingAuthorization(authorizationToDelete, storedAuthorization))
@@ -176,11 +177,9 @@ public class DbAuthorizationState implements MutableAuthorizationState {
                           authorizationToDelete.getResourcePropertyName())));
             });
 
-    // delete the old authorization record
     this.authorizationKey.wrapLong(authorizationToDelete.getAuthorizationKey());
     authorizationByAuthorizationKeyColumnFamily.deleteExisting(this.authorizationKey);
 
-    // remove authorization key from owner
     final var keys = authorizationKeysByOwnerColumnFamily.get(ownerTypeAndOwnerId);
     keys.removeAuthorizationKey(authorizationKey);
     authorizationKeysByOwnerColumnFamily.update(ownerTypeAndOwnerId, keys);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -36,7 +36,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
       new EnumProperty<>("resourceMatcher", AuthorizationResourceMatcher.class);
   private final StringProperty resourceIdProp = new StringProperty("resourceId");
   private final StringProperty resourcePropertyNameProp =
-      new StringProperty("resourcePropertyName");
+      new StringProperty("resourcePropertyName", "");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>("resourceType", AuthorizationResourceType.class);
   private final ArrayProperty<StringValue> permissionTypesProp =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_4.DbSignalSubscriptionMigrat
 import io.camunda.zeebe.engine.state.migration.to_8_5.DbColumnFamilyCorrectionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_6.DbDistributionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_7.DbDistributionMigrationState8dot7;
+import io.camunda.zeebe.engine.state.migration.to_8_8.DbPermissionMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
@@ -131,6 +132,7 @@ public class DbMigrationState implements MutableMigrationState {
   private final DbColumnFamilyCorrectionMigrationState columnFamilyCorrectionMigrationState;
   private final DbDistributionMigrationState distributionState;
   private final DbDistributionMigrationState8dot7 distributionState8dot7;
+  private final DbPermissionMigrationState permissionMigrationState;
 
   public DbMigrationState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -291,6 +293,7 @@ public class DbMigrationState implements MutableMigrationState {
 
     distributionState = new DbDistributionMigrationState(zeebeDb, transactionContext);
     distributionState8dot7 = new DbDistributionMigrationState8dot7(zeebeDb, transactionContext);
+    permissionMigrationState = new DbPermissionMigrationState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -517,5 +520,10 @@ public class DbMigrationState implements MutableMigrationState {
   @Override
   public void migrateIdempotentCommandDistribution() {
     distributionState8dot7.migrateIdempotentCommandDistributions();
+  }
+
+  @Override
+  public void migrateMissingPermissionsForAuthorizations() {
+    permissionMigrationState.migrateMissingPermissionsForAuthorizations();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscrip
 import io.camunda.zeebe.engine.state.migration.to_8_5.ColumnFamilyPrefixCorrectionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistributionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_7.IdempotentCommandDistributionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_8.PermissionStateCorrectionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.util.VersionUtil;
@@ -61,7 +62,8 @@ public class DbMigratorImpl implements DbMigrator {
           new JobBackoffRestoreMigration(),
           new RoutingInfoInitializationMigration(),
           new OrderedCommandDistributionMigration(),
-          new IdempotentCommandDistributionMigration());
+          new IdempotentCommandDistributionMigration(),
+          new PermissionStateCorrectionMigration());
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
   // Be mindful of https://github.com/camunda/camunda/issues/7248. In particular, that issue

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_8/DbPermissionMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_8/DbPermissionMigrationState.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_8;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.authorization.Permissions;
+import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Set;
+
+public class DbPermissionMigrationState {
+  private final DbString ownerType;
+  private final DbString ownerId;
+  private final DbString resourceType;
+  private final DbCompositeKey<DbCompositeKey<DbString, DbString>, DbString>
+      ownerTypeOwnerIdAndResourceType;
+  // owner type + owner id + resource type -> permissions
+  private final ColumnFamily<
+          DbCompositeKey<DbCompositeKey<DbString, DbString>, DbString>, Permissions>
+      permissionsColumnFamily;
+
+  private final ColumnFamily<DbLong, PersistedAuthorization>
+      authorizationByAuthorizationKeyColumnFamily;
+
+  public DbPermissionMigrationState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    ownerType = new DbString();
+    ownerId = new DbString();
+    resourceType = new DbString();
+    final DbCompositeKey<DbString, DbString> ownerTypeAndOwnerId =
+        new DbCompositeKey<>(ownerType, ownerId);
+    ownerTypeOwnerIdAndResourceType = new DbCompositeKey<>(ownerTypeAndOwnerId, resourceType);
+    permissionsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PERMISSIONS,
+            transactionContext,
+            ownerTypeOwnerIdAndResourceType,
+            new Permissions());
+
+    // authorization key -> authorization
+    final DbLong authorizationKey = new DbLong();
+    authorizationByAuthorizationKeyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AUTHORIZATIONS,
+            transactionContext,
+            authorizationKey,
+            new PersistedAuthorization());
+  }
+
+  public void migrateMissingPermissionsForAuthorizations() {
+    authorizationByAuthorizationKeyColumnFamily.forEach(
+        (key, authorization) ->
+            authorization
+                .getPermissionTypes()
+                .forEach(
+                    permissionType -> {
+                      ownerType.wrapString(authorization.getOwnerType().name());
+                      ownerId.wrapString(authorization.getOwnerId());
+                      resourceType.wrapString(authorization.getResourceType().name());
+
+                      final var existingPermissionsForOwner =
+                          permissionsColumnFamily
+                              .get(ownerTypeOwnerIdAndResourceType, Permissions::new)
+                              .getPermissions();
+
+                      if (existingPermissionsForOwner.get(permissionType) == null) {
+                        final var permissionsToStore =
+                            buildPermissionsToStore(authorization, permissionType);
+
+                        permissionsColumnFamily.upsert(
+                            ownerTypeOwnerIdAndResourceType, permissionsToStore);
+                      } else if (!resourceMatchersContainAuthorizationScope(
+                          authorization, existingPermissionsForOwner.get(permissionType))) {
+
+                        final var permissionsToStore =
+                            buildPermissionsToStore(authorization, permissionType);
+                        permissionsColumnFamily.upsert(
+                            ownerTypeOwnerIdAndResourceType, permissionsToStore);
+                      }
+                    }));
+  }
+
+  private boolean resourceMatchersContainAuthorizationScope(
+      final PersistedAuthorization authorization,
+      final Set<AuthorizationScope> authorizationScopes) {
+    final var expectedAuthorizationScope =
+        new AuthorizationScope(
+            authorization.getResourceMatcher(),
+            authorization.getResourceId(),
+            authorization.getResourcePropertyName());
+
+    return authorizationScopes.contains(expectedAuthorizationScope);
+  }
+
+  private Permissions buildPermissionsToStore(
+      final PersistedAuthorization authorization, final PermissionType permissionType) {
+    final var permissions = permissionsColumnFamily.get(ownerTypeOwnerIdAndResourceType);
+
+    permissions.addAuthorizationScope(
+        permissionType,
+        new AuthorizationScope(
+            authorization.getResourceMatcher(),
+            authorization.getResourceId(),
+            authorization.getResourcePropertyName()));
+
+    return permissions;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_8/PermissionStateCorrectionMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_8/PermissionStateCorrectionMigration.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.state.migration.to_8_8;
 import io.camunda.zeebe.engine.state.migration.MigrationTask;
 import io.camunda.zeebe.engine.state.migration.MigrationTaskContext;
 import io.camunda.zeebe.engine.state.migration.MutableMigrationTaskContext;
-import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 public class PermissionStateCorrectionMigration implements MigrationTask {
   @Override
@@ -20,14 +19,7 @@ public class PermissionStateCorrectionMigration implements MigrationTask {
 
   @Override
   public boolean needsToRun(final MigrationTaskContext context) {
-    final var processingState = context.processingState();
-
-    /*
-     * We need to correct any instances where a permission does not exist in the permissions CF but
-     * does exist in a record in the authorizations CF under permissionType. We only need to do this
-     * if we have authorizations present.
-     */
-    return !processingState.isEmpty(ZbColumnFamilies.AUTHORIZATIONS);
+    return true;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_8/PermissionStateCorrectionMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_8/PermissionStateCorrectionMigration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_8;
+
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContext;
+import io.camunda.zeebe.engine.state.migration.MutableMigrationTaskContext;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+
+public class PermissionStateCorrectionMigration implements MigrationTask {
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean needsToRun(final MigrationTaskContext context) {
+    final var processingState = context.processingState();
+
+    /*
+     * We need to correct any instances where a permission does not exist in the permissions CF but
+     * does exist in a record in the authorizations CF under permissionType. We only need to do this
+     * if we have authorizations present.
+     */
+    return !processingState.isEmpty(ZbColumnFamilies.AUTHORIZATIONS);
+  }
+
+  @Override
+  public void runMigration(final MutableMigrationTaskContext context) {
+    context.processingState().getMigrationState().migrateMissingPermissionsForAuthorizations();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -54,4 +54,6 @@ public interface MutableMigrationState extends MigrationState {
   void migrateOrderedCommandDistribution();
 
   void migrateIdempotentCommandDistribution();
+
+  void migrateMissingPermissionsForAuthorizations();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_8/PermissionStateCorrectionMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_8/PermissionStateCorrectionMigrationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_8;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.authorization.DbAuthorizationState;
+import io.camunda.zeebe.engine.state.authorization.Permissions;
+import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContextImpl;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.impl.ClusterContextImpl;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class PermissionStateCorrectionMigrationTest {
+  final PermissionStateCorrectionMigration sut = new PermissionStateCorrectionMigration();
+
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private MutableProcessingState processingState;
+  private TransactionContext transactionContext;
+
+  private DbAuthorizationState state;
+
+  private DbString ownerType;
+  private DbString ownerId;
+  private DbString resourceType;
+  private DbCompositeKey<DbCompositeKey<DbString, DbString>, DbString>
+      ownerTypeOwnerIdAndResourceType;
+  // owner type + owner id + resource type -> permissions
+  private ColumnFamily<DbCompositeKey<DbCompositeKey<DbString, DbString>, DbString>, Permissions>
+      permissionsColumnFamily;
+
+  private ColumnFamily<DbLong, PersistedAuthorization> authorizationByAuthorizationKeyColumnFamily;
+
+  @BeforeEach
+  void setup() {
+    state = new DbAuthorizationState(zeebeDb, transactionContext);
+
+    ownerType = new DbString();
+    ownerId = new DbString();
+    resourceType = new DbString();
+    final DbCompositeKey<DbString, DbString> ownerTypeAndOwnerId =
+        new DbCompositeKey<>(ownerType, ownerId);
+    ownerTypeOwnerIdAndResourceType = new DbCompositeKey<>(ownerTypeAndOwnerId, resourceType);
+    permissionsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PERMISSIONS,
+            transactionContext,
+            ownerTypeOwnerIdAndResourceType,
+            new Permissions());
+
+    // authorization key -> authorization
+    final DbLong authorizationKey = new DbLong();
+    authorizationByAuthorizationKeyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AUTHORIZATIONS,
+            transactionContext,
+            authorizationKey,
+            new PersistedAuthorization());
+  }
+
+  @Test
+  void shouldMigrateWhenPermissionTypeIsMissing() {
+    // given
+    final var authorizationKey = 1L;
+    final var resourceId = "process-definition-1";
+    final var permissionTypes =
+        Set.of(PermissionType.CREATE_PROCESS_INSTANCE, PermissionType.DELETE_PROCESS_INSTANCE);
+    final var authorizationRecord =
+        generateAuthorizationRecord(authorizationKey, resourceId, permissionTypes);
+
+    state.create(authorizationKey, authorizationRecord);
+
+    // verify permissionState is complete
+    ownerType.wrapString(authorizationRecord.getOwnerType().name());
+    ownerId.wrapString(authorizationRecord.getOwnerId());
+    resourceType.wrapString(authorizationRecord.getResourceType().name());
+
+    final var existingPermissionsForOwner =
+        permissionsColumnFamily.get(ownerTypeOwnerIdAndResourceType, Permissions::new);
+
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.CREATE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId));
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.DELETE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId));
+
+    // here we want to put the permissions CF into a state where one permission is missing
+    // to allow the migration to add it back
+    existingPermissionsForOwner.removeAuthorizationScopes(
+        PermissionType.CREATE_PROCESS_INSTANCE, Set.of(AuthorizationScope.of(resourceId)));
+
+    permissionsColumnFamily.upsert(ownerTypeOwnerIdAndResourceType, existingPermissionsForOwner);
+
+    assertThat(existingPermissionsForOwner.getPermissions())
+        .doesNotContainKey(PermissionType.CREATE_PROCESS_INSTANCE);
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.DELETE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId));
+
+    // verify that after the migration is run, the missing permission is added back
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    assertThat(sut.needsToRun(context)).isTrue();
+    sut.runMigration(context);
+
+    final var permissionsAfterMigration =
+        permissionsColumnFamily.get(ownerTypeOwnerIdAndResourceType, Permissions::new);
+    assertThat(
+            permissionsAfterMigration.getPermissions().get(PermissionType.CREATE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId));
+    assertThat(
+            permissionsAfterMigration.getPermissions().get(PermissionType.DELETE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId));
+  }
+
+  @Test
+  void shouldMigrateWhenAuthorizationScopeIsMissing() {
+    // given
+    final var authorizationKey1 = 1L;
+    final var resourceId1 = "process-definition-1";
+    final var permissionTypes1 =
+        Set.of(PermissionType.CREATE_PROCESS_INSTANCE, PermissionType.DELETE_PROCESS_INSTANCE);
+    final var authorizationRecord1 =
+        generateAuthorizationRecord(authorizationKey1, resourceId1, permissionTypes1);
+
+    state.create(authorizationKey1, authorizationRecord1);
+
+    final var authorizationKey2 = 2L;
+    final var resourceId2 = "process-definition-2";
+    final var permissionTypes2 = Set.of(PermissionType.CREATE_PROCESS_INSTANCE);
+    final var authorizationRecord2 =
+        generateAuthorizationRecord(authorizationKey2, resourceId2, permissionTypes2);
+
+    state.create(authorizationKey2, authorizationRecord2);
+
+    // verify permissionState is complete
+    ownerType.wrapString(authorizationRecord1.getOwnerType().name());
+    ownerId.wrapString(authorizationRecord1.getOwnerId());
+    resourceType.wrapString(authorizationRecord1.getResourceType().name());
+
+    final var existingPermissionsForOwner =
+        permissionsColumnFamily.get(ownerTypeOwnerIdAndResourceType, Permissions::new);
+
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.CREATE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactlyInAnyOrder(
+            AuthorizationScope.of(resourceId1), AuthorizationScope.of(resourceId2));
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.DELETE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId1));
+
+    // here we want to put the permissions CF into a state where one permission is missing
+    // to allow the migration to add it back
+    existingPermissionsForOwner.removeAuthorizationScopes(
+        PermissionType.CREATE_PROCESS_INSTANCE, Set.of(AuthorizationScope.of(resourceId1)));
+
+    permissionsColumnFamily.upsert(ownerTypeOwnerIdAndResourceType, existingPermissionsForOwner);
+
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.CREATE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId2));
+    assertThat(
+            existingPermissionsForOwner
+                .getPermissions()
+                .get(PermissionType.DELETE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId1));
+
+    // verify that after the migration is run, the missing permission is added back
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    assertThat(sut.needsToRun(context)).isTrue();
+    sut.runMigration(context);
+
+    final var permissionsAfterMigration =
+        permissionsColumnFamily.get(ownerTypeOwnerIdAndResourceType, Permissions::new);
+    assertThat(
+            permissionsAfterMigration.getPermissions().get(PermissionType.CREATE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactlyInAnyOrder(
+            AuthorizationScope.of(resourceId1), AuthorizationScope.of(resourceId2));
+    assertThat(
+            permissionsAfterMigration.getPermissions().get(PermissionType.DELETE_PROCESS_INSTANCE))
+        .isNotEmpty()
+        .containsExactly(AuthorizationScope.of(resourceId1));
+  }
+
+  private static AuthorizationRecord generateAuthorizationRecord(
+      final long authorizationKey,
+      final String resourceId,
+      final Set<PermissionType> permissionTypes) {
+    final var authorizationRecord = new AuthorizationRecord();
+    authorizationRecord.setAuthorizationKey(authorizationKey);
+    authorizationRecord.setOwnerType(AuthorizationOwnerType.USER);
+    authorizationRecord.setOwnerId("user-1");
+    authorizationRecord.setResourceType(AuthorizationResourceType.PROCESS_DEFINITION);
+    authorizationRecord.setResourceId(resourceId);
+    authorizationRecord.setResourceMatcher(AuthorizationResourceMatcher.ID);
+    authorizationRecord.setPermissionTypes(permissionTypes);
+    return authorizationRecord;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The linked issue contains deeper context for the fix so I would strongly suggest reviewing there also, specifically the rootcause investigation comment [here](https://github.com/camunda/camunda/issues/40276#issuecomment-3583481909).

The core of this change is to make the deletion logic against the permissions CF more intelligent/tollerant in situations where a permission is shared across different authorizations but only one authorization is deleted (therefore the permission must remain in the CF to support the remaining authorization).

There are conversations regarding the usage patterns of these flows, for example, not allowing duplicate `ownerId+ownerType+resourceId+resourceType` keys with different permission sets (that can be then updated causing the bug) but that is a broader topic that I am not addressing with this PR :)

## Related issues

closes #40276
