### PR TITLE
[Backport stable/8.8] fix: remove stale .lock files so c8un restarts after aggressive shutdown

### DIFF
--- a/c8run/internal/processmanagement/processhandler.go
+++ b/c8run/internal/processmanagement/processhandler.go
@@ -50,9 +50,14 @@ func (p *ProcessHandler) cleanUp(pidPath string) {
 	if err != nil {
 		return
 	}
-	defer releaseLock(fileLock, lockPath)
+	defer func() {
+		releaseLock(fileLock, lockPath)
+		if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+			log.Err(err).Msgf("Failed to remove lock file: %s", lockPath)
+		}
+	}()
 
-	if err := os.Remove(pidPath); err != nil {
+	if err := os.Remove(pidPath); err != nil && !os.IsNotExist(err) {
 		log.Err(err).Msgf("Failed to remove pid file: %s", pidPath)
 	}
 }

--- a/c8run/internal/processmanagement/processhandler_test.go
+++ b/c8run/internal/processmanagement/processhandler_test.go
@@ -71,16 +71,23 @@ func TestReadPIDFromFile_InvalidPID(t *testing.T) {
 	}
 }
 
-func TestCleanUp_RemovesPIDFile(t *testing.T) {
+func TestCleanUp_RemovesPIDAndLockFiles(t *testing.T) {
 	dir := t.TempDir()
 	pidPath := filepath.Join(dir, "cleanup.pid")
 	if err := os.WriteFile(pidPath, []byte("123"), 0644); err != nil {
 		t.Fatalf("Failed to write PID file: %v", err)
 	}
+	lockPath := pidPath + ".lock"
+	if err := os.WriteFile(lockPath, []byte(""), 0644); err != nil {
+		t.Fatalf("Failed to write lock file: %v", err)
+	}
 	h := &ProcessHandler{}
 	h.cleanUp(pidPath)
 	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
 		t.Error("PID file was not removed by cleanUp")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Error("Lock file was not removed by cleanUp")
 	}
 }
 


### PR DESCRIPTION
# Description
Backport of #42002 to `stable/8.8`.

relates to #41727