### PR TITLE
Add authorization claims in Identity-related events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -82,7 +82,10 @@ public class AuthorizationCreateProcessor
         .ifRightOrLeft(
             ignored -> {
               stateWriter.appendFollowUpEvent(
-                  command.getKey(), AuthorizationIntent.CREATED, command.getValue());
+                  command.getKey(),
+                  AuthorizationIntent.CREATED,
+                  command.getValue(),
+                  command.getAuthorizations());
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
@@ -100,7 +103,8 @@ public class AuthorizationCreateProcessor
       final AuthorizationRecord authorizationRecord) {
     final long key = keyGenerator.nextKey();
     authorizationRecord.setAuthorizationKey(key);
-    stateWriter.appendFollowUpEvent(key, AuthorizationIntent.CREATED, authorizationRecord);
+    stateWriter.appendFollowUpEvent(
+        key, AuthorizationIntent.CREATED, authorizationRecord, command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         key, AuthorizationIntent.CREATED, authorizationRecord, command);
     distributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -81,7 +81,8 @@ public class AuthorizationDeleteProcessor
               stateWriter.appendFollowUpEvent(
                   command.getValue().getAuthorizationKey(),
                   AuthorizationIntent.DELETED,
-                  command.getValue());
+                  command.getValue(),
+                  command.getAuthorizations());
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
@@ -102,7 +103,10 @@ public class AuthorizationDeleteProcessor
         .setAuthorizationKey(authorizationKey)
         .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
     stateWriter.appendFollowUpEvent(
-        authorizationKey, AuthorizationIntent.DELETED, command.getValue());
+        authorizationKey,
+        AuthorizationIntent.DELETED,
+        command.getValue(),
+        command.getAuthorizations());
     distributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -88,7 +88,8 @@ public class AuthorizationUpdateProcessor
               stateWriter.appendFollowUpEvent(
                   command.getValue().getAuthorizationKey(),
                   AuthorizationIntent.UPDATED,
-                  command.getValue());
+                  command.getValue(),
+                  command.getAuthorizations());
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
@@ -108,7 +109,8 @@ public class AuthorizationUpdateProcessor
     stateWriter.appendFollowUpEvent(
         authorizationRecord.getAuthorizationKey(),
         AuthorizationIntent.UPDATED,
-        authorizationRecord);
+        authorizationRecord,
+        command.getAuthorizations());
     distributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -106,7 +106,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
       return;
     }
 
-    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_ADDED, record);
+    stateWriter.appendFollowUpEvent(
+        groupKey, GroupIntent.ENTITY_ADDED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_ADDED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -125,7 +126,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
               record.getEntityId(), record.getGroupId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
     } else {
-      stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.ENTITY_ADDED, record);
+      stateWriter.appendFollowUpEvent(
+          command.getKey(), GroupIntent.ENTITY_ADDED, record, command.getAuthorizations());
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -77,7 +77,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
     final long key = keyGenerator.nextKey();
     record.setGroupKey(key);
 
-    stateWriter.appendFollowUpEvent(key, GroupIntent.CREATED, record);
+    stateWriter.appendFollowUpEvent(key, GroupIntent.CREATED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(key, GroupIntent.CREATED, record, command);
 
     commandDistributionBehavior
@@ -97,7 +97,9 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
                   GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(persistedGroup.getGroupId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
-            () -> stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.CREATED, record));
+            () ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), GroupIntent.CREATED, record, command.getAuthorizations()));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -105,7 +105,8 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     }
 
     final var groupKey = persistedRecord.get().getGroupKey();
