### PR TITLE
feat: add daily stress test

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -1,0 +1,115 @@
+# description: Deploys new load test daily.
+# type: CI
+# owner: @camunda/reliability-testing
+name: Daily Camunda Platform Load Tests
+on:
+  workflow_dispatch:
+     inputs:
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the load tests. Allows to skip the docker image build step, can be used for recreating previous tests.'
+        type: string
+        default: ""
+        required: false
+  schedule:
+    # Runs at 4 am every day https://crontab.guru/#0_4_*_*_*
+    - cron: 0 4 * * *
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  benchmark-data:
+    name: Collect benchmark data
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: { }
+    outputs:
+      benchmark: ${{ steps.data.outputs.benchmark }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Collect benchmark data
+        id: data
+        run: |
+          var=${{ inputs.reuse-tag || '' }}
+          # ${#var} will return the length of the string
+          if [[ ${#var} -eq 0 ]]; then
+            echo "Creating new daily load test benchmark"
+            echo "benchmark=medic-daily-$(date --utc "+%Y-%m-%d")-$(git rev-parse --short HEAD)-test" >> "$GITHUB_OUTPUT"
+          else
+            # Example:
+            # $ echo ${tag%?}
+            # medic-daily-2025-12-18-b1bd4006-test-b1bd400
+            # $ echo ${tag%-*}
+            # medic-daily-2025-12-18-b1bd4006-test
+            tag=${{ inputs.reuse-tag }}
+            var=${tag%-*}
+            echo "Re-creating daily load test, with name: $var and tag: $tag"
+            echo "benchmark=$var" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+
+  setup-max-load-test:
+    name: Setup max load test
+    needs:
+      - benchmark-data
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.benchmark-data.outputs.benchmark }}
+      ttl: 1
+      load-test-load: "--set starter.rate=300"
+
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [ setup-max-load-test ]
+    if: failure()
+    timeout-minutes: 5
+    permissions: { }
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Daily load test creation failed:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

 * Adds a daily stress test based on chaos day https://camunda.github.io/zeebe-chaos/2025/11/27/Stress-testing-Camunda

## Benefits

Max load tests daily 

  1. We have a better overview of how the system performs over time
  2. Detect regressions earlier - shorter feedback loop when we break something
  3. Also allows better integration with charts - sanity check every day that load tests work with charts and application


## Related issues

* related slack thread https://camunda.slack.com/archives/C0807665N8G/p1764927107923139
* chaos day  https://camunda.github.io/zeebe-chaos/2025/11/27/Stress-testing-Camunda
