### PR TITLE
ci: add vitest retries to frontend unit tests

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "start": "vite",
     "build": "npm run ts-check && vite build && node ./renameProdIndex.js && node license-build.js",
-    "test": "vitest run --project=unit",
+    "test": "vitest run --project=unit --retry=3",
     "test:browser": "vitest run --project=browser",
     "ts-check": "tsc -b",
     "eslint": "eslint .",

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build && node ./renameProdIndex.mjs",
-    "test": "TZ=utc vitest run",
+    "test": "TZ=utc vitest run --retry=3",
     "test:ci": "CI=true npm run test",
     "test:visual": "playwright test --project=visual",
     "test:a11y": "IS_A11Y=true playwright test --project=a11y",


### PR DESCRIPTION
## Description

Use https://vitest.dev/config/retry to solve our recurring problems with instable FE unit tests of Operate and/or Tasklist. Examples:

* https://github.com/camunda/camunda/actions/runs/19898103260/job/57033932352
* https://github.com/camunda/camunda/actions/runs/19895465199/job/57024657711

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
