### PR TITLE
Add auth claims zeebe events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -93,7 +93,7 @@ public final class BatchOperationCancelProcessor
 
     final var batchOperation = batchOperationState.get(batchOperationKey);
     if (batchOperation.isPresent() && batchOperation.get().canCancel()) {
-      cancelBatchOperationEvent(cancelKey, command);
+      cancelBatchOperationEvent(cancelKey, recordValue);
       responseWriter.writeEventOnCommand(
           cancelKey, BatchOperationIntent.CANCELED, command.getValue(), command);
       commandDistributionBehavior
@@ -132,19 +132,17 @@ public final class BatchOperationCancelProcessor
         "Processing distributed command to cancel a batch operation with key '{}': {}",
         batchOperationKey,
         recordValue);
-    cancelBatchOperationEvent(batchOperationKey, command);
+    cancelBatchOperationEvent(batchOperationKey, recordValue);
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
   private void cancelBatchOperationEvent(
-      final Long cancelKey, final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
-    final var recordValue = command.getValue();
-    final var claims = command.getAuthorizations();
+      final Long cancelKey, final BatchOperationLifecycleManagementRecord recordValue) {
     stateWriter.appendFollowUpEvent(
         cancelKey,
         BatchOperationIntent.CANCELED,
         recordValue,
         FollowUpEventMetadata.of(
-            b -> b.batchOperationReference(recordValue.getBatchOperationKey()).claims(claims)));
+            b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -69,7 +69,7 @@ public final class BatchOperationCreateProcessor
       final RoutingInfo routingInfo,
       final BatchOperationMetrics metrics) {
     stateWriter = writers.state();
-    this.batchOperationState = state.getBatchOperationState();
+    batchOperationState = state.getBatchOperationState();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.keyGenerator = keyGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -69,7 +69,7 @@ public final class BatchOperationCreateProcessor
       final RoutingInfo routingInfo,
       final BatchOperationMetrics metrics) {
     stateWriter = writers.state();
-    batchOperationState = state.getBatchOperationState();
+    this.batchOperationState = state.getBatchOperationState();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.keyGenerator = keyGenerator;
@@ -113,8 +113,7 @@ public final class BatchOperationCreateProcessor
         key,
         BatchOperationIntent.CREATED,
         recordWithKey,
-        FollowUpEventMetadata.of(
-            b -> b.batchOperationReference(key).claims(command.getAuthorizations())));
+        FollowUpEventMetadata.of(b -> b.batchOperationReference(key)));
     responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);
     commandDistributionBehavior
         .withKey(key)
@@ -147,10 +146,7 @@ public final class BatchOperationCreateProcessor
                     command.getKey(),
                     BatchOperationIntent.CREATED,
                     command.getValue(),
-                    FollowUpEventMetadata.of(
-                        b ->
-                            b.batchOperationReference(command.getKey())
-                                .claims(command.getAuthorizations()))));
+                    FollowUpEventMetadata.of(b -> b.batchOperationReference(command.getKey()))));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -35,7 +35,6 @@ import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.VisibleForTesting;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,8 +116,7 @@ public final class BatchOperationResumeProcessor
       return;
     }
 
-    resumeBatchOperation(
-        resumeKey, batchOperation.get(), command.getValue(), command.getAuthorizations());
+    resumeBatchOperation(resumeKey, batchOperation.get(), command.getValue());
     responseWriter.writeEventOnCommand(
         resumeKey, BatchOperationIntent.RESUMED, command.getValue(), command);
     commandDistributionBehavior
@@ -142,8 +140,7 @@ public final class BatchOperationResumeProcessor
           "Processing distributed command to resume with key '{}': {}",
           batchOperationKey,
           recordValue);
-      resumeBatchOperation(
-          command.getKey(), batchOperation.get(), command.getValue(), command.getAuthorizations());
+      resumeBatchOperation(command.getKey(), batchOperation.get(), recordValue);
     } else {
       LOGGER.debug(
           "Distributed command to resume a batch operation with key '{}' will be ignored: {}",
@@ -157,14 +154,12 @@ public final class BatchOperationResumeProcessor
   void resumeBatchOperation(
       final Long resumeKey,
       final PersistedBatchOperation batchOperation,
-      final BatchOperationLifecycleManagementRecord recordValue,
-      final Map<String, Object> claims) {
+      final BatchOperationLifecycleManagementRecord recordValue) {
     stateWriter.appendFollowUpEvent(
         resumeKey,
         BatchOperationIntent.RESUMED,
         recordValue,
-        FollowUpEventMetadata.of(
-            m -> m.batchOperationReference(batchOperation.getKey()).claims(claims)));
+        FollowUpEventMetadata.of(m -> m.batchOperationReference(batchOperation.getKey())));
 
     final var batchExecute = new BatchOperationExecutionRecord();
     batchExecute.setBatchOperationKey(batchOperation.getKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -109,7 +109,7 @@ public final class BatchOperationSuspendProcessor
       return;
     }
 
-    suspendBatchOperation(suspendKey, command);
+    suspendBatchOperation(suspendKey, recordValue);
     responseWriter.writeEventOnCommand(
         suspendKey, BatchOperationIntent.SUSPENDED, command.getValue(), command);
     commandDistributionBehavior
@@ -133,7 +133,7 @@ public final class BatchOperationSuspendProcessor
           "Processing distributed command to suspend with key '{}': {}",
           batchOperationKey,
           recordValue);
-      suspendBatchOperation(batchOperationKey, command);
+      suspendBatchOperation(batchOperationKey, recordValue);
     } else {
       LOGGER.debug(
           "Distributed command to suspend batch operation with key '{}' will be ignored: {}",
@@ -145,15 +145,13 @@ public final class BatchOperationSuspendProcessor
   }
 
   private void suspendBatchOperation(
-      final Long suspendKey, final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
-    final var recordValue = command.getValue();
-    final var claims = command.getAuthorizations();
+      final Long suspendKey, final BatchOperationLifecycleManagementRecord recordValue) {
     stateWriter.appendFollowUpEvent(
         suspendKey,
         BatchOperationIntent.SUSPENDED,
         recordValue,
         FollowUpEventMetadata.of(
-            b -> b.batchOperationReference(recordValue.getBatchOperationKey()).claims(claims)));
+            b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
   }
 
   private void rejectInvalidState(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -111,8 +111,7 @@ public class DecisionEvaluationEvaluteProcessor
               stateWriter.appendFollowUpEvent(
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),
-                  evaluationRecordTuple.getRight(),
-                  command.getAuthorizations());
+                  evaluationRecordTuple.getRight());
               responseWriter.writeEventOnCommand(
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -82,10 +82,7 @@ public class AuthorizationCreateProcessor
         .ifRightOrLeft(
             ignored -> {
               stateWriter.appendFollowUpEvent(
-                  command.getKey(),
-                  AuthorizationIntent.CREATED,
-                  command.getValue(),
-                  command.getAuthorizations());
+                  command.getKey(), AuthorizationIntent.CREATED, command.getValue());
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
@@ -103,8 +100,7 @@ public class AuthorizationCreateProcessor
       final AuthorizationRecord authorizationRecord) {
     final long key = keyGenerator.nextKey();
     authorizationRecord.setAuthorizationKey(key);
-    stateWriter.appendFollowUpEvent(
-        key, AuthorizationIntent.CREATED, authorizationRecord, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, AuthorizationIntent.CREATED, authorizationRecord);
     responseWriter.writeEventOnCommand(
         key, AuthorizationIntent.CREATED, authorizationRecord, command);
     distributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -81,8 +81,7 @@ public class AuthorizationDeleteProcessor
               stateWriter.appendFollowUpEvent(
                   command.getValue().getAuthorizationKey(),
                   AuthorizationIntent.DELETED,
-                  command.getValue(),
-                  command.getAuthorizations());
+                  command.getValue());
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
@@ -103,10 +102,7 @@ public class AuthorizationDeleteProcessor
         .setAuthorizationKey(authorizationKey)
         .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
     stateWriter.appendFollowUpEvent(
-        authorizationKey,
-        AuthorizationIntent.DELETED,
-        command.getValue(),
-        command.getAuthorizations());
+        authorizationKey, AuthorizationIntent.DELETED, command.getValue());
     distributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -88,8 +88,7 @@ public class AuthorizationUpdateProcessor
               stateWriter.appendFollowUpEvent(
                   command.getValue().getAuthorizationKey(),
                   AuthorizationIntent.UPDATED,
-                  command.getValue(),
-                  command.getAuthorizations());
+                  command.getValue());
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
@@ -109,8 +108,7 @@ public class AuthorizationUpdateProcessor
     stateWriter.appendFollowUpEvent(
         authorizationRecord.getAuthorizationKey(),
         AuthorizationIntent.UPDATED,
-        authorizationRecord,
-        command.getAuthorizations());
+        authorizationRecord);
     distributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -106,8 +106,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        groupKey, GroupIntent.ENTITY_ADDED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_ADDED, record);
     responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_ADDED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -126,8 +125,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
               record.getEntityId(), record.getGroupId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
     } else {
-      stateWriter.appendFollowUpEvent(
-          command.getKey(), GroupIntent.ENTITY_ADDED, record, command.getAuthorizations());
+      stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.ENTITY_ADDED, record);
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -77,7 +77,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
     final long key = keyGenerator.nextKey();
     record.setGroupKey(key);
 
