### PR TITLE
Include audit log entries in archiver jobs

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors;
+
+/**
+ * Marker interface for descriptors that are dependant on decision instances. Used to identify
+ * related documents that need to be archived together with decision instances.
+ *
+ * <p>When implementing this inteface, the {@code getDecisionDependantField} method can be
+ * overridden to specify a different field name if the default {@code DECISION_INSTANCE_KEY} does
+ * not apply.
+ */
+public interface DecisionInstanceDependant {
+
+  String DECISION_INSTANCE_KEY = "decisionDefinitionKey";
+
+  String getFullQualifiedName();
+
+  default String getDecisionDependantField() {
+    return DECISION_INSTANCE_KEY;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.descriptors.template;
 
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogJoinRelationshipType;
@@ -16,7 +17,7 @@ import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.Enti
 import java.util.Optional;
 
 public class AuditLogTemplate extends AbstractTemplateDescriptor
-    implements ProcessInstanceDependant, Prio5Backup {
+    implements ProcessInstanceDependant, DecisionInstanceDependant, Prio5Backup {
 
   public static final String INDEX_NAME = "audit-log";
   public static final String INDEX_VERSION = "8.9.0";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -40,6 +40,7 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
 import io.camunda.exporter.tasks.incident.OpenSearchIncidentUpdateRepository;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
@@ -378,13 +379,20 @@ public final class BackgroundTaskManagerFactory {
   }
 
   private ReschedulingTask buildStandaloneDecisionArchiverJob() {
+    final var dependantTemplates = new ArrayList<DecisionInstanceDependant>();
+    resourceProvider.getIndexTemplateDescriptors().stream()
+        .filter(DecisionInstanceDependant.class::isInstance)
+        .map(DecisionInstanceDependant.class::cast)
+        .forEach(dependantTemplates::add);
+
     return buildReschedulingArchiverTask(
         new StandaloneDecisionArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class),
             metrics,
             logger,
-            executor));
+            executor,
+            dependantTemplates));
   }
 
   private ReschedulingTask buildReschedulingArchiverTask(final BackgroundTask task) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -8,7 +8,10 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
