### PR TITLE
feat: Introduce ConditionalEvaluationProcessor

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -19,6 +19,9 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequestMetadata;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -84,6 +87,11 @@ public class AuthorizationArchTest {
         // The processor should directly check authorizations
         ArchConditions.callMethod(
                 AuthorizationCheckBehavior.class, "isAuthorized", AuthorizationRequest.class)
+            .or(
+                ArchConditions.callMethod(
+                    AuthorizationCheckBehavior.class,
+                    "isAuthorized",
+                    AuthorizationRequestMetadata.class))
             .or(
                 ArchConditions.callMethod(
                     AuthorizationCheckBehavior.class,

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -19,9 +19,6 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequestMetadata;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -87,11 +84,6 @@ public class AuthorizationArchTest {
         // The processor should directly check authorizations
         ArchConditions.callMethod(
                 AuthorizationCheckBehavior.class, "isAuthorized", AuthorizationRequest.class)
-            .or(
-                ArchConditions.callMethod(
-                    AuthorizationCheckBehavior.class,
-                    "isAuthorized",
-                    AuthorizationRequestMetadata.class))
             .or(
                 ArchConditions.callMethod(
                     AuthorizationCheckBehavior.class,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.clock.ClockProcessors;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableProcessors;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
+import io.camunda.zeebe.engine.processing.conditional.evaluation.ConditionalEvaluationProcessor;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
@@ -69,6 +70,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
@@ -251,6 +253,8 @@ public final class EngineProcessors {
         processingState,
         commandDistributionBehavior,
         authCheckBehavior);
+    addConditionalEvaluationProcessors(
+        typedRecordProcessors, bpmnBehaviors, writers, processingState, authCheckBehavior);
     addCommandDistributionProcessors(
         commandDistributionBehavior,
         scheduledTaskStateFactory,
@@ -606,6 +610,27 @@ public final class EngineProcessors {
             authCheckBehavior);
     typedRecordProcessors.onCommand(
         ValueType.SIGNAL, SignalIntent.BROADCAST, signalBroadcastProcessor);
+  }
+
+  private static void addConditionalEvaluationProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final BpmnBehaviors bpmnBehaviors,
+      final Writers writers,
+      final MutableProcessingState processingState,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    final var conditionalEvaluationProcessor =
+        new ConditionalEvaluationProcessor(
+            writers,
+            processingState.getKeyGenerator(),
+            processingState,
+            bpmnBehaviors.stateBehavior(),
+            bpmnBehaviors.eventTriggerBehavior(),
+            authCheckBehavior,
+            bpmnBehaviors.expressionBehavior());
+    typedRecordProcessors.onCommand(
+        ValueType.CONDITIONAL_EVALUATION,
+        ConditionalEvaluationIntent.EVALUATE,
+        conditionalEvaluationProcessor);
   }
 
   private static void addUserTaskProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -134,7 +134,8 @@ public final class ProcessProcessor
       final ExecutableFlowElementContainer element, final BpmnElementContext activated) {
     if (element.hasMessageStartEvent()
         || element.hasTimerStartEvent()
-        || element.hasSignalStartEvent()) {
+        || element.hasSignalStartEvent()
+        || element.hasConditionalStartEvent()) {
       eventSubscriptionBehavior
           .findEventTriggerForStartEvent(
               activated.getProcessDefinitionKey(), activated.getProcessInstanceKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -149,6 +149,14 @@ public final class ExpressionProcessor {
         .map(EvaluationResult::getBoolean);
   }
 
+  public Either<Failure, Boolean> evaluateBooleanExpression(
+      final Expression expression, final EvaluationContext context) {
+    return evaluateExpressionAsEither(expression, context)
+        // scopeKey is -1 because the context is already provided
+        .flatMap(result -> typeCheck(result, ResultType.BOOLEAN, -1))
+        .map(EvaluationResult::getBoolean);
+  }
+
   /**
    * Evaluates the given expression and returns the result as an Interval. If the evaluation fails
    * or the result is not an interval then a failure is returned.
@@ -435,6 +443,14 @@ public final class ExpressionProcessor {
     final var result = evaluateExpression(expression, variableScopeKey, tenantId);
     return result.isFailure()
         ? Either.left(createFailureMessage(result, result.getFailureMessage(), variableScopeKey))
+        : Either.right(result);
+  }
+
+  private Either<Failure, EvaluationResult> evaluateExpressionAsEither(
+      final Expression expression, final EvaluationContext context) {
+    final var result = expressionLanguage.evaluateExpression(expression, context);
+    return result.isFailure()
+        ? Either.left(createFailureMessage(result, result.getFailureMessage(), -1))
         : Either.right(result);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/evaluation/ConditionalEvaluationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/evaluation/ConditionalEvaluationProcessor.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.conditional.evaluation;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
+import io.camunda.zeebe.engine.processing.expression.InMemoryVariableEvaluationContext;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.ForbiddenException;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.conditionalevaluation.ConditionalEvaluationRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConditionalEvaluationProcessor
+    implements TypedRecordProcessor<ConditionalEvaluationRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConditionalEvaluationProcessor.class);
+
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private final EventHandle eventHandle;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final ProcessState processState;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final ExpressionProcessor expressionProcessor;
+
+  public ConditionalEvaluationProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState,
+      final BpmnStateBehavior stateBehavior,
+      final EventTriggerBehavior eventTriggerBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final ExpressionProcessor expressionProcessor) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    processState = processingState.getProcessState();
+    this.keyGenerator = keyGenerator;
+    this.authCheckBehavior = authCheckBehavior;
+    this.expressionProcessor = expressionProcessor;
+    eventHandle =
+        new EventHandle(
+            keyGenerator,
+            processingState.getEventScopeInstanceState(),
+            writers,
+            processState,
+            eventTriggerBehavior,
+            stateBehavior);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ConditionalEvaluationRecord> command) {
+    final var record = command.getValue();
+
+    final var isAuthNeeded =
+        !authCheckBehavior.isInternalCommand(
+            command.hasRequestMetadata(), command.getBatchOperationReference());
+
+    if (isAuthNeeded) {
+      if (!authCheckBehavior.isAssignedToTenant(command, record.getTenantId())) {
+        final var message =
+            "Expected to evaluate conditional for tenant '%s', but user is not assigned to this tenant."
+                .formatted(record.getTenantId());
+        rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
+        responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
+        return;
+      }
+    }
+
+    final var processDefinitionKey = record.getProcessDefinitionKey();
+
+    final List<MatchedStartEvent> matchedStartEvents;
+    if (processDefinitionKey > 0) {
+      final var process =
+          processState.getProcessByKeyAndTenant(processDefinitionKey, record.getTenantId());
+      if (process == null) {
+        rejectionWriter.appendRejection(
+            command,
+            RejectionType.NOT_FOUND,
+            String.format(
+                "Expected to evaluate conditional with command key '%d' for process definition key '%d', but no such process was found",
+                command.getKey(), processDefinitionKey));
+        return;
+      }
+      matchedStartEvents = collectMatchingStartEvents(record, process);
+    } else {
+      matchedStartEvents = collectMatchingStartEvents(record);
+    }
+
+    if (isAuthNeeded) {
+      for (final var match : matchedStartEvents) {
+        checkAuthorizationToStartProcessInstance(command, match.process());
+      }
+    }
+
+    final long eventKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(eventKey, ConditionalEvaluationIntent.EVALUATED, record);
+
+    for (final var match : matchedStartEvents) {
+      eventHandle.activateProcessInstanceForStartEvent(
+          match.process().getKey(),
+          keyGenerator.nextKey(),
+          match.startEventId(),
+          record.getVariablesBuffer(),
+          record.getTenantId());
+    }
+
+    if (command.hasRequestMetadata()) {
+      responseWriter.writeEventOnCommand(
+          eventKey, ConditionalEvaluationIntent.EVALUATED, record, command);
+    }
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<ConditionalEvaluationRecord> command, final Throwable error) {
+    if (error instanceof final ForbiddenException exception) {
+      rejectionWriter.appendRejection(
+          command, exception.getRejectionType(), exception.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          command, exception.getRejectionType(), exception.getMessage());
+      return ProcessingError.EXPECTED_ERROR;
+    }
+    return ProcessingError.UNEXPECTED_ERROR;
+  }
+
+  private List<MatchedStartEvent> collectMatchingStartEvents(
+      final ConditionalEvaluationRecord record, final DeployedProcess process) {
+    final var variables = record.getVariables();
+    return findMatchingConditionalStartEvents(process, variables.keySet(), variables);
+  }
+
+  private List<MatchedStartEvent> collectMatchingStartEvents(
+      final ConditionalEvaluationRecord record) {
+
+    final List<MatchedStartEvent> matches = new ArrayList<>();
+
+    final var tenantId = record.getTenantId();
+    final var variables = record.getVariables();
+
+    processState.forEachProcessWithLatestVersion(
+        persistedProcess -> {
+          if (persistedProcess.getTenantId().equals(tenantId)) {
+            final var process =
+                processState.getProcessByKeyAndTenant(persistedProcess.getKey(), tenantId);
+            if (process != null) {
+              matches.addAll(
+                  findMatchingConditionalStartEvents(process, variables.keySet(), variables));
+            }
+          }
+          return true; // continue iteration
+        });
+    return matches;
+  }
+
+  private List<MatchedStartEvent> findMatchingConditionalStartEvents(
+      final DeployedProcess process,
+      final Set<String> providedVariableNames,
+      final Map<String, Object> variables) {
+    final var executableProcess = process.getProcess();
+
+    final List<MatchedStartEvent> matches = new ArrayList<>();
+
+    executableProcess.getStartEvents().stream()
+        .filter(ExecutableStartEvent::isConditional)
+        .filter(
+            startEvent ->
+                startEvent.getConditional() != null
+                    && startEvent.getConditional().getConditionExpression() != null)
+        .filter(
+            startEvent -> {
+              final var subscriptionVariableNames = startEvent.getConditional().getVariableNames();
+
+              // If no variable names are specified, the subscription matches any variable change
+              if (subscriptionVariableNames.isEmpty()) {
+                return true;
+              }
+
+              return subscriptionVariableNames.stream().anyMatch(providedVariableNames::contains);
+            })
+        .forEach(
+            startEvent -> {
+              final var conditionExpression = startEvent.getConditional().getConditionExpression();
+
+              final var result =
+                  expressionProcessor.evaluateBooleanExpression(
+                      conditionExpression, new InMemoryVariableEvaluationContext(variables));
+
+              if (result.isRight()) {
+                if (Boolean.TRUE.equals(result.get())) {
+                  matches.add(new MatchedStartEvent(process, startEvent.getId()));
+                }
+              } else {
+                LOG.debug(
+                    "Failed to evaluate condition on conditional start event '{}' in process '{}': {}",
+                    BufferUtil.bufferAsString(startEvent.getId()),
+                    BufferUtil.bufferAsString(process.getBpmnProcessId()),
+                    result.getLeft().getMessage());
+              }
+            });
+
+    return matches;
+  }
+
+  private void checkAuthorizationToStartProcessInstance(
+      final TypedRecord<ConditionalEvaluationRecord> command, final DeployedProcess process) {
+    final var authRequest =
+        new AuthorizationRequest(
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.CREATE_PROCESS_INSTANCE,
+                command.getValue().getTenantId())
+            .addResourceId(BufferUtil.bufferAsString(process.getBpmnProcessId()));
+
+    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest.build());
+    if (isAuthorized.isLeft()) {
+      throw new ForbiddenException(authRequest);
+    }
+  }
+
+  private record MatchedStartEvent(DeployedProcess process, DirectBuffer startEventId) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowElementContainer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowElementContainer.java
@@ -63,6 +63,10 @@ public class ExecutableFlowElementContainer extends ExecutableActivity {
     return startEvents.stream().anyMatch(ExecutableCatchEventElement::isSignal);
   }
 
+  public boolean hasConditionalStartEvent() {
+    return startEvents.stream().anyMatch(ExecutableCatchEventElement::isConditional);
+  }
+
   public void addChildElement(final AbstractFlowElement element) {
     childElements.put(element.getId(), element);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/InMemoryVariableEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/InMemoryVariableEvaluationContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+public final class InMemoryVariableEvaluationContext implements ScopedEvaluationContext {
+  private final Map<String, Object> variables;
+
+  public InMemoryVariableEvaluationContext(final Map<String, Object> variables) {
+    this.variables = variables;
+  }
+
+  @Override
+  public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
+    if (variables.containsKey(variableName)) {
+      final var value = variables.get(variableName);
+      final var msgPackBytes = MsgPackConverter.convertToMsgPack(value);
+      return Either.left(BufferUtil.wrapArray(msgPackBytes));
+    }
+    return Either.left(null);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/evaluation/ConditionalEvaluationAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/evaluation/ConditionalEvaluationAuthorizationTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.conditional.evaluation;
+
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ConditionalEvaluationAuthorizationTest {
+
+  private static final String PROCESS_ID = "processId";
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getMultiTenancy().setChecksEnabled(true);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Before
+  public void before() {
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
+
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldBeAuthorizedToEvaluateConditionalWithDefaultUser() {
+    // when
+    engine
+        .conditionalEvaluation()
+        .withVariables(Map.of("x", 100, "y", 1))
+        .evaluate(DEFAULT_USER.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .limit(1))
+        .hasSize(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(PROCESS_ID)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldBeAuthorizedToEvaluateConditionalWithUser() {
+    // given
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUser(
+        user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.CREATE_PROCESS_INSTANCE);
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withVariables(Map.of("x", 100, "y", 1))
+        .evaluate(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .limit(1))
+        .hasSize(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(PROCESS_ID)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldRejectWhenUserLacksProcessPermissions() {
+    // given
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+
+    // when
+    final var rejection =
+        engine
+            .conditionalEvaluation()
+            .withVariables(Map.of("x", 100, "y", 1))
+            .expectRejection()
+            .evaluate(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                .formatted(PROCESS_ID));
+  }
+
+  @Test
+  public void shouldRejectWhenUserLacksPermissionForOneOfMultipleMatchingProcesses() {
+    // given
+    final String secondProcessId = "second-" + UUID.randomUUID();
+    engine
+        .deployment()
+        .withXmlResource(
+            "second-process.bpmn",
+            Bpmn.createExecutableProcess(secondProcessId)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUserForSpecificProcess(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.CREATE_PROCESS_INSTANCE,
+        PROCESS_ID);
+
+    // when
+    final var rejection =
+        engine
+            .conditionalEvaluation()
+            .withVariables(Map.of("x", 100, "y", 1))
+            .expectRejection()
+            .evaluate(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                .formatted(secondProcessId));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .onlyEvents()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldRejectWhenUserNotAssignedToTenant() {
+    // given
+    final String tenant = "restricted-tenant";
+
+    engine.tenant().newTenant().withTenantId(tenant).withName("Restricted Tenant").create();
+    assignUserToTenant(tenant, DEFAULT_USER.getUsername());
+
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUser(
+        user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.CREATE_PROCESS_INSTANCE);
+
+    engine
+        .deployment()
+        .withXmlResource(
+            "tenant-process.bpmn",
+            Bpmn.createExecutableProcess("tenant-process")
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .withTenantId(tenant)
+        .deploy(DEFAULT_USER.getUsername());
+
+    // when
+    final var rejection =
+        engine
+            .conditionalEvaluation()
+            .withTenantId(tenant)
+            .withVariables(Map.of("x", 100, "y", 1))
+            .expectRejection()
+            .evaluate(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    assertThat(rejection.getRejectionReason()).contains("user is not assigned to this tenant");
+  }
+
+  private void assignUserToTenant(final String tenantId, final String username) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private void addPermissionsToUserForSpecificProcess(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final String processId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(processId)
+        .create(DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/evaluation/ConditionalEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/evaluation/ConditionalEvaluationTest.java
@@ -1,0 +1,528 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.conditional.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ConditionalEvaluationTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  private String processId;
+
+  @Before
+  public void init() {
+    processId = helper.getBpmnProcessId();
+  }
+
+  @Test
+  public void shouldEvaluateConditionalAndCreateProcessInstance() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("start")
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("x", 1000, "y", 100)).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldEvaluateMultipleMatchingConditionals() {
+    // given
+    final String process1 = "process-" + UUID.randomUUID();
+    final String process2 = "process-" + UUID.randomUUID();
+
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(process1)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(process2)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("x", 1000, "y", 100)).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(process1)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(process2)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldWriteEvaluatedEventWhenNoConditionalsMatch() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=false").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("x", 1000, "y", 100)).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotMatchConditionalWithNonMatchingVariableName() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("a", 1000, "b", "test")).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldMatchConditionalWhenOneOfMultipleVariablesMatches() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y, z"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withVariables(Map.of("x", 1000, "y", 100, "a", "123"))
+        .evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldEvaluateConditionWithVariableReference() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=orderAmount > 500").zeebeVariableNames("orderAmount"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariable("orderAmount", 1000).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotMatchWhenConditionEvaluatesToFalse() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=orderAmount > 500").zeebeVariableNames("orderAmount"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariable("orderAmount", 100).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldEvaluateComplexConditionWithMultipleVariables() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(
+                    c ->
+                        c.condition("=status = \"VIP\" and orderAmount > 500")
+                            .zeebeVariableNames("status, orderAmount"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withVariables(Map.of("status", "VIP", "orderAmount", 1000))
+        .evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldEvaluateSpecificProcessByKey() {
+    // given
+    final var deployment1 =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process-" + UUID.randomUUID())
+                    .startEvent()
+                    .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final var deployment2 =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process-" + UUID.randomUUID())
+                    .startEvent()
+                    .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long process1Key =
+        deployment1.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+    final long process2Key =
+        deployment2.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withProcessDefinitionKey(process1Key)
+        .withVariables(Map.of("x", 100, "y", 1))
+        .evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withProcessDefinitionKey(process1Key)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withProcessDefinitionKey(process2Key)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldEvaluateAllProcessesWhenNoKeyProvided() {
+    // given
+    final var deployment1 =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process-" + UUID.randomUUID())
+                    .startEvent()
+                    .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final var deployment2 =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process-" + UUID.randomUUID())
+                    .startEvent()
+                    .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long process1Key =
+        deployment1.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+    final long process2Key =
+        deployment2.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("x", 100, "y", 1)).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withProcessDefinitionKey(process1Key)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withProcessDefinitionKey(process2Key)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldRejectWhenProcessDefinitionKeyNotFound() {
+    // given
+    final long nonExistentKey = 999999L;
+
+    // when
+    final var rejection =
+        engine
+            .conditionalEvaluation()
+            .withProcessDefinitionKey(nonExistentKey)
+            .withVariables(Map.of("x", 100, "y", 1))
+            .expectRejection()
+            .evaluate();
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldEvaluateConditionalForSpecificTenant() {
+    // given
+    final String tenant1 = "tenant1";
+    final String tenant2 = "tenant2";
+    final String process1Id = "process-" + UUID.randomUUID();
+    final String process2Id = "process-" + UUID.randomUUID();
+
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(process1Id)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .withTenantId(tenant1)
+        .deploy();
+
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(process2Id)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .withTenantId(tenant2)
+        .deploy();
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withTenantId(tenant1)
+        .withVariables(Map.of("x", 100, "y", 1))
+        .evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(process1Id)
+                .withTenantId(tenant1)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withTenantId(tenant2)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotMatchWhenOnlyPartialVariablesGiven() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("start")
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("x", 1000)).evaluate();
+
+    // then
+    assertThat(
+            RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldWriteEvaluatedRecordWithCorrectValues() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=x > y").zeebeVariableNames("x, y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final Map<String, Object> variables = Map.of("x", 100, "y", 10, "z", "test");
+
+    // when
+    final var record = engine.conditionalEvaluation().withVariables(variables).evaluate();
+
+    // then
+    Assertions.assertThat(record).hasIntent(ConditionalEvaluationIntent.EVALUATED);
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(processId)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+    assertThat(record.getValue().getVariables()).containsAllEntriesOf(variables);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.util.client.AuthorizationClient;
 import io.camunda.zeebe.engine.util.client.BatchOperationClient;
 import io.camunda.zeebe.engine.util.client.ClockClient;
 import io.camunda.zeebe.engine.util.client.ClusterVariableClient;
+import io.camunda.zeebe.engine.util.client.ConditionalEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.GroupClient;
@@ -519,6 +520,10 @@ public final class EngineRule extends ExternalResource {
 
   public SignalClient signal() {
     return new SignalClient(environmentRule);
+  }
+
+  public ConditionalEvaluationClient conditionalEvaluation() {
+    return new ConditionalEvaluationClient(environmentRule);
   }
 
   public UserTaskClient userTask() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ConditionalEvaluationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ConditionalEvaluationClient.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.conditionalevaluation.ConditionalEvaluationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.ConditionalEvaluationRecordValue;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ConditionalEvaluationClient {
+
+  private static final Function<Long, Record<ConditionalEvaluationRecordValue>>
+      SUCCESS_EXPECTATION =
+          (position) ->
+              RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+                  .withSourceRecordPosition(position)
+                  .getFirst();
+
+  private static final Function<Long, Record<ConditionalEvaluationRecordValue>>
+      REJECTION_EXPECTATION =
+          (position) ->
+              RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATE)
+                  .onlyCommandRejections()
+                  .withSourceRecordPosition(position)
+                  .getFirst();
+
+  private final CommandWriter writer;
+  private final ConditionalEvaluationRecord conditionalEvaluationRecord =
+      new ConditionalEvaluationRecord();
+  private Function<Long, Record<ConditionalEvaluationRecordValue>> expectation =
+      SUCCESS_EXPECTATION;
+
+  public ConditionalEvaluationClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public ConditionalEvaluationClient withProcessDefinitionKey(final long processDefinitionKey) {
+    conditionalEvaluationRecord.setProcessDefinitionKey(processDefinitionKey);
+    return this;
+  }
+
+  public ConditionalEvaluationClient withVariables(final Map<String, Object> variables) {
+    conditionalEvaluationRecord.setVariables(MsgPackUtil.asMsgPack(variables));
+    return this;
+  }
+
+  public ConditionalEvaluationClient withVariable(final String key, final Object value) {
+    conditionalEvaluationRecord.setVariables(MsgPackUtil.asMsgPack(key, value));
+    return this;
+  }
+
+  public ConditionalEvaluationClient withTenantId(final String tenantId) {
+    conditionalEvaluationRecord.setTenantId(tenantId);
+    return this;
+  }
+
+  public ConditionalEvaluationClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
+    return this;
+  }
+
+  public Record<ConditionalEvaluationRecordValue> evaluate() {
+    final long position =
+        writer.writeCommand(ConditionalEvaluationIntent.EVALUATE, conditionalEvaluationRecord);
+    return expectation.apply(position);
+  }
+
+  public Record<ConditionalEvaluationRecordValue> evaluate(final String username) {
+    final long position =
+        writer.writeCommand(
+            ConditionalEvaluationIntent.EVALUATE, username, conditionalEvaluationRecord);
+    return expectation.apply(position);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditionalevaluation/ConditionalEvaluationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditionalevaluation/ConditionalEvaluationRecord.java
@@ -43,6 +43,12 @@ public final class ConditionalEvaluationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp);
   }
 
+  public void wrap(final ConditionalEvaluationRecord other) {
+    processDefinitionKeyProp.setValue(other.getProcessDefinitionKey());
+    variablesProp.setValue(other.getVariablesBuffer());
+    tenantIdProp.setValue(other.getTenantId());
+  }
+
   @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ConditionalEvaluationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ConditionalEvaluationRecordStream.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ConditionalEvaluationRecordValue;
+import java.util.stream.Stream;
+
+public final class ConditionalEvaluationRecordStream
+    extends ExporterRecordWithVariablesStream<
+        ConditionalEvaluationRecordValue, ConditionalEvaluationRecordStream> {
+
+  public ConditionalEvaluationRecordStream(
+      final Stream<Record<ConditionalEvaluationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ConditionalEvaluationRecordStream supply(
+      final Stream<Record<ConditionalEvaluationRecordValue>> wrappedStream) {
+    return new ConditionalEvaluationRecordStream(wrappedStream);
+  }
+
+  public ConditionalEvaluationRecordStream withProcessDefinitionKey(
+      final long processDefinitionKey) {
+    return valueFilter(v -> v.getProcessDefinitionKey() == processDefinitionKey);
+  }
+
+  public ConditionalEvaluationRecordStream withTenantId(final String tenantId) {
+    return valueFilter(v -> tenantId.equals(v.getTenantId()));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
@@ -64,6 +65,7 @@ import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ConditionalEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
@@ -471,6 +473,16 @@ public final class RecordingExporter implements Exporter {
   public static ConditionalSubscriptionRecordStream conditionalSubscriptionRecords(
       final ConditionalSubscriptionIntent intent) {
     return conditionalSubscriptionRecords().withIntent(intent);
+  }
+
+  public static ConditionalEvaluationRecordStream conditionalEvaluationRecords() {
+    return new ConditionalEvaluationRecordStream(
+        records(ValueType.CONDITIONAL_EVALUATION, ConditionalEvaluationRecordValue.class));
+  }
+
+  public static ConditionalEvaluationRecordStream conditionalEvaluationRecords(
+      final ConditionalEvaluationIntent intent) {
+    return conditionalEvaluationRecords().withIntent(intent);
   }
 
   public static ResourceDeletionRecordStream resourceDeletionRecords() {


### PR DESCRIPTION
## Description

Introduces ConditionalEvaluationProcessor which will be used for the evaluation of conditions in root-level conditional start events

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/40949
