### PR TITLE
[Backport stable/8.8] fix: C8Run Docker shutdown docker fix

### DIFF
--- a/c8run/shutdown.sh
+++ b/c8run/shutdown.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./c8run stop
+./c8run stop "$@"


### PR DESCRIPTION
# Description
Backport of #41403 to `stable/8.8`.

relates to #37323