-    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_REMOVED, record);
+    stateWriter.appendFollowUpEvent(
+        groupKey, GroupIntent.ENTITY_REMOVED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_REMOVED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -121,7 +122,10 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
     if (isEntityAssigned(record)) {
       stateWriter.appendFollowUpEvent(
-          command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue());
+          command.getKey(),
+          GroupIntent.ENTITY_REMOVED,
+          command.getValue(),
+          command.getAuthorizations());
     } else {
       final var errorMessage =
           ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getGroupKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -89,7 +89,10 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
   @Override
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getValue().getGroupKey(), GroupIntent.UPDATED, command.getValue());
+        command.getValue().getGroupKey(),
+        GroupIntent.UPDATED,
+        command.getValue(),
+        command.getAuthorizations());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
@@ -115,7 +118,10 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
             .setDescription(persistedGroup.getDescription());
 
     stateWriter.appendFollowUpEvent(
-        persistedGroup.getGroupKey(), GroupIntent.UPDATED, updatedRecord);
+        persistedGroup.getGroupKey(),
+        GroupIntent.UPDATED,
+        updatedRecord,
+        command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         persistedGroup.getGroupKey(), GroupIntent.UPDATED, updatedRecord, command);
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -113,7 +113,8 @@ public class MappingRuleCreateProcessor
     final long key = keyGenerator.nextKey();
     record.setMappingRuleKey(key);
 
-    stateWriter.appendFollowUpEvent(key, MappingRuleIntent.CREATED, record);
+    stateWriter.appendFollowUpEvent(
+        key, MappingRuleIntent.CREATED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(key, MappingRuleIntent.CREATED, record, command);
 
     commandDistributionBehavior
@@ -136,7 +137,10 @@ public class MappingRuleCreateProcessor
             },
             () ->
                 stateWriter.appendFollowUpEvent(
-                    command.getKey(), MappingRuleIntent.CREATED, record));
+                    command.getKey(),
+                    MappingRuleIntent.CREATED,
+                    record,
+                    command.getAuthorizations()));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -113,7 +113,8 @@ public class MappingRuleUpdateProcessor
       return;
     }
 
-    stateWriter.appendFollowUpEvent(record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record);
+    stateWriter.appendFollowUpEvent(
+        record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record, command);
 
@@ -126,7 +127,10 @@ public class MappingRuleUpdateProcessor
   @Override
   public void processDistributedCommand(final TypedRecord<MappingRuleRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getKey(), MappingRuleIntent.UPDATED, command.getValue());
+        command.getKey(),
+        MappingRuleIntent.UPDATED,
+        command.getValue(),
+        command.getAuthorizations());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -114,7 +114,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       return;
     }
 
-    stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.ENTITY_ADDED, record);
+    stateWriter.appendFollowUpEvent(
+        record.getRoleKey(), RoleIntent.ENTITY_ADDED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         record.getRoleKey(), RoleIntent.ENTITY_ADDED, record, command);
 
@@ -133,7 +134,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
           ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
     } else {
-      stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.ENTITY_ADDED, record);
+      stateWriter.appendFollowUpEvent(
+          command.getKey(), RoleIntent.ENTITY_ADDED, record, command.getAuthorizations());
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -74,7 +74,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
     final long key = keyGenerator.nextKey();
     record.setRoleKey(key);
 
-    stateWriter.appendFollowUpEvent(key, RoleIntent.CREATED, record);
+    stateWriter.appendFollowUpEvent(key, RoleIntent.CREATED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(key, RoleIntent.CREATED, record, command);
 
     commandDistributionBehavior
@@ -94,7 +94,9 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
                   ROLE_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getRoleId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
-            () -> stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.CREATED, record));
+            () ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), RoleIntent.CREATED, record, command.getAuthorizations()));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -108,7 +108,8 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
       return;
     }
 
-    stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record);
+    stateWriter.appendFollowUpEvent(
+        record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record, command);
 
