### PR TITLE
Send batch PI delete request from gateway to broker

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -365,7 +365,12 @@ public final class ProcessInstanceServices
 
   public CompletableFuture<BatchOperationCreationRecord> deleteProcessInstancesBatchOperation(
       final ProcessInstanceFilter filter) {
-    throw new UnsupportedOperationException("Batch deletion of process instances is coming soon!");
+    final var brokerRequest =
+        new BrokerCreateBatchOperationRequest()
+            .setFilter(filter)
+            .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+            .setAuthentication(authentication);
+    return sendBrokerRequest(brokerRequest);
   }
 
   public SearchQueryResult<IncidentEntity> searchIncidents(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
@@ -36,8 +36,8 @@ public final class BatchOperationCreateChunkProcessor
     final var recordValue = command.getValue();
     LOGGER.debug(
         "Creating a new chunk with {} items for batch operation {}",
-        recordValue.getBatchOperationKey(),
-        recordValue.getItems().size());
+        recordValue.getItems().size(),
+        recordValue.getBatchOperationKey());
 
     stateWriter.appendFollowUpEvent(
         command.getKey(), BatchOperationChunkIntent.CREATED, recordValue);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/DeleteProcessInstanceBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/DeleteProcessInstanceBatchExecutorTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
@@ -51,7 +52,12 @@ public final class DeleteProcessInstanceBatchExecutorTest extends AbstractBatchO
     final var batchOperationKey =
         createDeleteProcessInstanceBatchOperation(List.of(processInstanceKey), claims);
 
-    // TODO assert HistoryDeletionIntent.DELETE is appended
+    assertThat(
+            RecordingExporter.historyDeletionRecords()
+                .withResourceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == HistoryDeletionIntent.DELETED))
+        .extracting(Record::getIntent)
+        .containsSequence(HistoryDeletionIntent.DELETE, HistoryDeletionIntent.DELETED);
 
     // then we have completed event
     assertThat(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -42,7 +42,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -2171,13 +2170,11 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  @Disabled("Enable in https://github.com/camunda/camunda/issues/41754")
   void shouldDeleteProcessInstanceBatchOperation() {
     // given
     final var record = new BatchOperationCreationRecord();
     record.setBatchOperationKey(123L);
-    // TODO Uncomment once batch operation type is available
-    // record.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    record.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
 
     when(processInstanceServices.deleteProcessInstancesBatchOperation(
             any(ProcessInstanceFilter.class)))


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The endpoint was still a NOOP. We need to pass the request to the broker with the correct batch operation type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41754 
