### PR TITLE
docs: fixed documentation of the v1 search endpoint.

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -95,7 +95,7 @@ public class TaskController extends ApiErrorController {
       summary = "Search tasks",
       description =
           "Returns the list of tasks that satisfy search request params.<br>"
-              + "<ul><li>If an empty body is provided, all tasks are returned.</li>"
+              + "<ul><li>If an empty body is provided, return all tasks except CANCELED.</li>"
               + "<li>Only one of `[searchAfter, searchAfterOrEqual, searchBefore, searchBeforeOrEqual]` search options must be present in request.</li></ul>",
       responses = {
         @ApiResponse(

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -95,7 +95,7 @@ public class TaskController extends ApiErrorController {
       summary = "Search tasks",
       description =
           "Returns the list of tasks that satisfy search request params.<br>"
-              + "<ul><li>If an empty body is provided, return all tasks except CANCELED.</li>"
+              + "<ul><li>If an empty body is provided, all tasks except CANCELED are returned.</li>"
               + "<li>Only one of `[searchAfter, searchAfterOrEqual, searchBefore, searchBeforeOrEqual]` search options must be present in request.</li></ul>",
       responses = {
         @ApiResponse(


### PR DESCRIPTION
## Description

Since the `v1` is deprecated we've decided instead of changing logic update the documentation and make it clear that calls to `/v1/tasks/search` with **empty** `RequestBody` returns all the tasks except the tasks in state `CANCELED`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37785 