@@ -16,13 +19,16 @@ import org.slf4j.Logger;
 public class StandaloneDecisionArchiverJob extends ArchiverJob {
 
   private final DecisionInstanceTemplate decisionInstanceTemplate;
+  private final List<DecisionInstanceDependant> decisionInstanceDependants;
+  private final Executor executor;
 
   public StandaloneDecisionArchiverJob(
       final ArchiverRepository repository,
       final DecisionInstanceTemplate decisionInstanceTemplate,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final Executor executor) {
+      final Executor executor,
+      final List<DecisionInstanceDependant> decisionInstanceDependants) {
     super(
         repository,
         metrics,
@@ -31,6 +37,11 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob {
         metrics::recordStandaloneDecisionsArchiving,
         metrics::recordStandaloneDecisionsArchived);
     this.decisionInstanceTemplate = decisionInstanceTemplate;
+    this.decisionInstanceDependants =
+        decisionInstanceDependants.stream()
+            .sorted(Comparator.comparing(DecisionInstanceDependant::getFullQualifiedName))
+            .toList(); // sort to ensure the execution order is stable;
+    this.executor = executor;
   }
 
   @Override
@@ -51,5 +62,39 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob {
   @Override
   String getIdFieldName() {
     return DecisionInstanceTemplate.ID;
+  }
+
+  /**
+   * Overridden to archive dependants first and then move the decision instances themselves.
+   *
+   * @param sourceIdx decision instance index
+   * @param finishDate move to the dated index
+   * @param idFieldName decision instance key field
+   * @param ids list of decision instance keys to archive
+   * @return number of archived decision instances
+   */
+  @Override
+  protected CompletableFuture<Integer> archive(
+      final String sourceIdx,
+      final String finishDate,
+      final String idFieldName,
+      final List<String> ids) {
+    return archiveDecisionDependants(finishDate, ids)
+        .thenComposeAsync(v -> super.archive(sourceIdx, finishDate, idFieldName, ids), executor);
+  }
+
+  private CompletableFuture<Void> archiveDecisionDependants(
+      final String finishDate, final List<String> decisionInstanceKeys) {
+    final var moveDependentDocuments =
+        decisionInstanceDependants.stream()
+            .map(
+                dependant -> {
+                  final var dependentSourceIdx = dependant.getFullQualifiedName();
+                  final var dependentIdFieldName = dependant.getDecisionDependantField();
+                  return super.archive(
+                      dependentSourceIdx, finishDate, dependentIdFieldName, decisionInstanceKeys);
+                })
+            .toArray(CompletableFuture[]::new);
+    return CompletableFuture.allOf(moveDependentDocuments);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
@@ -35,6 +36,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
   private final DecisionInstanceTemplate decisionInstanceTemplate =
       new DecisionInstanceTemplate("", true);
   private final SequenceFlowTemplate sequenceFlowTemplate = new SequenceFlowTemplate("", true);
+  private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
 
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
@@ -43,7 +45,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
       new ProcessInstanceArchiverJob(
           repository,
           processInstanceTemplate,
-          List.of(decisionInstanceTemplate, sequenceFlowTemplate),
+          List.of(decisionInstanceTemplate, sequenceFlowTemplate, auditLogTemplate),
           metrics,
           LOGGER,
           executor);
@@ -114,6 +116,12 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     assertThat(repository.moves)
         .containsExactly(
             new DocumentMove(
+                auditLogTemplate.getFullQualifiedName(),
+                auditLogTemplate.getFullQualifiedName() + "2024-01-01",
+                auditLogTemplate.getProcessInstanceDependantField(),
+                List.of("1", "2", "3"),
+                executor),
+            new DocumentMove(
                 decisionInstanceTemplate.getFullQualifiedName(),
                 decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
                 decisionInstanceTemplate.getProcessInstanceDependantField(),
@@ -147,6 +155,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     assertThat(repository.moves)
         .map(DocumentMove::sourceIndexName)
         .containsExactly(
+            auditLogTemplate.getFullQualifiedName(),
             decisionInstanceTemplate.getFullQualifiedName(),
             sequenceFlowTemplate.getFullQualifiedName(),
             processInstanceTemplate.getFullQualifiedName());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
+import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
@@ -31,12 +33,19 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   private final TestRepository repository = new TestRepository();
   private final DecisionInstanceTemplate decisionInstanceTemplate =
       new DecisionInstanceTemplate("", true);
+  private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
+
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
 
   private final StandaloneDecisionArchiverJob job =
       new StandaloneDecisionArchiverJob(
-          repository, decisionInstanceTemplate, metrics, LOGGER, executor);
+          repository,
+          decisionInstanceTemplate,
+          metrics,
+          LOGGER,
+          executor,
+          List.of(auditLogTemplate));
 
   @BeforeEach
   void setUp() {
@@ -65,9 +74,14 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   }
 
   @Test
-  void shouldMoveStandaloneDecisionInstances() {
+  void shouldOnlyMoveDecisionInstancesWhenNoDependentTemplates() {
+    // given
+    final StandaloneDecisionArchiverJob standaloneDecisionArchiverJob =
+        new StandaloneDecisionArchiverJob(
+            repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of());
+
     // when
-    final int count = job.execute().toCompletableFuture().join();
+    final int count = standaloneDecisionArchiverJob.execute().toCompletableFuture().join();
 
     // then
     assertThat(count).isEqualTo(3); // batch has 3 ids
@@ -83,5 +97,84 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
                 DecisionInstanceTemplate.ID,
                 List.of("1", "2", "3"),
                 executor));
+  }
+
+  @Test
+  void shouldMoveDependants() {
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count).isEqualTo(3); // batch has 3 ids
+    assertArchivingCounts(count); // asserted as 3 above
+    assertArchiverTimer(1);
+
+    // then should move
+    assertThat(repository.moves)
+        .containsExactly(
+            new DocumentMove(
+                auditLogTemplate.getFullQualifiedName(),
+                auditLogTemplate.getFullQualifiedName() + "2024-01-01",
+                auditLogTemplate.getDecisionDependantField(),
+                List.of("1", "2", "3"),
+                executor),
+            new DocumentMove(
+                decisionInstanceTemplate.getFullQualifiedName(),
+                decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
+                DecisionInstanceTemplate.ID,
+                List.of("1", "2", "3"),
+                executor));
+  }
+
+  @Test
+  void shouldMoveDependantsBeforeDecisionInstances() {
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count).isEqualTo(3); // batch has 3 ids
+    assertArchivingCounts(count); // asserted as 3 above
+    assertArchiverTimer(1);
+
+    // then should move in correct order
+    assertThat(repository.moves)
+        .map(DocumentMove::sourceIndexName)
+        .containsExactly(
+            auditLogTemplate.getFullQualifiedName(),
+            decisionInstanceTemplate.getFullQualifiedName());
+  }
+
+  @Test
+  void shouldMoveDependantsViaCorrectField() {
+    // given
+    final var dependant = new WeirdlyNamedDependant();
+    final var job =
+        new StandaloneDecisionArchiverJob(
+            repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of(dependant));
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2"));
+
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count).isEqualTo(2); // batch has 2 ids
+    assertArchivingCounts(count); // asserted as 2 above
+    assertArchiverTimer(1);
+    assertThat(repository.moves)
+        .contains(
+            new DocumentMove("foo_", "foo_" + "2024-01-01", "bar", List.of("1", "2"), executor));
+  }
+
+  private static final class WeirdlyNamedDependant implements DecisionInstanceDependant {
+
+    @Override
+    public String getFullQualifiedName() {
+      return "foo_";
+    }
+
+    @Override
+    public String getDecisionDependantField() {
+      return "bar";
+    }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure that process and decision-related audit log entries can be archived by the respective archiver jobs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41128
closes #41347
