### PR TITLE
Implement trigger processor for conditional catch events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstruc
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.conditional.ConditionalTriggerProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionChecker;
@@ -45,6 +46,7 @@ import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -101,6 +103,7 @@ public final class BpmnProcessors {
         transientProcessMessageSubscriptionState);
     addTimerStreamProcessors(
         typedRecordProcessors, timerChecker, processingState, bpmnBehaviors, writers);
+    addConditionalStreamProcessors(typedRecordProcessors, processingState, bpmnBehaviors, writers);
     addVariableDocumentStreamProcessors(
         typedRecordProcessors,
         bpmnBehaviors,
@@ -135,6 +138,17 @@ public final class BpmnProcessors {
         typedRecordProcessors, processingState, writers, authCheckBehavior, bpmnBehaviors);
 
     return bpmnStreamProcessor;
+  }
+
+  private static void addConditionalStreamProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final MutableProcessingState processingState,
+      final BpmnBehaviors bpmnBehaviors,
+      final Writers writers) {
+    typedRecordProcessors.onCommand(
+        ValueType.CONDITIONAL_SUBSCRIPTION,
+        ConditionalSubscriptionIntent.TRIGGER,
+        new ConditionalTriggerProcessor(processingState, bpmnBehaviors, writers));
   }
 
   private static void addProcessInstanceCommandProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalTriggerProcessor.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.conditional;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ConditionalSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+@ExcludeAuthorizationCheck
+public class ConditionalTriggerProcessor
+    implements TypedRecordProcessor<ConditionalSubscriptionRecord> {
+
+  private static final String NO_CONDITIONAL_FOUND_MESSAGE =
+      "Expected to trigger condition subscription with key '%d', but no such subscription was found "
+          + "for process instance with key '%d' and catch event id '%s'.";
+
+  private static final String NO_ACTIVE_ELEMENT_FOUND_FOR_CONDITIONAL_MESSAGE =
+      "Expected to trigger condition subscription with key '%d', but the element with key '%s' is "
+          + "not active anymore for process instance with key '%d' and catch event id '%s'.";
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+
+  private final ConditionalSubscriptionState conditionSubscriptionState;
+  private final ProcessState processState;
+  private final ElementInstanceState elementInstanceState;
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+
+  private final EventHandle eventHandle;
+
+  public ConditionalTriggerProcessor(
+      final MutableProcessingState processingState,
+      final BpmnBehaviors bpmnBehaviors,
+      final Writers writers) {
+    conditionSubscriptionState = processingState.getConditionalSubscriptionState();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    keyGenerator = processingState.getKeyGenerator();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    eventHandle =
+        new EventHandle(
+            keyGenerator,
+            processingState.getEventScopeInstanceState(),
+            writers,
+            processState,
+            bpmnBehaviors.eventTriggerBehavior(),
+            bpmnBehaviors.stateBehavior());
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ConditionalSubscriptionRecord> record) {
+    final var subscription = record.getValue();
+    final String tenantId = subscription.getTenantId();
+
+    final boolean exists = conditionSubscriptionState.exists(tenantId, record.getKey());
+    if (!exists) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.NOT_FOUND,
+          String.format(
+              NO_CONDITIONAL_FOUND_MESSAGE,
+              record.getKey(),
+              subscription.getProcessInstanceKey(),
+              subscription.getCatchEventId()));
+      return;
+    }
+
+    final var elementInstanceKey = subscription.getElementInstanceKey();
+    final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+    final DirectBuffer catchEventIdBuffer = subscription.getCatchEventIdBuffer();
+    if (!eventHandle.canTriggerElement(elementInstance, catchEventIdBuffer)) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.INVALID_STATE,
+          String.format(
+              NO_ACTIVE_ELEMENT_FOUND_FOR_CONDITIONAL_MESSAGE,
+              record.getKey(),
+              elementInstanceKey,
+              subscription.getProcessInstanceKey(),
+              subscription.getCatchEventId()));
+      return;
+    }
+
+    final boolean isStartEvent = elementInstanceKey < 0;
+    if (isStartEvent) {
+      final long processInstanceKey = keyGenerator.nextKey();
+      subscription.setProcessInstanceKey(processInstanceKey);
+      stateWriter.appendFollowUpEvent(
+          record.getKey(), ConditionalSubscriptionIntent.TRIGGERED, subscription);
+      eventHandle.activateProcessInstanceForStartEvent(
+          subscription.getProcessDefinitionKey(),
+          processInstanceKey,
+          subscription.getCatchEventIdBuffer(),
+          NO_VARIABLES, // TODO - this needs to updated to pass variables from the condition
+          tenantId);
+    } else {
+      stateWriter.appendFollowUpEvent(
+          record.getKey(), ConditionalSubscriptionIntent.TRIGGERED, subscription);
+    }
+
+    final var catchEvent =
+        processState.getFlowElement(
+            subscription.getProcessDefinitionKey(),
+            tenantId,
+            catchEventIdBuffer,
+            ExecutableCatchEvent.class);
+    eventHandle.activateElement(catchEvent, elementInstanceKey, elementInstance.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalTriggerProcessor.java
@@ -31,12 +31,12 @@ import org.agrona.concurrent.UnsafeBuffer;
 public class ConditionalTriggerProcessor
     implements TypedRecordProcessor<ConditionalSubscriptionRecord> {
 
-  private static final String NO_CONDITIONAL_FOUND_MESSAGE =
+  private static final String NO_CONDITIONAL_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to trigger condition subscription with key '%d', but no such subscription was found "
           + "for process instance with key '%d' and catch event id '%s'.";
 
   private static final String NO_ACTIVE_ELEMENT_FOUND_FOR_CONDITIONAL_MESSAGE =
-      "Expected to trigger condition subscription with key '%d', but the element with key '%s' is "
+      "Expected to trigger condition subscription with key '%d', but the element with key '%d' is "
           + "not active anymore for process instance with key '%d' and catch event id '%s'.";
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
@@ -80,7 +80,7 @@ public class ConditionalTriggerProcessor
           record,
           RejectionType.NOT_FOUND,
           String.format(
-              NO_CONDITIONAL_FOUND_MESSAGE,
+              NO_CONDITIONAL_SUBSCRIPTION_FOUND_MESSAGE,
               record.getKey(),
               subscription.getProcessInstanceKey(),
               subscription.getCatchEventId()));
@@ -115,11 +115,11 @@ public class ConditionalTriggerProcessor
           subscription.getCatchEventIdBuffer(),
           NO_VARIABLES, // TODO - this needs to updated to pass variables from the condition
           tenantId);
