### PR TITLE
fix: reduce post exporter max idle time to 5s

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/PostExport.java
+++ b/configuration/src/main/java/io/camunda/configuration/PostExport.java
@@ -16,7 +16,7 @@ public class PostExport {
 
   private static final int DEFAULT_BATCH_SIZE = 100;
   private static final Duration DEFAULT_DELAY_BETWEEN_RUNS = Duration.ofSeconds(2);
-  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofSeconds(60);
+  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofSeconds(5);
   private static final boolean DEFAULT_IGNORE_MISSING_DATA = false;
 
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -338,7 +338,7 @@ public class ExporterConfiguration {
   public static final class PostExportConfiguration {
     private int batchSize = 100;
     private int delayBetweenRuns = 2000;
-    private int maxDelayBetweenRuns = 60000;
+    private int maxDelayBetweenRuns = 5000;
     private boolean ignoreMissingData = false;
 
     public int getBatchSize() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This max idle backoff property is used by 2 jobs:
- IncidentUpdateTask => Aligning it with the [backoff value of IncidentPostImportAction in 8.7 (5 seconds)](https://github.com/camunda/camunda/blob/6de17bef5903d2e60e4019fbedb1ab7bf20ebf76/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java#L35)
- BatchOperationUpdateTask => in 8.7, the backoff of [OperationExecutor is set to 2 seconds](https://github.com/camunda/camunda/blob/6de17bef5903d2e60e4019fbedb1ab7bf20ebf76/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java#L40)

This should make the incidents appearing faster in Operate, also aligns with the polling interval done in Operate UI (also done every 5 seconds)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39962
