### PR TITLE
Add authorization claims in Batch-related events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -69,7 +69,7 @@ public final class BatchOperationCreateProcessor
       final RoutingInfo routingInfo,
       final BatchOperationMetrics metrics) {
     stateWriter = writers.state();
-    this.batchOperationState = state.getBatchOperationState();
+    batchOperationState = state.getBatchOperationState();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.keyGenerator = keyGenerator;
@@ -113,7 +113,8 @@ public final class BatchOperationCreateProcessor
         key,
         BatchOperationIntent.CREATED,
         recordWithKey,
-        FollowUpEventMetadata.of(b -> b.batchOperationReference(key)));
+        FollowUpEventMetadata.of(
+            b -> b.batchOperationReference(key).claims(command.getAuthorizations())));
     responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);
     commandDistributionBehavior
         .withKey(key)
@@ -146,7 +147,10 @@ public final class BatchOperationCreateProcessor
                     command.getKey(),
                     BatchOperationIntent.CREATED,
                     command.getValue(),
-                    FollowUpEventMetadata.of(b -> b.batchOperationReference(command.getKey()))));
+                    FollowUpEventMetadata.of(
+                        b ->
+                            b.batchOperationReference(command.getKey())
+                                .claims(command.getAuthorizations()))));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -109,7 +109,7 @@ public final class BatchOperationSuspendProcessor
       return;
     }
 
-    suspendBatchOperation(suspendKey, recordValue);
+    suspendBatchOperation(suspendKey, command);
     responseWriter.writeEventOnCommand(
         suspendKey, BatchOperationIntent.SUSPENDED, command.getValue(), command);
     commandDistributionBehavior
@@ -133,7 +133,7 @@ public final class BatchOperationSuspendProcessor
           "Processing distributed command to suspend with key '{}': {}",
           batchOperationKey,
           recordValue);
-      suspendBatchOperation(batchOperationKey, recordValue);
+      suspendBatchOperation(batchOperationKey, command);
     } else {
       LOGGER.debug(
           "Distributed command to suspend batch operation with key '{}' will be ignored: {}",
@@ -145,13 +145,15 @@ public final class BatchOperationSuspendProcessor
   }
 
   private void suspendBatchOperation(
-      final Long suspendKey, final BatchOperationLifecycleManagementRecord recordValue) {
+      final Long suspendKey, final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
+    final var recordValue = command.getValue();
+    final var claims = command.getAuthorizations();
     stateWriter.appendFollowUpEvent(
         suspendKey,
         BatchOperationIntent.SUSPENDED,
         recordValue,
         FollowUpEventMetadata.of(
-            b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
+            b -> b.batchOperationReference(recordValue.getBatchOperationKey()).claims(claims)));
   }
 
   private void rejectInvalidState(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class BatchEventsClaimsTest {
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .getDefaultRoles()
+                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldIncludeClaimsInBatchOperationCreatedEvents() {
+    // when
+    final var batchOperation =
+        engine
+            .batchOperation()
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
+            .withFilter(new UnsafeBuffer("{\"hasIncident\": false}".getBytes()))
+            .create(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.batchOperationCreationRecords(BatchOperationIntent.CREATED)
+            .withBatchOperationKey(batchOperation.getKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInBatchOperationCanceledEvents() {
+    // given
+    final var batchOperation =
+        engine
+            .batchOperation()
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
+            .withFilter(new UnsafeBuffer("{\"hasIncident\": false}".getBytes()))
+            .create(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .batchOperation()
+        .newLifecycle()
+        .withBatchOperationKey(batchOperation.getKey())
+        .cancel(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.batchOperationLifecycleRecords(BatchOperationIntent.CANCELED)
+            .withBatchOperationKey(batchOperation.getKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInBatchOperationSuspendedEvents() {
+    // given
+    final var batchOperation =
+        engine
+            .batchOperation()
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
+            .withFilter(new UnsafeBuffer("{\"hasIncident\": false}".getBytes()))
+            .create(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .batchOperation()
+        .newLifecycle()
+        .withBatchOperationKey(batchOperation.getKey())
+        .suspend(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.batchOperationLifecycleRecords(BatchOperationIntent.SUSPENDED)
+            .withBatchOperationKey(batchOperation.getKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInBatchOperationResumedEvents() {
+    // given
+    final var batchOperation =
+        engine
+            .batchOperation()
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
+            .withFilter(new UnsafeBuffer("{\"hasIncident\": false}".getBytes()))
+            .create(DEFAULT_USER.getUsername());
+
+    engine
+        .batchOperation()
+        .newLifecycle()
+        .withBatchOperationKey(batchOperation.getKey())
+        .suspend(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .batchOperation()
+        .newLifecycle()
+        .withBatchOperationKey(batchOperation.getKey())
+        .resume(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.batchOperationLifecycleRecords(BatchOperationIntent.RESUMED)
+            .withBatchOperationKey(batchOperation.getKey())
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  private void assertAuthorizationClaims(final java.util.Optional<?> record) {
+    assertThat(record).isPresent();
+    assertThat(((io.camunda.zeebe.protocol.record.Record<?>) record.get()).getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessorTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -65,7 +66,7 @@ class BatchOperationResumeProcessorTest {
     when(batchOperation.isInitialized()).thenReturn(false);
 
     // when
-    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue);
+    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue, Map.of());
 
     // then
     verify(stateWriter)
@@ -91,7 +92,7 @@ class BatchOperationResumeProcessorTest {
     when(batchOperation.isInitialized()).thenReturn(true);
 
     // when
-    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue);
+    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue, Map.of());
 
     // then
     verify(stateWriter)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Pass authorization claims to Zeebe events created by user-triggered Batch operations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41942
