### PR TITLE
fix: metrics enums become public so that they can be used in downstream test libs

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/metrics/JobHandlerMetrics.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/metrics/JobHandlerMetrics.java
@@ -43,7 +43,7 @@ public final class JobHandlerMetrics {
   }
 
   /** Contains constants for the tags used in job handler metrics. */
-  enum Tag {
+  public enum Tag {
     TYPE("type"),
     ACTION("action");
 
@@ -59,7 +59,7 @@ public final class JobHandlerMetrics {
   }
 
   /** Contains constants for the names of job handler metrics. */
-  enum Name {
+  public enum Name {
     INVOCATION("camunda.job.invocations"),
     EXECUTION_TIME("camunda.job.execution-time");
 
@@ -79,7 +79,7 @@ public final class JobHandlerMetrics {
    *
    * <p>These are used as values for the {@link Tag#ACTION} tag.
    */
-  enum Action {
+  public enum Action {
     ACTIVATED("activated"),
     COMPLETED("completed"),
     FAILED("failed"),


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR makes the JobHandlerMetrics inner enums public so that they can be used in downstream test libraries

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
