### PR TITLE
fix: reduce postgres varchar column size to 2692 for indexable columns

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/postgresql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/postgresql.properties
@@ -10,7 +10,8 @@ paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
 errorMessage.size=4000
-userCharColumn.size=32768
+# postgres has a max BTree entry size of 2704 bytes (12 bytes are metadata)
+userCharColumn.size=2692
 disableFkBeforeTruncate=false
 escapeChar='\\'
 true=TRUE


### PR DESCRIPTION
## Description

When writing a very long processDefinitionId, postgres can't insert the data because it is too large for the BTree index on the field. This PR reduces the max userCharColumnSize for postgres to 2692 (with metadata below the limit of 2704 bytes).