### PR TITLE
test: fix 8.8 nightly runs

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -176,7 +176,7 @@ jobs:
               echo "Running all tests in V2 mode on main branch, excluding V1-specific tests"
               npm run test -- --project=chromium --grep-invert "tests/(common-flows/v1|tasklist/v1)/"
             else
-              echo "Running focused tests in V2 mode: Tasklist + HTO flows (excluding @v1-only tests)"
+              echo "Running all tests in V2 mode: excluding @v1-only tests"
               npm run test -- --project=chromium --grep-invert "@v1-only"
             fi
           else

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -177,12 +177,16 @@ jobs:
               npm run test -- --project=chromium --grep-invert "tests/(common-flows/v1|tasklist/v1)/"
             else
               echo "Running focused tests in V2 mode: Tasklist + HTO flows (excluding @v1-only tests)"
-              npm run test -- --project=chromium tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert "@v1-only"
+              npm run test -- --project=chromium --grep-invert "@v1-only"
             fi
           else
             if [[ "${{ matrix.branch }}" == "main" ]]; then
               echo "Running V1 specific tests only: common-flows/v1/ and tests/tasklist/v1/"
               npm run test -- --project=chromium tests/common-flows/v1/ tests/tasklist/v1/
+            elif [[ "${{ matrix.branch }}" == "stable/8.8" ]]; then
+              # stable/8.8: no v1/ directories, run regular directories for V1 mode
+              echo "Running focused tests in V1 mode"
+              npm run test -- --project=chromium tests/tasklist/ tests/common-flows/
             else
               echo "Running all tests in V1 mode"
               npm run test -- --project=chromium


### PR DESCRIPTION
## Description
closes #41894


<!-- Describe the goal and purpose of this PR. -->

- The on-demand workflow is used for the single source of truth.
- For 8.8 v1, tests were previously run with `npm run test -- --project=chromium`, which triggered all tests. Going forward, only the Tasklist and common-flows tests will run: 
`npm run test -- --project=chromium tests/tasklist/ tests/common-flows/`
- For 8.8 v2, we previously ran only the Tasklist and specific common-flows tests. Now, all tests will run except those tagged as @v1-only, using:
`npm run test -- --project=chromium --grep-invert "@v1-only".`
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