@@ -125,7 +126,10 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
     if (isEntityAssigned(record)) {
       stateWriter.appendFollowUpEvent(
-          command.getKey(), RoleIntent.ENTITY_REMOVED, command.getValue());
+          command.getKey(),
+          RoleIntent.ENTITY_REMOVED,
+          command.getValue(),
+          command.getAuthorizations());
     } else {
       final var errorMessage =
           ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -75,7 +75,8 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
 
     final var persistedRole = persistedRecord.get();
     record.setRoleKey(persistedRole.getRoleKey());
-    stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.UPDATED, record);
+    stateWriter.appendFollowUpEvent(
+        record.getRoleKey(), RoleIntent.UPDATED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(record.getRoleKey(), RoleIntent.UPDATED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -88,7 +89,10 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
   @Override
   public void processDistributedCommand(final TypedRecord<RoleRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getValue().getRoleKey(), RoleIntent.UPDATED, command.getValue());
+        command.getValue().getRoleKey(),
+        RoleIntent.UPDATED,
+        command.getValue(),
+        command.getAuthorizations());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -115,7 +115,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       return;
     }
 
-    stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_ADDED, record);
+    stateWriter.appendFollowUpEvent(
+        tenantKey, TenantIntent.ENTITY_ADDED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_ADDED, record, command);
     sideEffectWriter.appendSideEffect(
         () -> {
@@ -133,7 +134,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       createAlreadyAssignedRejectCommand(
           command, record.getEntityId(), record.getEntityType(), record.getTenantId());
     } else {
-      stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.ENTITY_ADDED, record);
+      stateWriter.appendFollowUpEvent(
+          command.getKey(), TenantIntent.ENTITY_ADDED, record, command.getAuthorizations());
       sideEffectWriter.appendSideEffect(
           () -> {
             authCheckBehavior.clearAuthorizationsCache();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -82,7 +82,9 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
                   TENANT_ALREADY_EXISTS_ERROR_MESSAGE.formatted(tenant.getTenantId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
-            () -> stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.CREATED, record));
+            () ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), TenantIntent.CREATED, record, command.getAuthorizations()));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }
@@ -105,7 +107,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   private void createTenant(final TypedRecord<TenantRecord> command, final TenantRecord record) {
     final long key = keyGenerator.nextKey();
     record.setTenantKey(key);
-    stateWriter.appendFollowUpEvent(key, TenantIntent.CREATED, record);
+    stateWriter.appendFollowUpEvent(key, TenantIntent.CREATED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(key, TenantIntent.CREATED, record, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
-import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -40,7 +39,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
 
   private final TenantState tenantState;
   private final MappingRuleState mappingRuleState;
-  private final GroupState groupState;
   private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -58,7 +56,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
       final CommandDistributionBehavior commandDistributionBehavior) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
-    groupState = state.getGroupState();
     membershipState = state.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
@@ -99,7 +96,8 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     }
 
     final var tenantKey = persistedTenant.get().getTenantKey();
-    stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_REMOVED, record);
+    stateWriter.appendFollowUpEvent(
+        tenantKey, TenantIntent.ENTITY_REMOVED, record, command.getAuthorizations());
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_REMOVED, record, command);
     sideEffectWriter.appendSideEffect(
         () -> {
@@ -114,7 +112,10 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
     if (validateEntityAssignment(command, command.getValue().getTenantId())) {
       stateWriter.appendFollowUpEvent(
-          command.getKey(), TenantIntent.ENTITY_REMOVED, command.getValue());
+          command.getKey(),
+          TenantIntent.ENTITY_REMOVED,
+          command.getValue(),
+          command.getAuthorizations());
       sideEffectWriter.appendSideEffect(
           () -> {
             authCheckBehavior.clearAuthorizationsCache();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -80,7 +80,10 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
   @Override
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getValue().getTenantKey(), TenantIntent.UPDATED, command.getValue());
+        command.getValue().getTenantKey(),
+        TenantIntent.UPDATED,
+        command.getValue(),
+        command.getAuthorizations());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
@@ -119,7 +122,10 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
             .setDescription(persistedTenant.getDescription());
 
     stateWriter.appendFollowUpEvent(
-        persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
+        persistedTenant.getTenantKey(),
+        TenantIntent.UPDATED,
+        updatedRecord,
+        command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -86,7 +86,8 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     final long key = keyGenerator.nextKey();
     command.getValue().setUserKey(key);
 
-    stateWriter.appendFollowUpEvent(key, UserIntent.CREATED, command.getValue());
+    stateWriter.appendFollowUpEvent(
+        key, UserIntent.CREATED, command.getValue(), command.getAuthorizations());
     addUserPermissions(key, username);
     responseWriter.writeEventOnCommand(key, UserIntent.CREATED, command.getValue(), command);
 
@@ -108,7 +109,8 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, message);
             },
             () -> {
-              stateWriter.appendFollowUpEvent(command.getKey(), UserIntent.CREATED, record);
+              stateWriter.appendFollowUpEvent(
+                  command.getKey(), UserIntent.CREATED, record, command.getAuthorizations());
             });
 
     distributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -82,7 +82,8 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
 
     final var updatedUser = overlayUser(persistedUser.getUser(), record);
 