-    } else {
-      stateWriter.appendFollowUpEvent(
-          record.getKey(), ConditionalSubscriptionIntent.TRIGGERED, subscription);
+      return;
     }
 
+    stateWriter.appendFollowUpEvent(
+        record.getKey(), ConditionalSubscriptionIntent.TRIGGERED, subscription);
     final var catchEvent =
         processState.getFlowElement(
             subscription.getProcessDefinitionKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/conditional/DbConditionalSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/conditional/DbConditionalSubscriptionState.java
@@ -61,4 +61,12 @@ public class DbConditionalSubscriptionState implements MutableConditionalSubscri
 
     conditionalKeyColumnFamily.deleteExisting(tenantAwareSubscriptionKey);
   }
+
+  @Override
+  public boolean exists(final String tenantId, final long subscriptionKey) {
+    this.subscriptionKey.wrapLong(subscriptionKey);
+    tenantIdKey.wrapString(tenantId);
+
+    return conditionalKeyColumnFamily.exists(tenantAwareSubscriptionKey);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ConditionalSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ConditionalSubscriptionState.java
@@ -7,4 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
-public interface ConditionalSubscriptionState {}
+public interface ConditionalSubscriptionState {
+
+  boolean exists(String tenantId, long subscriptionKey);
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalBoundaryEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalBoundaryEventTest.java
@@ -11,11 +11,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -33,22 +37,24 @@ public final class ConditionalBoundaryEventTest {
   public void shouldTriggerOnBoundaryEventActivationWhenConditionIsTrue() {
     // given
     final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId = "boundary";
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
                     .startEvent()
-                    .serviceTask("task")
-                    .zeebeJobType("task")
-                    .boundaryEvent("boundary")
+                    .serviceTask(serviceTaskId)
+                    .zeebeJobType(serviceTaskId)
+                    .boundaryEvent(catchEventId)
                     .condition(
                         c ->
                             c.condition("=x > y")
                                 .zeebeVariableNames("x, y")
                                 .zeebeVariableEvents("create, update"))
                     .endEvent()
-                    .moveToActivity("task")
+                    .moveToActivity(serviceTaskId)
                     .endEvent()
                     .done())
             .deploy();
@@ -68,9 +74,21 @@ public final class ConditionalBoundaryEventTest {
     final long serviceTaskKey =
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task")
+            .withElementId(serviceTaskId)
             .getFirst()
             .getKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
 
     final long subscriptionKey =
         RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
@@ -78,38 +96,44 @@ public final class ConditionalBoundaryEventTest {
             .getKey();
 
     assertThat(
-            RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
+            RecordingExporter.conditionalSubscriptionRecords()
                 .withRecordKey(subscriptionKey)
                 .withScopeKey(serviceTaskKey)
                 .withElementInstanceKey(serviceTaskKey)
                 .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(processDefinitionKey)
-                .withCatchEventId("boundary")
+                .withCatchEventId(catchEventId)
                 .withCondition("=x > y")
                 .withVariableNames("x", "y")
                 .withVariableEvents("create", "update")
                 .isInterrupting(true)
                 .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-                .limit(1))
-        .hasSize(1);
+                .limit(3))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ConditionalSubscriptionIntent.CREATED,
+            ConditionalSubscriptionIntent.TRIGGER,
+            ConditionalSubscriptionIntent.TRIGGERED);
   }
 
   @Test
   public void shouldTriggerOnBoundaryEventActivationWhenConditionIsTrueWithoutFilters() {
     // given
     final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId = "boundary";
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
                     .startEvent()
-                    .serviceTask("task")
-                    .zeebeJobType("task")
-                    .boundaryEvent("boundary")
+                    .serviceTask(serviceTaskId)
+                    .zeebeJobType(serviceTaskId)
+                    .boundaryEvent(catchEventId)
                     .condition(c -> c.condition("=x > y"))
                     .endEvent()
-                    .moveToActivity("task")
+                    .moveToActivity(serviceTaskId)
                     .endEvent()
                     .done())
             .deploy();
@@ -129,9 +153,21 @@ public final class ConditionalBoundaryEventTest {
     final long serviceTaskKey =
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task")
+            .withElementId(serviceTaskId)
             .getFirst()
             .getKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
 
     final long subscriptionKey =
         RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
@@ -139,43 +175,50 @@ public final class ConditionalBoundaryEventTest {
             .getKey();
 
     assertThat(
-            RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
+            RecordingExporter.conditionalSubscriptionRecords()
                 .withRecordKey(subscriptionKey)
                 .withScopeKey(serviceTaskKey)
                 .withElementInstanceKey(serviceTaskKey)
                 .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(processDefinitionKey)
-                .withCatchEventId("boundary")
+                .withCatchEventId(catchEventId)
                 .withCondition("=x > y")
                 .withVariableNames(List.of())
                 .withVariableEvents(List.of())
                 .isInterrupting(true)
                 .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-                .limit(1))
-        .hasSize(1);
+                .limit(3))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ConditionalSubscriptionIntent.CREATED,
+            ConditionalSubscriptionIntent.TRIGGER,
+            ConditionalSubscriptionIntent.TRIGGERED);
   }
 
   @Test
   public void shouldTriggerOnBoundaryEventActivationWhenConditionIsTrueForNonInterrupting() {
     // given
     final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId = "boundary";
+    final String catchEventEndId = "end";
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
                     .startEvent()
-                    .serviceTask("task")
-                    .zeebeJobType("task")
-                    .boundaryEvent("boundary")
+                    .serviceTask(serviceTaskId)
+                    .zeebeJobType(serviceTaskId)
+                    .boundaryEvent(catchEventId)
                     .cancelActivity(false)
                     .condition(
                         c ->
                             c.condition("=x > y")
                                 .zeebeVariableNames("x, y")
                                 .zeebeVariableEvents("create, update"))
-                    .endEvent()
-                    .moveToActivity("task")
+                    .endEvent(catchEventEndId)
+                    .moveToActivity(serviceTaskId)
                     .endEvent()
                     .done())
             .deploy();
@@ -191,33 +234,63 @@ public final class ConditionalBoundaryEventTest {
             .withVariables(Map.of("x", 2, "y", 1))
             .create();
 
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(serviceTaskId)
+        .await();
+
+    final Record<JobBatchRecordValue> batchRecord =
+        engine.jobs().withType(serviceTaskId).activate();
+    engine.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete();
+
     // then
     final long serviceTaskKey =
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task")
+            .withElementId(serviceTaskId)
             .getFirst()
             .getKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(catchEventEndId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventEndId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
     final long subscriptionKey =
         RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
             .getFirst()
             .getKey();
 
     assertThat(
-            RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
+            RecordingExporter.conditionalSubscriptionRecords()
                 .withRecordKey(subscriptionKey)
                 .withScopeKey(serviceTaskKey)
                 .withElementInstanceKey(serviceTaskKey)
                 .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(processDefinitionKey)
-                .withCatchEventId("boundary")
+                .withCatchEventId(catchEventId)
                 .withCondition("=x > y")
                 .withVariableNames("x", "y")
                 .withVariableEvents("create", "update")
                 .isInterrupting(false)
                 .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-                .limit(1))
-        .hasSize(1);
+                .limit(3))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ConditionalSubscriptionIntent.CREATED,
+            ConditionalSubscriptionIntent.TRIGGER,
+            ConditionalSubscriptionIntent.TRIGGERED);
   }
 
   @Test
