### PR TITLE
test: migrate processInstanceListeners.spec to OC

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithListener.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithListener.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0w6mdov" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+  <bpmn:process id="processWithListener" name="processWithListener" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0kmwpwc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="taskWithListener" name="Service Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="serviceTaskB" retries="3" />
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="listener_start" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0kmwpwc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cwk0jf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0kmwpwc" sourceRef="StartEvent_1" targetRef="taskWithListener" />
+    <bpmn:endEvent id="Event_1uhi56e">
+      <bpmn:incoming>Flow_0cwk0jf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0cwk0jf" sourceRef="taskWithListener" targetRef="Event_1uhi56e" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithListener">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pg75w9_di" bpmnElement="taskWithListener">
+        <dc:Bounds x="350" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1uhi56e_di" bpmnElement="Event_1uhi56e">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0kmwpwc_di" bpmnElement="Flow_0kmwpwc">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="350" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cwk0jf_di" bpmnElement="Flow_0cwk0jf">
+        <di:waypoint x="450" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithListenerOnRoot.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithListenerOnRoot.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0w6mdov" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241106">
+  <bpmn:process id="processWithListenerOnRoot" name="processWithListenerOnRoot" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="end" type="processEndListener" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent" name="Start event">
+      <bpmn:outgoing>Flow_0kmwpwc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="taskWithListener" name="Service Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="serviceTaskB" retries="3" />
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="listener_start" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0kmwpwc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cwk0jf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0kmwpwc" sourceRef="StartEvent" targetRef="taskWithListener" />
+    <bpmn:endEvent id="EndEvent" name="End event">
+      <bpmn:incoming>Flow_0cwk0jf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0cwk0jf" sourceRef="taskWithListener" targetRef="EndEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithListenerOnRoot">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="170" y="142" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pg75w9_di" bpmnElement="taskWithListener">
+        <dc:Bounds x="350" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1uhi56e_di" bpmnElement="EndEvent">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="586" y="142" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0kmwpwc_di" bpmnElement="Flow_0kmwpwc">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="350" y="117" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="258" y="99" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cwk0jf_di" bpmnElement="Flow_0cwk0jf">
+        <di:waypoint x="450" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithUserTaskListener.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithUserTaskListener.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0w6mdov" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241106" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="processWithUserTaskListener" name="processWithUserTaskListener" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0kmwpwc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0kmwpwc" sourceRef="StartEvent_1" targetRef="Activity_07awxi2" />
+    <bpmn:endEvent id="Event_1uhi56e">
+      <bpmn:incoming>Flow_0cwk0jf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0cwk0jf" sourceRef="Activity_07awxi2" targetRef="Event_1uhi56e" />
+    <bpmn:userTask id="Activity_07awxi2" name="Service Task B">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:taskListeners>
+          <zeebe:taskListener eventType="complete" type="completeListener"/>
+        </zeebe:taskListeners>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="endListener" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0kmwpwc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cwk0jf</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithUserTaskListener">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1uhi56e_di" bpmnElement="Event_1uhi56e">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0byds6u_di" bpmnElement="Activity_07awxi2">
+        <dc:Bounds x="352" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0kmwpwc_di" bpmnElement="Flow_0kmwpwc">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="352" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cwk0jf_di" bpmnElement="Flow_0cwk0jf">
+        <di:waypoint x="452" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+import {completeUserTask} from '@requestHelpers';
+
+let initialData: {
+  processWithListenerInstance: {processInstanceKey: string};
+  processWithListenerOnRootInstance: {processInstanceKey: string};
+  userTaskProcessInstance: {processInstanceKey: string};
+};
+
+test.beforeAll(async () => {
+  // Deploy processes and create instances
+  await deploy(['./resources/processWithListener.bpmn']);
+  const processWithListenerInstance = await createSingleInstance(
+    'processWithListener',
+    1,
+  );
+
+  await deploy(['./resources/processWithListenerOnRoot.bpmn']);
+  createWorker('processStartListener', false);
+  const processWithListenerOnRootInstance = await createSingleInstance(
+    'processWithListenerOnRoot',
+    1,
+  );
+
+  await deploy(['./resources/processWithUserTaskListener.bpmn']);
+  const userTaskProcessInstance = await createSingleInstance(
+    'processWithUserTaskListener',
+    1,
+  );
+  createWorker('completeListener', false);
+  createWorker('endListener', false);
+
+  initialData = {
+    processWithListenerInstance,
+    processWithListenerOnRootInstance,
+    userTaskProcessInstance,
+  };
+
+  // Wait for deployment to be processed
+  await sleep(3000);
+});
+
+test.describe('Process Instance Listeners', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Listeners tab should always be visible', async ({
+    operateProcessInstancePage,
+  }) => {
+    const processInstanceKey =
+      initialData.processWithListenerInstance.processInstanceKey;
+
+    await test.step('Navigate to process instance page', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      await operateProcessInstancePage.verifyListenersTabVisible();
+    });
+
+    await test.step('Verify listeners tab is visible when selecting start event', async () => {
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        'StartEvent_1',
+      );
+      await expect(operateProcessInstancePage.listenersTabButton).toBeVisible();
+    });
+
+    await test.step('Verify listeners tab is visible when selecting service task', async () => {
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        /service task b/i,
+      );
+      await expect(operateProcessInstancePage.listenersTabButton).toBeVisible();
+    });
+  });
+
+  test('Listeners data displayed', async ({operateProcessInstancePage}) => {
+    const processInstanceKey =
+      initialData.processWithListenerInstance.processInstanceKey;
+
+    await test.step('Navigate to process instance and select service task', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        /service task b/i,
+      );
+    });
+
+    await test.step('Open listeners tab and verify execution listener is displayed', async () => {
+      await operateProcessInstancePage.openListenersTab();
+      await expect(
+        operateProcessInstancePage.executionListenerText,
+      ).toBeVisible();
+    });
+  });
+
+  test('Listeners list filtered by flow node instance', async ({
+    operateProcessInstancePage,
+  }) => {
+    const processInstanceKey =
+      initialData.processWithListenerInstance.processInstanceKey;
+
+    await test.step('Navigate to process instance and verify initial listener count', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      await operateProcessInstancePage.diagramHelper.clickFlowNode(
+        'Service Task B',
+      );
+      await operateProcessInstancePage.openListenersTab();
+      await expect(
+        operateProcessInstancePage.getListenerRows('execution'),
+      ).toHaveCount(1);
+    });
+
+    await test.step('Add a new flow node instance', async () => {
+      await operateProcessInstancePage.startModificationFlow();
+      await operateProcessInstancePage.diagramHelper.clickFlowNode(
+        'Service Task B',
+      );
+      await operateProcessInstancePage.addSingleFlowNodeInstanceButton.click();
+      await operateProcessInstancePage.applyModifications();
+    });
+
+    await test.step('Wait for new instance to appear and verify listener count', async () => {
+      await expect
+        .poll(async () => {
+          return operateProcessInstancePage.instanceHistory
+            .getByText('Service Task B')
+            .count();
+        })
+        .toBe(2);
+
+      await operateProcessInstancePage.diagramHelper.clickFlowNode(
+        'Service Task B',
+      );
+      await operateProcessInstancePage.openListenersTab();
+      await expect(
+        operateProcessInstancePage.getListenerRows('execution'),
+      ).toHaveCount(2);
+    });
+
+    await test.step('Select specific flow node instance and verify single listener', async () => {
+      await operateProcessInstancePage
+        .getInstanceHistoryElement('Service Task B')
+        .first()
+        .click();
+      await operateProcessInstancePage.openListenersTab();
+      await expect(
+        operateProcessInstancePage.getListenerRows('execution'),
+      ).toHaveCount(1);
+    });
+  });
+
+  test('Listeners list filtered by listener type', async ({
+    page,
+    request,
+    operateProcessInstancePage,
+  }) => {
+    const processInstanceKey =
+      initialData.userTaskProcessInstance.processInstanceKey;
+    const userTaskKeyRegex = new RegExp('\\d{16}');
+    let userTaskKey = '';
+
+    await test.step('Navigate to process instance and get user task key', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      const responsePromise = page.waitForResponse('**/flow-node-metadata');
+
+      await expect(
+        operateProcessInstancePage.diagramHelper.getFlowNode('Service Task B'),
+      ).toBeVisible();
+      await operateProcessInstancePage.diagramHelper.clickFlowNode(
+        'Service Task B',
+      );
+
+      const response = await responsePromise;
+      const data = await response.json();
+      userTaskKey = String(data.instanceMetadata.userTaskKey);
+
+      expect(userTaskKey).toMatch(userTaskKeyRegex);
+      await expect(operateProcessInstancePage.stateOverlayActive).toBeVisible();
+    });
+
+    await test.step('Complete the user task', async () => {
+      const completeRes = await completeUserTask(request, userTaskKey);
+      expect(completeRes.status()).toBe(204);
+
+      await expect(operateProcessInstancePage.stateOverlayActive).toBeHidden();
+      await expect(
+        operateProcessInstancePage.stateOverlayCompletedEndEvents,
+      ).toBeVisible();
+      await sleep(1000);
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        'Service Task B',
+      );
+      await operateProcessInstancePage.diagramHelper.moveCanvasHorizontally(
+        -400,
+      );
+    });
+
+    await test.step('Verify both listener types are visible by default', async () => {
+      await operateProcessInstancePage.openListenersTab();
+      await expect(
+        operateProcessInstancePage.executionListenerText,
+      ).toBeVisible();
+      await expect(operateProcessInstancePage.taskListenerText).toBeVisible();
+    });
+
+    await test.step('Filter to show only execution listeners', async () => {
+      await operateProcessInstancePage.listenerTypeFilter.click();
+      await operateProcessInstancePage
+        .getListenerTypeFilterOption('Execution listeners')
+        .click();
+      await expect(
+        operateProcessInstancePage.getExecutionListenerText(true),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getTaskListenerText(true),
+      ).toBeHidden();
+    });
+
+    await test.step('Filter to show only user task listeners', async () => {
+      await operateProcessInstancePage.listenerTypeFilter.click();
+      await operateProcessInstancePage
+        .getListenerTypeFilterOption('User task listeners')
+        .click();
+      await expect(
+        operateProcessInstancePage.getTaskListenerText(true),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getExecutionListenerText(true),
+      ).toBeHidden();
+    });
+
+    await test.step('Filter to show all listeners', async () => {
+      await operateProcessInstancePage.listenerTypeFilter.click();
+      await operateProcessInstancePage
+        .getListenerTypeFilterOption('All listeners')
+        .click();
+      await expect(
+        operateProcessInstancePage.getExecutionListenerText(true),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getTaskListenerText(true),
+      ).toBeVisible();
+    });
+  });
+
+  test('Listeners on process instance or participant (root flow node)', async ({
+    operateProcessInstancePage,
+  }) => {
+    const processInstanceKey =
+      initialData.processWithListenerOnRootInstance.processInstanceKey;
+
+    await test.step('Navigate to process instance and modify it', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      await operateProcessInstancePage.startModificationFlow();
+      await operateProcessInstancePage.diagramHelper.clickFlowNode(
+        'Service Task B',
+      );
+      await operateProcessInstancePage.moveSelectedInstanceButton.click({
+        timeout: 30000,
+      });
+      await operateProcessInstancePage.diagramHelper.clickEvent('EndEvent');
+      await operateProcessInstancePage.applyModifications();
+    });
+
+    await test.step('Select root process node and verify listeners tab visibility', async () => {
+      await expect
+        .poll(async () => {
+          await operateProcessInstancePage.clickInstanceHistoryElement(
+            /Start event/i,
+          );
+          await operateProcessInstancePage.clickInstanceHistoryElement(
+            /processWithListenerOnRoot/i,
+          );
+
+          try {
+            await expect(
+              operateProcessInstancePage.listenersTabButton,
+            ).toBeVisible({
+              timeout: 500,
+            });
+          } catch {
+            return false;
+          }
+          return true;
+        })
+        .toBe(true);
+    });
+
+    await test.step('Open listeners tab and verify execution listener is displayed', async () => {
+      await operateProcessInstancePage.openListenersTab();
+      await expect(
+        operateProcessInstancePage.executionListenerText,
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -296,7 +296,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
-      await expect(operateProcessesPage.resultsText).toBeVisible({
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
         timeout: 30000,
       });
 
@@ -334,7 +334,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(sourceVersion);
 
-      await expect(operateProcessesPage.resultsText).toBeVisible({
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
         timeout: 30000,
       });
     });
@@ -531,7 +531,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
-      await expect(operateProcessesPage.resultsText).toBeVisible({
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
         timeout: 30000,
       });
 
@@ -574,7 +574,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
-      await expect(operateProcessesPage.resultsText).toBeVisible({
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
         timeout: 30000,
       });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -20,6 +20,7 @@ const c8 = new Camunda8({
   CAMUNDA_BASIC_AUTH_USERNAME: process.env.CAMUNDA_BASIC_AUTH_USERNAME,
   CAMUNDA_BASIC_AUTH_PASSWORD: process.env.CAMUNDA_BASIC_AUTH_PASSWORD,
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
+  ZEEBE_GRPC_ADDRESS: process.env.ZEEBE_GRPC_ADDRESS,
 });
 
 function generateManyVariables(): Record<string, string> {
@@ -34,6 +35,7 @@ function generateManyVariables(): Record<string, string> {
 }
 
 const zeebe = c8.getCamundaRestClient();
+const zeebeGrpc = c8.getZeebeGrpcApiClient();
 const deploy = async (processFilePaths: string[]) => {
   try {
     const results = await zeebe.deployResourcesFromFiles(processFilePaths);
@@ -78,6 +80,29 @@ const cancelProcessInstance = async (processInstanceKey: string) => {
   return zeebe.cancelProcessInstance({processInstanceKey});
 };
 
+const createWorker = (
+  taskType: string,
+  shouldFail: boolean = false,
+  variables: JSONDoc = {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler?: (job: any) => any,
+  timeout?: number,
+) => {
+  return zeebeGrpc.createWorker({
+    taskType,
+    taskHandler:
+      handler ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((job: any) => {
+        if (shouldFail) {
+          return job.fail('Task failed for testing purposes');
+        }
+        return job.complete(variables);
+      }),
+    ...(timeout ? {timeout} : {}),
+  });
+};
+
 async function checkUpdateOnVersion(
   targetVersion: string,
   processInstanceKey: string,
@@ -100,4 +125,5 @@ export {
   checkUpdateOnVersion,
   createSingleInstance,
   cancelProcessInstance,
+  createWorker,
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR migrates the `processInstanceListeners.spec` test from an Operate test suite to the Orchestration Cluster (OC) E2E test suite. The migration adds comprehensive test coverage for process execution listeners and user task listeners in the Operate UI, including functionality for filtering, viewing, and interacting with listeners across different flow node types.

- Added new E2E test file with 4 test cases covering listener visibility, data display, filtering, and root-level listeners

Also add a fix for processInstanceMigration test
closes #42134
relates to #34089
🧪 [TestRun](https://github.com/camunda/camunda/actions/runs/19961839136)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
