### PR TITLE
build: add upgrade factory to 8.7.15

### DIFF
--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8714To8715PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8714To8715PlanFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.upgrade.plan.factories;
+
+import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
+import io.camunda.optimize.upgrade.plan.UpgradePlan;
+import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Upgrade8714To8715PlanFactory implements UpgradePlanFactory {
+
+  @Override
+  public UpgradePlan createUpgradePlan(final UpgradeExecutionDependencies dependencies) {
+    return UpgradePlanBuilder.createUpgradePlan().fromVersion("8.7.14").toVersion("8.7.15").build();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Update the missing upgrade factory to rerelease Optimize with an upgrade path from 8.7.14 to 8.7.15.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
