### PR TITLE
Store a batch operation's  actor info in ES/OS secondary storage

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationActorType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationActorType.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.operation;
+
+public enum BatchOperationActorType {
+  USER,
+  CLIENT;
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.operation;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -22,6 +23,14 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   @BeforeVersion880 private OffsetDateTime startDate;
   @BeforeVersion880 private OffsetDateTime endDate;
   @BeforeVersion880 private String username;
+
+  // the type of the actor that performed the operation, (USER or CLIENT)
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private BatchOperationActorType actorType;
+
+  // the id of the actor that performed the operation
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String actorId;
 
   @BeforeVersion880 private Integer instancesCount = 0;
   @BeforeVersion880 private Integer operationsTotalCount = 0;
@@ -156,6 +165,24 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     return this;
   }
 
+  public BatchOperationActorType getActorType() {
+    return actorType;
+  }
+
+  public BatchOperationEntity setActorType(final BatchOperationActorType actorType) {
+    this.actorType = actorType;
+    return this;
+  }
+
+  public String getActorId() {
+    return actorId;
+  }
+
+  public BatchOperationEntity setActorId(final String actorId) {
+    this.actorId = actorId;
+    return this;
+  }
+
   public BatchOperationEntity withGeneratedId() {
     setId(UUID.randomUUID().toString());
     return this;
@@ -169,6 +196,8 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     result = 31 * result + (startDate != null ? startDate.hashCode() : 0);
     result = 31 * result + (endDate != null ? endDate.hashCode() : 0);
     result = 31 * result + (username != null ? username.hashCode() : 0);
+    result = 31 * result + (actorType != null ? actorType.hashCode() : 0);
+    result = 31 * result + (actorId != null ? actorId.hashCode() : 0);
     result = 31 * result + (instancesCount != null ? instancesCount.hashCode() : 0);
     result = 31 * result + (operationsTotalCount != null ? operationsTotalCount.hashCode() : 0);
     result = 31 * result + (state != null ? state.hashCode() : 0);
@@ -208,6 +237,12 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
       return false;
     }
     if (username != null ? !username.equals(that.username) : that.username != null) {
+      return false;
+    }
+    if (!Objects.equals(actorType, that.actorType)) {
+      return false;
+    }
+    if (!Objects.equals(actorId, that.actorId)) {
       return false;
     }
     if (instancesCount != null
@@ -254,6 +289,11 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
         + endDate
         + ", username='"
         + username
+        + '\''
+        + ", actorType="
+        + actorType
+        + ", actorId='"
+        + actorId
         + '\''
         + ", instancesCount="
         + instancesCount

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
@@ -30,8 +30,14 @@
 			},
 			"username": {
 				"type": "keyword"
-      },
-      "state": {
+			},
+			"actorType": {
+				"type": "keyword"
+			},
+			"actorId": {
+				"type": "keyword"
+			},
+			"state": {
         "type": "keyword"
       },
       "operationsFailedCount": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
@@ -30,9 +30,15 @@
 			},
 			"username": {
 				"type": "keyword"
-      },
-      "state": {
-        "type": "keyword"
+			},
+			"actorType": {
+				"type": "keyword"
+			},
+			"actorId": {
+				"type": "keyword"
+			},
+			"state": {
+				"type": "keyword"
       },
       "operationsFailedCount": {
         "type": "long"

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -139,16 +139,15 @@ public record AuditLogInfo(
 
     public static AuditLogActor of(final Record<?> record) {
       final Map<String, Object> authorizations = record.getAuthorizations();
-      if (authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) != null) {
-        return new AuditLogActor(
-            AuditLogActorType.CLIENT,
-            (String) authorizations.get(Authorization.AUTHORIZED_CLIENT_ID));
-      } else if (authorizations.get(Authorization.AUTHORIZED_USERNAME) != null) {
-        return new AuditLogActor(
-            AuditLogActorType.USER, (String) authorizations.get(Authorization.AUTHORIZED_USERNAME));
-      } else {
-        return null;
+      final var clientId = (String) authorizations.get(Authorization.AUTHORIZED_CLIENT_ID);
+      if (clientId != null) {
+        return new AuditLogActor(AuditLogActorType.CLIENT, clientId);
       }
+      final var username = (String) authorizations.get(Authorization.AUTHORIZED_USERNAME);
+      if (username != null) {
+        return new AuditLogActor(AuditLogActorType.USER, username);
+      }
+      return null;
     }
   }
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -34,7 +34,7 @@ public record AuditLogInfo(
         getOperationCategory(record.getValueType()),
         getEntityType(record.getValueType()),
         getOperationType(record.getIntent()),
-        getActor(record.getAuthorizations()),
+        AuditLogActor.of(record),
         getBatchOperation(record));
   }
 
