### PR TITLE
Change weekly load test to make use of typical process

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -1,6 +1,6 @@
 # description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - typical, realistic, latency
 # type: CI
-# owner: camunda/reliability-testing
+# owner: @camunda/reliability-testing
 name: Camunda weekly medic load test
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
-      name: ${{ needs.test-data.outputs.test }}
+      name: ${{ needs.test-data.outputs.test }}-typical
       ttl: 28
       load-test-load: >
         --set starter.rate=50

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -53,7 +53,9 @@ jobs:
     with:
       name: ${{ needs.test-data.outputs.test }}
       ttl: 28
-      load-test-load: "--set starter.rate=50 --set starter.bpmnXmlPath=\"bpmn/typical_process.bpmn\""
+      load-test-load: >
+        --set starter.rate=50
+        --set starter.bpmnXmlPath="bpmn/typical_process.bpmn"
   setup-realistic-test:
     name: Realistic load test
     uses: ./.github/workflows/camunda-load-test.yml

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -1,12 +1,12 @@
-# description: Deploys new zeebe benchmarks weekly. Old benchmarks are removed. Multiple kinds of benchmarks are created - Data, Normal, Mixed, Latency
+# description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - typical, realistic, latency
 # type: CI
-# owner @camunda/core-features
-name: Zeebe Weekly medic benchmark
+# owner: camunda/reliability-testing
+name: Camunda weekly medic load test
 on:
   workflow_dispatch:
      inputs:
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the medic benchmarks. Allows to skip the docker image build step, can be used for recreating previous weekly benchmarks.'
+        description: 'Docker image tag, that should be reused for the weekly load tests. Allows to skip the docker image build step, can be used for recreating previous weekly tests.'
         type: string
         default: ""
         required: false
@@ -15,65 +15,65 @@ on:
     - cron: 0 1 * * 1
 
 jobs:
-  benchmark-data:
-    name: Collect benchmark data
+  test-data:
+    name: Collect test data
     runs-on: ubuntu-latest
     outputs:
-      benchmark: ${{ steps.data.outputs.benchmark }}
+      test: ${{ steps.data.outputs.test }}
       operate: ${{ steps.data.outputs.operate }}
     steps:
       - uses: actions/checkout@v4
