### PR TITLE
feat: add transformers, document reader and implement search client

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.CamundaSearchClients;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
+import io.camunda.search.clients.reader.AuditLogReader;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.BatchOperationItemReader;
 import io.camunda.search.clients.reader.BatchOperationReader;
@@ -131,7 +132,8 @@ public class SearchClientConfiguration {
       final UserReader userReader,
       final UserTaskReader userTaskReader,
       final VariableReader variableReader,
-      final ClusterVariableReader clusterVariableReader) {
+      final ClusterVariableReader clusterVariableReader,
+      final AuditLogReader auditLogReader) {
     return new SearchClientReaders(
         authorizationReader,
         batchOperationReader,
@@ -164,6 +166,7 @@ public class SearchClientConfiguration {
         userReader,
         userTaskReader,
         variableReader,
-        clusterVariableReader);
+        clusterVariableReader,
+        auditLogReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -11,6 +11,8 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.clients.reader.AuditLogDocumentReader;
+import io.camunda.search.clients.reader.AuditLogReader;
 import io.camunda.search.clients.reader.AuthorizationDocumentReader;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.BatchOperationDocumentReader;
@@ -90,6 +92,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -374,5 +377,11 @@ public class SearchClientReaderConfiguration {
   public ClusterVariableReader clusterVariableReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
     return new ClusterVariableDocumentReader(executor, descriptors.get(ClusterVariableIndex.class));
+  }
+
+  @Bean
+  public AuditLogReader auditLogReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new AuditLogDocumentReader(executor, descriptors.get(AuditLogTemplate.class));
   }
 }

--- a/search/search-client-query-transformer/pom.xml
+++ b/search/search-client-query-transformer/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
     <dependency>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AuditLogDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AuditLogDocumentReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.query.AuditLogQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class AuditLogDocumentReader extends DocumentBasedReader implements AuditLogReader {
+
+  public AuditLogDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public AuditLogEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getByQuery(
+            AuditLogQuery.of(b -> b.filter(f -> f.auditLogKeys(id)).singleResult()),
+            io.camunda.webapps.schema.entities.auditlog.AuditLogEntity.class);
+  }
+
+  @Override
+  public SearchQueryResult<AuditLogEntity> search(
+      final AuditLogQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.auditlog.AuditLogEntity.class,
+            resourceAccessChecks);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -43,6 +43,7 @@ import io.camunda.search.clients.transformers.aggregation.result.ProcessDefiniti
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUAggregationResultTransformer;
+import io.camunda.search.clients.transformers.entity.AuditLogEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationItemEntityTransformer;
@@ -69,6 +70,7 @@ import io.camunda.search.clients.transformers.entity.TenantMemberEntityTransform
 import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
+import io.camunda.search.clients.transformers.filter.AuditLogFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationItemFilterTransformer;
@@ -106,6 +108,7 @@ import io.camunda.search.clients.transformers.query.TypedSearchQueryTransformer;
 import io.camunda.search.clients.transformers.result.DecisionInstanceResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.DecisionRequirementsResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
+import io.camunda.search.clients.transformers.sort.AuditLogSortTransformer;
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationItemFieldSortingTransformer;
@@ -133,6 +136,7 @@ import io.camunda.search.clients.transformers.sort.UsageMetricsFieldSortingTrans
 import io.camunda.search.clients.transformers.sort.UserFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
+import io.camunda.search.filter.AuditLogFilter;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.BatchOperationItemFilter;
@@ -166,6 +170,7 @@ import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
+import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
@@ -202,6 +207,7 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
+import io.camunda.search.sort.AuditLogSort;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
 import io.camunda.search.sort.BatchOperationSort;