-    stateWriter.appendFollowUpEvent(key, GroupIntent.CREATED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, GroupIntent.CREATED, record);
     responseWriter.writeEventOnCommand(key, GroupIntent.CREATED, record, command);
 
     commandDistributionBehavior
@@ -97,9 +97,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
                   GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(persistedGroup.getGroupId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
-            () ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), GroupIntent.CREATED, record, command.getAuthorizations()));
+            () -> stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.CREATED, record));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -105,8 +105,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     }
 
     final var groupKey = persistedRecord.get().getGroupKey();
-    stateWriter.appendFollowUpEvent(
-        groupKey, GroupIntent.ENTITY_REMOVED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_REMOVED, record);
     responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_REMOVED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -122,10 +121,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
     if (isEntityAssigned(record)) {
       stateWriter.appendFollowUpEvent(
-          command.getKey(),
-          GroupIntent.ENTITY_REMOVED,
-          command.getValue(),
-          command.getAuthorizations());
+          command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue());
     } else {
       final var errorMessage =
           ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getGroupKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -89,10 +89,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
   @Override
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getValue().getGroupKey(),
-        GroupIntent.UPDATED,
-        command.getValue(),
-        command.getAuthorizations());
+        command.getValue().getGroupKey(), GroupIntent.UPDATED, command.getValue());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
@@ -118,10 +115,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
             .setDescription(persistedGroup.getDescription());
 
     stateWriter.appendFollowUpEvent(
-        persistedGroup.getGroupKey(),
-        GroupIntent.UPDATED,
-        updatedRecord,
-        command.getAuthorizations());
+        persistedGroup.getGroupKey(), GroupIntent.UPDATED, updatedRecord);
     responseWriter.writeEventOnCommand(
         persistedGroup.getGroupKey(), GroupIntent.UPDATED, updatedRecord, command);
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -113,8 +113,7 @@ public class MappingRuleCreateProcessor
     final long key = keyGenerator.nextKey();
     record.setMappingRuleKey(key);
 
-    stateWriter.appendFollowUpEvent(
-        key, MappingRuleIntent.CREATED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, MappingRuleIntent.CREATED, record);
     responseWriter.writeEventOnCommand(key, MappingRuleIntent.CREATED, record, command);
 
     commandDistributionBehavior
@@ -137,10 +136,7 @@ public class MappingRuleCreateProcessor
             },
             () ->
                 stateWriter.appendFollowUpEvent(
-                    command.getKey(),
-                    MappingRuleIntent.CREATED,
-                    record,
-                    command.getAuthorizations()));
+                    command.getKey(), MappingRuleIntent.CREATED, record));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -42,7 +42,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.util.Map;
 
 public class MappingRuleDeleteProcessor
     implements DistributedTypedRecordProcessor<MappingRuleRecord> {
@@ -105,7 +104,7 @@ public class MappingRuleDeleteProcessor
       return;
     }
     final long key = keyGenerator.nextKey();
-    deleteMappingRule(persistedMappingRuleOptional.get(), key, command.getAuthorizations());
+    deleteMappingRule(persistedMappingRuleOptional.get(), key);
     responseWriter.writeEventOnCommand(key, MappingRuleIntent.DELETED, record, command);
 
     commandDistributionBehavior
@@ -120,9 +119,7 @@ public class MappingRuleDeleteProcessor
     mappingRuleState
         .get(record.getMappingRuleId())
         .ifPresentOrElse(
-            persistedMappingRule ->
-                deleteMappingRule(
-                    persistedMappingRule, command.getKey(), command.getAuthorizations()),
+            persistedMappingRule -> deleteMappingRule(persistedMappingRule, command.getKey()),
             () -> {
               final var errorMessage =
                   MAPPING_RULE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getMappingRuleKey());
@@ -132,12 +129,9 @@ public class MappingRuleDeleteProcessor
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private void deleteMappingRule(
-      final PersistedMappingRule mappingRule,
-      final long key,
-      final Map<String, Object> authorizationClaims) {
+  private void deleteMappingRule(final PersistedMappingRule mappingRule, final long key) {
     final var mappingRuleId = mappingRule.getMappingRuleId();
-    deleteAuthorizations(mappingRuleId, authorizationClaims);
+    deleteAuthorizations(mappingRuleId);
     for (final var tenantId :
         membershipState.getMemberships(
             EntityType.MAPPING_RULE, mappingRule.getMappingRuleId(), RelationType.TENANT)) {
@@ -149,8 +143,7 @@ public class MappingRuleDeleteProcessor
               .setTenantKey(tenant.getTenantKey())
               .setTenantId(tenant.getTenantId())
               .setEntityId(mappingRule.getMappingRuleId())
-              .setEntityType(EntityType.MAPPING_RULE),
-          authorizationClaims);
+              .setEntityType(EntityType.MAPPING_RULE));
     }
     for (final var roleId :
         membershipState.getMemberships(EntityType.MAPPING_RULE, mappingRuleId, RelationType.ROLE)) {
@@ -162,8 +155,7 @@ public class MappingRuleDeleteProcessor
               .setRoleKey(role.getRoleKey())
               .setRoleId(roleId)
               .setEntityId(mappingRuleId)
-              .setEntityType(EntityType.MAPPING_RULE),
-          authorizationClaims);
+              .setEntityType(EntityType.MAPPING_RULE));
     }
     for (final var groupId :
         membershipState.getMemberships(
@@ -176,18 +168,15 @@ public class MappingRuleDeleteProcessor
               .setGroupKey(group.getGroupKey())
               .setGroupId(groupId)
               .setEntityId(mappingRule.getMappingRuleId())
-              .setEntityType(EntityType.MAPPING_RULE),
-          authorizationClaims);
+              .setEntityType(EntityType.MAPPING_RULE));
     }
     stateWriter.appendFollowUpEvent(
         key,
         MappingRuleIntent.DELETED,
-        new MappingRuleRecord().setMappingRuleId(mappingRule.getMappingRuleId()),
-        authorizationClaims);
+        new MappingRuleRecord().setMappingRuleId(mappingRule.getMappingRuleId()));
   }
 
