### PR TITLE
feat: support filtering BO items by operation type

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.22
+
+### 🚀 Enhancements
+
+- support filtering BO items by operation type ([#42106](https://github.com/camunda/camunda/pull/42106))
+
+### ❤️ Contributors
+
+- Vinicius Goulart ([@vsgoulart](https://github.com/vsgoulart))
+
 ## v0.0.21
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/batch-operation.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/batch-operation.ts
@@ -7,7 +7,14 @@
  */
 
 import {z} from 'zod';
-import {API_VERSION, getQueryRequestBodySchema, getQueryResponseBodySchema, type Endpoint} from '../common';
+import {
+	API_VERSION,
+	basicStringFilterSchema,
+	getEnumFilterSchema,
+	getQueryRequestBodySchema,
+	getQueryResponseBodySchema,
+	type Endpoint,
+} from '../common';
 
 const batchOperationTypeSchema = z.enum([
 	'CANCEL_PROCESS_INSTANCE',
@@ -17,6 +24,8 @@ const batchOperationTypeSchema = z.enum([
 	'DELETE_DECISION_DEFINITION',
 	'DELETE_PROCESS_DEFINITION',
 	'DELETE_PROCESS_INSTANCE',
+	'ADD_VARIABLE',
+	'UPDATE_VARIABLE',
 ]);
 type BatchOperationType = z.infer<typeof batchOperationTypeSchema>;
 
@@ -61,9 +70,9 @@ const queryBatchOperationsRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['batchOperationKey', 'operationType', 'state', 'startDate', 'endDate'] as const,
 	filter: z
 		.object({
-			batchOperationKey: z.string(),
-			operationType: batchOperationTypeSchema,
-			state: batchOperationStateSchema,
+			batchOperationKey: basicStringFilterSchema,
+			operationType: getEnumFilterSchema(batchOperationTypeSchema),
+			state: getEnumFilterSchema(batchOperationStateSchema),
 		})
 		.partial(),
 });
@@ -76,10 +85,11 @@ const queryBatchOperationItemsRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['batchOperationKey', 'itemKey', 'processedDate', 'processInstanceKey', 'state'] as const,
 	filter: z
 		.object({
-			batchOperationKey: z.string(),
-			itemKey: z.string(),
-			processInstanceKey: z.string(),
-			state: batchOperationItemStateSchema,
+			batchOperationKey: basicStringFilterSchema,
+			itemKey: basicStringFilterSchema,
+			processInstanceKey: basicStringFilterSchema,
+			state: getEnumFilterSchema(batchOperationItemStateSchema),
+			operationType: getEnumFilterSchema(batchOperationTypeSchema),
 		})
 		.partial(),
 });

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.21",
+        "@camunda/camunda-api-zod-schemas": "0.0.22",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -515,9 +515,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.21.tgz",
-      "integrity": "sha512-dh/LUMwpiSSCmes5jAiTYO6G0xG5iPdeQ7tvD4Nt8Xh/I+bkWNoODqF//IfF9NeG3eJk9oCJhXaoGfwOZEMgoA==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.22.tgz",
+      "integrity": "sha512-3LsiXKUO3MnXaT59xf3DHeYhJ4ng7YQiqgWc0NPVvSP8EoJfRv3vIW4qXIhmgMcnIO5N145Do3d5enosplwJDQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.21",
+    "@camunda/camunda-api-zod-schemas": "0.0.22",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.setup.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.setup.ts
@@ -88,6 +88,26 @@ const OPERATIONS: Record<
     operationsCompletedCount: 1,
     state: 'COMPLETED',
   },
+  ADD_VARIABLE: {
+    batchOperationKey: 'add-var-44444-55555-66666',
+    batchOperationType: 'ADD_VARIABLE',
+    startDate: '2023-11-22T10:00:00.000+0100',
+    endDate: '2023-11-22T10:05:00.000+0100',
+    operationsFailedCount: 0,
+    operationsTotalCount: 2,
+    operationsCompletedCount: 2,
+    state: 'COMPLETED',
+  },
+  UPDATE_VARIABLE: {
+    batchOperationKey: 'update-var-77777-88888-99999',
+    batchOperationType: 'UPDATE_VARIABLE',
+    startDate: '2023-11-22T11:00:00.000+0100',
+    endDate: '2023-11-22T11:05:00.000+0100',
+    operationsFailedCount: 0,
+    operationsTotalCount: 1,
+    operationsCompletedCount: 1,
+    state: 'COMPLETED',
+  },
 } as const;
 
 const mockProps = {

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -25,7 +25,14 @@ import type {
   BatchOperationType,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
-type OperationLabelType = 'Retry' | 'Cancel' | 'Modify' | 'Migrate' | 'Delete';
+type OperationLabelType =
+  | 'Retry'
+  | 'Cancel'
+  | 'Modify'
+  | 'Migrate'
+  | 'Delete'
+  | 'Add variable'
+  | 'Update variable';
 
 const TYPE_LABELS: Readonly<Record<BatchOperationType, OperationLabelType>> = {
   RESOLVE_INCIDENT: 'Retry',
@@ -35,6 +42,8 @@ const TYPE_LABELS: Readonly<Record<BatchOperationType, OperationLabelType>> = {
   DELETE_PROCESS_INSTANCE: 'Delete',
   DELETE_PROCESS_DEFINITION: 'Delete',
   DELETE_DECISION_DEFINITION: 'Delete',
+  ADD_VARIABLE: 'Add variable',
+  UPDATE_VARIABLE: 'Update variable',
 };
 
 type Props = {

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.21",
+        "@camunda/camunda-api-zod-schemas": "0.0.22",
         "@camunda/camunda-composite-components": "0.21.1",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.21.tgz",
-      "integrity": "sha512-dh/LUMwpiSSCmes5jAiTYO6G0xG5iPdeQ7tvD4Nt8Xh/I+bkWNoODqF//IfF9NeG3eJk9oCJhXaoGfwOZEMgoA==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.22.tgz",
+      "integrity": "sha512-3LsiXKUO3MnXaT59xf3DHeYhJ4ng7YQiqgWc0NPVvSP8EoJfRv3vIW4qXIhmgMcnIO5N145Do3d5enosplwJDQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.21",
+    "@camunda/camunda-api-zod-schemas": "0.0.22",
     "@camunda/camunda-composite-components": "0.21.1",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add type defs for new batch operation items `operationType` filter

This filter will be added by https://github.com/camunda/camunda/pull/42096

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

realted to #42095
