### PR TITLE
Add starter client metrics

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -382,6 +382,8 @@ jobs:
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set starter.resources.limits.cpu=3
+          --set starter.resources.requests.cpu=3
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.load-test-load }}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -200,6 +200,12 @@ public class Starter extends App {
 
   private void checkForProcessInstanceExistence(
       final CamundaClient client, final long startTime, final long processInstanceKey) {
+
+    LOG.warn(
+        "Process instance {} started at {} (delay {} ms) try to get from API",
+        processInstanceKey,
+        startTime,
+        Duration.ofNanos(System.nanoTime() - startTime).toMillis());
     client
         .newProcessInstanceGetRequest(processInstanceKey)
         .send()
@@ -214,7 +220,7 @@ public class Starter extends App {
                 LOG.trace("Failed to get process instance {}", processInstanceKey, err);
               } else {
                 final long durationNanos = System.nanoTime() - startTime;
-                LOG.debug(
+                LOG.warn(
                     "Process instance {} retrieved in {} ms",
                     processInstanceKey,
                     durationNanos / 1_000_000);

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -190,8 +190,7 @@ public class Starter extends App {
         .whenCompleteAsync(
             (resp, err) -> {
               if (err != null) {
-                THROTTLED_LOGGER.error(
-                    "Failed to get process instance {}", processInstanceKey, err);
+                LOG.trace("Failed to get process instance {}", processInstanceKey, err);
                 LockSupport.parkNanos(Duration.ofMillis(10).toNanos());
                 checkForProcessInstanceExistence(client, startTime, processInstanceKey);
               } else {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -84,7 +84,7 @@ public class Starter extends App {
     deployProcess(client, starterCfg);
 
     // setup to start instances on given rate
-    piCheckExecutorService = Executors.newScheduledThreadPool(3);
+    piCheckExecutorService = Executors.newScheduledThreadPool(20);
     final CountDownLatch countDownLatch = new CountDownLatch(1);
     executorService = Executors.newScheduledThreadPool(starterCfg.getThreads());
     final ScheduledFuture<?> scheduledTask =

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -63,6 +63,8 @@ public class Starter extends App {
   @Override
   public void run() {
     partitionToTimerMap = new ConcurrentHashMap<>();
+    responseLatencyTimer =
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.RESPONSE_LATENCY).register(registry);
     partitionToTimerMap.put(
         1,
         MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -27,13 +27,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +50,6 @@ public class Starter extends App {
   private final StarterCfg starterCfg;
   private Timer dataAvailabilityLatencyTimer;
   private Timer responseLatencyTimer;
-  private ConcurrentHashMap<Long, Long> piKeyToStartTime;
 
   Starter(final AppCfg config) {
     super(config);
@@ -76,35 +75,6 @@ public class Starter extends App {
         Executors.newScheduledThreadPool(starterCfg.getThreads());
     final ScheduledFuture<?> scheduledTask =
         scheduleProcessInstanceCreation(executorService, countDownLatch, client);
-
-    piKeyToStartTime = new ConcurrentHashMap<>();
-    executorService.scheduleAtFixedRate(
-        () -> {
-          for (final Map.Entry<Long, Long> entry : piKeyToStartTime.entrySet()) {
-            final long processInstanceKey = entry.getKey();
-            client
-                .newProcessInstanceGetRequest(processInstanceKey)
-                .send()
-                .whenCompleteAsync(
-                    (resp, err) -> {
-                      if (err == null) {
-                        // remove from map once we were able to retrieve it
-                        piKeyToStartTime.remove(processInstanceKey);
-                        final long durationNanos = System.nanoTime() - entry.getValue();
-
-                        LOG.debug(
-                            "Process instance {} retrieved in {} ms",
-                            processInstanceKey,
-                            durationNanos / 1_000_000);
-
-                        dataAvailabilityLatencyTimer.record(durationNanos, TimeUnit.NANOSECONDS);
-                      }
-                    });
-          }
-        },
-        1000,
-        100,
-        TimeUnit.MILLISECONDS);
 
     Runtime.getRuntime()
         .addShutdownHook(
@@ -207,8 +177,31 @@ public class Starter extends App {
         .thenApply(
             (response) -> {
               final long processInstanceKey = response.getProcessInstanceKey();
-              piKeyToStartTime.put(processInstanceKey, startTime);
+              checkForProcessInstanceExistence(client, startTime, processInstanceKey);
               return response;
+            });
+  }
+
+  private void checkForProcessInstanceExistence(
+      final CamundaClient client, final long startTime, final long processInstanceKey) {
+    client
+        .newProcessInstanceGetRequest(processInstanceKey)
+        .send()
+        .whenCompleteAsync(
+            (resp, err) -> {
+              if (err != null) {
+                LOG.trace("Failed to get process instance {}", processInstanceKey, err);
+                LockSupport.parkNanos(Duration.ofMillis(10).toNanos());
+                checkForProcessInstanceExistence(client, startTime, processInstanceKey);
+              } else {
+                final long durationNanos = System.nanoTime() - startTime;
+                LOG.debug(
+                    "Process instance {} retrieved in {} ms",
+                    processInstanceKey,
+                    durationNanos / 1_000_000);
+
+                dataAvailabilityLatencyTimer.record(durationNanos, TimeUnit.NANOSECONDS);
+              }
             });
   }
 

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -222,7 +222,8 @@ public class Starter extends App {
                 final int partitionId = Protocol.decodePartitionId(processInstanceKey);
                 partitionToTimerMap.get(partitionId).record(durationNanos, TimeUnit.NANOSECONDS);
               }
-            });
+            },
+            piCheckExecutorService);
   }
 
   private CompletionStage<?> startInstanceWithAwaitingResult(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -21,6 +21,7 @@ import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -204,7 +205,7 @@ public class Starter extends App {
     LOG.warn(
         "Process instance {} started at {} (delay {} ms) try to get from API",
         processInstanceKey,
-        startTime,
+        Instant.ofEpochMilli(startTime / 1_000_000),
         Duration.ofNanos(System.nanoTime() - startTime).toMillis());
     client
         .newProcessInstanceGetRequest(processInstanceKey)

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * The data availability latency when starting process instances. It measures the time from
+   * instance creation to the time the instance can be queried.
+   */
+  DATA_AVAILABILITY_LATENCY {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The data availability latency when starting process instances. It measures the time from instance creation to the time the instance can be queried.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.data.availability.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  };
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -18,19 +18,16 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
    */
   DATA_AVAILABILITY_LATENCY {
     private static final Duration[] BUCKETS = {
-      Duration.ofMillis(50),
-      Duration.ofMillis(75),
-      Duration.ofMillis(100),
-      Duration.ofMillis(250),
       Duration.ofMillis(500),
-      Duration.ofMillis(750),
       Duration.ofSeconds(1),
       Duration.ofMillis(2500),
       Duration.ofSeconds(5),
       Duration.ofSeconds(10),
       Duration.ofSeconds(15),
       Duration.ofSeconds(30),
-      Duration.ofSeconds(45)
+      Duration.ofSeconds(45),
+      Duration.ofSeconds(60),
+      Duration.ofSeconds(90),
     };
 
     @Override

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -52,5 +52,45 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
     public Duration[] getTimerSLOs() {
       return BUCKETS;
     }
+  },
+
+  /**
+   * The response latency when starting process instances. It measures the time from sending the
+   * request to receiving the response.
+   */
+  RESPONSE_LATENCY {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(10),
+      Duration.ofMillis(25),
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The response latency when starting process instances. It measures the time from sending the request to receiving the response.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.response.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
   };
 }


### PR DESCRIPTION
## Description

 Based on https://github.com/camunda/camunda/pull/42074 - previous refactoring

This PR adds new client metrics to measure:

 * latency of responses
 * latency of data availability, meaning when the user can actually see the data via the API


related https://github.com/camunda/camunda/issues/38890
