### PR TITLE
ci: fix Zeebe version compat job by giving Minimus access

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -103,6 +103,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-zeebe
         with:
           maven-extra-args: -PskipFrontendBuild


### PR DESCRIPTION
## Description

Fixes failures like https://github.com/camunda/camunda/actions/runs/19954378030 due to missing credentials.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - not needed as Minimus is only used on `main` for now

## Related issues

[Slack](https://camunda.slack.com/archives/C013MEVQ4M9/p1764936557692439)

Related to https://github.com/camunda/camunda/issues/40739