### PR TITLE
[Backport stable/8.8] fix: reduce post exporter max idle time to 5s

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -327,7 +327,7 @@ public class ExporterConfiguration {
   public static final class PostExportConfiguration {
     private int batchSize = 100;
     private int delayBetweenRuns = 2000;
-    private int maxDelayBetweenRuns = 60000;
+    private int maxDelayBetweenRuns = 5000;
     private boolean ignoreMissingData = false;
 
     public int getBatchSize() {


### PR DESCRIPTION
# Description
Backport of #42119 to `stable/8.8`.

relates to #39962