### PR TITLE
fix: run docker tool checks on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -796,10 +796,10 @@ jobs:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"
     needs: [ detect-changes ]
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-4-default
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       security-events: write
     services:


### PR DESCRIPTION
## Description

This PR makes `docker-checks` executed on a self-hosted runner. The 14 GB SSD of the managed runners is often not enough, or very tight at best. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

https://camunda.slack.com/archives/C071KP5BTHB/p1764758120609829