### PR TITLE
fix: don't apply tenant check to Identity-related entities

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -157,10 +157,15 @@ abstract class AbstractEntityReader<T> {
    * @return {@code true} if the search result should be empty, {@code false
    */
   protected boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
-    return resourceAccessChecks.authorizationCheck().enabled()
-            && !resourceAccessChecks.hasAnyResourceId()
-        || resourceAccessChecks.tenantCheck().enabled()
-            && resourceAccessChecks.getAuthorizedTenantIds().isEmpty();
+    return noResourceAccess(resourceAccessChecks) || noTenantAccess(resourceAccessChecks);
+  }
+
+  protected boolean noResourceAccess(final ResourceAccessChecks resourceAccessChecks) {
+    return !resourceAccessChecks.authorizationCheck().hasAnyResourceAccess();
+  }
+
+  protected boolean noTenantAccess(final ResourceAccessChecks resourceAccessChecks) {
+    return !resourceAccessChecks.tenantCheck().hasAnyTenantAccess();
   }
 
   /**

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -111,10 +111,4 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
         model.resourcePropertyName(),
         new HashSet<>(model.permissionTypes()));
   }
-
-  @Override
-  protected boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
-    return resourceAccessChecks.authorizationCheck().enabled()
-        && !resourceAccessChecks.hasAnyResourceId();
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -85,8 +85,9 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
   }
 
   @Override
-  protected boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
-    return resourceAccessChecks.authorizationCheck().enabled()
-        && !resourceAccessChecks.hasAnyResourceId();
+  protected boolean noTenantAccess(final ResourceAccessChecks resourceAccessChecks) {
+    // return always false => even when the principal has not any tenant assigned
+    // they still may have access to globally scoped cluster variables
+    return false;
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -88,7 +88,6 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
   private boolean shouldReturnEmptyResult(
       final GroupFilter filter, final ResourceAccessChecks resourceAccessChecks) {
     return (filter.memberIds() != null && filter.memberIds().isEmpty())
-        || (resourceAccessChecks.authorizationCheck().enabled()
-            && !resourceAccessChecks.hasAnyResourceId());
+        || shouldReturnEmptyResult(resourceAccessChecks);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
@@ -95,7 +95,6 @@ public class MappingRuleDbReader extends AbstractEntityReader<MappingRuleEntity>
   private boolean shouldReturnEmptyResult(
       final MappingRuleFilter filter, final ResourceAccessChecks resourceAccessChecks) {
     return (filter.mappingRuleIds() != null && filter.mappingRuleIds().isEmpty())
-        || (resourceAccessChecks.authorizationCheck().enabled()
-            && !resourceAccessChecks.hasAnyResourceId());
+        || shouldReturnEmptyResult(resourceAccessChecks);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -88,7 +88,6 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
   private boolean shouldReturnEmptyResult(
       final TenantFilter filter, final ResourceAccessChecks resourceAccessChecks) {
     return (filter.memberIds() != null && filter.memberIds().isEmpty())
-        || (resourceAccessChecks.authorizationCheck().enabled()
-            && !resourceAccessChecks.hasAnyResourceId());
+        || shouldReturnEmptyResult(resourceAccessChecks);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
@@ -83,10 +83,4 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
   public SearchQueryResult<UserEntity> search(final UserQuery query) {
     return search(query, ResourceAccessChecks.disabled());
   }
-
-  @Override
-  protected boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
-    return (resourceAccessChecks.authorizationCheck().enabled()
-        && !resourceAccessChecks.hasAnyResourceId());
-  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MappingRuleTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MappingRuleTenancyIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class MappingRuleTenancyIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String MAPPING_RULE_A = "mappingRuleA";
+  private static final String MAPPING_RULE_B = "mappingRuleB";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    createMappingRule(adminClient, MAPPING_RULE_A);
+    createMappingRule(adminClient, MAPPING_RULE_B);
+    waitForMappingRulesBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAllMappingRulesWithTenantAccess(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newMappingRulesSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().stream().map(MappingRule::getMappingRuleId).toList())
+        .containsExactlyInAnyOrder("default", MAPPING_RULE_A, MAPPING_RULE_B);
+  }
+
+  @Test
+  public void shouldReturnAllMappingRulesWithNoTenantAccess(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newMappingRulesSearchRequest().send().join();
+    // then
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().stream().map(MappingRule::getMappingRuleId).toList())
+        .containsExactlyInAnyOrder("default", MAPPING_RULE_A, MAPPING_RULE_B);
+  }
+
+  private static void createMappingRule(
+      final CamundaClient camundaClient, final String mappingRule) {
+    camundaClient
+        .newCreateMappingRuleCommand()
+        .mappingRuleId(mappingRule)
+        .name(mappingRule)
+        .claimName(mappingRule)
+        .claimValue(mappingRule)
+        .send()
+        .join();
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void waitForMappingRulesBeingExported(final CamundaClient camundaClient) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(camundaClient.newMappingRulesSearchRequest().send().join().items())
+                  .hasSize(3);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/TenantTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/TenantTenancyIT.java
@@ -10,13 +10,14 @@ package io.camunda.it.tenancy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.response.Group;
-import io.camunda.client.api.search.response.GroupUser;
+import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-public class GroupTenancyIT {
+public class TenantTenancyIT {
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
@@ -40,8 +41,6 @@ public class GroupTenancyIT {
   private static final String USER1 = "user1";
   private static final String TENANT_A = "tenantA";
   private static final String TENANT_B = "tenantB";
-  private static final String GROUP_A = "groupA";
-  private static final String GROUP_B = "groupB";
 
   @UserDefinition
   private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
@@ -55,59 +54,52 @@ public class GroupTenancyIT {
     createTenant(adminClient, TENANT_B);
     assignUserToTenant(adminClient, ADMIN, TENANT_A);
     assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    createGroup(adminClient, GROUP_A);
-    createGroup(adminClient, GROUP_B);
-    assignUserToGroup(adminClient, ADMIN, GROUP_A);
-    waitForGroupsBeingExported(adminClient);
-    waitForGroupMembershipsBeingExported(adminClient);
+    waitForTenantsBeingExported(adminClient);
+    waitForTenantMembershipBeingExported(adminClient);
   }
 
   @Test
-  public void shouldReturnAllGroupsWithTenantAccess(
+  public void shouldReturnAllTenantsWithTenantAccess(
       @Authenticated(ADMIN) final CamundaClient camundaClient) {
     // when
-    final var result = camundaClient.newGroupsSearchRequest().send().join();
+    final var result = camundaClient.newTenantsSearchRequest().send().join();
     // then
-    assertThat(result.items()).hasSize(2);
-    assertThat(result.items().stream().map(Group::getGroupId).toList())
-        .containsExactlyInAnyOrder(GROUP_A, GROUP_B);
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().stream().map(Tenant::getTenantId).toList())
+        .containsExactlyInAnyOrder(TenantOwned.DEFAULT_TENANT_IDENTIFIER, TENANT_A, TENANT_B);
   }
 
   @Test
-  public void shouldReturnGroupMembershipsWithTenantAccess(
+  public void shouldReturnAllTenantMembershipsWithTenantAccess(
       @Authenticated(ADMIN) final CamundaClient camundaClient) {
     // when
-    final var result = camundaClient.newUsersByGroupSearchRequest(GROUP_A).send().join();
+    final var result = camundaClient.newUsersByTenantSearchRequest(TENANT_A).send().join();
     // then
     assertThat(result.items()).hasSize(1);
-    assertThat(result.items().stream().map(GroupUser::getUsername).toList())
+    assertThat(result.items().stream().map(TenantUser::getUsername).toList())
         .containsExactlyInAnyOrder(ADMIN);
   }
 
   @Test
-  public void shouldReturnAllGroupsWithNoTenantAccess(
+  public void shouldReturnAllTenantsWithNoTenantAccess(
       @Authenticated(USER1) final CamundaClient camundaClient) {
     // when
-    final var result = camundaClient.newGroupsSearchRequest().send().join();
+    final var result = camundaClient.newTenantsSearchRequest().send().join();
     // then
-    assertThat(result.items()).hasSize(2);
-    assertThat(result.items().stream().map(Group::getGroupId).toList())
-        .containsExactlyInAnyOrder(GROUP_A, GROUP_B);
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().stream().map(Tenant::getTenantId).toList())
+        .containsExactlyInAnyOrder(TenantOwned.DEFAULT_TENANT_IDENTIFIER, TENANT_A, TENANT_B);
   }
 
   @Test
-  public void shouldReturnGroupMembershipsWithNoTenantAccess(
+  public void shouldReturnAllTenantMembershipsWithNoTenantAccess(
       @Authenticated(USER1) final CamundaClient camundaClient) {
     // when
-    final var result = camundaClient.newUsersByGroupSearchRequest(GROUP_A).send().join();
+    final var result = camundaClient.newUsersByTenantSearchRequest(TENANT_A).send().join();
     // then
     assertThat(result.items()).hasSize(1);
-    assertThat(result.items().stream().map(GroupUser::getUsername).toList())
+    assertThat(result.items().stream().map(TenantUser::getUsername).toList())
         .containsExactlyInAnyOrder(ADMIN);
-  }
-
-  private static void createGroup(final CamundaClient camundaClient, final String group) {
-    camundaClient.newCreateGroupCommand().groupId(group).name(group).send().join();
   }
 
   private static void createTenant(final CamundaClient camundaClient, final String tenant) {
@@ -119,28 +111,24 @@ public class GroupTenancyIT {
     camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 
-  private static void assignUserToGroup(
-      final CamundaClient camundaClient, final String username, final String group) {
-    camundaClient.newAssignUserToGroupCommand().username(username).groupId(group).send().join();
-  }
-
-  private static void waitForGroupsBeingExported(final CamundaClient camundaClient) {
+  private static void waitForTenantsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
-              assertThat(camundaClient.newGroupsSearchRequest().send().join().items()).hasSize(2);
+              assertThat(camundaClient.newTenantsSearchRequest().send().join().items()).hasSize(3);
             });
   }
 
-  private static void waitForGroupMembershipsBeingExported(final CamundaClient camundaClient) {
+  private static void waitForTenantMembershipBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
-              assertThat(camundaClient.newUsersByGroupSearchRequest(GROUP_A).send().join().items())
+              assertThat(
+                      camundaClient.newUsersByTenantSearchRequest(TENANT_B).send().join().items())
                   .hasSize(1);
             });
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -49,12 +49,12 @@ public final class ClusterVariableFilterTransformer
 
   @Override
   protected SearchQuery toTenantCheckSearchQuery(
-      final TenantCheck tenantCheck, final Optional<String> field) {
+      final TenantCheck tenantCheck, final String field) {
     final var tenantCheckQuery =
         Optional.of(tenantCheck)
             .map(TenantCheck::tenantIds)
             .filter(t -> !t.isEmpty())
-            .map(t -> stringTerms(field.get(), t))
+            .map(t -> stringTerms(field, t))
             .orElse(null);
 
     final var matchGlobalQuery =

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -46,6 +46,10 @@ public record Authorization<T>(
     @JsonProperty("resource_ids") List<String> resourceIds,
     @JsonIgnore Function<T, String> resourceIdSupplier) {
 
+  public boolean hasAnyResourceIds() {
+    return resourceIds != null && !resourceIds.isEmpty();
+  }
+
   public static <T> Authorization<T> withAuthorization(
       final Authorization<T> authorization, final String resourceId) {
     return of(

--- a/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
@@ -28,4 +28,21 @@ public record AuthorizationCheck(boolean enabled, AuthorizationCondition authori
   public static AuthorizationCheck disabled() {
     return new AuthorizationCheck(false, null);
   }
+
+  public boolean hasAnyResourceAccess() {
+    return !enabled || hasAnyResourceIdAccess();
+  }
+
+  private boolean hasAnyResourceIdAccess() {
+    if (authorizationCondition == null) {
+      return false;
+    }
+
+    final var auths = authorizationCondition.authorizations();
+    if (auths == null || auths.isEmpty()) {
+      return false;
+    }
+
+    return auths.stream().anyMatch(Authorization::hasAnyResourceIds);
+  }
 }

--- a/security/security-core/src/main/java/io/camunda/security/reader/TenantCheck.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/TenantCheck.java
@@ -21,4 +21,12 @@ public record TenantCheck(boolean enabled, List<String> tenantIds) {
   public static TenantCheck disabled() {
     return new TenantCheck(false, null);
   }
+
+  public boolean hasAnyTenantAccess() {
+    return !enabled || hasAnyTenantIdAccess();
+  }
+
+  private boolean hasAnyTenantIdAccess() {
+    return tenantIds != null && !tenantIds.isEmpty();
+  }
 }

--- a/security/security-core/src/test/java/io/camunda/security/reader/ResourceAccessChecksTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/reader/ResourceAccessChecksTest.java
@@ -183,12 +183,12 @@ class ResourceAccessChecksTest {
   class HasAnyResourceId {
 
     @Test
-    void shouldReturnFalseWhenAuthorizationDisabled() {
-      // given
+    void shouldReturnTrueWhenAuthorizationDisabled() {
+      // given - authorization check disabled
       final var checks = ResourceAccessChecks.disabled();
 
-      // when - then
-      assertThat(checks.hasAnyResourceId()).isFalse();
+      // when - then - since disabled, they have access to any resource
+      assertThat(checks.authorizationCheck().hasAnyResourceAccess()).isTrue();
     }
 
     @Test
@@ -199,7 +199,7 @@ class ResourceAccessChecksTest {
               AuthorizationCheck.enabled((AuthorizationCondition) null), TenantCheck.disabled());
 
       // when - then
-      assertThat(checks.hasAnyResourceId()).isFalse();
+      assertThat(checks.authorizationCheck().hasAnyResourceAccess()).isFalse();
     }
 
     @Test
@@ -211,7 +211,7 @@ class ResourceAccessChecksTest {
               AuthorizationCheck.enabled(authorization), TenantCheck.disabled());
 
       // when - then
-      assertThat(checks.hasAnyResourceId()).isFalse();
+      assertThat(checks.authorizationCheck().hasAnyResourceAccess()).isFalse();
     }
 
     @Test
@@ -225,7 +225,7 @@ class ResourceAccessChecksTest {
           ResourceAccessChecks.of(AuthorizationCheck.enabled(condition), TenantCheck.disabled());
 
       // when - then
-      assertThat(checks.hasAnyResourceId()).isTrue();
+      assertThat(checks.authorizationCheck().hasAnyResourceAccess()).isTrue();
     }
   }
 }


### PR DESCRIPTION
## Description

* Disables the tenant check for Identity-related entities (Authorization, Group, Group Membership, Role, Role Membership, Mapping Rules, and User)
* Adds missing test cases
* Applies some minor refactoring for better readibility and udnerstanding of the code 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42175
