### PR TITLE
[Backport stable/8.8] feat: added warning to user about port for Camunda in already use

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.go]
+indent_style = tab
+indent_size = 4
+
 [*.xml]
 indent_size = 2
 

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -223,17 +223,13 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 		os.Exit(1)
 	}
 
-<<<<<<< HEAD
 	err = overrides.SetEnvVars(javaHome)
-=======
 	if err := ensurePortAvailable(settings.Port); err != nil {
 		log.Error().Err(err).Int("port", settings.Port).Msg("Camunda Run port is unavailable")
 		fmt.Printf("Port %d is already in use. Stop the other service or run `c8run start --port <free-port>`.\n", settings.Port)
 		os.Exit(1)
 	}
 
-	err = overrides.SetEnvVars(javaHome, shouldStartElasticsearch)
->>>>>>> a003eb41 (feat: added warning to user about port for Camunda in already use)
 	if err != nil {
 		fmt.Println("Failed to set envVars:", err)
 	}

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -2,7 +2,9 @@ package start
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/camunda/camunda/c8run/internal/health"
 	"github.com/camunda/camunda/c8run/internal/overrides"
@@ -58,6 +61,35 @@ func getJavaVersion(javaBinary string) (string, error) {
 
 type StartupHandler struct {
 	ProcessHandler *processmanagement.ProcessHandler
+}
+
+func ensurePortAvailable(port int) error {
+	networks := []string{"tcp4", "tcp6"}
+	for _, network := range networks {
+		listener, err := net.Listen(network, fmt.Sprintf(":%d", port))
+		if err != nil {
+			if isNetworkUnsupported(err) {
+				continue
+			}
+			return fmt.Errorf("port %d is already in use (%s)", port, network)
+		}
+		if err := listener.Close(); err != nil {
+			return fmt.Errorf("failed to release temporary port check listener: %w", err)
+		}
+	}
+	return nil
+}
+
+func isNetworkUnsupported(err error) bool {
+	switch {
+	case errors.Is(err, syscall.EAFNOSUPPORT),
+		errors.Is(err, syscall.EPROTONOSUPPORT),
+		errors.Is(err, syscall.EPFNOSUPPORT),
+		errors.Is(err, syscall.EADDRNOTAVAIL):
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *StartupHandler) startApplication(cmd *exec.Cmd, pid string, logPath string, stop context.CancelFunc) error {
@@ -191,7 +223,17 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 		os.Exit(1)
 	}
 
+<<<<<<< HEAD
 	err = overrides.SetEnvVars(javaHome)
+=======
+	if err := ensurePortAvailable(settings.Port); err != nil {
+		log.Error().Err(err).Int("port", settings.Port).Msg("Camunda Run port is unavailable")
+		fmt.Printf("Port %d is already in use. Stop the other service or run `c8run start --port <free-port>`.\n", settings.Port)
+		os.Exit(1)
+	}
+
+	err = overrides.SetEnvVars(javaHome, shouldStartElasticsearch)
+>>>>>>> a003eb41 (feat: added warning to user about port for Camunda in already use)
 	if err != nil {
 		fmt.Println("Failed to set envVars:", err)
 	}

--- a/c8run/internal/start/startuphandler_test.go
+++ b/c8run/internal/start/startuphandler_test.go
@@ -1,0 +1,29 @@
+package start
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestEnsurePortAvailable(t *testing.T) {
+	inUseListener, err := net.Listen("tcp4", ":0")
+	if err != nil {
+		t.Fatalf("failed to get ephemeral listener: %v", err)
+	}
+
+	port := inUseListener.Addr().(*net.TCPAddr).Port
+
+	if err := ensurePortAvailable(port); err == nil {
+		t.Fatalf("expected error when port %d is already bound", port)
+	}
+
+	if err := inUseListener.Close(); err != nil {
+		t.Fatalf("failed to close temporary listener: %v", err)
+	}
+	time.Sleep(25 * time.Millisecond) // give the OS a moment to release the port
+
+	if err := ensurePortAvailable(port); err != nil {
+		t.Fatalf("expected port %d to be reported as available: %v", port, err)
+	}
+}


### PR DESCRIPTION
# Description
Backport of #41979 to `stable/8.8`.

relates to #41743