### PR TITLE
feat: support filtering BO items by operation type

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
@@ -16,9 +16,11 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
+import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
@@ -88,4 +90,20 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   BatchOperationItemFilter state(final Consumer<BatchOperationItemStateProperty> fn);
+
+  /**
+   * Filters batch operation items by the specified operationType.
+   *
+   * @param operationType the operationType
+   * @return the updated filter
+   */
+  BatchOperationItemFilter operationType(final BatchOperationType operationType);
+
+  /**
+   * Filter by operationType using {@link BatchOperationTypeProperty} consumer
+   *
+   * @param fn the consumer to apply to the BatchOperationTypeProperty
+   * @return the updated filter
+   */
+  BatchOperationItemFilter operationType(Consumer<BatchOperationTypeProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
@@ -16,12 +16,15 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
+import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
 import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationItemStatePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BatchOperationTypePropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationItemFilter;
 import java.util.function.Consumer;
@@ -100,6 +103,26 @@ public class BatchOperationItemFilterImpl
     final BatchOperationItemStateProperty property = new BatchOperationItemStatePropertyImpl();
     fn.accept(property);
     filter.setState(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter operationType(
+      final BatchOperationType operationType) {
+    if (operationType == null) {
+      filter.setOperationType(null);
+      return this;
+    }
+
+    return operationType(b -> b.eq(operationType));
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter operationType(
+      final Consumer<BatchOperationTypeProperty> fn) {
+    final BatchOperationTypeProperty property = new BatchOperationTypePropertyImpl();
+    fn.accept(property);
+    filter.setOperationType(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.protocol.rest.BatchOperationItemSearchQuerySortRequest.FieldEnum;
 import io.camunda.client.util.ClientRestTest;
@@ -68,7 +69,8 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
                 f.batchOperationKey("123")
                     .state(BatchOperationItemState.ACTIVE)
                     .processInstanceKey(123L)
-                    .itemKey(456L))
+                    .itemKey(456L)
+                    .operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE))
         .send()
         .join();
 
@@ -80,6 +82,8 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
         .isEqualTo(BatchOperationItemStateEnum.ACTIVE);
     assertThat(request.getFilter().getProcessInstanceKey().get$Eq()).isEqualTo("123");
     assertThat(request.getFilter().getItemKey().get$Eq()).isEqualTo("456");
+    assertThat(request.getFilter().getOperationType().get$Eq())
+        .isEqualTo(BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE);
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -310,6 +310,7 @@
   <select id="countItems" resultType="java.lang.Long">
     SELECT COUNT(*)
     FROM ${prefix}BATCH_OPERATION_ITEM bi
+    JOIN ${prefix}BATCH_OPERATION bo ON (bi.batch_operation_key = bo.batch_operation_key)
     <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.itemSearchFilter"/>
   </select>
 

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -365,6 +365,13 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
+    <if
+      test="filter.operationTypeOperations != null and !filter.operationTypeOperations.isEmpty()">
+      <foreach collection="filter.operationTypeOperations" item="operation">
+        AND bo.OPERATION_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
   </sql>
 
   <update id="updateHistoryCleanupDate">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
@@ -333,6 +333,36 @@ public class BatchOperationSearchIT {
   }
 
   @Test
+  void shouldSearchBatchOperationItemsByOperationType() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertItems(page, ACTIVE_PROCESS_INSTANCES_1);
+  }
+
+  @Test
+  void shouldSearchBatchOperationItemsByOperationTypeWithNeq() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.operationType(p -> p.neq(BatchOperationType.CANCEL_PROCESS_INSTANCE)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertItems(page, ACTIVE_PROCESS_INSTANCES_2);
+  }
+
+  @Test
   void shouldSearchProcessInstanceByBatchOperationKey() {
     // when
     final var page =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
@@ -30,7 +30,8 @@ public final class BatchOperationItemFilterTransformer
         stringOperations(BATCH_OPERATION_ID, filter.batchOperationKeyOperations()),
         stringOperations(STATE, mapStateOperations(filter.stateOperations())),
         longOperations(ITEM_KEY, filter.itemKeyOperations()),
-        longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
+        longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()),
+        stringOperations(TYPE, filter.operationTypeOperations()));
   }
 
   @Override

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformerTest.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
 import io.camunda.security.auth.Authorization;
