### PR TITLE
Increase load test resources for Camunda

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -72,10 +72,10 @@ orchestration:
   # Resources of the orchestration cluster
   resources:
     requests:
-      cpu: 2000m
+      cpu: 3500m
       memory: 2Gi
     limits:
-      cpu: 2000m
+      cpu: 3500m
       memory: 2Gi
 
   nodeSelector:


### PR DESCRIPTION
## Description

* With the architecture streamlining, we have merged several components, Operate, Tasklist, Identity webapps, Importer, Exporter Gateway
 * All of these are running now in the same application, and the resources haven't fully adjusted to the new requirements
 * Latest chaos days https://camunda.github.io/zeebe-chaos/2025/11/27/Stress-testing-Camunda show the need for higher resources to perform well
 * This commit increases the resources to 3500 CPU (the maximum we can get on the n2-standard-4 nodes)

To provide some more details on the calculation:

> 
> 8.8:
> 
> * Camunda 3x 3.5 CPU = 10.5
> * Elasticsearch 3x 3 CPU = 9
> * Sum= 19.5
> 
> 8.7:
> 
>  * Zeebe Broker 3x 1.7 = 5.1
>  * Zeebe Gateway 2x 450m = 0.9
>  * Elasticsearch 3x 2 = 6
>  * Sum = 12 - that was deployed, to measure just for processing
>  * Operate had 2 cores (limits)
>  * Tasklist had 1 core (limit)
>  * Identity had 2 cores (limit) - this requires more dependencies like Keycloak, Postgres, etc. which I will not list here now
>  * Sum = 17

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related https://camunda.github.io/zeebe-chaos/2025/11/27/Stress-testing-Camunda#results
related slack thread https://camunda.slack.com/archives/C0807665N8G/p1764328547228309?thread_ts=1764249628.788339&cid=C0807665N8G