-  private void deleteAuthorizations(
-      final String mappingRuleId, final Map<String, Object> authorizationClaims) {
+  private void deleteAuthorizations(final String mappingRuleId) {
     final var authorizationKeysForMappingRule =
         authorizationState.getAuthorizationKeysForOwner(
             AuthorizationOwnerType.MAPPING_RULE, mappingRuleId);
@@ -199,7 +188,7 @@ public class MappingRuleDeleteProcessor
                   .setAuthorizationKey(authorizationKey)
                   .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
-              authorizationKey, AuthorizationIntent.DELETED, authorization, authorizationClaims);
+              authorizationKey, AuthorizationIntent.DELETED, authorization);
         });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -113,8 +113,7 @@ public class MappingRuleUpdateProcessor
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record);
     responseWriter.writeEventOnCommand(
         record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record, command);
 
@@ -127,10 +126,7 @@ public class MappingRuleUpdateProcessor
   @Override
   public void processDistributedCommand(final TypedRecord<MappingRuleRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getKey(),
-        MappingRuleIntent.UPDATED,
-        command.getValue(),
-        command.getAuthorizations());
+        command.getKey(), MappingRuleIntent.UPDATED, command.getValue());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -114,8 +114,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        record.getRoleKey(), RoleIntent.ENTITY_ADDED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.ENTITY_ADDED, record);
     responseWriter.writeEventOnCommand(
         record.getRoleKey(), RoleIntent.ENTITY_ADDED, record, command);
 
@@ -134,8 +133,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
           ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
     } else {
-      stateWriter.appendFollowUpEvent(
-          command.getKey(), RoleIntent.ENTITY_ADDED, record, command.getAuthorizations());
+      stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.ENTITY_ADDED, record);
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -74,7 +74,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
     final long key = keyGenerator.nextKey();
     record.setRoleKey(key);
 
-    stateWriter.appendFollowUpEvent(key, RoleIntent.CREATED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, RoleIntent.CREATED, record);
     responseWriter.writeEventOnCommand(key, RoleIntent.CREATED, record, command);
 
     commandDistributionBehavior
@@ -94,9 +94,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
                   ROLE_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getRoleId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
-            () ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), RoleIntent.CREATED, record, command.getAuthorizations()));
+            () -> stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.CREATED, record));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -91,11 +91,10 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     final var roleKey = persistedRole.getRoleKey();
     record.setRoleKey(roleKey);
 
-    removeMembers(command);
-    deleteAuthorizations(command);
+    removeMembers(record);
+    deleteAuthorizations(record);
 
-    stateWriter.appendFollowUpEvent(
-        roleKey, RoleIntent.DELETED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(roleKey, RoleIntent.DELETED, record);
     responseWriter.writeEventOnCommand(roleKey, RoleIntent.DELETED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -112,13 +111,10 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
         .getRole(record.getRoleId())
         .ifPresentOrElse(
             role -> {
-              removeMembers(command);
-              deleteAuthorizations(command);
+              removeMembers(command.getValue());
+              deleteAuthorizations(command.getValue());
               stateWriter.appendFollowUpEvent(
-                  command.getKey(),
-                  RoleIntent.DELETED,
-                  command.getValue(),
-                  command.getAuthorizations());
+                  command.getKey(), RoleIntent.DELETED, command.getValue());
             },
             () -> {
               final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleId());
@@ -128,9 +124,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private void removeMembers(final TypedRecord<RoleRecord> command) {
-    final var record = command.getValue();
-    final var authorizationClaims = command.getAuthorizations();
+  private void removeMembers(final RoleRecord record) {
     final var roleId = record.getRoleId();
     membershipState.forEachMember(
         RelationType.ROLE,
@@ -139,14 +133,11 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
           stateWriter.appendFollowUpEvent(
               record.getRoleKey(),
               RoleIntent.ENTITY_REMOVED,
-              new RoleRecord().setRoleId(roleId).setEntityId(entityId).setEntityType(entityType),
-              authorizationClaims);
+              new RoleRecord().setRoleId(roleId).setEntityId(entityId).setEntityType(entityType));
         });
   }
 
-  private void deleteAuthorizations(final TypedRecord<RoleRecord> command) {
-    final var record = command.getValue();
-    final var authorizationClaims = command.getAuthorizations();
+  private void deleteAuthorizations(final RoleRecord record) {
     final var roleId = record.getRoleId();
     final var authorizationKeysForRole =
         authorizationState.getAuthorizationKeysForOwner(AuthorizationOwnerType.ROLE, roleId);
@@ -158,7 +149,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
                   .setAuthorizationKey(authorizationKey)
                   .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
-              authorizationKey, AuthorizationIntent.DELETED, authorization, authorizationClaims);
+              authorizationKey, AuthorizationIntent.DELETED, authorization);
         });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -108,8 +108,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record);
     responseWriter.writeEventOnCommand(
         record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record, command);
 
@@ -126,10 +125,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
     if (isEntityAssigned(record)) {
       stateWriter.appendFollowUpEvent(
-          command.getKey(),
-          RoleIntent.ENTITY_REMOVED,
-          command.getValue(),
-          command.getAuthorizations());
+          command.getKey(), RoleIntent.ENTITY_REMOVED, command.getValue());
     } else {
       final var errorMessage =
           ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -75,8 +75,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
 
     final var persistedRole = persistedRecord.get();
     record.setRoleKey(persistedRole.getRoleKey());
-    stateWriter.appendFollowUpEvent(
-        record.getRoleKey(), RoleIntent.UPDATED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.UPDATED, record);
     responseWriter.writeEventOnCommand(record.getRoleKey(), RoleIntent.UPDATED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
@@ -89,10 +88,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
   @Override
   public void processDistributedCommand(final TypedRecord<RoleRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getValue().getRoleKey(),
-        RoleIntent.UPDATED,
-        command.getValue(),
-        command.getAuthorizations());
+        command.getValue().getRoleKey(), RoleIntent.UPDATED, command.getValue());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -115,8 +115,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        key, IncidentIntent.RESOLVED, incident, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
 
     publishIncidentRelatedJob(jobKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -80,8 +80,7 @@ public final class ProcessInstanceCancelProcessor
     asyncRequestBehavior.writeAsyncRequestReceived(command.getKey(), command);
 
     final ProcessInstanceRecord value = elementInstance.getValue();
-    stateWriter.appendFollowUpEvent(
-        command.getKey(), ProcessInstanceIntent.CANCELING, value, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.CANCELING, value);
     commandWriter.appendFollowUpCommand(
         command.getKey(), ProcessInstanceIntent.TERMINATE_ELEMENT, value);
     responseWriter.writeEventOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -46,7 +46,6 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.TagUtil;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
@@ -118,7 +117,7 @@ public final class ProcessInstanceCreationCreateProcessor
         .flatMap(process -> isAuthorized(command, process))
         .flatMap(process -> validateCommand(command.getValue(), process))
         .ifRightOrLeft(
-            process -> createProcessInstance(controller, command, process),
+            process -> createProcessInstance(controller, record, process),
             rejection -> controller.reject(rejection.type(), rejection.reason()));
 
     return true;
@@ -168,17 +167,16 @@ public final class ProcessInstanceCreationCreateProcessor
 
   private void createProcessInstance(
       final CommandControl<ProcessInstanceCreationRecord> controller,
-      final TypedRecord<ProcessInstanceCreationRecord> command,
+      final ProcessInstanceCreationRecord record,
       final DeployedProcess process) {
     final long processInstanceKey = keyGenerator.nextKey();
-    final ProcessInstanceCreationRecord record = command.getValue();
+
     setVariablesFromDocument(
         record,
         process.getKey(),
         processInstanceKey,
         process.getBpmnProcessId(),
-        process.getTenantId(),
-        command.getAuthorizations());
+        process.getTenantId());
 
     final var processInstance =
         initProcessInstanceRecord(process, processInstanceKey, record.getTags());
@@ -412,8 +410,7 @@ public final class ProcessInstanceCreationCreateProcessor
       final long processDefinitionKey,
       final long processInstanceKey,
       final DirectBuffer bpmnProcessId,
-      final String tenantId,
-      final Map<String, Object> authorizationClaims) {
+      final String tenantId) {
 
     variableBehavior.mergeLocalDocument(
         processInstanceKey,
@@ -421,8 +418,7 @@ public final class ProcessInstanceCreationCreateProcessor
         processInstanceKey,
         bpmnProcessId,
         tenantId,
-        record.getVariablesBuffer(),
-        authorizationClaims);
+        record.getVariablesBuffer());
   }
 
   private ProcessInstanceRecord initProcessInstanceRecord(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -194,10 +194,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     }
 
     stateWriter.appendFollowUpEvent(
-        processInstanceKey,
-        ProcessInstanceMigrationIntent.MIGRATED,
-        value,
-        command.getAuthorizations());
+        processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
     responseWriter.writeEventOnCommand(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value, command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -305,8 +305,7 @@ public final class ProcessInstanceModificationModifyProcessor
                                   scopeKey,
                                   processInstance,
                                   process,
-                                  instruction,
-                                  command.getAuthorizations()));
+                                  instruction));
 
                   extendedRecord.addActivateInstruction(
                       ((ProcessInstanceModificationActivateInstruction) instruction)
@@ -334,10 +333,7 @@ public final class ProcessInstanceModificationModifyProcessor
         });
 
     stateWriter.appendFollowUpEvent(
-        eventKey,
-        ProcessInstanceModificationIntent.MODIFIED,
-        extendedRecord,
-        command.getAuthorizations());
+        eventKey, ProcessInstanceModificationIntent.MODIFIED, extendedRecord);
 
     responseWriter.writeEventOnCommand(
         eventKey, ProcessInstanceModificationIntent.MODIFIED, extendedRecord, command);