@@ -225,22 +298,24 @@ public final class ConditionalBoundaryEventTest {
     // given
     final String processId = helper.getBpmnProcessId();
     final String tenantId = "tenant1";
+    final String serviceTaskId = "task";
+    final String catchEventId = "boundary";
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
                     .startEvent()
-                    .serviceTask("task")
-                    .zeebeJobType("task")
-                    .boundaryEvent("boundary")
+                    .serviceTask(serviceTaskId)
+                    .zeebeJobType(serviceTaskId)
+                    .boundaryEvent(catchEventId)
                     .condition(
                         c ->
                             c.condition("=x > y")
                                 .zeebeVariableNames("x, y")
                                 .zeebeVariableEvents("create, update"))
                     .endEvent()
-                    .moveToActivity("task")
+                    .moveToActivity(serviceTaskId)
                     .endEvent()
                     .done())
             .withTenantId(tenantId)
@@ -262,9 +337,21 @@ public final class ConditionalBoundaryEventTest {
     final long serviceTaskKey =
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task")
+            .withElementId(serviceTaskId)
             .getFirst()
             .getKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
 
     final long subscriptionKey =
         RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
@@ -272,50 +359,170 @@ public final class ConditionalBoundaryEventTest {
             .getKey();
 
     assertThat(
-            RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
+            RecordingExporter.conditionalSubscriptionRecords()
                 .withRecordKey(subscriptionKey)
                 .withScopeKey(serviceTaskKey)
                 .withElementInstanceKey(serviceTaskKey)
                 .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(processDefinitionKey)
-                .withCatchEventId("boundary")
+                .withCatchEventId(catchEventId)
                 .withCondition("=x > y")
                 .withVariableNames("x", "y")
                 .withVariableEvents("create", "update")
                 .isInterrupting(true)
                 .withTenantId(tenantId)
-                .limit(1))
-        .hasSize(1);
+                .limit(3))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ConditionalSubscriptionIntent.CREATED,
+            ConditionalSubscriptionIntent.TRIGGER,
+            ConditionalSubscriptionIntent.TRIGGERED);
   }
 
   @Test
   public void shouldTriggerMultipleTimesOnBoundaryEventActivationWhenConditionIsTrue() {
     // given
     final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId1 = "boundary1";
+    final String catchEventId2 = "boundary2";
+    final String catchEventEndId1 = "end1";
+    final String catchEventEndId2 = "end2";
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
                     .startEvent()
-                    .serviceTask("task")
-                    .zeebeJobType("task")
-                    .boundaryEvent("boundary1")
+                    .serviceTask(serviceTaskId)
+                    .zeebeJobType(serviceTaskId)
+                    .boundaryEvent(catchEventId1)
+                    .cancelActivity(false)
                     .condition(
                         c ->
                             c.condition("=x > y")
                                 .zeebeVariableNames("x, y")
                                 .zeebeVariableEvents("create, update"))
-                    .endEvent()
-                    .moveToActivity("task")
-                    .boundaryEvent("boundary2")
+                    .endEvent(catchEventEndId1)
+                    .moveToActivity(serviceTaskId)
+                    .boundaryEvent(catchEventId2)
+                    .cancelActivity(false)
                     .condition(
                         c ->
                             c.condition("=x != y")
                                 .zeebeVariableNames("x, y")
                                 .zeebeVariableEvents("create, update"))
+                    .endEvent(catchEventEndId2)
+                    .moveToActivity(serviceTaskId)
                     .endEvent()
-                    .moveToActivity("task")
+                    .done())
+            .deploy();
+
+    final long processDefinitionKey =
+        deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey();
+
+    // when
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(Map.of("x", 2, "y", 1))
+            .create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(serviceTaskId)
+        .await();
+
+    final Record<JobBatchRecordValue> batchRecord =
+        engine.jobs().withType(serviceTaskId).activate();
+    engine.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete();
+
+    // then
+    final long serviceTaskKey =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(serviceTaskId)
+            .getFirst()
+            .getKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(catchEventId2, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(catchEventId1, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId1, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(catchEventEndId2, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventEndId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(catchEventEndId1, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventEndId1, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertThat(
+            RecordingExporter.conditionalSubscriptionRecords()
+                .withScopeKey(serviceTaskKey)
+                .withElementInstanceKey(serviceTaskKey)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withVariableNames("x", "y")
+                .withVariableEvents("create", "update")
+                .isInterrupting(false)
+                .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+                .limit(6))
+        .extracting(
+            Record::getIntent,
+            r -> r.getValue().getCatchEventId(),
+            r -> r.getValue().getCondition())
+        .containsSubsequence(
+            tuple(ConditionalSubscriptionIntent.CREATED, catchEventId2, "=x != y"),
+            tuple(ConditionalSubscriptionIntent.TRIGGER, catchEventId2, "=x != y"),
+            tuple(ConditionalSubscriptionIntent.CREATED, catchEventId1, "=x > y"),
+            tuple(ConditionalSubscriptionIntent.TRIGGER, catchEventId1, "=x > y"),
+            tuple(ConditionalSubscriptionIntent.TRIGGERED, catchEventId2, "=x != y"),
+            tuple(ConditionalSubscriptionIntent.TRIGGERED, catchEventId1, "=x > y"));
+  }
+
+  @Test
+  public void shouldRejectConditionalEventTriggerCommandWhenScopeIsAlreadyInterrupted() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId1 = "boundary1";
+    final String catchEventId2 = "boundary2";
+    final String catchEventEndId1 = "end1";
+    final String catchEventEndId2 = "end2";
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(serviceTaskId)
+                    .zeebeJobType(serviceTaskId)
+                    .boundaryEvent(catchEventId1)
+                    .condition(
+                        c ->
+                            c.condition("=x > y")
+                                .zeebeVariableNames("x, y")
+                                .zeebeVariableEvents("create, update"))
+                    .endEvent(catchEventEndId1)
+                    .moveToActivity(serviceTaskId)
+                    .boundaryEvent(catchEventId2)
+                    .condition(
+                        c ->
+                            c.condition("=x != y")
+                                .zeebeVariableNames("x, y")
+                                .zeebeVariableEvents("create, update"))
+                    .endEvent(catchEventEndId2)
+                    .moveToActivity(serviceTaskId)
                     .endEvent()
                     .done())
             .deploy();
@@ -335,26 +542,214 @@ public final class ConditionalBoundaryEventTest {
     final long serviceTaskKey =
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task")
+            .withElementId(serviceTaskId)
             .getFirst()
             .getKey();
 
     assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(serviceTaskId, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(catchEventId2, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(catchEventEndId2, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(catchEventEndId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final long subscriptionKey2 =
+        RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
+            .withCatchEventId(catchEventId2)
+            .getFirst()
+            .getKey();
+
+    assertThat(
+            RecordingExporter.conditionalSubscriptionRecords()
+                .withRecordKey(subscriptionKey2)
+                .withScopeKey(serviceTaskKey)
+                .withElementInstanceKey(serviceTaskKey)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .withCatchEventId(catchEventId2)
+                .withCondition("=x != y")
+                .withVariableNames("x", "y")
+                .withVariableEvents("create", "update")
+                .isInterrupting(true)
+                .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+                .limit(3))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ConditionalSubscriptionIntent.CREATED,
+            ConditionalSubscriptionIntent.TRIGGER,
+            ConditionalSubscriptionIntent.TRIGGERED);
+
+    final long subscriptionKey1 =
+        RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
+            .withCatchEventId(catchEventId1)
+            .getFirst()
+            .getKey();
+
+    Assertions.assertThat(
             RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
                 .withScopeKey(serviceTaskKey)
                 .withElementInstanceKey(serviceTaskKey)
                 .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(processDefinitionKey)
+                .withCatchEventId(catchEventId1)
+                .withCondition("=x > y")
                 .withVariableNames("x", "y")
                 .withVariableEvents("create", "update")
                 .isInterrupting(true)
                 .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-                .limit(2))
-        .extracting(Record::getValue)
-        .extracting(
-            ConditionalSubscriptionRecordValue::getCatchEventId,
-            ConditionalSubscriptionRecordValue::getCondition)
-        .containsExactlyInAnyOrder(tuple("boundary1", "=x > y"), tuple("boundary2", "=x != y"));
+                .onlyCommandRejections()
+                .limit(1)
+                .getFirst())
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                "Expected to trigger condition subscription with key '%d', but the element with key "
+                    + "'%d' is not active anymore for process instance with key '%d' and catch "
+                    + "event id '%s'.",
+                subscriptionKey1, serviceTaskKey, processInstanceKey, catchEventId1));
+  }
+
+  @Test
+  public void shouldRejectConditionalEventTriggerCommandWhenSubscriptionDeleted() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId = "boundary";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(serviceTaskId)
+                .zeebeJobType(serviceTaskId)
+                .boundaryEvent(catchEventId)
+                .condition(
+                    c ->
+                        c.condition("=x > y")
+                            .zeebeVariableNames("x, y")
+                            .zeebeVariableEvents("create, update"))
+                .endEvent()
+                .moveToActivity(serviceTaskId)
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    // do not set variables yet to avoid triggering the condition
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(serviceTaskId)
+        .await();
+
+    engine.pauseProcessing(1);
+    engine.stop();
+
+    final var conditionalRecord =
+        RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
+            .getFirst();
+    final long subscriptionKey = conditionalRecord.getKey();
+    engine.writeRecords(
+        RecordToWrite.event()
+            .conditional(ConditionalSubscriptionIntent.DELETED, conditionalRecord.getValue())
+            .key(subscriptionKey),
+        RecordToWrite.command()
+            .conditional(ConditionalSubscriptionIntent.TRIGGER, conditionalRecord.getValue())
+            .key(subscriptionKey));
+
+    engine.start();
+
+    // then
+    final var rejection =
+        RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to trigger condition subscription with key '%d', but no such subscription was "
+                    + "found for process instance with key '%d' and catch event id '%s'.",
+                subscriptionKey, processInstanceKey, catchEventId));
+  }
+
+  @Test
+  public void shouldRejectConditionalEventTriggerCommandWhenSubscriptionTriggered() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String serviceTaskId = "task";
+    final String catchEventId = "boundary";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(serviceTaskId)
+                .zeebeJobType(serviceTaskId)
+                .boundaryEvent(catchEventId)
+                .condition(
+                    c ->
+                        c.condition("=x > y")
+                            .zeebeVariableNames("x, y")
+                            .zeebeVariableEvents("create, update"))
+                .endEvent()
+                .moveToActivity(serviceTaskId)
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    // do not set variables yet to avoid triggering the condition
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(serviceTaskId)
+        .await();
+
+    engine.pauseProcessing(1);
+    engine.stop();
+
+    final var conditionalRecord =
+        RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.CREATED)
+            .getFirst();
+    final long subscriptionKey = conditionalRecord.getKey();
+    engine.writeRecords(
+        RecordToWrite.event()
+            .conditional(ConditionalSubscriptionIntent.TRIGGERED, conditionalRecord.getValue())
+            .key(subscriptionKey),
+        RecordToWrite.command()
+            .conditional(ConditionalSubscriptionIntent.TRIGGER, conditionalRecord.getValue())
+            .key(subscriptionKey));
+
+    engine.start();
+
+    // then
+    final var rejection =
+        RecordingExporter.conditionalSubscriptionRecords(ConditionalSubscriptionIntent.TRIGGER)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to trigger condition subscription with key '%d', but no such subscription was "
+                    + "found for process instance with key '%d' and catch event id '%s'.",
+                subscriptionKey, processInstanceKey, catchEventId));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentReco
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
@@ -41,6 +43,7 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
@@ -191,6 +194,13 @@ public final class RecordToWrite implements LogAppendEntry {
       final AdHocSubProcessInstructionRecordValue value) {
     recordMetadata.valueType(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION).intent(intent);
     unifiedRecordValue = (AdHocSubProcessInstructionRecord) value;
+    return this;
+  }
+
+  public RecordToWrite conditional(
+      final ConditionalSubscriptionIntent intent, final ConditionalSubscriptionRecordValue value) {
+    recordMetadata.valueType(ValueType.CONDITIONAL_SUBSCRIPTION).intent(intent);
+    unifiedRecordValue = (ConditionalSubscriptionRecord) value;
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.conditional;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -147,9 +148,10 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     return bufferAsString(catchEventIdProp.getValue());
   }
 
