### PR TITLE
39653 fix operate importer issue with generating correct nested treePaths

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/tenant/TenantAwareElasticsearchClient.java
+++ b/operate/common/src/main/java/io/camunda/operate/tenant/TenantAwareElasticsearchClient.java
@@ -33,7 +33,7 @@ public class TenantAwareElasticsearchClient
   private TenantCheckApplier<SearchRequest> tenantCheckApplier;
 
   @Override
-  public SearchResponse search(SearchRequest searchRequest) throws IOException {
+  public SearchResponse search(final SearchRequest searchRequest) throws IOException {
     return search(
         searchRequest,
         () -> {
@@ -42,15 +42,16 @@ public class TenantAwareElasticsearchClient
   }
 
   @Override
-  public <C> C search(SearchRequest searchRequest, Callable<C> searchExecutor) throws IOException {
+  public <C> C search(final SearchRequest searchRequest, final Callable<C> searchExecutor)
+      throws IOException {
     applyTenantCheckIfPresent(searchRequest);
     try {
       return searchExecutor.call();
-    } catch (IOException ioe) {
+    } catch (final IOException ioe) {
       throw ioe;
-    } catch (RuntimeException re) {
+    } catch (final RuntimeException re) {
       throw re;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final var message =
           String.format("Unexpectedly failed to execute search request with %s", e.getMessage());
       throw new OperateRuntimeException(message, e);

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/v8_6/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/v8_6/processors/ListViewZeebeRecordProcessor.java
@@ -440,7 +440,8 @@ public class ListViewZeebeRecordProcessor {
     if (parentTreePath != null) {
       final String flowNodeInstanceId =
           ConversionUtils.toStringOrNull(recordValue.getParentElementInstanceKey());
-      final String callActivityId = getCallActivityId(flowNodeInstanceId);
+      final String callActivityId =
+          getCallActivityId(recordValue.getParentProcessInstanceKey(), flowNodeInstanceId);
       final String treePath =
           new TreePath(parentTreePath)
               .appendEntries(
@@ -465,10 +466,11 @@ public class ListViewZeebeRecordProcessor {
     }
   }
 
-  private String getCallActivityId(final String flowNodeInstanceId) {
+  private String getCallActivityId(final long processInstanceId, final String flowNodeInstanceId) {
     String callActivityId = getCallActivityIdCache().get(flowNodeInstanceId);
     if (callActivityId == null) {
-      callActivityId = flowNodeStore.getFlowNodeIdByFlowNodeInstanceId(flowNodeInstanceId);
+      callActivityId =
+          flowNodeStore.getFlowNodeIdByFlowNodeInstanceId(processInstanceId, flowNodeInstanceId);
       getCallActivityIdCache().put(flowNodeInstanceId, callActivityId);
     }
     return callActivityId;

--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
@@ -442,7 +442,8 @@ public class ListViewZeebeRecordProcessor {
     if (parentTreePath != null) {
       final String flowNodeInstanceId =
           ConversionUtils.toStringOrNull(recordValue.getParentElementInstanceKey());
-      final String callActivityId = getCallActivityId(flowNodeInstanceId);
+      final String callActivityId =
+          getCallActivityId(recordValue.getParentProcessInstanceKey(), flowNodeInstanceId);
       final String treePath =
           new TreePath(parentTreePath)
               .appendEntries(
@@ -467,10 +468,11 @@ public class ListViewZeebeRecordProcessor {
     }
   }
 
-  private String getCallActivityId(final String flowNodeInstanceId) {
+  private String getCallActivityId(final long processInstanceId, final String flowNodeInstanceId) {
     String callActivityId = getCallActivityIdCache().get(flowNodeInstanceId);
     if (callActivityId == null) {
-      callActivityId = flowNodeStore.getFlowNodeIdByFlowNodeInstanceId(flowNodeInstanceId);
+      callActivityId =
+          flowNodeStore.getFlowNodeIdByFlowNodeInstanceId(processInstanceId, flowNodeInstanceId);
       getCallActivityIdCache().put(flowNodeInstanceId, callActivityId);
     }
     return callActivityId;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
@@ -44,7 +44,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(
+    properties = {
+      // force more shards to expose issue with child docs and routing
+      "camunda.operate.elasticsearch.numberOfShards=10",
+      "camunda.operate.opensearch.numberOfShards=10"
+    })
 public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   private static final int EMPTY_PARENT_PROCESS_INSTANCE_ID = -1;
   private final String newBpmnProcessId = "newBpmnProcessId";

--- a/operate/schema/src/main/java/io/camunda/operate/store/FlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/FlowNodeStore.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public interface FlowNodeStore {
 
-  String getFlowNodeIdByFlowNodeInstanceId(String flowNodeInstanceId);
+  String getFlowNodeIdByFlowNodeInstanceId(final long processInstanceId, String flowNodeInstanceId);
 
   Map<String, String> getFlowNodeIdsForFlowNodeInstances(Set<String> flowNodeInstances);
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.store.elasticsearch;
 
-import static io.camunda.operate.schema.templates.ListViewTemplate.*;
 import static io.camunda.operate.schema.templates.ListViewTemplate.ACTIVITY_ID;
 import static io.camunda.operate.util.ElasticsearchUtil.QueryType.ONLY_RUNTIME;
 import static io.camunda.operate.util.ElasticsearchUtil.scrollWith;
@@ -52,7 +51,8 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public String getFlowNodeIdByFlowNodeInstanceId(final String flowNodeInstanceId) {
+  public String getFlowNodeIdByFlowNodeInstanceId(
+      final long processInstanceId, final String flowNodeInstanceId) {
     final ElasticsearchUtil.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
             ? ElasticsearchUtil.QueryType.ALL

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
@@ -10,7 +10,6 @@ package io.camunda.operate.store.elasticsearch;
 import static io.camunda.operate.schema.templates.ListViewTemplate.*;
 import static io.camunda.operate.schema.templates.ListViewTemplate.ACTIVITY_ID;
 import static io.camunda.operate.util.ElasticsearchUtil.QueryType.ONLY_RUNTIME;
-import static io.camunda.operate.util.ElasticsearchUtil.joinWithAnd;
 import static io.camunda.operate.util.ElasticsearchUtil.scrollWith;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
@@ -30,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHits;
@@ -55,30 +53,23 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
 
   @Override
   public String getFlowNodeIdByFlowNodeInstanceId(final String flowNodeInstanceId) {
-    // TODO Elasticsearch changes
     final ElasticsearchUtil.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
             ? ElasticsearchUtil.QueryType.ALL
             : ElasticsearchUtil.QueryType.ONLY_RUNTIME;
-    final QueryBuilder query =
-        joinWithAnd(
-            termQuery(JOIN_RELATION, ACTIVITIES_JOIN_RELATION),
-            termQuery(ListViewTemplate.ID, flowNodeInstanceId));
-    final SearchRequest request =
-        ElasticsearchUtil.createSearchRequest(listViewTemplate, queryType)
-            .source(new SearchSourceBuilder().query(query).fetchSource(ACTIVITY_ID, null));
-    final SearchResponse response;
+
     try {
-      response = tenantAwareClient.search(request);
-      if (response.getHits().getTotalHits().value != 1) {
-        throw new OperateRuntimeException("Flow node instance is not found: " + flowNodeInstanceId);
-      } else {
-        return String.valueOf(response.getHits().getAt(0).getSourceAsMap().get(ACTIVITY_ID));
+      final Map<String, Object> processInstance =
+          ElasticsearchUtil.getByIdOrSearchArchives(
+              esClient, listViewTemplate, flowNodeInstanceId, queryType, ACTIVITY_ID);
+      if (processInstance != null) {
+        return (String) processInstance.get(ACTIVITY_ID);
       }
     } catch (final IOException e) {
       throw new OperateRuntimeException(
           "Error occurred when searching for flow node instance: " + flowNodeInstanceId, e);
     }
+    throw new OperateRuntimeException("Flow node instance is not found: " + flowNodeInstanceId);
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
@@ -59,9 +59,10 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
             : ElasticsearchUtil.QueryType.ONLY_RUNTIME;
 
     try {
+      final String routing = String.valueOf(processInstanceId);
       final Map<String, Object> processInstance =
           ElasticsearchUtil.getByIdOrSearchArchives(
-              esClient, listViewTemplate, flowNodeInstanceId, queryType, ACTIVITY_ID);
+              esClient, listViewTemplate, flowNodeInstanceId, routing, queryType, ACTIVITY_ID);
       if (processInstance != null) {
         return (String) processInstance.get(ACTIVITY_ID);
       }

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchListViewStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchListViewStore.java
@@ -49,8 +49,8 @@ public class ElasticsearchListViewStore implements ListViewStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public Map<Long, String> getListViewIndicesForProcessInstances(List<Long> processInstanceIds)
-      throws IOException {
+  public Map<Long, String> getListViewIndicesForProcessInstances(
+      final List<Long> processInstanceIds) throws IOException {
     final List<String> processInstanceIdsAsStrings = map(processInstanceIds, Object::toString);
 
     final SearchRequest searchRequest =
@@ -67,7 +67,7 @@ public class ElasticsearchListViewStore implements ListViewStore {
               searchRequest,
               esClient,
               searchHits -> {
-                for (SearchHit searchHit : searchHits.getHits()) {
+                for (final SearchHit searchHit : searchHits.getHits()) {
                   final String indexName = searchHit.getIndex();
                   final Long id = Long.valueOf(searchHit.getId());
                   processInstanceId2IndexName.put(id, indexName);
@@ -84,7 +84,7 @@ public class ElasticsearchListViewStore implements ListViewStore {
   }
 
   @Override
-  public String findProcessInstanceTreePathFor(long processInstanceKey) {
+  public String findProcessInstanceTreePathFor(final long processInstanceKey) {
     final ElasticsearchUtil.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
             ? ElasticsearchUtil.QueryType.ALL
@@ -101,7 +101,7 @@ public class ElasticsearchListViewStore implements ListViewStore {
         return (String) hits.getHits()[0].getSourceAsMap().get(ListViewTemplate.TREE_PATH);
       }
       return null;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while searching for process instance tree path: %s",
@@ -111,7 +111,8 @@ public class ElasticsearchListViewStore implements ListViewStore {
   }
 
   @Override
-  public List<Long> getProcessInstanceKeysWithEmptyProcessVersionFor(Long processDefinitionKey) {
+  public List<Long> getProcessInstanceKeysWithEmptyProcessVersionFor(
+      final Long processDefinitionKey) {
     final QueryBuilder queryBuilder =
         constantScoreQuery(
             joinWithAnd(
@@ -126,7 +127,7 @@ public class ElasticsearchListViewStore implements ListViewStore {
           () -> {
             return ElasticsearchUtil.scrollKeysToList(searchRequest, esClient);
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining process instance that has empty versions: %s",

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
@@ -49,11 +49,13 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
         operateProperties.getImporter().isReadArchivedParents()
             ? RequestDSL.QueryType.ALL
             : RequestDSL.QueryType.ONLY_RUNTIME;
+    final String routing = String.valueOf(processInstanceId);
     final Map<String, Object> flowNodeInstance =
         OpensearchUtil.getByIdOrSearchArchives(
             richOpenSearchClient,
             listViewTemplate,
             flowNodeInstanceId,
+            routing,
             queryType,
             ListViewTemplate.ACTIVITY_ID);
     if (flowNodeInstance != null) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
@@ -43,7 +43,8 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public String getFlowNodeIdByFlowNodeInstanceId(final String flowNodeInstanceId) {
+  public String getFlowNodeIdByFlowNodeInstanceId(
+      final long processInstanceId, final String flowNodeInstanceId) {
     final RequestDSL.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
             ? RequestDSL.QueryType.ALL

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -342,6 +342,16 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
         });
   }
 
+  public <R> Optional<R> getWithRetries(
+      final String index, final String id, final String routing, final Class<R> entitiyClass) {
+    return executeWithRetries(
+        () -> {
+          final GetResponse<R> response =
+              openSearchClient.get(getRequest(index, id, routing), entitiyClass);
+          return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+        });
+  }
+
   public DeleteResponse delete(final String index, final String id) {
     final var deleteRequestBuilder = new DeleteRequest.Builder().index(index).id(id);
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -334,20 +334,20 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
   }
 
   public <R> Optional<R> getWithRetries(
-      final String index, final String id, final Class<R> entitiyClass) {
+      final String index, final String id, final Class<R> entityClass) {
     return executeWithRetries(
         () -> {
-          final GetResponse<R> response = openSearchClient.get(getRequest(index, id), entitiyClass);
+          final GetResponse<R> response = openSearchClient.get(getRequest(index, id), entityClass);
           return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
         });
   }
 
   public <R> Optional<R> getWithRetries(
-      final String index, final String id, final String routing, final Class<R> entitiyClass) {
+      final String index, final String id, final String routing, final Class<R> entityClass) {
     return executeWithRetries(
         () -> {
           final GetResponse<R> response =
-              openSearchClient.get(getRequest(index, id, routing), entitiyClass);
+              openSearchClient.get(getRequest(index, id, routing), entityClass);
           return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
         });
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/RequestDSL.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/RequestDSL.java
@@ -37,7 +37,8 @@ import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
 
 public interface RequestDSL {
-  private static String whereToSearch(TemplateDescriptor template, QueryType queryType) {
+  private static String whereToSearch(
+      final TemplateDescriptor template, final QueryType queryType) {
     return switch (queryType) {
       case ONLY_RUNTIME -> template.getFullQualifiedName();
       case ALL -> template.getAlias();
@@ -45,7 +46,7 @@ public interface RequestDSL {
   }
 
   static CreateIndexRequest.Builder createIndexRequestBuilder(
-      String index, IndexState patternIndex) {
+      final String index, final IndexState patternIndex) {
     return new CreateIndexRequest.Builder()
         .index(index)
         .aliases(patternIndex.aliases())
@@ -60,47 +61,50 @@ public interface RequestDSL {
   }
 
   static CreateSnapshotRequest.Builder createSnapshotRequestBuilder(
-      String repository, String snapshot, List<String> indices) {
+      final String repository, final String snapshot, final List<String> indices) {
     return new CreateSnapshotRequest.Builder()
         .repository(repository)
         .snapshot(snapshot)
         .indices(indices);
   }
 
-  static DeleteRequest.Builder deleteRequestBuilder(String index, String id) {
+  static DeleteRequest.Builder deleteRequestBuilder(final String index, final String id) {
     return new DeleteRequest.Builder().index(index).id(id);
   }
 
-  static DeleteByQueryRequest.Builder deleteByQueryRequestBuilder(String index) {
+  static DeleteByQueryRequest.Builder deleteByQueryRequestBuilder(final String index) {
     return new DeleteByQueryRequest.Builder().index(index);
   }
 
   static DeleteSnapshotRequest.Builder deleteSnapshotRequestBuilder(
-      String repositoryName, String snapshotName) {
+      final String repositoryName, final String snapshotName) {
     return new DeleteSnapshotRequest.Builder().repository(repositoryName).snapshot(snapshotName);
   }
 
-  static <R> IndexRequest.Builder<R> indexRequestBuilder(String index) {
+  static <R> IndexRequest.Builder<R> indexRequestBuilder(final String index) {
     return new IndexRequest.Builder<R>().index(index);
   }
 
-  static GetIndexRequest.Builder getIndexRequestBuilder(String index) {
+  static GetIndexRequest.Builder getIndexRequestBuilder(final String index) {
     return new GetIndexRequest.Builder().index(index);
   }
 
-  static PutComponentTemplateRequest.Builder componentTemplateRequestBuilder(String name) {
+  static PutComponentTemplateRequest.Builder componentTemplateRequestBuilder(final String name) {
     return new PutComponentTemplateRequest.Builder().name(name);
   }
 
   static ReindexRequest.Builder reindexRequestBuilder(
-      String srcIndex, Query srcQuery, String dstIndex) {
+      final String srcIndex, final Query srcQuery, final String dstIndex) {
     return new ReindexRequest.Builder()
         .source(Source.of(b -> b.index(srcIndex).query(srcQuery)))
         .dest(Destination.of(b -> b.index(dstIndex)));
   }
 
   static ReindexRequest.Builder reindexRequestBuilder(
-      String srcIndex, String dstIndex, String script, Map<String, Object> scriptParams) {
+      final String srcIndex,
+      final String dstIndex,
+      final String script,
+      final Map<String, Object> scriptParams) {
     final var jsonParams =
         scriptParams.entrySet().stream()
             .collect(Collectors.toMap(Map.Entry::getKey, e -> JsonData.of(e.getValue())));
@@ -111,54 +115,59 @@ public interface RequestDSL {
         .script(b -> b.inline(i -> i.source(script).params(jsonParams)));
   }
 
-  static GetRepositoryRequest.Builder repositoryRequestBuilder(String name) {
+  static GetRepositoryRequest.Builder repositoryRequestBuilder(final String name) {
     return new GetRepositoryRequest.Builder().name(name);
   }
 
-  static SearchRequest.Builder searchRequestBuilder(String index) {
+  static SearchRequest.Builder searchRequestBuilder(final String index) {
     return new SearchRequest.Builder().index(index);
   }
 
   static SearchRequest.Builder searchRequestBuilder(
-      TemplateDescriptor template, QueryType queryType) {
+      final TemplateDescriptor template, final QueryType queryType) {
     final SearchRequest.Builder builder = new SearchRequest.Builder();
     builder.index(whereToSearch(template, queryType));
     return builder;
   }
 
-  static SearchRequest.Builder searchRequestBuilder(TemplateDescriptor template) {
+  static SearchRequest.Builder searchRequestBuilder(final TemplateDescriptor template) {
     return searchRequestBuilder(template, QueryType.ALL);
   }
 
-  static GetSnapshotRequest.Builder getSnapshotRequestBuilder(String repository, String snapshot) {
+  static GetSnapshotRequest.Builder getSnapshotRequestBuilder(
+      final String repository, final String snapshot) {
     return new GetSnapshotRequest.Builder().repository(repository).snapshot(snapshot);
   }
 
-  static <A, R> UpdateRequest.Builder<R, A> updateRequestBuilder(String index) {
+  static <A, R> UpdateRequest.Builder<R, A> updateRequestBuilder(final String index) {
     return new UpdateRequest.Builder<R, A>().index(index);
   }
 
-  static GetRequest.Builder getRequestBuilder(String index) {
+  static GetRequest.Builder getRequestBuilder(final String index) {
     return new GetRequest.Builder().index(index);
   }
 
-  static GetRequest getRequest(String index, String id) {
+  static GetRequest getRequest(final String index, final String id) {
     return new GetRequest.Builder().index(index).id(id).build();
   }
 
-  static ScrollRequest scrollRequest(String scrollId, String time) {
+  static GetRequest getRequest(final String index, final String id, final String routing) {
+    return new GetRequest.Builder().index(index).id(id).routing(routing).build();
+  }
+
+  static ScrollRequest scrollRequest(final String scrollId, final String time) {
     return new ScrollRequest.Builder().scrollId(scrollId).scroll(time(time)).build();
   }
 
-  static ScrollRequest scrollRequest(String scrollId) {
+  static ScrollRequest scrollRequest(final String scrollId) {
     return scrollRequest(scrollId, SCROLL_KEEP_ALIVE_MS);
   }
 
-  static ClearScrollRequest clearScrollRequest(String scrollId) {
+  static ClearScrollRequest clearScrollRequest(final String scrollId) {
     return new ClearScrollRequest.Builder().scrollId(scrollId).build();
   }
 
-  static Time time(String value) {
+  static Time time(final String value) {
     return Time.of(b -> b.time(value));
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -124,11 +124,23 @@ public abstract class ElasticsearchUtil {
       final QueryType queryType,
       final String... fields)
       throws IOException {
+    return getByIdOrSearchArchives(esClient, template, id, id, queryType, fields);
+  }
+
+  public static Map<String, Object> getByIdOrSearchArchives(
+      final RestHighLevelClient esClient,
+      final TemplateDescriptor template,
+      final String id,
+      final String routing,
+      final QueryType queryType,
+      final String... fields)
+      throws IOException {
     // first we'll search using a get request in the runtime index
     // as that usually should be where the doc is and a get request will avoid
     // issues with the indexes not being refreshed yet
     final GetRequest getRequest =
         new GetRequest(template.getFullQualifiedName(), id)
+            .routing(routing)
             .fetchSourceContext(new FetchSourceContext(true, fields, null));
 
     final GetResponse response = esClient.get(getRequest, RequestOptions.DEFAULT);

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -21,7 +21,6 @@ import io.camunda.operate.schema.templates.AbstractTemplateDescriptor;
 import io.camunda.operate.schema.templates.EventTemplate;
 import io.camunda.operate.schema.templates.IncidentTemplate;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
-import io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;

--- a/operate/schema/src/main/java/io/camunda/operate/util/OpensearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/OpensearchUtil.java
@@ -101,12 +101,22 @@ public final class OpensearchUtil {
       final String id,
       final QueryType queryType,
       final String... fields) {
+    return getByIdOrSearchArchives(osClient, template, id, id, queryType, fields);
+  }
+
+  public static Map<String, Object> getByIdOrSearchArchives(
+      final RichOpenSearchClient osClient,
+      final TemplateDescriptor template,
+      final String id,
+      final String routing,
+      final QueryType queryType,
+      final String... fields) {
 
     // first we'll search using a get request in the runtime index
     // as that usually should be where the doc is and a get request will avoid
     // issues with the indexes not being refreshed yet
     final Optional<Map> maybeDoc =
-        osClient.doc().getWithRetries(template.getFullQualifiedName(), id, Map.class);
+        osClient.doc().getWithRetries(template.getFullQualifiedName(), id, routing, Map.class);
     if (maybeDoc.isPresent()) {
       return maybeDoc.get();
     }

--- a/operate/schema/src/test/java/io/camunda/operate/util/ElasticsearchUtilTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/ElasticsearchUtilTest.java
@@ -71,6 +71,17 @@ class ElasticsearchUtilTest {
   }
 
   @Test
+  void shouldUseCorrectRoutingWhenCallingGetById() throws IOException {
+    assertThat(
+            ElasticsearchUtil.getByIdOrSearchArchives(
+                esClient, templateDescr, DOC_ID, "routing", QueryType.ONLY_RUNTIME, "treePath"))
+        .isNull();
+
+    verifyGetRequest("routing");
+    verifyNoMoreInteractions(esClient);
+  }
+
+  @Test
   void shouldReturnNullWhenCallingGetByIdAndGetResultDoesNotExists() throws IOException {
     assertThat(
             ElasticsearchUtil.getByIdOrSearchArchives(
@@ -111,11 +122,16 @@ class ElasticsearchUtilTest {
   }
 
   private void verifyGetRequest() throws IOException {
+    verifyGetRequest(DOC_ID);
+  }
+
+  private void verifyGetRequest(final String routing) throws IOException {
     verify(esClient).get(getRequestCaptor.capture(), any());
 
     final GetRequest getRequest = getRequestCaptor.getValue();
     assertThat(getRequest.index()).isEqualTo(INDEX_NAME);
     assertThat(getRequest.id()).isEqualTo(DOC_ID);
+    assertThat(getRequest.routing()).isEqualTo(routing);
   }
 
   private void verifySearchRequest() throws IOException {

--- a/operate/schema/src/test/java/io/camunda/operate/util/ElasticsearchUtilTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/ElasticsearchUtilTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.schema.templates.TemplateDescriptor;
+import io.camunda.operate.util.ElasticsearchUtil.QueryType;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElasticsearchUtilTest {
+  private static final String INDEX_NAME = "list-view-index";
+  private static final String ALIAS_NAME = "list-view-alias";
+  private static final String DOC_ID = "123";
+
+  @Mock private TemplateDescriptor templateDescr;
+  @Mock private RestHighLevelClient esClient;
+
+  @Mock private GetResponse getResponse;
+  @Captor private ArgumentCaptor<GetRequest> getRequestCaptor;
+  @Mock private SearchResponse searchResponse;
+  @Mock private SearchHit searchHit;
+  @Captor private ArgumentCaptor<SearchRequest> searchRequestCaptor;
+
+  @BeforeEach
+  void setup() throws IOException {
+    lenient().when(templateDescr.getFullQualifiedName()).thenReturn(INDEX_NAME);
+    lenient().when(templateDescr.getAlias()).thenReturn(ALIAS_NAME);
+    when(esClient.get(any(), any())).thenReturn(getResponse);
+  }
+
+  @Test
+  void shouldReturnSourceWhenCallingGetByIdAndGetResultExists() throws IOException {
+    when(getResponse.isExists()).thenReturn(true);
+    when(getResponse.getSourceAsMap()).thenReturn(Map.of("treePath", "/a/b/c"));
+
+    assertThat(
+            ElasticsearchUtil.getByIdOrSearchArchives(
+                esClient, templateDescr, DOC_ID, QueryType.ONLY_RUNTIME, "treePath"))
+        .isEqualTo(Map.of("treePath", "/a/b/c"));
+
+    verifyGetRequest();
+    verifyNoMoreInteractions(esClient);
+  }
+
+  @Test
+  void shouldReturnNullWhenCallingGetByIdAndGetResultDoesNotExists() throws IOException {
+    assertThat(
+            ElasticsearchUtil.getByIdOrSearchArchives(
+                esClient, templateDescr, DOC_ID, QueryType.ONLY_RUNTIME, "treePath"))
+        .isNull();
+
+    verifyGetRequest();
+    verifyNoMoreInteractions(esClient);
+  }
+
+  @Test
+  void shouldFallbackOnSearchWhenCallingGetByIdAndGetRequestFindsNothingAndReadingArchive()
+      throws IOException {
+
+    givenSearchReturns(searchHit);
+    when(searchHit.getSourceAsMap()).thenReturn(Map.of("treePath", "/search/a/b/c"));
+
+    assertThat(
+            ElasticsearchUtil.getByIdOrSearchArchives(
+                esClient, templateDescr, DOC_ID, QueryType.ALL, "treePath"))
+        .isEqualTo(Map.of("treePath", "/search/a/b/c"));
+
+    verifyGetRequest();
+    verifySearchRequest();
+  }
+
+  @Test
+  void shouldReturnNullWhenCallingGetByIdAndSearchFallbackAlsoReturnsNothing() throws IOException {
+    givenSearchReturns();
+
+    assertThat(
+            ElasticsearchUtil.getByIdOrSearchArchives(
+                esClient, templateDescr, DOC_ID, QueryType.ALL, "treePath"))
+        .isNull();
+
+    verifyGetRequest();
+    verifySearchRequest();
+  }
+
+  private void verifyGetRequest() throws IOException {
+    verify(esClient).get(getRequestCaptor.capture(), any());
+
+    final GetRequest getRequest = getRequestCaptor.getValue();
+    assertThat(getRequest.index()).isEqualTo(INDEX_NAME);
+    assertThat(getRequest.id()).isEqualTo(DOC_ID);
+  }
+
+  private void verifySearchRequest() throws IOException {
+    verify(esClient).search(searchRequestCaptor.capture(), any());
+
+    final SearchRequest searchRequest = searchRequestCaptor.getValue();
+    assertThat(searchRequest.indices()).isEqualTo(new String[] {ALIAS_NAME});
+    assertThat(searchRequest.source().toString())
+        .isEqualTo(
+            """
+            {"query":{"ids":{"values":["123"],"boost":1.0}},"_source":{"includes":["treePath"],"excludes":[]}}""");
+  }
+
+  private void givenSearchReturns(final SearchHit... hits) throws IOException {
+    when(esClient.search(any(), any())).thenReturn(searchResponse);
+    when(searchResponse.getHits())
+        .thenReturn(
+            new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f));
+  }
+}

--- a/operate/schema/src/test/java/io/camunda/operate/util/OpensearchUtilTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/OpensearchUtilTest.java
@@ -60,7 +60,7 @@ class OpensearchUtilTest {
 
   @Test
   void shouldReturnSourceWhenCallingGetByIdAndGetResultExists() {
-    when(docOperations.getWithRetries(any(), any(), any()))
+    when(docOperations.getWithRetries(any(), any(), any(), any()))
         .thenReturn(Optional.of(Map.of("treePath", "/a/b/c")));
 
     assertThat(
@@ -69,6 +69,17 @@ class OpensearchUtilTest {
         .isEqualTo(Map.of("treePath", "/a/b/c"));
 
     verifyGetRequest();
+    verifyNoMoreInteractions(docOperations);
+  }
+
+  @Test
+  void shouldUseCorrectRoutingWhenCallingGetById() {
+    assertThat(
+            OpensearchUtil.getByIdOrSearchArchives(
+                osClient, templateDescr, DOC_ID, "routing", QueryType.ONLY_RUNTIME, "treePath"))
+        .isNull();
+
+    verifyGetRequest("routing");
     verifyNoMoreInteractions(docOperations);
   }
 
@@ -111,7 +122,11 @@ class OpensearchUtilTest {
   }
 
   private void verifyGetRequest() {
-    verify(docOperations).getWithRetries(INDEX_NAME, DOC_ID, Map.class);
+    verifyGetRequest(DOC_ID);
+  }
+
+  private void verifyGetRequest(final String routing) {
+    verify(docOperations).getWithRetries(INDEX_NAME, DOC_ID, routing, Map.class);
   }
 
   private void verifySearchRequest() {

--- a/operate/schema/src/test/java/io/camunda/operate/util/OpensearchUtilTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/OpensearchUtilTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.schema.templates.TemplateDescriptor;
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType;
+import jakarta.json.stream.JsonGenerator;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+@ExtendWith(MockitoExtension.class)
+class OpensearchUtilTest {
+  private static final String INDEX_NAME = "list-view-index";
+  private static final String ALIAS_NAME = "list-view-alias";
+  private static final String DOC_ID = "123";
+
+  @Mock private TemplateDescriptor templateDescr;
+  @Mock private RichOpenSearchClient osClient;
+
+  @Mock private OpenSearchDocumentOperations docOperations;
+
+  @Mock private SearchResponse searchResponse;
+  // @Mock private SearchHit searchHit;
+  @Captor private ArgumentCaptor<SearchRequest.Builder> searchRequestCaptor;
+
+  @BeforeEach
+  void setup() {
+    lenient().when(templateDescr.getFullQualifiedName()).thenReturn(INDEX_NAME);
+    lenient().when(templateDescr.getAlias()).thenReturn(ALIAS_NAME);
+    when(osClient.doc()).thenReturn(docOperations);
+  }
+
+  @Test
+  void shouldReturnSourceWhenCallingGetByIdAndGetResultExists() {
+    when(docOperations.getWithRetries(any(), any(), any()))
+        .thenReturn(Optional.of(Map.of("treePath", "/a/b/c")));
+
+    assertThat(
+            OpensearchUtil.getByIdOrSearchArchives(
+                osClient, templateDescr, DOC_ID, QueryType.ONLY_RUNTIME, "treePath"))
+        .isEqualTo(Map.of("treePath", "/a/b/c"));
+
+    verifyGetRequest();
+    verifyNoMoreInteractions(docOperations);
+  }
+
+  @Test
+  void shouldReturnNullWhenCallingGetByIdAndGetResultDoesNotExists() {
+    assertThat(
+            OpensearchUtil.getByIdOrSearchArchives(
+                osClient, templateDescr, DOC_ID, QueryType.ONLY_RUNTIME, "treePath"))
+        .isNull();
+
+    verifyGetRequest();
+    verifyNoMoreInteractions(docOperations);
+  }
+
+  @Test
+  void shouldFallbackOnSearchWhenCallingGetByIdAndGetRequestFindsNothingAndReadingArchive() {
+
+    givenSearchReturns(Map.of("treePath", "/search/a/b/c"));
+
+    assertThat(
+            OpensearchUtil.getByIdOrSearchArchives(
+                osClient, templateDescr, DOC_ID, QueryType.ALL, "treePath"))
+        .isEqualTo(Map.of("treePath", "/search/a/b/c"));
+
+    verifyGetRequest();
+    verifySearchRequest();
+  }
+
+  @Test
+  void shouldReturnNullWhenCallingGetByIdAndSearchFallbackAlsoReturnsNothing() {
+    givenSearchReturns();
+
+    assertThat(
+            OpensearchUtil.getByIdOrSearchArchives(
+                osClient, templateDescr, DOC_ID, QueryType.ALL, "treePath"))
+        .isNull();
+
+    verifyGetRequest();
+    verifySearchRequest();
+  }
+
+  private void verifyGetRequest() {
+    verify(docOperations).getWithRetries(INDEX_NAME, DOC_ID, Map.class);
+  }
+
+  private void verifySearchRequest() {
+    verify(docOperations).search(searchRequestCaptor.capture(), any());
+
+    final SearchRequest.Builder searchRequestBuilder = searchRequestCaptor.getValue();
+    final SearchRequest searchRequest = searchRequestBuilder.build();
+    assertThat(searchRequest.index()).isEqualTo(List.of(ALIAS_NAME));
+    assertThat(json(searchRequest))
+        .isEqualTo(
+            """
+            {"_source":{"includes":["treePath"]},"query":{"ids":{"values":["123"]}}}""");
+  }
+
+  private void givenSearchReturns(final Map... docs) {
+    when(docOperations.search(any(), any())).thenReturn(searchResponse);
+    when(searchResponse.documents()).thenReturn(Arrays.asList(docs));
+  }
+
+  private String json(final JsonpSerializable serializable) {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final JsonbJsonpMapper mapper = new JsonbJsonpMapper();
+    final JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
+    serializable.serialize(generator, mapper);
+    generator.close();
+    return baos.toString();
+  }
+}

--- a/operate/schema/src/test/java/io/camunda/operate/util/OpensearchUtilTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/OpensearchUtilTest.java
@@ -48,7 +48,6 @@ class OpensearchUtilTest {
   @Mock private OpenSearchDocumentOperations docOperations;
 
   @Mock private SearchResponse searchResponse;
-  // @Mock private SearchHit searchHit;
   @Captor private ArgumentCaptor<SearchRequest.Builder> searchRequestCaptor;
 
   @BeforeEach


### PR DESCRIPTION
This changes how we read a couple of things out of Elasticsearch/Opensearch when setting treePaths while running the operate importer.  Previously we would try a regular search, but there was a risk that the document we wanted was not visible (if the index has not been refreshed).  Now instead we try a `GetRequest` on the runtime indexes first (which should usually be enough) and then only fallback to performing a search on all indexes if the importer has been configured that way (which is not the default).  There's still a small chance that the search may have the same problem, but it's less likely to happen (as the archives will usually be a bit more static in nature).

There will need to be some follow up work to update the `PostImporterNullTreePathIT` test in the 8.8 branch later.

Refs: #39653