### PR TITLE
fix: validate cluster variable requests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableCommandIT.java
@@ -51,7 +51,7 @@ public class ClusterVariableCommandIT {
     // given
     final var variableName = "tenantVar_" + UUID.randomUUID();
     final var variableValue = "testValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     // when
     final var response =
@@ -138,7 +138,7 @@ public class ClusterVariableCommandIT {
     // given
     final var variableName = "duplicateTenantVar_" + UUID.randomUUID();
     final var variableValue = "testValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     camundaClient
         .newTenantScopedClusterVariableCreateRequest(tenantId)
@@ -164,7 +164,7 @@ public class ClusterVariableCommandIT {
     final var variableName = "sameNameVar_" + UUID.randomUUID();
     final var globalValue = "globalValue_" + UUID.randomUUID();
     final var tenantValue = "tenantValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     // when - create in global scope
     final var response1 =
@@ -228,7 +228,7 @@ public class ClusterVariableCommandIT {
     // given
     final var variableName = "tenantVarDelete_" + UUID.randomUUID();
     final var variableValue = "testValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     camundaClient
         .newTenantScopedClusterVariableCreateRequest(tenantId)
@@ -295,8 +295,8 @@ public class ClusterVariableCommandIT {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newTenantScopedClusterVariableDeleteRequest("tenant_" + UUID.randomUUID())
-                    .delete("nonExistentVar_" + UUID.randomUUID())
+                    .newTenantScopedClusterVariableDeleteRequest("tenant_123")
+                    .delete("nonExistentVar_657")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -315,7 +315,7 @@ public class ClusterVariableCommandIT {
         .send()
         .join();
 
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     // when / then
     assertThatThrownBy(
@@ -334,7 +334,7 @@ public class ClusterVariableCommandIT {
     // given
     final var variableName = "tenantVarNoGlobalDelete_" + UUID.randomUUID();
     final var variableValue = "testValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     camundaClient
         .newTenantScopedClusterVariableCreateRequest(tenantId)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableFetchIT.java
@@ -59,7 +59,7 @@ public class ClusterVariableFetchIT {
     // given
     final var variableName = "tenantVarGet_" + UUID.randomUUID();
     final var variableValue = "testValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     camundaClient
         .newTenantScopedClusterVariableCreateRequest(tenantId)
@@ -134,7 +134,7 @@ public class ClusterVariableFetchIT {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newTenantScopedClusterVariableGetRequest("tenant_" + UUID.randomUUID())
+                    .newTenantScopedClusterVariableGetRequest("tenant_1")
                     .withName("nonExistentVar_" + UUID.randomUUID())
                     .send()
                     .join())
@@ -154,7 +154,7 @@ public class ClusterVariableFetchIT {
         .send()
         .join();
 
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     // when / then
     assertThatThrownBy(
@@ -173,7 +173,7 @@ public class ClusterVariableFetchIT {
     // given
     final var variableName = "tenantVarNoGlobalGet_" + UUID.randomUUID();
     final var variableValue = "testValue_" + UUID.randomUUID();
-    final var tenantId = "tenant_" + UUID.randomUUID();
+    final var tenantId = "tenant_1";
 
     camundaClient
         .newTenantScopedClusterVariableCreateRequest(tenantId)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
@@ -84,7 +84,7 @@ public class ClusterVariableSearchIT {
     tenantVarValue1 = "testValue1_" + UUID.randomUUID();
     tenantVarName2 = "tenantVarSearch2_" + UUID.randomUUID();
     tenantVarValue2 = "testValue2_" + UUID.randomUUID();
-    tenantId = "tenant_" + UUID.randomUUID();
+    tenantId = "tenant_1";
 
     camundaClient
         .newTenantScopedClusterVariableCreateRequest(tenantId)
@@ -103,7 +103,7 @@ public class ClusterVariableSearchIT {
     globalVarValueMixed = "globalValue_" + UUID.randomUUID();
     tenantVarNameMixed = "tenantVarSearchOnly_" + UUID.randomUUID();
     tenantVarValueMixed = "tenantValue_" + UUID.randomUUID();
-    tenantIdMixed = "tenant_" + UUID.randomUUID();
+    tenantIdMixed = "tenant_2";
 
     camundaClient
         .newGloballyScopedClusterVariableCreateRequest()
@@ -122,7 +122,7 @@ public class ClusterVariableSearchIT {
     globalVarValueTenantOnly = "globalValue_" + UUID.randomUUID();
     tenantVarNameTenantOnly = "tenantVarTenantSearch_" + UUID.randomUUID();
     tenantVarValueTenantOnly = "tenantValue_" + UUID.randomUUID();
-    tenantIdTenantOnly = "tenant_" + UUID.randomUUID();
+    tenantIdTenantOnly = "tenant_3";
 
     camundaClient
         .newGloballyScopedClusterVariableCreateRequest()

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/RequestMapper.java
@@ -42,6 +42,7 @@ import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivat
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
+import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
 import io.camunda.service.DocumentServices.DocumentLinkParams;
 import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
@@ -73,6 +74,7 @@ import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
+import io.camunda.zeebe.gateway.protocol.rest.CreateClusterVariableRequest;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionEvaluationById;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionEvaluationByKey;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionEvaluationInstruction;
@@ -114,6 +116,7 @@ import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserUpdateRequest;
 import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryFilterMapper;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
+import io.camunda.zeebe.gateway.rest.validator.ClusterVariableRequestValidator;
 import io.camunda.zeebe.gateway.rest.validator.DocumentValidator;
 import io.camunda.zeebe.gateway.rest.validator.GroupRequestValidator;
 import io.camunda.zeebe.gateway.rest.validator.MappingRuleRequestValidator;
@@ -681,6 +684,40 @@ public class RequestMapper {
         () ->
             new MappingRuleDTO(
                 request.getClaimName(), request.getClaimValue(), request.getName(), mappingRuleId));
+  }
+
+  public static Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableCreateRequest(
+      final CreateClusterVariableRequest request, final Pattern identifierPattern) {
+    return getResult(
+        ClusterVariableRequestValidator.validateGlobalClusterVariableCreateRequest(
+            request, identifierPattern),
+        () -> new ClusterVariableRequest(request.getName(), request.getValue(), null));
+  }
+
+  public static Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableRequest(
+      final String name, final Pattern identifierPattern) {
+    return getResult(
+        ClusterVariableRequestValidator.validateGlobalClusterVariableRequest(
+            name, identifierPattern),
+        () -> new ClusterVariableRequest(name, null, null));
+  }
+
+  public static Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableCreateRequest(
+      final CreateClusterVariableRequest request,
+      final String tenantId,
+      final Pattern identifierPattern) {
+    return getResult(
+        ClusterVariableRequestValidator.validateTenantClusterVariableCreateRequest(
+            request, tenantId, identifierPattern),
+        () -> new ClusterVariableRequest(request.getName(), request.getValue(), tenantId));
+  }
+
+  public static Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableRequest(
+      final String name, final String tenantId, final Pattern identifierPattern) {
+    return getResult(
+        ClusterVariableRequestValidator.validateTenantClusterVariableRequest(
+            name, tenantId, identifierPattern),
+        () -> new ClusterVariableRequest(name, null, tenantId));
   }
 
   public static <BrokerResponseT> CompletableFuture<ResponseEntity<Object>> executeServiceMethod(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClusterVariableRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClusterVariableRequestValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+
+import io.camunda.zeebe.gateway.protocol.rest.CreateClusterVariableRequest;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.springframework.http.ProblemDetail;
+
+public class ClusterVariableRequestValidator {
+
+  public static Optional<ProblemDetail> validateTenantClusterVariableCreateRequest(
+      final CreateClusterVariableRequest request,
+      final String tenantId,
+      final Pattern identifierPattern) {
+    return validate(
+        violations -> {
+          validateClusterVariableName(request.getName(), violations, identifierPattern);
+          validateTenantId(tenantId, violations);
+          validateValue(request.getValue(), violations);
+        });
+  }
+
+  public static Optional<ProblemDetail> validateGlobalClusterVariableCreateRequest(
+      final CreateClusterVariableRequest request, final Pattern identifierPattern) {
+    return validate(
+        violations -> {
+          validateClusterVariableName(request.getName(), violations, identifierPattern);
+          validateValue(request.getValue(), violations);
+        });
+  }
+
+  public static Optional<ProblemDetail> validateTenantClusterVariableRequest(
+      final String name, final String tenantId, final Pattern identifierPattern) {
+    return validate(
+        violations -> {
+          validateClusterVariableName(name, violations, identifierPattern);
+          validateTenantId(tenantId, violations);
+        });
+  }
+
+  public static Optional<ProblemDetail> validateGlobalClusterVariableRequest(
+      final String name, final Pattern identifierPattern) {
+    return validate(
+        violations -> {
+          validateClusterVariableName(name, violations, identifierPattern);
+        });
+  }
+
+  private static void validateClusterVariableName(
+      final String variableName, final List<String> violations, final Pattern identifierPattern) {
+    IdentifierValidator.validateId(variableName, "name", violations, identifierPattern);
+  }
+
+  private static void validateTenantId(final String id, final List<String> violations) {
+    IdentifierValidator.validateTenantId(
+        id, violations, TenantOwned.DEFAULT_TENANT_IDENTIFIER::equals);
+  }
+
+  private static void validateValue(final Object value, final List<String> violations) {
+    if (value == null) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("value"));
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -1,0 +1,654 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableScope;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.service.ClusterVariableServices;
+import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(value = ClusterVariableController.class)
+public class ClusterVariableControllerTest extends RestControllerTest {
+
+  static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
+  static final String CLUSTER_VARIABLE_PREFIX_URL = "/v2/cluster-variables";
+  static final String GLOBAL_URL = CLUSTER_VARIABLE_PREFIX_URL + "/global";
+  static final String GLOBAL_WITH_NAME_URL = GLOBAL_URL + "/%s";
+  static final String TENANT_URL = CLUSTER_VARIABLE_PREFIX_URL + "/tenants/%s";
+  static final String TENANT_WITH_NAME_URL = TENANT_URL + "/%s";
+
+  @Captor ArgumentCaptor<ClusterVariableRequest> createRequestCaptor;
+  @MockitoBean ClusterVariableServices clusterVariableServices;
+  @MockitoBean SecurityConfiguration securityConfiguration;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(clusterVariableServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(clusterVariableServices);
+    when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
+  }
+
+  @Test
+  void shouldGetGlobalClusterVariable() {
+    // given
+    final var clusterVariableEntity = mock(ClusterVariableEntity.class);
+    when(clusterVariableEntity.name()).thenReturn("name");
+    when(clusterVariableEntity.value()).thenReturn("value");
+    when(clusterVariableEntity.isPreview()).thenReturn(false);
+    when(clusterVariableEntity.scope()).thenReturn(ClusterVariableScope.GLOBAL);
+
+    when(clusterVariableServices.getGloballyScopedClusterVariable(
+            any(ClusterVariableRequest.class)))
+        .thenReturn(clusterVariableEntity);
+
+    // when / then
+    webClient
+        .get()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterVariableServices).getGloballyScopedClusterVariable(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isNull();
+    assertThat(capturedRequest.tenantId()).isNull();
+  }
+
+  @Test
+  void shouldRejectGetGlobalClusterVariableWithInvalidName() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided name contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_WITH_NAME_URL.formatted("$foo"));
+
+    // when / then
+    webClient
+        .get()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("$foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldCreateGlobalClusterVariable() {
+    // given
+    when(clusterVariableServices.createGloballyScopedClusterVariable(
+            any(ClusterVariableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
+
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar"
+        }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterVariableServices)
+        .createGloballyScopedClusterVariable(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isEqualTo("bar");
+    assertThat(capturedRequest.tenantId()).isNull();
+  }
+
+  @Test
+  void shouldRejectCreationWithMissingGlobalClusterVariableName() {
+    // given
+    final var request =
+        """
+        {
+            "value": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "No name provided.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_URL);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreationWithInvalidGlobalClusterVariableName() {
+    // given
+    final var request =
+        """
+        {
+            "name": "$foo",
+            "value": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided name contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_URL);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreationWithoutGlobalClusterVariableValue() {
+    // given
+    final var request =
+        """
+        {
+            "name": "foo"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "No value provided.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_URL);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldDeleteGlobalClusterVariable() {
+    // given
+    when(clusterVariableServices.deleteGloballyScopedClusterVariable(
+            any(ClusterVariableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clusterVariableServices)
+        .deleteGloballyScopedClusterVariable(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isNull();
+    assertThat(capturedRequest.tenantId()).isNull();
+  }
+
+  @Test
+  void shouldRejectDeletionWithInvalidGlobalClusterVariableName() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided name contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_WITH_NAME_URL.formatted("$foo"));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("$foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldGetTenantClusterVariable() {
+    // given
+    final var clusterVariableEntity = mock(ClusterVariableEntity.class);
+    when(clusterVariableEntity.name()).thenReturn("name");
+    when(clusterVariableEntity.value()).thenReturn("value");
+    when(clusterVariableEntity.isPreview()).thenReturn(false);
+    when(clusterVariableEntity.scope()).thenReturn(ClusterVariableScope.TENANT);
+    when(clusterVariableEntity.tenantId()).thenReturn("tenant1");
+
+    when(clusterVariableServices.getTenantScopedClusterVariable(any(ClusterVariableRequest.class)))
+        .thenReturn(clusterVariableEntity);
+
+    // when / then
+    webClient
+        .get()
+        .uri(TENANT_WITH_NAME_URL.formatted("tenant1", "foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterVariableServices).getTenantScopedClusterVariable(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isNull();
+    assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
+  }
+
+  @Test
+  void shouldRejectGetTenantClusterVariableWithInvalidName() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided name contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_WITH_NAME_URL.formatted("tenant1", "$foo"));
+
+    // when / then
+    webClient
+        .get()
+        .uri(TENANT_WITH_NAME_URL.formatted("tenant1", "$foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectGetTenantClusterVariableWithInvalidTenantId() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided tenantId contains illegal characters. It must match the pattern '^[\\\\w\\\\.-]{1,31}$'.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_WITH_NAME_URL.formatted("$tenant1", "foo"));
+
+    // when / then
+    webClient
+        .get()
+        .uri(TENANT_WITH_NAME_URL.formatted("$tenant1", "foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldCreateTenantClusterVariable() {
+    // given
+    when(clusterVariableServices.createTenantScopedClusterVariable(
+            any(ClusterVariableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
+
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar"
+        }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(TENANT_URL.formatted("tenant1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterVariableServices)
+        .createTenantScopedClusterVariable(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isEqualTo("bar");
+    assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
+  }
+
+  @Test
+  void shouldRejectCreationWithMissingTenantClusterVariableName() {
+    // given
+    final var request =
+        """
+        {
+            "value": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "No name provided.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_URL.formatted("tenant1"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(TENANT_URL.formatted("tenant1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreationWithInvalidTenantClusterVariableName() {
+    // given
+    final var request =
+        """
+        {
+            "name": "$foo",
+            "value": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided name contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_URL.formatted("tenant1"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(TENANT_URL.formatted("tenant1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreationWithInvalidTenantId() {
+    // given
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided tenantId contains illegal characters. It must match the pattern '^[\\\\w\\\\.-]{1,31}$'.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_URL.formatted("$tenant1"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(TENANT_URL.formatted("$tenant1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreationWithoutValue() {
+    // given
+    final var request =
+        """
+        {
+            "name": "foo"
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "No value provided.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_URL.formatted("tenant1"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(TENANT_URL.formatted("tenant1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldDeleteTenantClusterVariable() {
+    // given
+    when(clusterVariableServices.deleteTenantScopedClusterVariable(
+            any(ClusterVariableRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(TENANT_WITH_NAME_URL.formatted("tenant1", "foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clusterVariableServices)
+        .deleteTenantScopedClusterVariable(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isNull();
+    assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
+  }
+
+  @Test
+  void shouldRejectDeletionWithInvalidTenantId() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided tenantId contains illegal characters. It must match the pattern '^[\\\\w\\\\.-]{1,31}$'.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_WITH_NAME_URL.formatted("$tenant", "foo"));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(TENANT_WITH_NAME_URL.formatted("$tenant", "foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectDeletionWithInvalidName() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The provided name contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.",
+              "instance": "%s"
+            }"""
+            .formatted(TENANT_WITH_NAME_URL.formatted("tenant", "$foo"));
+
+    // when / then
+    webClient
+        .delete()
+        .uri(TENANT_WITH_NAME_URL.formatted("tenant", "$foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+}


### PR DESCRIPTION
## Description

Validates the requests
* Ensures that the cluster variable name is valid by checking if it matches the configured id pattern
* Ensures that the tenant id is valid by checking if it matches the configured id pattern and length
* Ensures that a value is provided (when creating a cluster variable)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42045, #42047, #42048
related to #39060
