### PR TITLE
ci: remove zeebe build step from tasklist-ci

### DIFF
--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -111,9 +111,7 @@ jobs:
       # Run integration tests in parallel
       - name: Backend - ${{ inputs.test-type }}
         run: |
-          ${{ inputs.command }} \
-          -Dzeebe.currentVersion.docker.tag=${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }} \
-          -Dzeebe.currentVersion.docker.repo=${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
+          ${{ inputs.command }}
 
       # Reports: publish test metrics results
       - name: Upload Test Report

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -62,8 +62,6 @@ jobs:
             testProfile: docker-os
             url: http://localhost:9200
     env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe
-      ZEEBE_TEST_DOCKER_IMAGE_TAG: current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
     services:
@@ -95,15 +93,6 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild
-      - uses: ./.github/actions/build-platform-docker
-        id: build-camunda-docker
-        with:
-          # we use a local registry for pushing
-          repository: ${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          version: ${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }}
-          # push is needed to make accessible for integration tests
-          push: true
 
       # Run integration tests in parallel
       - name: Run Integration Tests


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Remove unnecessary build zeebe step from Tasklists test pipeline

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