@@ -241,6 +247,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -260,6 +267,7 @@ import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
@@ -378,7 +386,8 @@ public final class ServiceTransformers {
             UserTaskQuery.class,
             UserQuery.class,
             VariableQuery.class,
-            ClusterVariableQuery.class)
+            ClusterVariableQuery.class,
+            AuditLogQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -410,6 +419,7 @@ public final class ServiceTransformers {
     mappers.put(TenantEntity.class, new TenantEntityTransformer());
     mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
     mappers.put(UserEntity.class, new UserEntityTransformer());
+    mappers.put(AuditLogEntity.class, new AuditLogEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
@@ -441,6 +451,7 @@ public final class ServiceTransformers {
     mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
     mappers.put(UserSort.class, new UserFieldSortingTransformer());
+    mappers.put(AuditLogSort.class, new AuditLogSortTransformer());
 
     // filters -> search query
     mappers.put(
@@ -470,6 +481,9 @@ public final class ServiceTransformers {
         new DecisionInstanceFilterTransformer(
             indexDescriptors.get(DecisionInstanceTemplate.class)));
     mappers.put(UserFilter.class, new UserFilterTransformer(indexDescriptors.get(UserIndex.class)));
+    mappers.put(
+        AuditLogFilter.class,
+        new AuditLogFilterTransformer(indexDescriptors.get(AuditLogTemplate.class)));
     mappers.put(
         AuthorizationFilter.class,
         new AuthorizationFilterTransformer(indexDescriptors.get(AuthorizationIndex.class)));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.BatchOperationType;
+
+public class AuditLogEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.auditlog.AuditLogEntity, AuditLogEntity> {
+
+  @Override
+  public AuditLogEntity apply(
+      final io.camunda.webapps.schema.entities.auditlog.AuditLogEntity value) {
+    return new AuditLogEntity(
+        value.getId(),
+        value.getEntityKey(),
+        value.getEntityType(),
+        value.getOperationType(),
+        value.getBatchOperationKey(),
+        mapBatchOperationType(value.getBatchOperationType()),
+        value.getTimestamp(),
+        value.getActorId(),
+        value.getActorType(),
+        value.getTenantId(),
+        value.getResult(),
+        value.getAnnotation(),
+        value.getCategory(),
+        value.getProcessDefinitionId(),
+        value.getProcessDefinitionKey(),
+        value.getProcessInstanceKey(),
+        value.getElementInstanceKey(),
+        value.getJobKey(),
+        value.getUserTaskKey(),
+        value.getDecisionRequirementsId(),
+        value.getDecisionRequirementsKey(),
+        value.getDecisionDefinitionId(),
+        value.getDecisionDefinitionKey(),
+        value.getDecisionEvaluationKey(),
+        value.getDeploymentKey(),
+        value.getFormKey(),
+        value.getResourceKey());
+  }
+
+  private BatchOperationType mapBatchOperationType(
+      final io.camunda.zeebe.protocol.record.value.BatchOperationType batchOperationType) {
+    if (batchOperationType == null) {
+      return null;
+    }
+
+    return switch (batchOperationType) {
+      case RESOLVE_INCIDENT -> BatchOperationType.RESOLVE_INCIDENT;
+      case CANCEL_PROCESS_INSTANCE -> BatchOperationType.CANCEL_PROCESS_INSTANCE;
+      case DELETE_PROCESS_INSTANCE -> BatchOperationType.DELETE_PROCESS_INSTANCE;
+      case MODIFY_PROCESS_INSTANCE -> BatchOperationType.MODIFY_PROCESS_INSTANCE;
+      case MIGRATE_PROCESS_INSTANCE -> BatchOperationType.MIGRATE_PROCESS_INSTANCE;
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuditLogFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuditLogFilterTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.*;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.AuditLogFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class AuditLogFilterTransformer extends IndexFilterTransformer<AuditLogFilter> {
+
+  public AuditLogFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final AuditLogFilter filter) {
+    return and(
+        stringOperations(ACTOR_ID, filter.actorIdOperations()),
+        stringOperations(ACTOR_TYPE, filter.actorTypeOperations()),
+        stringOperations(AUDIT_LOG_KEY, filter.auditLogKeyOperations()),
+        longOperations(BATCH_OPERATION_KEY, filter.batchOperationKeyOperations()),
+        stringOperations(CATEGORY, filter.categoryOperations()),
+        longOperations(DECISION_DEFINITION_KEY, filter.decisionDefinitionKeyOperations()),
+        longOperations(DECISION_EVALUATION_KEY, filter.decisionEvaluationKeyOperations()),
+        longOperations(DEPLOYMENT_KEY, filter.deploymentKeyOperations()),
+        longOperations(ELEMENT_INSTANCE_KEY, filter.elementInstanceKeyOperations()),
+        stringOperations(ENTITY_KEY, filter.entityKeyOperations()),
+        stringOperations(ENTITY_TYPE, filter.entityTypeOperations()),
+        longOperations(FORM_KEY, filter.formKeyOperations()),
+        longOperations(JOB_KEY, filter.jobKeyOperations()),
+        stringOperations(OPERATION_TYPE, filter.operationTypeOperations()),
+        stringOperations(PROCESS_DEFINITION_ID, filter.processDefinitionIdOperations()),
+        longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()),
+        longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()),
+        longOperations(RESOURCE_KEY, filter.resourceKeyOperations()),
+        stringOperations(RESULT, filter.resultOperations()),
+        stringOperations(TENANT_ID, filter.tenantIdOperations()),
+        dateTimeOperations(TIMESTAMP, filter.timestampOperations()),
+        longOperations(USER_TASK_KEY, filter.userTaskKeyOperations()));
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuditLogSortTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuditLogSortTransformer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ACTOR_ID;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ACTOR_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ANNOTATION;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.AUDIT_LOG_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.BATCH_OPERATION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.BATCH_OPERATION_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.CATEGORY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.DECISION_DEFINITION_ID;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.DECISION_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.DECISION_EVALUATION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.DECISION_REQUIREMENTS_ID;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.DECISION_REQUIREMENTS_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ELEMENT_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ENTITY_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ENTITY_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.JOB_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.OPERATION_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.PROCESS_DEFINITION_ID;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.RESULT;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.TIMESTAMP;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.USER_TASK_KEY;
+
+public class AuditLogSortTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "actorId" -> ACTOR_ID;
+      case "actorType" -> ACTOR_TYPE;
+      case "annotation" -> ANNOTATION;
+      case "auditLogKey" -> AUDIT_LOG_KEY;
+      case "batchOperationKey" -> BATCH_OPERATION_KEY;
+      case "batchOperationType" -> BATCH_OPERATION_TYPE;
+      case "category" -> CATEGORY;
+      case "decisionDefinitionId" -> DECISION_DEFINITION_ID;
+      case "decisionDefinitionKey" -> DECISION_DEFINITION_KEY;
+      case "decisionEvaluationKey" -> DECISION_EVALUATION_KEY;
+      case "decisionRequirementsId" -> DECISION_REQUIREMENTS_ID;
+      case "decisionRequirementsKey" -> DECISION_REQUIREMENTS_KEY;
+      case "elementInstanceKey" -> ELEMENT_INSTANCE_KEY;
+      case "entityKey" -> ENTITY_KEY;
+      case "entityType" -> ENTITY_TYPE;
+      case "jobKey" -> JOB_KEY;
+      case "operationType" -> OPERATION_TYPE;
+      case "processDefinitionId" -> PROCESS_DEFINITION_ID;
+      case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "result" -> RESULT;
+      case "tenantId" -> TENANT_ID;
+      case "timestamp" -> TIMESTAMP;
+      case "userTaskKey" -> USER_TASK_KEY;
+      default -> throw new IllegalArgumentException("Unknown field: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return TIMESTAMP;
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -40,4 +40,5 @@ public record SearchClientReaders(
     UserReader userReader,
     UserTaskReader userTaskReader,
     VariableReader variableReader,
-    ClusterVariableReader clusterVariableReader) {}
+    ClusterVariableReader clusterVariableReader,
+    AuditLogReader auditLogReader) {}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -178,12 +178,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   @Override
   public AuditLogEntity getAuditLog(final String id) {
-    throw new RuntimeException("Not implemented yet");
+    return doGetWithReader(readers.auditLogReader(), id)
+        .orElseThrow(() -> entityByIdNotFoundException("Audit log", id));
   }
 
   @Override
   public SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query) {
-    throw new RuntimeException("Not implemented yet");
+    return doSearchWithReader(readers.auditLogReader(), query);
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -19,7 +19,34 @@ public class AuditLogTemplate extends AbstractTemplateDescriptor
 
   public static final String INDEX_NAME = "audit-log";
   public static final String INDEX_VERSION = "8.9.0";
+
+  public static final String ACTOR_ID = "actorId";
+  public static final String ACTOR_TYPE = "actorType";
+  public static final String ANNOTATION = "annotation";
+  public static final String AUDIT_LOG_KEY = "auditLogKey";
+  public static final String BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String BATCH_OPERATION_TYPE = "batchOperationType";
+  public static final String CATEGORY = "category";
+  public static final String DECISION_DEFINITION_ID = "decisionDefinitionId";
+  public static final String DECISION_DEFINITION_KEY = "decisionDefinitionKey";
+  public static final String DECISION_EVALUATION_KEY = "decisionEvaluationKey";
+  public static final String DECISION_REQUIREMENTS_ID = "decisionRequirementsId";
+  public static final String DECISION_REQUIREMENTS_KEY = "decisionRequirementsKey";
+  public static final String DEPLOYMENT_KEY = "deploymentKey";
+  public static final String ELEMENT_INSTANCE_KEY = "elementInstanceKey";
   public static final String ENTITY_KEY = "entityKey";
+  public static final String ENTITY_TYPE = "entityType";
+  public static final String FORM_KEY = "formKey";
+  public static final String JOB_KEY = "jobKey";
+  public static final String OPERATION_TYPE = "operationType";
+  public static final String PROCESS_DEFINITION_ID = "processDefinitionId";
+  public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
+  public static final String RESOURCE_KEY = "resourceKey";
+  public static final String RESULT = "result";
+  public static final String TENANT_ID = "tenantId";
+  public static final String TIMESTAMP = "timestamp";
+  public static final String USER_TASK_KEY = "userTaskKey";
 
   public static final EntityJoinRelationFactory<AuditLogJoinRelationshipType>
       JOIN_RELATION_FACTORY =


### PR DESCRIPTION
## Description

Add transformers for AuditLog entities, filters, and sorting
Implement AuditLogDocumentReader and integrate into search client configuration
Implement methods for retrieving and searching audit logs

## Related issues

related to https://github.com/camunda/camunda/issues/42132
