### PR TITLE
Weekly load test: bring back reuse-tag

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -53,6 +53,7 @@ jobs:
     with:
       name: ${{ needs.test-data.outputs.test }}-typical
       ttl: 28
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
       load-test-load: >
         --set starter.rate=50
         --set starter.bpmnXmlPath="bpmn/typical_process.bpmn"
@@ -65,6 +66,7 @@ jobs:
     with:
       name: ${{ needs.test-data.outputs.test }}-mixed
       ttl: 28
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
       realistic: true
   setup-latency-test:
     name: Latency test
@@ -75,6 +77,7 @@ jobs:
     with:
       name: ${{ needs.test-data.outputs.test }}-latency
       ttl: 28
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
       load-test-load: >
         --set starter.rate=1
         --set workers.worker.replicas=1


### PR DESCRIPTION
## Description
 * Was recently (mistakenly) removed, this causes that we are not able to correctly recreate medic weekly tests

Related commit https://github.com/camunda/camunda/commit/f5b29a881200c9f298c3f68c80848e5d36a700ba#diff-c6f4c4d1b1897d19059434fbca5ffa55952be0cd05388537a71c24801128141f
<!-- Describe the goal and purpose of this PR. -->