@@ -1025,8 +1021,7 @@ public final class ProcessInstanceModificationModifyProcessor
       final Long scopeKey,
       final ElementInstance processInstance,
       final DeployedProcess process,
-      final ProcessInstanceModificationActivateInstructionValue activate,
-      final Map<String, Object> authorizationClaims) {
+      final ProcessInstanceModificationActivateInstructionValue activate) {
     activate.getVariableInstructions().stream()
         .filter(
             instruction ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -74,8 +74,7 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
     final boolean respond = shouldRespond && command.hasRequestMetadata();
 
     if (isAccepted) {
-      stateWriter.appendFollowUpEvent(
-          entityKey, newState, updatedValue, command.getAuthorizations());
+      stateWriter.appendFollowUpEvent(entityKey, newState, updatedValue);
       wrappedProcessor.afterAccept(commandWriter, stateWriter, entityKey, newState, updatedValue);
       if (respond) {
         responseWriter.writeEventOnCommand(entityKey, newState, updatedValue, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
-import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -43,15 +42,6 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     final int latestVersion = eventApplier.getLatestVersion(intent);
     appendFollowUpEvent(key, intent, value, latestVersion);
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final Map<String, Object> claims) {
-    appendFollowUpEvent(key, intent, value, m -> m.claims(claims));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
-import java.util.Map;
 import java.util.function.Consumer;
 
 public interface TypedEventWriter {
@@ -38,31 +37,6 @@ public interface TypedEventWriter {
    * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
    */
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
-
-  /**
-   * Append a follow-up event to the result builder.
-   *
-   * <p>Different versions of event records may be applied by different {@link
-   * io.camunda.zeebe.engine.state.EventApplier EventApplier}s, leading to differing state changes.
-   * This allows fixing bugs in event appliers because every event applier must produce the same
-   * state changes for an event both when writing it and when replaying it, even on newer versions
-   * of Zeebe.
-   *
-   * <p>This method always uses the latest available {@link
-   * io.camunda.zeebe.engine.state.EventApplier}. If a specific version needs to be used, consider
-   * using {@link #appendFollowUpEvent(long, Intent, RecordValue, int)} instead.
-   *
-   * <p>For advanced use cases requiring enriched metadata such as {@code operationReference},
-   * consider using {@link #appendFollowUpEvent(long, Intent, RecordValue, FollowUpEventMetadata)}.
-   *
-   * @param key the key of the event
-   * @param intent the intent of the event
-   * @param value the record of the event
-   * @param claims the authorization claims to set in the event's metadata
-   * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
-   */
-  void appendFollowUpEvent(
-      long key, Intent intent, RecordValue value, final Map<String, Object> claims);
 
   /**
    * Append a specific version of a follow-up event to the result builder.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -115,8 +115,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        tenantKey, TenantIntent.ENTITY_ADDED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_ADDED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_ADDED, record, command);
     sideEffectWriter.appendSideEffect(
         () -> {
@@ -134,8 +133,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       createAlreadyAssignedRejectCommand(
           command, record.getEntityId(), record.getEntityType(), record.getTenantId());
     } else {
-      stateWriter.appendFollowUpEvent(
-          command.getKey(), TenantIntent.ENTITY_ADDED, record, command.getAuthorizations());
+      stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.ENTITY_ADDED, record);
       sideEffectWriter.appendSideEffect(
           () -> {
             authCheckBehavior.clearAuthorizationsCache();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -82,9 +82,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
                   TENANT_ALREADY_EXISTS_ERROR_MESSAGE.formatted(tenant.getTenantId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
-            () ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), TenantIntent.CREATED, record, command.getAuthorizations()));
+            () -> stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.CREATED, record));
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }
@@ -107,7 +105,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   private void createTenant(final TypedRecord<TenantRecord> command, final TenantRecord record) {
     final long key = keyGenerator.nextKey();
     record.setTenantKey(key);
-    stateWriter.appendFollowUpEvent(key, TenantIntent.CREATED, record, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, TenantIntent.CREATED, record);
     responseWriter.writeEventOnCommand(key, TenantIntent.CREATED, record, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
-import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -40,7 +39,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
 
   private final TenantState tenantState;
   private final MappingRuleState mappingRuleState;
-  private final GroupState groupState;
   private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -58,7 +56,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
       final CommandDistributionBehavior commandDistributionBehavior) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
-    groupState = state.getGroupState();
     membershipState = state.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -80,10 +80,7 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
   @Override
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
     stateWriter.appendFollowUpEvent(
-        command.getValue().getTenantKey(),
-        TenantIntent.UPDATED,
-        command.getValue(),
-        command.getAuthorizations());
+        command.getValue().getTenantKey(), TenantIntent.UPDATED, command.getValue());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
@@ -122,10 +119,7 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
             .setDescription(persistedTenant.getDescription());
 
     stateWriter.appendFollowUpEvent(
-        persistedTenant.getTenantKey(),
-        TenantIntent.UPDATED,
-        updatedRecord,
-        command.getAuthorizations());
+        persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
     responseWriter.writeEventOnCommand(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -86,8 +86,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     final long key = keyGenerator.nextKey();
     command.getValue().setUserKey(key);
 
-    stateWriter.appendFollowUpEvent(
-        key, UserIntent.CREATED, command.getValue(), command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(key, UserIntent.CREATED, command.getValue());
     addUserPermissions(key, username);
     responseWriter.writeEventOnCommand(key, UserIntent.CREATED, command.getValue(), command);
 
@@ -109,8 +108,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, message);
             },
             () -> {
-              stateWriter.appendFollowUpEvent(
-                  command.getKey(), UserIntent.CREATED, record, command.getAuthorizations());
+              stateWriter.appendFollowUpEvent(command.getKey(), UserIntent.CREATED, record);
             });
 
     distributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -43,7 +43,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.util.Map;
 
 public class UserDeleteProcessor implements DistributedTypedRecordProcessor<UserRecord> {
 
@@ -108,7 +107,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
       return;
     }
 
-    deleteUser(user, command.getAuthorizations());
+    deleteUser(user);
     responseWriter.writeEventOnCommand(
         user.getUserKey(), UserIntent.DELETED, command.getValue(), command);
 
@@ -125,7 +124,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     userState
         .getUser(username)
         .ifPresentOrElse(
-            user -> deleteUser(user, command.getAuthorizations()),
+            this::deleteUser,
             () -> {
               final var message = USER_DOES_NOT_EXIST_ERROR_MESSAGE.formatted(username);
               rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, message);
@@ -134,10 +133,10 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     distributionBehavior.acknowledgeCommand(command);
   }
 
-  private void deleteUser(final PersistedUser user, final Map<String, Object> authorizationClaims) {
+  private void deleteUser(final PersistedUser user) {
     final var userKey = user.getUserKey();
     final var username = user.getUsername();
-    deleteAuthorizations(username, authorizationClaims);
+    deleteAuthorizations(username);
     for (final var tenantId :
         membershipState.getMemberships(EntityType.USER, username, RelationType.TENANT)) {
       final var tenant = tenantState.getTenantById(tenantId).orElseThrow();
@@ -147,8 +146,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
           new TenantRecord()
               .setTenantId(tenantId)
               .setEntityId(user.getUsername())
-              .setEntityType(EntityType.USER),
-          authorizationClaims);
+              .setEntityType(EntityType.USER));
     }
 
     for (final var roleId :
@@ -161,8 +159,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
               .setRoleKey(role.getRoleKey())
               .setRoleId(roleId)
               .setEntityId(username)
-              .setEntityType(EntityType.USER),
-          authorizationClaims);
+              .setEntityType(EntityType.USER));
     }
 
     for (final var groupId :
@@ -175,16 +172,13 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
               .setGroupKey(group.getGroupKey())
               .setGroupId(groupId)
               .setEntityId(username)
-              .setEntityType(EntityType.USER),
-          authorizationClaims);
+              .setEntityType(EntityType.USER));
     }
 
-    stateWriter.appendFollowUpEvent(
-        userKey, UserIntent.DELETED, user.getUser(), authorizationClaims);
+    stateWriter.appendFollowUpEvent(userKey, UserIntent.DELETED, user.getUser());
   }
 
-  private void deleteAuthorizations(
-      final String username, final Map<String, Object> authorizationClaims) {
+  private void deleteAuthorizations(final String username) {
     final var authorizationKeysForGroup =
         authorizationState.getAuthorizationKeysForOwner(AuthorizationOwnerType.USER, username);
 
@@ -195,7 +189,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
                   .setAuthorizationKey(authorizationKey)
                   .setResourceMatcher(AuthorizationResourceMatcher.UNSPECIFIED);
           stateWriter.appendFollowUpEvent(
-              authorizationKey, AuthorizationIntent.DELETED, authorization, authorizationClaims);
+              authorizationKey, AuthorizationIntent.DELETED, authorization);
         });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -82,8 +82,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
 
     final var updatedUser = overlayUser(persistedUser.getUser(), record);
 
-    stateWriter.appendFollowUpEvent(
-        persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser, command.getAuthorizations());
+    stateWriter.appendFollowUpEvent(persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser);
     responseWriter.writeEventOnCommand(
         persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser, command);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,7 +139,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
 
         final var variableDocumentState = optionalVariableDocumentState.get();
         final var variableDocumentRecord = variableDocumentState.getRecord();
-        mergeVariables(userTaskRecord, variableDocumentRecord, command.getAuthorizations());
+        mergeVariables(userTaskRecord, variableDocumentRecord);
 
         // Write follow-up events
         stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
@@ -168,9 +167,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
   }
 
   private void mergeVariables(
-      final UserTaskRecord userTaskRecord,
-      final VariableDocumentRecord variableRecord,
-      final Map<String, Object> authorizationClaims) {
+      final UserTaskRecord userTaskRecord, final VariableDocumentRecord variableRecord) {
     switch (variableRecord.getUpdateSemantics()) {
       case LOCAL ->
           variableBehavior.mergeLocalDocument(
@@ -179,8 +176,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               userTaskRecord.getProcessInstanceKey(),
               userTaskRecord.getBpmnProcessIdBuffer(),
               userTaskRecord.getTenantId(),
-              variableRecord.getVariablesBuffer(),
-              authorizationClaims);
+              variableRecord.getVariablesBuffer());
       case PROPAGATE ->
           variableBehavior.mergeDocument(
               userTaskRecord.getElementInstanceKey(),
@@ -188,8 +184,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               userTaskRecord.getProcessInstanceKey(),
               userTaskRecord.getBpmnProcessIdBuffer(),
               userTaskRecord.getTenantId(),
-              variableRecord.getVariablesBuffer(),
-              authorizationClaims);
+              variableRecord.getVariablesBuffer());
       default ->
           throw new IllegalStateException(
               "Unexpected variable update semantic: '%s'. Expected either 'LOCAL' or 'PROPAGATE'."

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Iterator;
-import java.util.Map;
 import org.agrona.DirectBuffer;
 
 /**
@@ -65,24 +64,6 @@ public final class VariableBehavior {
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer document) {
-    mergeLocalDocument(
-        scopeKey,
-        processDefinitionKey,
-        processInstanceKey,
-        bpmnProcessId,
-        tenantId,
-        document,
-        Map.of());
-  }
-
-  public void mergeLocalDocument(
-      final long scopeKey,
-      final long processDefinitionKey,
-      final long processInstanceKey,
-      final DirectBuffer bpmnProcessId,
-      final String tenantId,
-      final DirectBuffer document,
-      final Map<String, Object> authorizationClaims) {
     indexedDocument.index(document);
     if (indexedDocument.isEmpty()) {
       return;
@@ -96,7 +77,7 @@ public final class VariableBehavior {
         .setTenantId(tenantId);
     for (final DocumentEntry entry : indexedDocument) {
       applyEntryToRecord(entry);
-      setLocalVariable(variableRecord, authorizationClaims);
+      setLocalVariable(variableRecord);
     }
   }
 
@@ -128,46 +109,6 @@ public final class VariableBehavior {
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer document) {
-    mergeDocument(
-        scopeKey,
-        processDefinitionKey,
-        processInstanceKey,
-        bpmnProcessId,
-        tenantId,
-        document,
-        Map.of());
-  }
-
-  /**
-   * Merges the given document, propagating its changes from the bottom to the top of the scope
-   * hierarchy.
-   *
-   * <p>Starting at the given {@code scopeKey}, it will overwrite any variables that exist in that
-   * scope with the corresponding values from the given document. Variables that were not set
-   * because they did not exist in the current scope are collected as a sub document, which will
-   * then be merged with the parent scope, recursively, until there are no more. If we reach a scope
-   * with no parent, then any remaining variables are created there.
-   *
-   * <p>If any variable from the document already exists on the current scope, a {@code
-   * Variable.UPDATED} record is produced as a follow up event.
-   *
-   * <p>For all variables from the document which do not exist in the current scope, a {@code
-   * Variable.CREATED} record is produced as a follow up event.
-   *
-   * @param scopeKey the scope key for each variable
-   * @param processDefinitionKey the process key to be associated with each variable
-   * @param processInstanceKey the process instance key to be associated with each variable
-   * @param document the document to merge
-   * @param authorizationClaims the authorization claims to include with each follow-up event
-   */
-  public void mergeDocument(
-      final long scopeKey,
-      final long processDefinitionKey,
-      final long processInstanceKey,
-      final DirectBuffer bpmnProcessId,
-      final String tenantId,
-      final DirectBuffer document,
-      final Map<String, Object> authorizationClaims) {
     indexedDocument.index(document);
     if (indexedDocument.isEmpty()) {
       return;
@@ -193,10 +134,7 @@ public final class VariableBehavior {
         if (variableInstance != null && !variableInstance.getValue().equals(entry.getValue())) {
           applyEntryToRecord(entry);
           stateWriter.appendFollowUpEvent(
-              variableInstance.getKey(),
-              VariableIntent.UPDATED,
-              variableRecord,
-              authorizationClaims);
+              variableInstance.getKey(), VariableIntent.UPDATED, variableRecord);
           entryIterator.remove();
         }
       }
@@ -207,7 +145,7 @@ public final class VariableBehavior {
     variableRecord.setScopeKey(currentScope);
     for (final DocumentEntry entry : indexedDocument) {
       applyEntryToRecord(entry);
-      setLocalVariable(variableRecord, authorizationClaims);
+      setLocalVariable(variableRecord);
     }
   }
 
@@ -247,19 +185,17 @@ public final class VariableBehavior {
         .setName(name)
         .setValue(value, valueOffset, valueLength);
 
-    setLocalVariable(variableRecord, Map.of()); // no authorization claims in internal usage
+    setLocalVariable(variableRecord);
   }
 
-  private void setLocalVariable(
-      final VariableRecord record, final Map<String, Object> authorizationClaims) {
+  private void setLocalVariable(final VariableRecord record) {
     final VariableInstance variableInstance =
         variableState.getVariableInstanceLocal(record.getScopeKey(), record.getNameBuffer());
     if (variableInstance == null) {
       final long key = keyGenerator.nextKey();
-      stateWriter.appendFollowUpEvent(key, VariableIntent.CREATED, record, authorizationClaims);
+      stateWriter.appendFollowUpEvent(key, VariableIntent.CREATED, record);
     } else if (!variableInstance.getValue().equals(record.getValueBuffer())) {
-      stateWriter.appendFollowUpEvent(
-          variableInstance.getKey(), VariableIntent.UPDATED, record, authorizationClaims);
+      stateWriter.appendFollowUpEvent(variableInstance.getKey(), VariableIntent.UPDATED, record);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -157,8 +157,7 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getProcessInstanceKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
-                value.getVariablesBuffer(),
-                record.getAuthorizations());
+                value.getVariablesBuffer());
         case PROPAGATE ->
             variableBehavior.mergeDocument(
                 userTaskRecord.getElementInstanceKey(),
@@ -166,8 +165,7 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getProcessInstanceKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
-                value.getVariablesBuffer(),
-                record.getAuthorizations());
+                value.getVariablesBuffer());
         default ->
             throw new IllegalStateException(
                 "Unexpected variable update semantic: '%s'. Expected either 'LOCAL' or 'PROPAGATE'."
@@ -199,8 +197,7 @@ public final class VariableDocumentUpdateProcessor
             processInstanceKey,
             bpmnProcessId,
             tenantId,
-            value.getVariablesBuffer(),
-            record.getAuthorizations());
+            value.getVariablesBuffer());
       } else {
         variableBehavior.mergeDocument(
             scope.getKey(),
@@ -208,8 +205,7 @@ public final class VariableDocumentUpdateProcessor
             processInstanceKey,
             bpmnProcessId,
             tenantId,
-            value.getVariablesBuffer(),
-            record.getAuthorizations());
+            value.getVariablesBuffer());
       }
     } catch (final MsgpackReaderException e) {
       final String reason =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
@@ -37,13 +37,14 @@ public class BatchEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
-          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
-              cfg ->
-                  cfg.getInitialization()
-                      .getDefaultRoles()
-                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+              cfg -> {
+                cfg.getAuthorizations().setEnabled(true);
+                cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+              });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
@@ -47,13 +47,14 @@ public class IdentityEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
-          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
-              cfg ->
-                  cfg.getInitialization()
-                      .getDefaultRoles()
-                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+              cfg -> {
+                cfg.getAuthorizations().setEnabled(true);
+                cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+              });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ProcessEventsClaimsTest {
+
+  private static final String PROCESS_ID = "testProcess";
+  private static final String PROCESS_ID_V2 = "testProcessV2";
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(
+              cfg -> {
+                cfg.getAuthorizations().setEnabled(true);
+                cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEvents() {
+    // given
+    deployProcess();
+
+    // when
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceModificationModifiedEvents() {
+    // given
+    deployProcessWithServiceTask();
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("taskB")
+        .modify(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.processInstanceModificationRecords(
+                ProcessInstanceModificationIntent.MODIFIED)
+            .withProcessInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceMigrationMigratedEvents() {
+    // given
+    deployProcess();
+    final var targetProcessDefinitionKey = deployProcessV2();
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("taskA", "taskA")
+        .migrate(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCancelingEvents() {
+    // given
+    deployProcess();
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+
+    // when
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCELING)
+            .withProcessInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInIncidentResolvedEvents() {
+    // given
+    deployProcessWithIncident();
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    // create incident by failing the job
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    engine.job().withKey(jobKey).withRetries(-1).fail();
+    final var incidentKey =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    // Fix the issue by setting the variable
+    engine
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("x", 10))
+        .update(DEFAULT_USER.getUsername());
+    engine.job().withKey(jobKey).withRetries(1).updateRetries();
+
+    // when
+    engine
+        .incident()
+        .ofInstance(processInstanceKey)
+        .withKey(incidentKey)
+        .resolve(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+            .withRecordKey(incidentKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInDecisionEvaluationEvaluatedEvents() {
+    // given
+    deployDecision("/dmn/decision-table.dmn");
+
+    // when
+    engine
+        .decision()
+        .ofDecisionId("jedi_or_sith")
+        .withVariable("lightsaberColor", "blue")
+        .evaluate(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED).findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInDecisionEvaluationFailedEvents() {
+    // given
+    deployDecision("/dmn/drg-force-user-with-assertions.dmn");
+
+    // when - evaluate without required variable
+    engine
+        .decision()
+        .ofDecisionId("jedi_or_sith")
+        .expectFailure()
+        .evaluate(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.FAILED).findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInVariableCreatedEvents() {
+    // given
+    deployProcess();
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("testVar", "initialValue")
+            .create(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("testVar")
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInVariableUpdatedEvents() {
+    // given
+    deployProcess();
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("testVar", "initialValue")
+            .create(DEFAULT_USER.getUsername());
+
+    // when - update the variable
+    engine
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("testVar", "updatedValue"))
+        .update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.variableRecords(VariableIntent.UPDATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("testVar")
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceMigrationRejectionEvents() {
+    // given
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process")
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process2")
+                    .startEvent()
+                    .userTask("A")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId("process").create();
+
+    final long targetProcessDefinitionKey =
+        extractTargetProcessDefinitionKey(deployment, "process2");
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .expectRejection()
+        .migrate(DEFAULT_USER.getUsername());
+
+    // then - verify the rejection record contains authorization claims
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+    assertThat(rejectionRecord.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejectionRecord.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCancelRejectionEvents() {
+    // given - deploy a process with a call activity that creates a child process instance
+    deployProcessWithCallActivity();
+    deployChildProcess();
+
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+
+    // Get the child process instance key from the call activity's activated record
+    final var childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(processInstanceKey)
+            .withBpmnProcessId("childProcess")
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when - attempt to cancel a child process instance directly (should be rejected)
+    // Child process instances can only be canceled through their parent
+    final var rejectionRecord =
+        engine
+            .processInstance()
+            .withInstanceKey(childProcessInstanceKey)
+            .expectRejection()
+            .cancel(DEFAULT_USER.getUsername());
+
+    // then - verify the rejection record contains authorization claims
+    assertThat(rejectionRecord.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejectionRecord.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldIncludeClaimsInIncidentResolveRejectionEvents() {
+    // given
+    deployProcessWithIncident();
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    // create incident by failing the job
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    engine.job().withKey(jobKey).withRetries(0).fail();
+    final var incidentKey =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when - attempt to resolve the incident (should be rejected with INVALID_STATE)
+    final var rejectionRecord =
+        engine
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentKey)
+            .expectRejection()
+            .resolve(DEFAULT_USER.getUsername());
+
+    // then - verify the rejection record contains authorization claims
+    assertThat(rejectionRecord.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejectionRecord.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+
+  private long deployProcess() {
+    return engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("taskA", t -> t.zeebeJobType("taskA"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername())
+        .getValue()
+        .getProcessesMetadata()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private long deployProcessV2() {
+    return engine
+        .deployment()
+        .withXmlResource(
+            "process_v2.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID_V2)
+                .startEvent()
+                .serviceTask("taskA", t -> t.zeebeJobType("taskA"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername())
+        .getValue()
+        .getProcessesMetadata()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private void deployProcessWithServiceTask() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("taskA", t -> t.zeebeJobType("taskA"))
+                .serviceTask("taskB", t -> t.zeebeJobType("taskB"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployProcessWithIncident() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("task").zeebeInputExpression("x", "y"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployDecision(final String decisionResource) {
+    engine
+        .deployment()
+        .withXmlClasspathResource(decisionResource)
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployProcessWithCallActivity() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("callActivity", c -> c.zeebeProcessId("childProcess"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployChildProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "childProcess.bpmn",
+            Bpmn.createExecutableProcess("childProcess")
+                .startEvent()
+                .serviceTask("childTask", t -> t.zeebeJobType("childTask"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void assertAuthorizationClaims(final java.util.Optional<?> record) {
+    assertThat(record).isPresent();
+    assertThat(((io.camunda.zeebe.protocol.record.Record<?>) record.get()).getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+
+  private static long extractTargetProcessDefinitionKey(
+      final Record<DeploymentRecordValue> deployment, final String bpmnProcessId) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(bpmnProcessId))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ResourceEventsClaimsTest {
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(
+              cfg -> {
+                cfg.getAuthorizations().setEnabled(true);
+                cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldIncludeClaimsInProcessCreatedEvents() {
+    // when
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess("testProcess").startEvent().endEvent().done())
+        .deploy(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.processRecords(ProcessIntent.CREATED)
+            .withBpmnProcessId("testProcess")
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessDeletedEvents() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess("testProcess").startEvent().endEvent().done())
+        .deploy(DEFAULT_USER.getUsername());
+
+    final var processDefinitionKey =
+        RecordingExporter.processRecords(ProcessIntent.CREATED)
+            .withBpmnProcessId("testProcess")
+            .getFirst()
+            .getKey();
+
+    // when
+    engine
+        .resourceDeletion()
+        .withResourceKey(processDefinitionKey)
+        .delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.processRecords(ProcessIntent.DELETED)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInDecisionRequirementsCreatedEvents() {
+    // when
+    engine
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .deploy(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.decisionRequirementsRecords()
+            .withIntent(DecisionRequirementsIntent.CREATED)
+            .findFirst();
+    final var decisionRecords =
+        RecordingExporter.decisionRecords().withIntent(DecisionIntent.CREATED).limit(3L);
+    assertAuthorizationClaims(record);
+    decisionRecords.forEach(decisionRecord -> assertAuthorizationClaims(decisionRecord));
+  }
+
+  @Test
+  public void shouldIncludeClaimsInDecisionRequirementsDeletedEvents() {
+    // given
+    engine
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .deploy(DEFAULT_USER.getUsername());
+
+    final var drgKey =
+        RecordingExporter.decisionRequirementsRecords()
+            .withIntent(DecisionRequirementsIntent.CREATED)
+            .getFirst()
+            .getKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(drgKey).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.decisionRequirementsRecords()
+            .withIntent(DecisionRequirementsIntent.DELETED)
+            .withDecisionRequirementsKey(drgKey)
+            .findFirst();
+    final var decisionRecords =
+        RecordingExporter.decisionRecords().withIntent(DecisionIntent.DELETED).limit(3L);
+    assertAuthorizationClaims(record);
+    decisionRecords.forEach(decisionRecord -> assertAuthorizationClaims(decisionRecord));
+  }
+
+  @Test
+  public void shouldIncludeClaimsInFormCreatedEvents() {
+    // when
+    engine
+        .deployment()
+        .withJsonClasspathResource("/form/test-form-1.form")
+        .deploy(DEFAULT_USER.getUsername());
+
+    // then
+    final var record = RecordingExporter.formRecords().withIntent(FormIntent.CREATED).findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInFormDeletedEvents() {
+    // given
+    engine
+        .deployment()
+        .withJsonClasspathResource("/form/test-form-1.form")
+        .deploy(DEFAULT_USER.getUsername());
+
+    final var formKey =
+        RecordingExporter.formRecords().withIntent(FormIntent.CREATED).getFirst().getKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(formKey).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.formRecords()
+            .withIntent(FormIntent.DELETED)
+            .withFormKey(formKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInResourceCreatedEvents() {
+    // when
+    engine
+        .deployment()
+        .withJsonClasspathResource("/resource/test-rpa-1.rpa")
+        .deploy(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.resourceRecords().withIntent(ResourceIntent.CREATED).findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInResourceDeletedEvents() {
+    // given
+    engine
+        .deployment()
+        .withJsonClasspathResource("/resource/test-rpa-1.rpa")
+        .deploy(DEFAULT_USER.getUsername());
+
+    final var resourceKey =
+        RecordingExporter.resourceRecords().withIntent(ResourceIntent.CREATED).getFirst().getKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(resourceKey).delete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.resourceRecords()
+            .withIntent(ResourceIntent.DELETED)
+            .withResourceKey(resourceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  private void assertAuthorizationClaims(final java.util.Optional<?> record) {
+    assertThat(record).isPresent();
+    final var typedRecord = (Record<?>) record.get();
+    assertAuthorizationClaims(typedRecord);
+  }
+
+  private void assertAuthorizationClaims(final Record record) {
+    assertThat(record.getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/UserTaskEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/UserTaskEventsClaimsTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class UserTaskEventsClaimsTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String USER_TASK_ID = "userTask";
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .getDefaultRoles()
+                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Before
+  public void deployProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask(USER_TASK_ID)
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserTaskAssignedEvents() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = findUserTaskKey(processInstanceKey);
+
+    // when
+    engine
+        .userTask()
+        .withKey(userTaskKey)
+        .withAssignee("testAssignee")
+        .assign(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+            .withRecordKey(userTaskKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserTaskUpdatedEvents() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = findUserTaskKey(processInstanceKey);
+
+    // when
+    engine.userTask().withKey(userTaskKey).withPriority(99).update(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+            .withRecordKey(userTaskKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserTaskCompletedEvents() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = findUserTaskKey(processInstanceKey);
+
+    // when
+    engine.userTask().withKey(userTaskKey).complete(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userTaskRecords(UserTaskIntent.COMPLETED)
+            .withRecordKey(userTaskKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserTaskClaimEvents() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = findUserTaskKey(processInstanceKey);
+
+    // when
+    engine
+        .userTask()
+        .withKey(userTaskKey)
+        .withAssignee(DEFAULT_USER.getUsername())
+        .claim(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+            .withRecordKey(userTaskKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserTaskUnassignEvents() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = findUserTaskKey(processInstanceKey);
+
+    // Assign first
+    engine
+        .userTask()
+        .withKey(userTaskKey)
+        .withAssignee("testAssignee")
+        .assign(DEFAULT_USER.getUsername());
+
+    // when - unassign
+    engine.userTask().withKey(userTaskKey).unassign(DEFAULT_USER.getUsername());
+
+    // then
+    final var record =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+            .withRecordKey(userTaskKey)
+            .skip(1) // Skip the initial assign event
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInUserTaskUpdatedEventsWhenUpdatingVariables() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskRecord = findUserTask(processInstanceKey);
+    final var userTaskKey = userTaskRecord.getKey();
+    final var elementInstanceKey = userTaskRecord.getValue().getElementInstanceKey();
+    final Map<String, Object> variables = Map.of("testVar", "testValue", "number", 42);
+
+    // when - update variables using VariableDocumentUpdateProcessor
+    engine
+        .variables()
+        .ofScope(elementInstanceKey)
+        .withDocument(variables)
+        .withUpdateSemantic(VariableDocumentUpdateSemantic.LOCAL)
+        .update(DEFAULT_USER.getUsername());
+
+    // then - verify UPDATED event is generated for the user task
+    final var record =
+        RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+            .withRecordKey(userTaskKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+  }
+
+  private long createProcessInstance() {
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+
+  private long findUserTaskKey(final long processInstanceKey) {
+    return findUserTask(processInstanceKey).getKey();
+  }
+
+  private Record<UserTaskRecordValue> findUserTask(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+
+  private void assertAuthorizationClaims(final java.util.Optional<?> record) {
+    assertThat(record).isPresent();
+    assertThat(((io.camunda.zeebe.protocol.record.Record<?>) record.get()).getAuthorizations())
+        .containsEntry(Authorization.AUTHORIZED_USERNAME, DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessorTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -66,7 +65,7 @@ class BatchOperationResumeProcessorTest {
     when(batchOperation.isInitialized()).thenReturn(false);
 
     // when
-    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue, Map.of());
+    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue);
 
     // then
     verify(stateWriter)
@@ -92,7 +91,7 @@ class BatchOperationResumeProcessorTest {
     when(batchOperation.isInitialized()).thenReturn(true);
 
     // when
-    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue, Map.of());
+    processor.resumeBatchOperation(resumeKey, batchOperation, recordValue);
 
     // then
     verify(stateWriter)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -90,8 +89,6 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
 
     // then
     assertThat(response.getValue().getDecisionOutput()).isEqualTo("\"Sith\"");
-    assertThat(response.getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   @Test
@@ -114,8 +111,6 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CREATE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(DECISION_ID));
-    assertThat(rejection.getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -98,13 +97,11 @@ public class IncidentResolveAuthorizationTest {
     engine.incident().ofInstance(processInstanceKey).resolve(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
-            .withProcessInstanceKey(processInstanceKey)
-            .findFirst();
-    assertThat(record).isPresent();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
   }
 
   @Test
@@ -127,8 +124,6 @@ public class IncidentResolveAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
-    assertThat(rejection.getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
@@ -97,14 +96,6 @@ public class ProcessInstanceCancelAuthorizationTest {
     engine.processInstance().withInstanceKey(processInstanceKey).cancel(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCELING)
-            .withProcessInstanceKey(processInstanceKey)
-            .findFirst();
-    assertThat(record).isPresent();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
-
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -132,8 +123,6 @@ public class ProcessInstanceCancelAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CANCEL_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
-    assertThat(rejection.getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -10,12 +10,10 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
@@ -113,15 +111,6 @@ public class ProcessInstanceCreateAuthorizationTest {
         engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceCreationRecords()
-            .withIntent(ProcessInstanceCreationIntent.CREATED)
-            .withInstanceKey(processInstanceKey)
-            .findFirst();
-    assertThat(record).isPresent();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
-
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -149,15 +138,6 @@ public class ProcessInstanceCreateAuthorizationTest {
             .create(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceCreationRecords()
-            .withIntent(ProcessInstanceCreationIntent.CREATED)
-            .withInstanceKey(processInstanceKey)
-            .findFirst();
-    assertThat(record).isPresent();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
-
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
@@ -118,14 +117,12 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .modify(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceModificationRecords(
-                ProcessInstanceModificationIntent.MODIFIED)
-            .withProcessInstanceKey(processInstanceKey)
-            .findFirst();
-    assertThat(record.isPresent()).isTrue();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+    assertThat(
+            RecordingExporter.processInstanceModificationRecords(
+                    ProcessInstanceModificationIntent.MODIFIED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
   }
 
   @Test
@@ -145,15 +142,14 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .modify(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
-    Assertions.assertThat(record)
+    Assertions.assertThat(
+            RecordingExporter.processInstanceModificationRecords()
+                .onlyCommandRejections()
+                .getFirst())
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'MODIFY_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
-    assertThat(record.getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.processinstance.migration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -133,13 +132,12 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
         .migrate(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .findFirst();
-    assertThat(record).isPresent();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
+    assertThat(
+            RecordingExporter.processInstanceMigrationRecords(
+                    ProcessInstanceMigrationIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
   }
 
   @Test
@@ -159,15 +157,12 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
         .migrate(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-    Assertions.assertThat(record)
+    Assertions.assertThat(
+            RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst())
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
-    assertThat(record.getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import java.util.Map;
 
 /**
  * A state writer that uses the event applier, to alter the state for each written event.
@@ -38,15 +37,6 @@ public final class EventApplyingStateWriter implements StateWriter {
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final Map<String, Object> claims) {
-    appendFollowUpEvent(key, intent, value, m -> m.claims(claims));
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -10,13 +10,11 @@ package io.camunda.zeebe.engine.processing.variable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
-import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -110,14 +108,6 @@ public class VariableDocumentUpdateAuthorizationTest {
         .update(user.getUsername());
 
     // then
-    final var record =
-        RecordingExporter.variableRecords(VariableIntent.CREATED)
-            .withScopeKey(processInstanceKey)
-            .findFirst();
-    assertThat(record).isPresent();
-    assertThat(record.get().getAuthorizations())
-        .containsEntry(Authorization.AUTHORIZED_USERNAME, user.getUsername());
-
     assertThat(
             RecordingExporter.variableDocumentRecords(VariableDocumentIntent.UPDATED)
                 .withScopeKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -32,15 +31,6 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final Map<String, Object> claims) {
-    appendFollowUpEvent(key, intent, value, FollowUpEventMetadata.builder().claims(claims).build());
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -191,6 +191,12 @@ public final class UserTaskClient {
     return withoutAssignee().withAction(userTaskRecord.getActionOrDefault("unassign")).assign();
   }
 
+  public Record<UserTaskRecordValue> unassign(final String username) {
+    return withoutAssignee()
+        .withAction(userTaskRecord.getActionOrDefault("unassign"))
+        .assign(username);
+  }
+
   public Record<UserTaskRecordValue> assign() {
     final long userTaskKey = findUserTaskKey();
     final long position =

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -344,7 +344,8 @@ public final class ProcessingStateMachine {
         new BufferedProcessingResultBuilder(
             logStreamWriter::canWriteEvents,
             initialCommand.getOperationReference(),
-            initialCommand.getBatchOperationReference());
+            initialCommand.getBatchOperationReference(),
+            initialCommand.getAuthorizations());
     var lastProcessingResultSize = 0;
 
     // It might be that we reached the batch size limit during processing a command.
@@ -544,7 +545,8 @@ public final class ProcessingStateMachine {
         new BufferedProcessingResultBuilder(
             logStreamWriter::canWriteEvents,
             typedCommand.getOperationReference(),
-            typedCommand.getBatchOperationReference());
+            typedCommand.getBatchOperationReference(),
+            typedCommand.getAuthorizations());
     final var errorRecord = new ErrorRecord();
     errorRecord.initErrorRecord(
         new CommandRejectionException(rejectionReason), currentRecord.getPosition());
@@ -588,7 +590,8 @@ public final class ProcessingStateMachine {
               new BufferedProcessingResultBuilder(
                   logStreamWriter::canWriteEvents,
                   typedCommand.getOperationReference(),
-                  typedCommand.getBatchOperationReference());
+                  typedCommand.getBatchOperationReference(),
+                  typedCommand.getAuthorizations());
           currentProcessingResult =
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessRecordStream.java
@@ -30,6 +30,10 @@ public final class ProcessRecordStream extends ExporterRecordStream<Process, Pro
     return valueFilter(v -> v.getBpmnProcessId().equals(bpmnProcessId));
   }
 
+  public ProcessRecordStream withProcessDefinitionKey(final long processDefinitionKey) {
+    return valueFilter(v -> v.getProcessDefinitionKey() == processDefinitionKey);
+  }
+
   public ProcessRecordStream withVersion(final int version) {
     return valueFilter(v -> v.getVersion() == version);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Ensure that authorization claims are included in all Zeebe events produced by a user-triggered command record.

ℹ️ This PR also reverts the changes made in specific processors, as they are unnecessary.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41124
