### PR TITLE
[Backport stable/8.8] fix: convert block comments to javadoc in CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -810,7 +810,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   ProcessDefinitionGetRequest newProcessDefinitionGetRequest(long processDefinitionKey);
 
-  /*
+  /**
    * Retrieves the XML representation of a process definition.
    *
    * <pre>
@@ -826,7 +826,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   ProcessDefinitionGetXmlRequest newProcessDefinitionGetXmlRequest(long processDefinitionKey);
 
-  /*
+  /**
    * Retrieves the Form of a process definition.
    *
    * <pre>
@@ -1042,7 +1042,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   DecisionRequirementsSearchRequest newDecisionRequirementsSearchRequest();
 
-  /*
+  /**
    * Executes a search request to query decision definitions.
    *
    * <pre>
@@ -1076,7 +1076,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   DecisionDefinitionGetRequest newDecisionDefinitionGetRequest(long decisionDefinitionKey);
 
-  /*
+  /**
    * Retrieves the XML representation of a decision definition.
    *
    * <pre>
@@ -1126,11 +1126,11 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   DecisionInstanceGetRequest newDecisionInstanceGetRequest(String decisionInstanceId);
 
-  /*
-   * Executes a search request to query decision definitions.
+  /**
+   * Executes a search request to query incidents.
    *
    * <pre>
-   * long decisionDefinitionKey = ...;
+   * long processInstanceKey = ...;
    *
    * camundaClient
    *  .newIncidentSearchRequest()
@@ -1719,7 +1719,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   CreateMappingRuleCommandStep1 newCreateMappingRuleCommand();
 
-  /*
+  /**
    * Retrieves the XML representation of a decision requirements.
    *
    * <pre>


### PR DESCRIPTION
# Description
Backport of #41852 to `stable/8.8`.

relates to 