@@ -44,19 +44,6 @@ public record AuditLogInfo(
       return Optional.of(new BatchOperation(batchOperationKey));
     }
     return Optional.empty();
-  }
-
-  private static AuditLogActor getActor(final Map<String, Object> authorizations) {
-    if (authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) != null) {
-      return new AuditLogActor(
-          AuditLogActorType.CLIENT,
-          (String) authorizations.get(Authorization.AUTHORIZED_CLIENT_ID));
-    } else if (authorizations.get(Authorization.AUTHORIZED_USERNAME) != null) {
-      return new AuditLogActor(
-          AuditLogActorType.USER, (String) authorizations.get(Authorization.AUTHORIZED_USERNAME));
-    } else {
-      return null;
-    }
   }
 
   private static AuditLogOperationCategory getOperationCategory(final ValueType valueType) {
@@ -148,7 +135,22 @@ public record AuditLogInfo(
     }
   }
 
-  public record AuditLogActor(AuditLogActorType actorType, String actorId) {}
+  public record AuditLogActor(AuditLogActorType actorType, String actorId) {
+
+    public static AuditLogActor of(final Record<?> record) {
+      final Map<String, Object> authorizations = record.getAuthorizations();
+      if (authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) != null) {
+        return new AuditLogActor(
+            AuditLogActorType.CLIENT,
+            (String) authorizations.get(Authorization.AUTHORIZED_CLIENT_ID));
+      } else if (authorizations.get(Authorization.AUTHORIZED_USERNAME) != null) {
+        return new AuditLogActor(
+            AuditLogActorType.USER, (String) authorizations.get(Authorization.AUTHORIZED_USERNAME));
+      } else {
+        return null;
+      }
+    }
+  }
 
   public record BatchOperation(long key) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -12,15 +12,18 @@ import static io.camunda.exporter.utils.ExporterUtil.map;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operation.BatchOperationActorType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
 import java.util.List;
 
 /**
@@ -34,6 +37,7 @@ public class BatchOperationCreatedHandler
 
   private final String indexName;
   private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
+  private final ActorInfoExtractor actorInfoExtractor = new ActorInfoExtractor();
 
   public BatchOperationCreatedHandler(
       final String indexName,
@@ -70,11 +74,14 @@ public class BatchOperationCreatedHandler
   @Override
   public void updateEntity(
       final Record<BatchOperationCreationRecordValue> record, final BatchOperationEntity entity) {
+    final var actorInfo = actorInfoExtractor.extract(record);
     final BatchOperationCreationRecordValue value = record.getValue();
     entity
         .setId(String.valueOf(value.getBatchOperationKey()))
         .setType(OperationType.valueOf(value.getBatchOperationType().name()))
-        .setState(BatchOperationState.CREATED);
+        .setState(BatchOperationState.CREATED)
+        .setActorType(actorInfo.type())
+        .setActorId(actorInfo.id());
 
     // update local cache so that the batch operation info is available immediately to operation
     // status handlers
@@ -91,5 +98,41 @@ public class BatchOperationCreatedHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  private record ActorInfo(BatchOperationActorType type, String id) {
+    static final ActorInfo NULL_VALUES = new ActorInfo(null, null);
+  }
+
+  private static final class ActorInfoExtractor {
+
+    private static final SemanticVersion VERSION_8_9_0 = new SemanticVersion(8, 9, 0, null, null);
+
+    /**
+     * Extracts the actor information from the record's authorizations based on the broker version.
+     * Actor info is only provided for broker versions 8.9.0 and above. If the actor info is not
+     * available, null values are provided.
+     */
+    private ActorInfo extract(final Record<BatchOperationCreationRecordValue> record) {
+      final var semanticVersion = SemanticVersion.parse(record.getBrokerVersion()).orElse(null);
+      if (semanticVersion == null || semanticVersion.compareTo(VERSION_8_9_0) < 0) {
+        // actor info should only be set for versions 8.9.0 and above
+        return ActorInfo.NULL_VALUES;
+      }
+
+      final var clientId =
+          (String) record.getAuthorizations().get(Authorization.AUTHORIZED_CLIENT_ID);
+      if (clientId != null) {
+        return new ActorInfo(BatchOperationActorType.CLIENT, clientId);
+      }
+
+      final var username =
+          (String) record.getAuthorizations().get(Authorization.AUTHORIZED_USERNAME);
+      if (username != null) {
+        return new ActorInfo(BatchOperationActorType.USER, username);
+      }
+
+      return ActorInfo.NULL_VALUES;
+    }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the `actorType` and `actorId` to the batch operation entity stored in the ES/OS secondary storage.

The info is only added on batch operations created from 8.9 onwards. Older batch operations will have `null` for both fields.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42065
