### PR TITLE
feat: support sorting BO items by processed date

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationItemSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationItemSort.java
@@ -26,4 +26,6 @@ public interface BatchOperationItemSort extends SearchRequestSort<BatchOperation
   BatchOperationItemSort itemKey();
 
   BatchOperationItemSort processInstanceKey();
+
+  BatchOperationItemSort processedDate();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationItemSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationItemSortImpl.java
@@ -42,6 +42,11 @@ public class BatchOperationItemSortImpl extends SearchRequestSortBase<BatchOpera
   }
 
   @Override
+  public BatchOperationItemSort processedDate() {
+    return field("processedDate");
+  }
+
+  @Override
   protected BatchOperationItemSort self() {
     return this;
   }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
@@ -96,14 +96,16 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
                     .processInstanceKey()
                     .desc()
                     .itemKey()
-                    .asc())
+                    .asc()
+                    .processedDate()
+                    .desc())
         .send()
         .join();
 
     // then
     final BatchOperationItemSearchQuery request =
         gatewayService.getLastRequest(BatchOperationItemSearchQuery.class);
-    assertThat(request.getSort().size()).isEqualTo(4);
+    assertThat(request.getSort().size()).isEqualTo(5);
     assertThat(request.getSort().get(0).getField()).isEqualTo(FieldEnum.BATCH_OPERATION_KEY);
     assertThat(request.getSort().get(0).getOrder()).isEqualTo(SortOrderEnum.ASC);
     assertThat(request.getSort().get(1).getField()).isEqualTo(FieldEnum.STATE);
@@ -112,5 +114,7 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
     assertThat(request.getSort().get(2).getOrder()).isEqualTo(SortOrderEnum.DESC);
     assertThat(request.getSort().get(3).getField()).isEqualTo(FieldEnum.ITEM_KEY);
     assertThat(request.getSort().get(3).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(4).getField()).isEqualTo(FieldEnum.PROCESSED_DATE);
+    assertThat(request.getSort().get(4).getOrder()).isEqualTo(SortOrderEnum.DESC);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.BATCH_OPERATION_ID;
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.COMPLETED_DATE;
 import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.ID;
 import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.ITEM_KEY;
 import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.PROCESS_INSTANCE_KEY;
@@ -22,6 +23,7 @@ public class BatchOperationItemFieldSortingTransformer implements FieldSortingTr
       case "state" -> STATE;
       case "itemKey" -> ITEM_KEY;
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "processedDate" -> COMPLETED_DATE;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformerTest.java
@@ -27,7 +27,8 @@ public class BatchOperationItemFieldSortingTransformerTest extends AbstractSortT
         new TestArguments("batchOperationId", SortOrder.ASC, s -> s.batchOperationKey().asc()),
         new TestArguments("state", SortOrder.DESC, s -> s.state().desc()),
         new TestArguments("itemKey", SortOrder.DESC, s -> s.itemKey().desc()),
-        new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()));
+        new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()),
+        new TestArguments("completedDate", SortOrder.ASC, s -> s.processedDate().asc()));
   }
 
   @ParameterizedTest

--- a/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationItemSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationItemSort.java
@@ -46,6 +46,11 @@ public record BatchOperationItemSort(List<FieldSorting> orderings) implements So
       return this;
     }
 
+    public Builder processedDate() {
+      currentOrdering = new FieldSorting("processedDate", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -358,6 +358,7 @@ components:
             - batchOperationKey
             - itemKey
             - processInstanceKey
+            - processedDate
             - state
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -300,6 +300,7 @@ public class SearchQuerySortRequestMapper {
         case BATCH_OPERATION_KEY -> builder.batchOperationKey();
         case ITEM_KEY -> builder.itemKey();
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        case PROCESSED_DATE -> builder.processedDate();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }


### PR DESCRIPTION
## Description

Adds a sort option for `processedDate` to the batch operation items search API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42043 