-  public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
-    catchEventIdProp.setValue(catchEventId);
-    return this;
+  @Override
+  @JsonIgnore
+  public DirectBuffer getCatchEventIdBuffer() {
+    return catchEventIdProp.getValue();
   }
 
   @Override
@@ -197,6 +199,11 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
 
   public ConditionalSubscriptionRecord setInterrupting(final boolean interrupting) {
     interruptingProp.setValue(interrupting);
+    return this;
+  }
+
+  public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
+    catchEventIdProp.setValue(catchEventId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
@@ -149,12 +149,6 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  @JsonIgnore
-  public DirectBuffer getCatchEventIdBuffer() {
-    return catchEventIdProp.getValue();
-  }
-
-  @Override
   public String getCondition() {
     return BufferUtil.bufferAsString(conditionProp.getValue());
   }
@@ -205,6 +199,11 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   public ConditionalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
     catchEventIdProp.setValue(catchEventId);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCatchEventIdBuffer() {
+    return catchEventIdProp.getValue();
   }
 
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
@@ -18,7 +18,6 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
-import org.agrona.DirectBuffer;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -63,11 +62,6 @@ public interface ConditionalSubscriptionRecordValue
    * @return the id of the catch event tied to the subscription
    */
   String getCatchEventId();
-
-  /**
-   * @return the id of the catch event tied to the subscription as a DirectBuffer
-   */
-  DirectBuffer getCatchEventIdBuffer();
 
   /**
    * The condition expression

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ConditionalSubscriptionRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
+import org.agrona.DirectBuffer;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -62,6 +63,11 @@ public interface ConditionalSubscriptionRecordValue
    * @return the id of the catch event tied to the subscription
    */
   String getCatchEventId();
+
+  /**
+   * @return the id of the catch event tied to the subscription as a DirectBuffer
+   */
+  DirectBuffer getCatchEventIdBuffer();
 
   /**
    * The condition expression


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We need to add variables to the `ConditionalSubscriptionRecord` to be able to pass variables to the newly created process instance by root level start event. Added a TODO to tackle this later in related PRs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40946 