-      - name: Collect benchmark data
+      - name: Collect test data
         id: data
         run: |
           var=${{ inputs.reuse-tag || '' }}
           # ${#var} will return the length of the string
           if [[ ${#var} -eq 0 ]]; then
-            echo "Creating new weekly benchmark"
-            echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> "$GITHUB_OUTPUT"
+            echo "Creating new weekly test tag"
+            echo "test=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-test" >> "$GITHUB_OUTPUT"
           else
             # Example:
             # $ echo ${var%?}
-            # medic-y-2025-cw-18-b1bd4006-benchmark-b1bd400
+            # medic-y-2025-cw-18-b1bd4006-test-b1bd400
             # $ echo ${var%-*}
-            # medic-y-2025-cw-18-b1bd4006-benchmark
+            # medic-y-2025-cw-18-b1bd4006-test
             tag=${{ inputs.reuse-tag }}
             var=${tag%-*}
-            echo "Re-creating weekly benchmark, with name: $var and tag: $tag"
-            echo "benchmark=$var" >> "$GITHUB_OUTPUT"
+            echo "Re-creating weekly test, with name: $var and tag: $tag"
+            echo "test=$var" >> "$GITHUB_OUTPUT"
           fi
           echo "full-ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   setup-typical-load-test:
     name: Typical load test
     needs:
-      - benchmark-data
+      - test-data
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
-      name: ${{ needs.benchmark-data.outputs.benchmark }}
+      name: ${{ needs.test-data.outputs.test }}
       ttl: 28
       load-test-load: "--set starter.rate=50 --set starter.bpmnXmlPath=\"bpmn/typical_process.bpmn\""
-  setup-mixed-benchmark:
-    name: Mixed Benchmark
+  setup-realistic-test:
+    name: Realistic load test
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     needs:
-      - benchmark-data
+      - test-data
     with:
-      name: ${{ needs.benchmark-data.outputs.benchmark }}-mixed
+      name: ${{ needs.test-data.outputs.test }}-mixed
       ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       realistic: true
-  setup-latency-benchmark:
-    name: Latency Benchmark
+  setup-latency-test:
+    name: Latency test
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     needs:
-      - benchmark-data
+      - test-data
     with:
-      name: ${{ needs.benchmark-data.outputs.benchmark }}-latency
+      name: ${{ needs.test-data.outputs.test }}-latency
       ttl: 28
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
@@ -84,7 +84,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ setup-normal-benchmark, setup-mixed-benchmark, setup-latency-benchmark ]
+    needs: [ setup-typical-load-test, setup-realistic-test, setup-latency-test ]
     if: failure()
     steps:
       - uses: actions/checkout@v4
@@ -100,7 +100,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: *Medic benchmark creation failed:*"
+                    "text": ":warning: *Medic load test creation failed:*"
                   }
                 },
                 {

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -65,8 +65,6 @@ jobs:
     with:
       name: ${{ needs.test-data.outputs.test }}-mixed
       ttl: 28
-      cluster: zeebe-cluster
-      cluster-region: europe-west1-b
       realistic: true
   setup-latency-test:
     name: Latency test
@@ -77,8 +75,6 @@ jobs:
     with:
       name: ${{ needs.test-data.outputs.test }}-latency
       ttl: 28
-      cluster: zeebe-cluster
-      cluster-region: europe-west1-b
       load-test-load: >
         --set starter.rate=1
         --set workers.worker.replicas=1

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -44,8 +44,8 @@ jobs:
           fi
           echo "full-ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-  setup-normal-benchmark:
-    name: Normal Benchmark
+  setup-typical-load-test:
+    name: Typical load test
     needs:
       - benchmark-data
     uses: ./.github/workflows/camunda-load-test.yml
@@ -53,9 +53,7 @@ jobs:
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
       ttl: 28
-      cluster: zeebe-cluster
-      cluster-region: europe-west1-b
-      publish: "slack"
+      load-test-load: "--set starter.rate=50 --set starter.bpmnXmlPath=\"bpmn/typical_process.bpmn\""
   setup-mixed-benchmark:
     name: Mixed Benchmark
     uses: ./.github/workflows/camunda-load-test.yml


### PR DESCRIPTION
## Description

 * Instead of using the normal, single service task, process we make use of a more
   typical process (straight trough process with 10 tasks)
   * While the one task process is helpful for stress tests, as it gives us a good sense of the maximum load,
     this is one of the smallest processes (including a service task) that we can model.
     Reducing the used feature set to a small amount allows easy comparison between tests,
     as fewer variations and outside factors can influence test results.
     Still, this is not very realistic and useful for our long-running tests.
 * In our endurance tests, I would like to focus on more real-world scenarios / realistic cases.
   As we have with our "realistic" or "mixed" test containing different variations of elements,
   we should also consider the case of straight-through processing.
 * The benefits of using such a process model are that we will be closer to reality, especially in terms of state size. This process model takes longer to execute, and we will have ~6000 PI in a state at all times.



The one task process
<img width="996" height="270" alt="normal" src="https://github.com/user-attachments/assets/93c0335d-3746-423c-95a3-4435acbcef53" />


Will be change to:


<img width="5823" height="576" alt="typical_process" src="https://github.com/user-attachments/assets/59a52d43-a89d-48a3-941f-1a9659f91006" />


<!-- Describe the goal and purpose of this PR. -->
## Related

* related slack thread https://camunda.slack.com/archives/C0807665N8G/p1764927107923139


Was running the test for some days before on my own

<img width="2507" height="914" alt="2025-12-05_10-29" src="https://github.com/user-attachments/assets/836306d7-7bcf-4057-ba6d-e865a4ff93a6" />
