### PR TITLE
[Backport stable/8.8] fix: skip check free disk space for ES to start

### DIFF
--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -45,7 +45,14 @@ func (w *UnixC8Run) VersionCmd(ctx context.Context, javaBinaryPath string) *exec
 
 func (w *UnixC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion string, parentDir string) *exec.Cmd {
 	elasticsearchCmdString := filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch")
-	elasticsearchCmd := exec.CommandContext(ctx, elasticsearchCmdString, "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false", "-E", "discovery.type=single-node")
+	elasticsearchCmd := exec.CommandContext(
+		ctx,
+		elasticsearchCmdString,
+		"-E", "xpack.ml.enabled=false",
+		"-E", "xpack.security.enabled=false",
+		"-E", "discovery.type=single-node",
+		"-E", "cluster.routing.allocation.disk.threshold_enabled=false",
+	)
 	elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return elasticsearchCmd
 }

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -34,7 +34,14 @@ func (w *WindowsC8Run) VersionCmd(ctx context.Context, javaBinaryPath string) *e
 }
 
 func (w *WindowsC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion string, parentDir string) *exec.Cmd {
-	elasticsearchCmd := exec.CommandContext(ctx, filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"), "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false", "-E", "discovery.type=single-node")
+	elasticsearchCmd := exec.CommandContext(
+		ctx,
+		filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"),
+		"-E", "xpack.ml.enabled=false",
+		"-E", "xpack.security.enabled=false",
+		"-E", "discovery.type=single-node",
+		"-E", "cluster.routing.allocation.disk.threshold_enabled=false",
+	)
 
 	elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags


### PR DESCRIPTION
# Description
Backport of #41918 to `stable/8.8`.

relates to #41726