-    stateWriter.appendFollowUpEvent(persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser);
+    stateWriter.appendFollowUpEvent(
+        persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser, command.getAuthorizations());
     responseWriter.writeEventOnCommand(
         persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser, command);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
@@ -1,0 +1,692 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.auditlog;
+
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IdentityEventsClaimsTest {
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .getDefaultRoles()
+                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldIncludeClaimsInUserCreatedEvents() {
+    // when
+    final var user = createUser(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userRecords(UserIntent.CREATED)
+            .withUserKey(user.getUserKey())
+            .withUsername(user.getUsername())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserUpdatedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .user()
+        .updateUser()
+        .withUsername(user.getUsername())
+        .withName(UUID.randomUUID().toString())
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userRecords(UserIntent.UPDATED)
+            .withUserKey(user.getUserKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserDeletedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+
+    // when
+    engine.user().deleteUser(user.getUsername()).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userRecords(UserIntent.DELETED)
+            .withUserKey(user.getUserKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInAuthorizationCreatedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+
+    // when
+    final var authorization =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withPermissions(PermissionType.READ_PROCESS_INSTANCE)
+            .withOwnerId(user.getUsername())
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // then
+    final var record =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
+            .withAuthorizationKey(authorization.getAuthorizationKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInAuthorizationUpdatedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var authorization =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withPermissions(PermissionType.READ_PROCESS_INSTANCE)
+            .withOwnerId(user.getUsername())
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
+            .withResourceId(WILDCARD.getResourceId())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .authorization()
+        .updateAuthorization(authorization.getAuthorizationKey())
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
+        .withResourceId(WILDCARD.getResourceId())
+        .withPermissions(PermissionType.CREATE_PROCESS_INSTANCE)
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.UPDATED)
+            .withAuthorizationKey(authorization.getAuthorizationKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInAuthorizationDeletedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var authorization =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withPermissions(PermissionType.CREATE_PROCESS_INSTANCE)
+            .withOwnerId(user.getUsername())
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .withResourceMatcher(WILDCARD.getMatcher())
+            .withResourceId(WILDCARD.getResourceId())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .authorization()
+        .deleteAuthorization(authorization.getAuthorizationKey())
+        .delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.DELETED)
+            .withAuthorizationKey(authorization.getAuthorizationKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInGroupCreatedEvents() {
+    // when
+    final var group =
+        engine
+            .group()
+            .newGroup(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // then
+    final var record =
+        RecordingExporter.groupRecords(GroupIntent.CREATED)
+            .withGroupKey(group.getGroupKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInGroupUpdatedEvents() {
+    // given
+    final var group =
+        engine
+            .group()
+            .newGroup(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create()
+            .getValue();
+
+    // when
+    engine
+        .group()
+        .updateGroup(group.getGroupId())
+        .withName(UUID.randomUUID().toString())
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.groupRecords(GroupIntent.UPDATED)
+            .withGroupKey(group.getGroupKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInGroupDeletedEvents() {
+    // given
+    final var group =
+        engine
+            .group()
+            .newGroup(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine.group().deleteGroup(group.getGroupId()).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.groupRecords(GroupIntent.DELETED)
+            .withGroupKey(group.getGroupKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInMappingRuleCreatedEvents() {
+    // when
+    final var mappingRule =
+        engine
+            .mappingRule()
+            .newMappingRule(UUID.randomUUID().toString())
+            .withClaimName(UUID.randomUUID().toString())
+            .withClaimValue(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // then
+    final var record =
+        RecordingExporter.mappingRuleRecords(MappingRuleIntent.CREATED)
+            .withMappingRuleId(mappingRule.getMappingRuleId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInMappingRuleUpdatedEvents() {
+    // given
+    final var mappingRule =
+        engine
+            .mappingRule()
+            .newMappingRule(UUID.randomUUID().toString())
+            .withClaimName(UUID.randomUUID().toString())
+            .withClaimValue(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .mappingRule()
+        .updateMappingRule(mappingRule.getMappingRuleId())
+        .withClaimName(UUID.randomUUID().toString())
+        .withClaimValue(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.mappingRuleRecords(MappingRuleIntent.UPDATED)
+            .withMappingRuleId(mappingRule.getMappingRuleId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInMappingRuleDeletedEvents() {
+    // given
+    final var mappingRule =
+        engine
+            .mappingRule()
+            .newMappingRule(UUID.randomUUID().toString())
+            .withClaimName(UUID.randomUUID().toString())
+            .withClaimValue(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .mappingRule()
+        .deleteMappingRule(mappingRule.getMappingRuleId())
+        .delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.mappingRuleRecords(MappingRuleIntent.DELETED)
+            .withMappingRuleId(mappingRule.getMappingRuleId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInRoleCreatedEvents() {
+    // when
+    final var role =
+        engine
+            .role()
+            .newRole(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // then
+    final var record =
+        RecordingExporter.roleRecords(RoleIntent.CREATED)
+            .withRoleKey(role.getRoleKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInRoleUpdatedEvents() {
+    // given
+    final var role =
+        engine
+            .role()
+            .newRole(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .role()
+        .updateRole(role.getRoleId())
+        .withName(UUID.randomUUID().toString())
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.roleRecords(RoleIntent.UPDATED)
+            .withRoleKey(role.getRoleKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInRoleDeletedEvents() {
+    // given
+    final var role =
+        engine
+            .role()
+            .newRole(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine.role().deleteRole(role.getRoleId()).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.roleRecords(RoleIntent.DELETED)
+            .withRoleKey(role.getRoleKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInTenantCreatedEvents() {
+    // when
+    final var tenant =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // then
+    final var record =
+        RecordingExporter.tenantRecords(TenantIntent.CREATED)
+            .withTenantKey(tenant.getTenantKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInTenantUpdatedEvents() {
+    // given
+    final var tenant =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .tenant()
+        .updateTenant(tenant.getTenantId())
+        .withName(UUID.randomUUID().toString())
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.tenantRecords(TenantIntent.UPDATED)
+            .withTenantKey(tenant.getTenantKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInTenantDeletedEvents() {
+    // given
+    final var tenant =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine.tenant().deleteTenant(tenant.getTenantId()).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.tenantRecords(TenantIntent.DELETED)
+            .withTenantKey(tenant.getTenantKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInTenantEntityAddedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var tenant =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .tenant()
+        .addEntity(tenant.getTenantId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.tenantRecords(TenantIntent.ENTITY_ADDED)
+            .withTenantKey(tenant.getTenantKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInTenantEntityRemovedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var tenant =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    engine
+        .tenant()
+        .addEntity(tenant.getTenantId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .tenant()
+        .removeEntity(tenant.getTenantId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .remove(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.tenantRecords(TenantIntent.ENTITY_REMOVED)
+            .withTenantId(tenant.getTenantId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInRoleEntityAddedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var role =
+        engine
+            .role()
+            .newRole(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .role()
+        .addEntity(role.getRoleId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED)
+            .withRoleId(role.getRoleId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInRoleEntityRemovedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var role =
+        engine
+            .role()
+            .newRole(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    engine
+        .role()
+        .addEntity(role.getRoleId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .role()
+        .removeEntity(role.getRoleId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .remove(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
+            .withRoleId(role.getRoleId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInGroupEntityAddedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var group =
+        engine
+            .group()
+            .newGroup(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // when
+    engine
+        .group()
+        .addEntity(group.getGroupId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.groupRecords(GroupIntent.ENTITY_ADDED)
+            .withGroupId(group.getGroupId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInGroupEntityRemovedEvents() {
+    // given
+    final var user = createUser(DEFAULT_USER.getUsername());
+    final var group =
+        engine
+            .group()
+            .newGroup(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    engine
+        .group()
+        .addEntity(group.getGroupId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .group()
+        .removeEntity(group.getGroupId())
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .remove(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
+            .withGroupId(group.getGroupId())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  private UserRecordValue createUser(final String authorizedUsername) {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(authorizedUsername)
+        .getValue();
+  }
+
+  private void assertAuthorizationClaims(final java.util.Optional<?> record) {
+    assertThat(record).isPresent();
+    assertThat(((io.camunda.zeebe.protocol.record.Record<?>) record.get()).getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -79,6 +79,11 @@ public class GroupClient {
       return expectation.apply(position);
     }
 
+    public Record<GroupRecordValue> create(final String username) {
+      final long position = writer.writeCommand(GroupIntent.CREATE, username, groupRecord);
+      return expectation.apply(position);
+    }
+
     public GroupCreateClient expectRejection() {
       expectation = REJECTION_SUPPLIER;
       return this;
@@ -119,6 +124,11 @@ public class GroupClient {
 
     public Record<GroupRecordValue> update() {
       final long position = writer.writeCommand(GroupIntent.UPDATE, groupRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<GroupRecordValue> update(final String username) {
+      final long position = writer.writeCommand(GroupIntent.UPDATE, username, groupRecord);
       return expectation.apply(position);
     }
 
@@ -171,6 +181,11 @@ public class GroupClient {
       return expectation.apply(position);
     }
 
+    public Record<GroupRecordValue> add(final String username) {
+      final long position = writer.writeCommand(GroupIntent.ADD_ENTITY, username, groupRecord);
+      return expectation.apply(position);
+    }
+
     public GroupAddEntityClient expectRejection() {
       expectation = REJECTION_SUPPLIER;
       return this;
@@ -219,6 +234,11 @@ public class GroupClient {
       return expectation.apply(position);
     }
 
+    public Record<GroupRecordValue> remove(final String username) {
+      final long position = writer.writeCommand(GroupIntent.REMOVE_ENTITY, username, groupRecord);
+      return expectation.apply(position);
+    }
+
     public GroupRemoveEntityClient expectRejection() {
       expectation = REJECTION_SUPPLIER;
       return this;
@@ -260,6 +280,11 @@ public class GroupClient {
 
     public Record<GroupRecordValue> delete() {
       final long position = writer.writeCommand(GroupIntent.DELETE, groupRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<GroupRecordValue> delete(final String username) {
+      final long position = writer.writeCommand(GroupIntent.DELETE, username, groupRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingRuleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingRuleClient.java
@@ -123,6 +123,12 @@ public class MappingRuleClient {
       return expectation.apply(position);
     }
 
+    public Record<MappingRuleRecordValue> delete(final String username) {
+      final long position =
+          writer.writeCommand(MappingRuleIntent.DELETE, username, mappingRuleRecord);
+      return expectation.apply(position);
+    }
+
     public MappingRuleDeleteClient expectRejection() {
       expectation = REJECTION_SUPPLIER;
       return this;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -142,6 +142,11 @@ public class RoleClient {
       return expectation.apply(position);
     }
 
+    public Record<RoleRecordValue> update(final String username) {
+      final long position = writer.writeCommand(RoleIntent.UPDATE, username, roleRecord);
+      return expectation.apply(position);
+    }
+
     public RoleUpdateClient expectRejection() {
       expectation = REJECTION_SUPPLIER;
       return this;
@@ -186,6 +191,11 @@ public class RoleClient {
 
     public Record<RoleRecordValue> add(final AuthInfo authorization) {
       final long position = writer.writeCommand(RoleIntent.ADD_ENTITY, roleRecord, authorization);
+      return expectation.apply(position);
+    }
+
+    public Record<RoleRecordValue> add(final String username) {
+      final long position = writer.writeCommand(RoleIntent.ADD_ENTITY, username, roleRecord);
       return expectation.apply(position);
     }
 
@@ -245,6 +255,11 @@ public class RoleClient {
       return expectation.apply(position);
     }
 
+    public Record<RoleRecordValue> remove(final String username) {
+      final long position = writer.writeCommand(RoleIntent.REMOVE_ENTITY, username, roleRecord);
+      return expectation.apply(position);
+    }
+
     public Record<RoleRecordValue> remove(final AuthInfo authorization) {
       final long position =
           writer.writeCommand(RoleIntent.REMOVE_ENTITY, roleRecord, authorization);
@@ -285,6 +300,11 @@ public class RoleClient {
 
     public Record<RoleRecordValue> delete() {
       final long position = writer.writeCommand(RoleIntent.DELETE, roleRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<RoleRecordValue> delete(final String username) {
+      final long position = writer.writeCommand(RoleIntent.DELETE, username, roleRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -140,6 +140,11 @@ public class TenantClient {
       return expectation.apply(position);
     }
 
+    public Record<TenantRecordValue> create(final String username) {
+      final long position = writer.writeCommand(TenantIntent.CREATE, username, tenantRecord);
+      return expectation.apply(position);
+    }
+
     /**
      * Expects the tenant creation to be rejected.
      *
@@ -210,6 +215,11 @@ public class TenantClient {
       return expectation.apply(position);
     }
 
+    public Record<TenantRecordValue> update(final String username) {
+      final long position = writer.writeCommand(TenantIntent.UPDATE, username, tenantRecord);
+      return expectation.apply(position);
+    }
+
     /**
      * Expects the tenant update to be rejected.
      *
@@ -260,6 +270,11 @@ public class TenantClient {
 
     public Record<TenantRecordValue> add() {
       final long position = writer.writeCommand(TenantIntent.ADD_ENTITY, tenantRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<TenantRecordValue> add(final String username) {
+      final long position = writer.writeCommand(TenantIntent.ADD_ENTITY, username, tenantRecord);
       return expectation.apply(position);
     }
 
@@ -314,6 +329,11 @@ public class TenantClient {
 
     public Record<TenantRecordValue> remove() {
       final long position = writer.writeCommand(TenantIntent.REMOVE_ENTITY, tenantRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<TenantRecordValue> remove(final String username) {
+      final long position = writer.writeCommand(TenantIntent.REMOVE_ENTITY, username, tenantRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -171,6 +171,11 @@ public final class UserClient {
       return expectation.apply(position);
     }
 
+    public Record<UserRecordValue> update(final String username) {
+      final long position = writer.writeCommand(UserIntent.UPDATE, username, userRecord);
+      return expectation.apply(position);
+    }
+
     public UpdateUserClient expectRejection() {
       expectation = REJECTION_SUPPLIER;
       return this;
@@ -224,6 +229,11 @@ public final class UserClient {
 
     public Record<UserRecordValue> delete() {
       final long position = writer.writeCommand(UserIntent.DELETE, userRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<UserRecordValue> delete(final String username) {
+      final long position = writer.writeCommand(UserIntent.DELETE, username, userRecord);
       return expectation.apply(position);
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Pass authorization claims to Zeebe events created by user-triggered Identity operations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41945
