### PR TITLE
Allow overwriting key in the state using debug-cli

### DIFF
--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -111,5 +111,43 @@
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-db</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-stream-platform</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-snapshots</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -144,10 +144,24 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dep>io.camunda:zeebe-protocol</dep>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -156,9 +156,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <dep>io.camunda:zeebe-protocol</dep>
-          </ignoredUnusedDeclaredDependencies>
+          <ignoredNonTestScopedDependencies>
+            <dependency>io.camunda:zeebe-protocol</dependency>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -123,12 +123,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-scheduler</artifactId>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-stream-platform</artifactId>
     </dependency>
 

--- a/debug-cli/src/main/java/io/camunda/debug/cli/CommonOptions.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/CommonOptions.java
@@ -10,7 +10,7 @@ package io.camunda.debug.cli;
 import java.nio.file.Path;
 import picocli.CommandLine.Option;
 
-abstract class CommonOptions {
+public abstract class CommonOptions {
 
   @Option(
       names = {"-r", "--root"},

--- a/debug-cli/src/main/java/io/camunda/debug/cli/CommonOptions.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/CommonOptions.java
@@ -10,7 +10,7 @@ package io.camunda.debug.cli;
 import java.nio.file.Path;
 import picocli.CommandLine.Option;
 
-public abstract class CommonOptions {
+abstract class CommonOptions {
 
   @Option(
       names = {"-r", "--root"},

--- a/debug-cli/src/main/java/io/camunda/debug/cli/Main.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/Main.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.debug.cli;
 
+import io.camunda.debug.cli.state.StateCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -15,7 +16,12 @@ import picocli.CommandLine.Command;
     description = "Camunda Debug CLI - A tool for debugging and troubleshooting Camunda instances",
     mixinStandardHelpOptions = true,
     version = "1.0.0",
-    subcommands = {CommandLine.HelpCommand.class, TopologyMetaCommand.class, RaftCommand.class})
+    subcommands = {
+      CommandLine.HelpCommand.class,
+      TopologyMetaCommand.class,
+      RaftCommand.class,
+      StateCommand.class
+    })
 public class Main {
 
   public static void main(final String[] args) {

--- a/debug-cli/src/main/java/io/camunda/debug/cli/concurrency/CurrentThreadConcurrencyControl.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/concurrency/CurrentThreadConcurrencyControl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.concurrency;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.ScheduledTimer;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class CurrentThreadConcurrencyControl implements ConcurrencyControl {
+
+  @Override
+  public <T> void runOnCompletion(
+      final ActorFuture<T> future, final BiConsumer<T, Throwable> callback) {
+    future.onComplete(callback);
+  }
+
+  @Override
+  public <T> void runOnCompletion(
+      final Collection<ActorFuture<T>> actorFutures, final Consumer<Throwable> callback) {
+    actorFutures.stream()
+        .collect(new ActorFutureCollector<>(this))
+        .onComplete(
+            (v, err) -> {
+              if (err != null) {
+                callback.accept(err);
+              }
+            });
+  }
+
+  @Override
+  public void run(final Runnable action) {
+    action.run();
+  }
+
+  @Override
+  public <T> ActorFuture<T> call(final Callable<T> callable) {
+    try {
+      return CompletableActorFuture.completed(callable.call());
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+  }
+
+  @Override
+  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+    throw new UnsupportedOperationException("schedule is not supported");
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.state;
+
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotMetadata;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
+import io.camunda.zeebe.snapshots.impl.SnapshotMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SnapshotUtil {
+
+  private final ZeebeRocksDbFactory zeebeDbFactory;
+
+  public SnapshotUtil() {
+    zeebeDbFactory =
+        new ZeebeRocksDbFactory<>(
+            new RocksDbConfiguration().setWalDisabled(false),
+            new ConsistencyChecksSettings(true, true),
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            SimpleMeterRegistry::new);
+  }
+
+  public ZeebeDb openSnapshot(final Path snapshotPath, final Path runtimePath) {
+    try (final var db = zeebeDbFactory.openSnapshotOnlyDb(snapshotPath.toFile())) {
+      db.createSnapshot(runtimePath.toFile());
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to open and copy snapshot", e);
+    }
+    final var runtimeDb = zeebeDbFactory.createDb(runtimePath.toFile());
+    return runtimeDb;
+  }
+
+  public PersistedSnapshot takeSnapshot(
+      final ZeebeDb runtime,
+      final Path rootDirectory,
+      final String stringSnapshotId,
+      final long lastFollowupEventPosition) {
+    final var snapshotStore =
+        new FileBasedSnapshotStoreImpl(
+            0,
+            rootDirectory,
+            new ChecksumProviderRocksDBImpl(),
+            new TestConcurrencyControl(),
+            new SnapshotMetrics(new SimpleMeterRegistry()));
+
+    final var snapshotId = FileBasedSnapshotId.ofFileName(stringSnapshotId).getOrThrow();
+
+    final var transientSnapshot =
+        snapshotStore
+            .newTransientSnapshot(
+                snapshotId.getIndex(),
+                snapshotId.getTerm(),
+                snapshotId.getProcessedPosition(),
+                snapshotId.getExportedPosition(),
+                true)
+            .get();
+
+    transientSnapshot
+        .withLastFollowupEventPosition(lastFollowupEventPosition)
+        .take(
+            path -> {
+              runtime.createSnapshot(path.toFile());
+            })
+        .join();
+
+    return transientSnapshot.persist().join();
+  }
+
+  public static long getLastFollowupEventPosition(final Path snapshotPath) throws IOException {
+    final var snapshotMetadata =
+        Files.readAllBytes(snapshotPath.resolve(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME));
+    final var metadata = FileBasedSnapshotMetadata.decode(snapshotMetadata);
+
+    final var lastFollowupEventPosition = metadata.lastFollowupEventPosition();
+    return lastFollowupEventPosition;
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.debug.cli.state;
 
+import io.camunda.debug.cli.concurrency.CurrentThreadConcurrencyControl;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
@@ -14,7 +15,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
-import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotMetadata;
@@ -58,7 +58,7 @@ public class SnapshotUtil {
             0,
             rootDirectory,
             new ChecksumProviderRocksDBImpl(),
-            new TestConcurrencyControl(),
+            new CurrentThreadConcurrencyControl(),
             new SnapshotMetrics(new SimpleMeterRegistry()));
 
     final var snapshotId = FileBasedSnapshotId.ofFileName(stringSnapshotId).getOrThrow();

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/StateCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/StateCommand.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.state;
+
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "state",
+    description = "State management commands",
+    subcommands = {StateUpdateKeyCommand.class})
+public class StateCommand {
+
+  private final ZeebeDbFactory zeebeDbFactory;
+
+  public StateCommand() {
+    zeebeDbFactory =
+        new ZeebeRocksDbFactory<>(
+            new RocksDbConfiguration().setWalDisabled(false),
+            new ConsistencyChecksSettings(true, true),
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            SimpleMeterRegistry::new);
+  }
+
+  public ZeebeDbFactory getZeebeDbFactory() {
+    return zeebeDbFactory;
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/StateUpdateKeyCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/StateUpdateKeyCommand.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.debug.cli.state;
 
-import io.camunda.debug.cli.CommonOptions;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import java.nio.file.Path;
@@ -19,9 +18,21 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 @Command(name = "update-key", description = "Overwrite the next key in the state")
-public class StateUpdateKeyCommand extends CommonOptions implements Callable<Integer> {
+public class StateUpdateKeyCommand implements Callable<Integer> {
+
+  @Option(
+      names = {"-v", "--verbose"},
+      description = "Enable verbose output")
+  protected boolean verbose;
 
   @Spec CommandSpec spec;
+
+  @Option(
+      names = {"-r", "--root"},
+      description = "Path of the root of the data folder",
+      required = true)
+  private Path root;
+
   @ParentCommand private StateCommand parentCommand;
 
   @Option(

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/StateUpdateKeyCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/StateUpdateKeyCommand.java
@@ -63,6 +63,7 @@ public class StateUpdateKeyCommand extends CommonOptions implements Callable<Int
       if (maxKey != null) {
         err.println("Target max key: " + maxKey);
       }
+      err.println("Root path: " + root);
       err.println("Snapshot ID: " + snapshotId);
       err.println("Runtime path: " + runtimePath);
     }

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/StateUpdateKeyCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/StateUpdateKeyCommand.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.state;
+
+import io.camunda.debug.cli.CommonOptions;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
+import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+@Command(name = "update-key", description = "Overwrite the next key in the state")
+public class StateUpdateKeyCommand extends CommonOptions implements Callable<Integer> {
+
+  @Spec CommandSpec spec;
+  @ParentCommand private StateCommand parentCommand;
+
+  @Option(
+      names = {"--runtime"},
+      description = "Path to the temporary runtime directory",
+      required = true)
+  private Path runtimePath;
+
+  @Option(
+      names = {"-s", "--snapshot"},
+      description = "Path to the source snapshot directory",
+      required = true)
+  private String snapshotId;
+
+  @Option(
+      names = {"-k", "--key"},
+      description = "Key to set",
+      required = true)
+  private long key;
+
+  @Option(
+      names = {"--max-key"},
+      description = "Max key to set")
+  private Long maxKey;
+
+  @Option(names = "--partition-id", description = "Partition ID", required = true)
+  private int partitionId;
+
+  @Override
+  public Integer call() throws Exception {
+    final var out = spec.commandLine().getOut();
+    final var err = spec.commandLine().getErr();
+
+    out.println("=== Starting key update process ===");
+
+    if (verbose) {
+      err.println("Partition ID: " + partitionId);
+      err.println("Target key: " + key);
+      if (maxKey != null) {
+        err.println("Target max key: " + maxKey);
+      }
+      err.println("Snapshot ID: " + snapshotId);
+      err.println("Runtime path: " + runtimePath);
+    }
+
+    final var snapshotUtil = new SnapshotUtil();
+    final var snapshotPath =
+        root.resolve(FileBasedSnapshotStoreImpl.SNAPSHOTS_DIRECTORY).resolve(snapshotId);
+
+    if (verbose) {
+      err.println("\nOpening snapshot from: " + snapshotPath);
+    }
+    final var db = snapshotUtil.openSnapshot(snapshotPath, runtimePath);
+    final var context = db.createContext();
+
+    final var dbKey = new DbKeyGenerator(partitionId, db, context);
+
+    if (verbose) {
+      err.println("\nExecuting key update transaction...");
+    }
+    context.runInTransaction(() -> context.getCurrentTransaction().run(() -> overwriteKeys(dbKey)));
+    context.getCurrentTransaction().commit();
+
+    final var lastFollowupEventPosition = SnapshotUtil.getLastFollowupEventPosition(snapshotPath);
+    if (verbose) {
+      err.println("\nTaking new snapshot...");
+    }
+    final var persistedSnapshot =
+        snapshotUtil.takeSnapshot(db, root, snapshotId, lastFollowupEventPosition);
+
+    out.println("\n=== Key update completed successfully ===");
+    out.println("Created new snapshot with updated key at: " + persistedSnapshot.getPath());
+    out.println("\nNext steps:");
+    out.println("1. Delete the previous snapshot: " + snapshotId);
+    out.println("2. Copy the data folder of partition to all replicas");
+    out.println("3. Restart the brokers to apply changes to the cluster");
+
+    return 0;
+  }
+
+  private void overwriteKeys(final DbKeyGenerator dbKey) {
+    final var out = spec.commandLine().getOut();
+    final var currentKey = dbKey.getCurrentKey();
+    if (maxKey != null) {
+      // Have to first set maxKey to ensure that  currentKey <= maxKey
+      out.println("  Setting max key to: " + maxKey);
+      dbKey.setMaxKeyValue(maxKey);
+      out.println("  ✓ Max key set successfully");
+    }
+
+    out.println("  Current key: " + currentKey);
+    out.println("  New key: " + key);
+
+    dbKey.overwriteKey(key);
+    out.println("  ✓ Key overwritten successfully");
+  }
+}

--- a/debug-cli/src/test/java/io/camunda/debug/cli/state/StateUpdateKeyCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/state/StateUpdateKeyCommandTest.java
@@ -47,6 +47,7 @@ class StateUpdateKeyCommandTest {
 
     // when
     final var resetKey = Protocol.encodePartitionId(1, 100L);
+    final var maxKey = resetKey + 1000;
     final int exitCode =
         commandLine.execute(
             "state",
@@ -56,7 +57,7 @@ class StateUpdateKeyCommandTest {
             partitionRoot.toString(),
             "--partition-id=1",
             "--key=" + resetKey,
-            "--max-key=" + (resetKey + 1000),
+            "--max-key=" + maxKey,
             "--snapshot=" + initialSnapshot.getId().toString(),
             "--runtime=" + tempDir.resolve("runtime"));
 
@@ -80,6 +81,7 @@ class StateUpdateKeyCommandTest {
     final var keyGen = new DbKeyGenerator(1, runtimeDb, runtimeDb.createContext());
     final var key = keyGen.nextKey();
     assertThat(key).isEqualTo(resetKey + 1);
+    assertThat(keyGen.getMaxKeyValue()).isEqualTo(maxKey);
   }
 
   private PersistedSnapshot takeInitialSnapshot(final Path partitionRoot) {

--- a/debug-cli/src/test/java/io/camunda/debug/cli/state/StateUpdateKeyCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/state/StateUpdateKeyCommandTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.debug.cli.Main;
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
+import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class StateUpdateKeyCommandTest {
+
+  CommandLine commandLine;
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() {
+    commandLine = new CommandLine(new Main());
+  }
+
+  @Test
+  void shouldUpdateKeyAndMaxKey() throws IOException {
+    // given
+    final Path partitionRoot = tempDir.resolve("partitionRoot");
+
+    final var initialSnapshot = takeInitialSnapshot(partitionRoot);
+
+    // when
+    final var resetKey = Protocol.encodePartitionId(1, 100L);
+    final int exitCode =
+        commandLine.execute(
+            "state",
+            "update-key",
+            "-v",
+            "-r",
+            partitionRoot.toString(),
+            "--partition-id=1",
+            "--key=" + resetKey,
+            "--max-key=" + (resetKey + 1000),
+            "--snapshot=" + initialSnapshot.getId().toString(),
+            "--runtime=" + tempDir.resolve("runtime"));
+
+    // then
+    assertThat(exitCode).isZero();
+
+    // open the snapshot and verify the key
+    // find the new snapshot id
+    final var newSnapshotPath =
+        Files.list(partitionRoot.resolve(FileBasedSnapshotStoreImpl.SNAPSHOTS_DIRECTORY))
+            .filter(Files::isDirectory)
+            .filter(
+                directoryName ->
+                    !directoryName.getFileName().toString().equals(initialSnapshot.getId()))
+            .findFirst()
+            .get();
+
+    final var snapshotUtil = new SnapshotUtil();
+    final var runtimeDb =
+        snapshotUtil.openSnapshot(newSnapshotPath, tempDir.resolve("openedRuntime"));
+    final var keyGen = new DbKeyGenerator(1, runtimeDb, runtimeDb.createContext());
+    final var key = keyGen.nextKey();
+    assertThat(key).isEqualTo(resetKey + 1);
+  }
+
+  private PersistedSnapshot takeInitialSnapshot(final Path partitionRoot) {
+    final var zeebeDbFactory =
+        new ZeebeRocksDbFactory<>(
+            new RocksDbConfiguration().setWalDisabled(false),
+            new ConsistencyChecksSettings(true, true),
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            SimpleMeterRegistry::new);
+
+    final var initialRuntime = zeebeDbFactory.createDb(tempDir.resolve("initialRuntime").toFile());
+
+    final var keyGen = new DbKeyGenerator(1, initialRuntime, initialRuntime.createContext());
+
+    assertThat(keyGen.nextKey()).isEqualTo(Protocol.encodePartitionId(1, 1L));
+
+    return new SnapshotUtil().takeSnapshot(initialRuntime, partitionRoot, "1-1-1-1-1", 1L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatException;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
@@ -75,25 +74,5 @@ public final class KeyGeneratorTest {
     assertThat(Protocol.decodePartitionId(keyOfSecondPartition)).isEqualTo(secondPartitionId);
 
     newDb.close();
-  }
-
-  @Test
-  public void shouldFailIfKeyOfAnotherPartitionIsSet() {
-    // given
-    final ZeebeDb<ZbColumnFamilies> newDb = stateRule.createNewDb();
-    final DbKeyGenerator keyGenerator2 =
-        new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, newDb, newDb.createContext());
-
-    final long keyOfAnotherPartition =
-        Protocol.encodePartitionId(Protocol.DEPLOYMENT_PARTITION + 1, 100);
-
-    // when - then
-    assertThatException()
-        .isThrownBy(() -> keyGenerator2.setKeyIfHigher(keyOfAnotherPartition))
-        .havingCause()
-        .withMessageContaining(
-            String.format(
-                "Provided key %d does not belong to partition %d",
-                keyOfAnotherPartition, Protocol.DEPLOYMENT_PARTITION));
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -76,6 +76,7 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
       // exhaust the entire key space and provide more options for recovery.
       maxKeyValue = Protocol.encodePartitionId(partitionId, 1L << (Protocol.KEY_BITS - 1));
     }
+    LOGGER.debug("DBKeyGenerator set key={} and maxKey={}", getCurrentKey(), maxKeyValue);
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -7,15 +7,21 @@
  */
 package io.camunda.zeebe.stream.impl.state;
 
+import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DbKeyGenerator implements KeyGeneratorControls {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DbKeyGenerator.class);
 
   private static final long INITIAL_VALUE = 0;
 
@@ -24,6 +30,11 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
   private final long keyStartValue;
   private final NextValueManager nextValueManager;
   private final int partitionId;
+
+  private final DbString maxKeyValueKey;
+  private final DbLong maxKeyValueValue = new DbLong();
+  private final ColumnFamily<DbString, DbLong> maxValueColumnFamily;
+  private long maxKeyValue;
 
   /**
    * Initializes the key state with the corresponding partition id, so that unique keys are
@@ -39,6 +50,13 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
         new NextValueManager(
             keyStartValue, zeebeDb, transactionContext, ZbColumnFamilies.KEY, LATEST_KEY);
 
+    maxKeyValueKey = new DbString();
+    maxKeyValueKey.wrapString("maxKeyValue");
+    // Reuse the column family of next key, but use a different key name.
+    maxValueColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.KEY, transactionContext, maxKeyValueKey, maxKeyValueValue);
+
     final var currentKey = nextValueManager.getCurrentValue();
     if (Protocol.decodePartitionId(currentKey) != partitionId) {
       throw new UnrecoverableException(
@@ -46,6 +64,16 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
               String.format(
                   "Current key in the state %d does not belong to partition %d, but belongs to %d. Potential data corruption suspected.",
                   currentKey, partitionId, Protocol.decodePartitionId(currentKey))));
+    }
+
+    final var max = maxValueColumnFamily.get(maxKeyValueKey);
+    if (max != null) {
+      maxKeyValue = max.getValue();
+    } else {
+      // We deliberately leave 1 extra bit to give a buffer space before hitting the actual max key
+      // range possible for this partition. This allows us to detect potential issues before we
+      // exhaust the entire key space and provide more options for recovery.
+      maxKeyValue = Protocol.encodePartitionId(partitionId, 1L << (Protocol.KEY_BITS - 1));
     }
   }
 
@@ -59,16 +87,23 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
                   "Generated key %d does not belong to partition %d, but belongs to %d",
                   nextKey, partitionId, Protocol.decodePartitionId(nextKey))));
     }
+
+    if (nextKey > maxKeyValue) {
+      throw new UnrecoverableException(
+          new IllegalStateException(
+              String.format(
+                  "Generated key %d exceeds the maximum allowed key value %d for partition %d",
+                  nextKey, maxKeyValue, partitionId)));
+    }
     return nextKey;
   }
 
   /**
-   * Retrieve the current key from the state, since it is only used in tests it is not part of the
-   * interface.
+   * Retrieve the current key from the state, since it is only used in tests and debug tools it is
+   * not part of the interface.
    *
    * @return the current key from the state
    */
-  @VisibleForTesting
   public long getCurrentKey() {
     return nextValueManager.getCurrentValue();
   }
@@ -85,7 +120,67 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
                     "Provided key %d does not belong to partition %d, it belongs to %d",
                     key, partitionId, Protocol.decodePartitionId(key))));
       }
+
+      if (key > maxKeyValue) {
+        // skip - we don't want to throw here to avoid stopping the processing of a partition due to
+        // an invalid key that was generated already. Instead, we log a warning.
+        LOGGER.warn(
+            "Provided key {} is higher than the maximum allowed key value {} for partition {}, skipping setKeyIfHigher.",
+            key,
+            maxKeyValue,
+            partitionId);
+        return;
+      }
       nextValueManager.setValue(LATEST_KEY, key);
     }
+  }
+
+  /**
+   * Overwrite the current key in the state. Since this is a dangerous operation, use it with
+   * caution. It is intended to be used to recover from specific failures manually..
+   */
+  public void overwriteKey(final long key) {
+    if (Protocol.decodePartitionId(key) != partitionId) {
+      throw new UnrecoverableException(
+          new IllegalArgumentException(
+              String.format(
+                  "Provided key %d does not belong to partition %d, it belongs to %d",
+                  key, partitionId, Protocol.decodePartitionId(key))));
+    }
+
+    if (key > maxKeyValue) {
+      throw new UnrecoverableException(
+          new IllegalArgumentException(
+              String.format(
+                  "Provided key %d exceeds the maximum allowed key value %d for partition %d",
+                  key, maxKeyValue, partitionId)));
+    }
+    nextValueManager.setValue(LATEST_KEY, key);
+  }
+
+  /**
+   * Retrieve the max key value allowed for this partition. Since it is only used in tests and debug
+   * tools it is not part of the interface.
+   *
+   * @return the max key value stored in the state , or null if not set
+   */
+  public Long getMaxKeyValue() {
+    final var readValue = maxValueColumnFamily.get(maxKeyValueKey);
+    if (readValue != null) {
+      return readValue.getValue();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * This operation is intended to be used only to manually recover from specific failures.
+   *
+   * @param maxValue the max value allowed for the key
+   */
+  public void setMaxKeyValue(final long maxValue) {
+    maxKeyValueValue.wrapLong(maxValue);
+    maxValueColumnFamily.upsert(maxKeyValueKey, maxKeyValueValue);
+    maxKeyValue = maxValue;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/DbKeyGenerator.java
@@ -26,6 +26,7 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
   private static final long INITIAL_VALUE = 0;
 
   private static final String LATEST_KEY = "latestKey";
+  private static final String MAX_KEY = "maxKeyValue";
 
   private final long keyStartValue;
   private final NextValueManager nextValueManager;
@@ -51,7 +52,7 @@ public final class DbKeyGenerator implements KeyGeneratorControls {
             keyStartValue, zeebeDb, transactionContext, ZbColumnFamilies.KEY, LATEST_KEY);
 
     maxKeyValueKey = new DbString();
-    maxKeyValueKey.wrapString("maxKeyValue");
+    maxKeyValueKey.wrapString(MAX_KEY);
     // Reuse the column family of next key, but use a different key name.
     maxValueColumnFamily =
         zeebeDb.createColumnFamily(

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorKeyGeneratorErrorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorKeyGeneratorErrorTest.java
@@ -39,7 +39,9 @@ final class StreamProcessorKeyGeneratorErrorTest {
     final var zeebeDb = streamPlatform.getZeebeDb();
     final DbKeyGenerator dbKeyGenerator = new DbKeyGenerator(1, zeebeDb, zeebeDb.createContext());
     // set the key generator to a value that will cause an overflow on next key generation
-    dbKeyGenerator.setKeyIfHigher(Protocol.encodePartitionId(1, (long) Math.pow(2, 51) - 1));
+    final var maxKeyValue = Protocol.encodePartitionId(1, (long) Math.pow(2, 51) - 1);
+    dbKeyGenerator.setMaxKeyValue(maxKeyValue);
+    dbKeyGenerator.setKeyIfHigher(maxKeyValue);
     when(mockedRecordProcessor.process(any(), any()))
         .thenAnswer(
             invocation -> {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/state/DbKeyGeneratorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/state/DbKeyGeneratorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.util.DefaultZeebeDbFactory;
+import java.io.File;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DbKeyGeneratorTest {
+  private static final int PARTITION_ID = 1;
+  @TempDir private File tempFolder;
+  private ZeebeDb<ZbColumnFamilies> db;
+  private DbKeyGenerator dbKeyGenerator;
+
+  @BeforeEach
+  void createDb() {
+    db = DefaultZeebeDbFactory.defaultFactory().createDb(tempFolder);
+    dbKeyGenerator = new DbKeyGenerator(PARTITION_ID, db, db.createContext());
+  }
+
+  @AfterEach
+  void closeDb() throws Exception {
+    db.close();
+  }
+
+  @Test
+  void shouldOverwriteKey() {
+    // when
+    dbKeyGenerator.overwriteKey(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+    final long nextKey = dbKeyGenerator.nextKey();
+
+    // then
+    assertThat(nextKey).isEqualTo(Protocol.encodePartitionId(PARTITION_ID, 1001L));
+  }
+
+  @Test
+  void shouldSetMaxKey() {
+    // when
+    dbKeyGenerator.setMaxKeyValue(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+
+    // then
+    assertThat(dbKeyGenerator.getMaxKeyValue())
+        .isEqualTo(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+  }
+
+  @Test
+  void shouldFailIfKeyOfAnotherPartitionIsSet() {
+    // given
+    final long keyOfAnotherPartition = Protocol.encodePartitionId(PARTITION_ID + 1, 100);
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> dbKeyGenerator.setKeyIfHigher(keyOfAnotherPartition))
+        .havingCause()
+        .withMessageContaining(
+            String.format(
+                "Provided key %d does not belong to partition %d",
+                keyOfAnotherPartition, Protocol.DEPLOYMENT_PARTITION));
+  }
+
+  @Test
+  void shouldFailNextKeyGenerationWhenMaxKeyReached() {
+    // given
+    dbKeyGenerator.setMaxKeyValue(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+    dbKeyGenerator.overwriteKey(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+
+    // when
+    assertThatException().isThrownBy(() -> dbKeyGenerator.nextKey());
+  }
+
+  @Test
+  void shouldNotSetKeyIfGreaterThanMaxKey() {
+    // given
+    dbKeyGenerator.setMaxKeyValue(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+    final long currentKey = Protocol.encodePartitionId(PARTITION_ID, 50L);
+    dbKeyGenerator.overwriteKey(currentKey);
+
+    // when
+    dbKeyGenerator.setKeyIfHigher(Protocol.encodePartitionId(PARTITION_ID, 2000L));
+
+    // then
+    assertThat(dbKeyGenerator.getCurrentKey()).isEqualTo(currentKey);
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/state/DbKeyGeneratorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/state/DbKeyGeneratorTest.java
@@ -95,4 +95,131 @@ class DbKeyGeneratorTest {
     // then
     assertThat(dbKeyGenerator.getCurrentKey()).isEqualTo(currentKey);
   }
+
+  @Test
+  void shouldGenerateSequentialKeys() {
+    // given
+    final long firstKey = dbKeyGenerator.nextKey();
+
+    // when
+    final long secondKey = dbKeyGenerator.nextKey();
+    final long thirdKey = dbKeyGenerator.nextKey();
+
+    // then
+    assertThat(secondKey).isEqualTo(firstKey + 1);
+    assertThat(thirdKey).isEqualTo(secondKey + 1);
+    assertThat(Protocol.decodePartitionId(firstKey)).isEqualTo(PARTITION_ID);
+    assertThat(Protocol.decodePartitionId(secondKey)).isEqualTo(PARTITION_ID);
+    assertThat(Protocol.decodePartitionId(thirdKey)).isEqualTo(PARTITION_ID);
+  }
+
+  @Test
+  void shouldSetKeyIfHigher() {
+    // given
+    dbKeyGenerator.nextKey(); // current key is 1
+    final long higherKey = Protocol.encodePartitionId(PARTITION_ID, 100L);
+
+    // when
+    dbKeyGenerator.setKeyIfHigher(higherKey);
+
+    // then
+    assertThat(dbKeyGenerator.getCurrentKey()).isEqualTo(higherKey);
+    assertThat(dbKeyGenerator.nextKey()).isEqualTo(higherKey + 1);
+  }
+
+  @Test
+  void shouldNotSetKeyIfLower() {
+    // given
+    final long currentKey = Protocol.encodePartitionId(PARTITION_ID, 100L);
+    dbKeyGenerator.overwriteKey(currentKey);
+    final long lowerKey = Protocol.encodePartitionId(PARTITION_ID, 50L);
+
+    // when
+    dbKeyGenerator.setKeyIfHigher(lowerKey);
+
+    // then
+    assertThat(dbKeyGenerator.getCurrentKey()).isEqualTo(currentKey);
+  }
+
+  @Test
+  void shouldFailOverwriteKeyWithWrongPartition() {
+    // given
+    final long keyOfAnotherPartition = Protocol.encodePartitionId(PARTITION_ID + 1, 100);
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> dbKeyGenerator.overwriteKey(keyOfAnotherPartition))
+        .havingCause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .withMessageContaining(
+            String.format(
+                "Provided key %d does not belong to partition %d",
+                keyOfAnotherPartition, PARTITION_ID));
+  }
+
+  @Test
+  void shouldFailOverwriteKeyExceedingMaxValue() {
+    // given
+    dbKeyGenerator.setMaxKeyValue(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+    final long keyExceedingMax = Protocol.encodePartitionId(PARTITION_ID, 2000L);
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> dbKeyGenerator.overwriteKey(keyExceedingMax))
+        .havingCause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .withMessageContaining(
+            String.format(
+                "Provided key %d exceeds the maximum allowed key value", keyExceedingMax));
+  }
+
+  @Test
+  void shouldReturnNullWhenMaxKeyNotSet() {
+    // when
+    final Long maxKeyValue = dbKeyGenerator.getMaxKeyValue();
+
+    // then
+    assertThat(maxKeyValue).isNull();
+  }
+
+  @Test
+  void shouldPersistMaxKeyValueAcrossInstances() {
+    // given
+    final long maxValue = Protocol.encodePartitionId(PARTITION_ID, 5000L);
+    dbKeyGenerator.setMaxKeyValue(maxValue);
+
+    // when - create new instance
+    final DbKeyGenerator newGenerator = new DbKeyGenerator(PARTITION_ID, db, db.createContext());
+
+    // then
+    assertThat(newGenerator.getMaxKeyValue()).isEqualTo(maxValue);
+  }
+
+  @Test
+  void shouldGenerateKeysUpToMaxValue() {
+    // given
+    final long maxValue = Protocol.encodePartitionId(PARTITION_ID, 10L);
+    dbKeyGenerator.setMaxKeyValue(maxValue);
+    dbKeyGenerator.overwriteKey(Protocol.encodePartitionId(PARTITION_ID, 8L));
+
+    // when - then
+    assertThat(dbKeyGenerator.nextKey()).isEqualTo(Protocol.encodePartitionId(PARTITION_ID, 9L));
+    assertThat(dbKeyGenerator.nextKey()).isEqualTo(Protocol.encodePartitionId(PARTITION_ID, 10L));
+    assertThatException().isThrownBy(() -> dbKeyGenerator.nextKey());
+  }
+
+  @Test
+  void shouldSetKeyIfHigherRespectingMaxValue() {
+    // given
+    dbKeyGenerator.setMaxKeyValue(Protocol.encodePartitionId(PARTITION_ID, 1000L));
+    final long currentKey = Protocol.encodePartitionId(PARTITION_ID, 50L);
+    dbKeyGenerator.overwriteKey(currentKey);
+    final long validHigherKey = Protocol.encodePartitionId(PARTITION_ID, 500L);
+
+    // when
+    dbKeyGenerator.setKeyIfHigher(validHigherKey);
+
+    // then
+    assertThat(dbKeyGenerator.getCurrentKey()).isEqualTo(validHigherKey);
+  }
 }


### PR DESCRIPTION
## Description

To overwrite the key in the state, run debug-cli command
`state update-key -k 2251799813685300 --max-key=<maxkey> --partition-id=1 --snapshot=source-snapshot`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #41871 