@@ -193,7 +194,8 @@ class BatchOperationItemFilterTransformerTest extends AbstractTransformerTest {
                 f.batchOperationKeys("123")
                     .states("ACTIVE")
                     .itemKeys(123L)
-                    .processInstanceKeys(456L));
+                    .processInstanceKeys(456L)
+                    .operationTypes(BatchOperationType.CANCEL_PROCESS_INSTANCE.name()));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -201,7 +203,7 @@ class BatchOperationItemFilterTransformerTest extends AbstractTransformerTest {
     // then
     final var queryVariant = searchRequest.queryOption();
     assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
-    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(4);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(5);
 
     assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
         .isInstanceOfSatisfying(
@@ -233,6 +235,97 @@ class BatchOperationItemFilterTransformerTest extends AbstractTransformerTest {
             t -> {
               assertThat(t.field()).isEqualTo("processInstanceKey");
               assertThat(t.value().longValue()).isEqualTo(456L);
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(4).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue())
+                  .isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE.name());
+            });
+  }
+
+  @Test
+  void shouldQueryByOperationType() {
+    // given
+    final var filter =
+        FilterBuilders.batchOperationItem(
+            f -> f.operationTypes(BatchOperationType.CANCEL_PROCESS_INSTANCE.name()));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue())
+                  .isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE.name());
+            });
+  }
+
+  @Test
+  void shouldQueryByMultipleOperationTypes() {
+    // given
+    final var filter =
+        FilterBuilders.batchOperationItem(
+            f ->
+                f.operationTypes(
+                    BatchOperationType.CANCEL_PROCESS_INSTANCE.name(),
+                    BatchOperationType.RESOLVE_INCIDENT.name(),
+                    BatchOperationType.DELETE_PROCESS_INSTANCE.name()));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermsQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.values())
+                  .containsExactlyInAnyOrder(
+                      TypedValue.of(BatchOperationType.CANCEL_PROCESS_INSTANCE.name()),
+                      TypedValue.of(BatchOperationType.RESOLVE_INCIDENT.name()),
+                      TypedValue.of(BatchOperationType.DELETE_PROCESS_INSTANCE.name()));
+            });
+  }
+
+  @Test
+  void shouldQueryByOperationTypeNegate() {
+    // given
+    final var filter =
+        FilterBuilders.batchOperationItem(
+            f ->
+                f.operationTypeOperations(
+                    Operation.neq(BatchOperationType.CANCEL_PROCESS_INSTANCE.name())));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            t -> {
+              assertThat(t.mustNot()).isNotEmpty();
+            });
+    final var mustNotQuery = ((SearchBoolQuery) queryVariant).mustNot().get(0).queryOption();
+    assertThat(mustNotQuery)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue())
+                  .isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE.name());
             });
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
@@ -21,7 +21,8 @@ public record BatchOperationItemFilter(
     List<Operation<String>> batchOperationKeyOperations,
     List<Operation<Long>> itemKeyOperations,
     List<Operation<Long>> processInstanceKeyOperations,
-    List<Operation<String>> stateOperations)
+    List<Operation<String>> stateOperations,
+    List<Operation<String>> operationTypeOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationItemFilter> {
@@ -30,6 +31,7 @@ public record BatchOperationItemFilter(
     private List<Operation<Long>> itemKeyOperations;
     private List<Operation<Long>> processInstanceKeyOperations;
     private List<Operation<String>> stateOperations;
+    private List<Operation<String>> operationTypeOperations;
 
     public Builder batchOperationKeyOperations(final List<Operation<String>> operations) {
       batchOperationKeyOperations = addValuesToList(batchOperationKeyOperations, operations);
@@ -111,13 +113,34 @@ public record BatchOperationItemFilter(
       return stateOperations(collectValues(operation, operations));
     }
 
+    public Builder operationTypeOperations(final List<Operation<String>> operations) {
+      operationTypeOperations = addValuesToList(operationTypeOperations, operations);
+      return this;
+    }
+
+    public Builder operationTypes(final String value, final String... values) {
+      return operationTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceOperationTypeOperations(final List<Operation<String>> operations) {
+      operationTypeOperations = new ArrayList<>(operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder operationTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return operationTypeOperations(collectValues(operation, operations));
+    }
+
     @Override
     public BatchOperationItemFilter build() {
       return new BatchOperationItemFilter(
           Objects.requireNonNullElse(batchOperationKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(itemKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(stateOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(operationTypeOperations, Collections.emptyList()));
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -403,6 +403,10 @@ components:
           description: The state of the batch operation.
           allOf:
             - $ref: '#/components/schemas/BatchOperationItemStateFilterProperty'
+        operationType:
+          description: The type of the batch operation.
+          allOf:
+            - $ref: '#/components/schemas/BatchOperationTypeFilterProperty'
 
     BatchOperationItemSearchQueryResult:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -366,6 +366,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getProcessInstanceKey())
           .map(mapToOperations(Long.class))
           .ifPresent(builder::processInstanceKeyOperations);
+      ofNullable(filter.getOperationType())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::operationTypeOperations);
     }
 
     return builder.build();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds a filter option for `operationType` to the batch operation items search API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42095
