### PR TITLE
fix: macOS signing use extracted versioned folder instead of hardcoded

### DIFF
--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -44,6 +44,7 @@ if [ ! -d "$C8RUN_DIR" ]; then
   echo "Error: '$C8RUN_DIR' is not a directory."
   exit 1
 fi
+C8RUN_BASENAME="$(basename "$C8RUN_DIR")"
 
 ##############################################
 # Patterns to exclude at top-level:
@@ -65,7 +66,7 @@ echo "=== Step A: Excluding top-level items that begin with: ${EXCLUDE_PREFIXES[
 find "$C8RUN_DIR" -maxdepth 1 \( -type f -o -type d \) -print0 | while IFS= read -r -d '' item; do
   base="$(basename "$item")"
   # Skip if it's c8run itself or hidden
-  if [ "$base" = "$(basename "$C8RUN_DIR")" ] || [[ "$base" == .* ]]; then
+  if [ "$base" = "$C8RUN_BASENAME" ] || [[ "$base" == .* ]]; then
     continue
   fi
 
@@ -165,7 +166,7 @@ sign_jars_in_folder() {
 ##############################################
 # C) Sign c8run
 ##############################################
-echo "=== Step B: Signing leftover c8run content ==="
+echo "=== Step B: Signing leftover ${C8RUN_BASENAME} content ==="
 sign_macho_in_folder "$C8RUN_DIR"
 sign_jars_in_folder "$C8RUN_DIR"
 
@@ -175,7 +176,7 @@ sign_jars_in_folder "$C8RUN_DIR"
 echo "=== Step C: Creating c8run_signed.zip with ditto (excluding removed items) ==="
 (
   cd "$(dirname "$C8RUN_DIR")"
-  /usr/bin/ditto -c -k --keepParent "$(basename "$C8RUN_DIR")" c8run_signed.zip
+  /usr/bin/ditto -c -k --keepParent "$C8RUN_BASENAME" c8run_signed.zip
 )
 SIGNED_ZIP_PATH="$(cd "$(dirname "$C8RUN_DIR")" && pwd -P)/c8run_signed.zip"
 echo "Created: $SIGNED_ZIP_PATH"
@@ -200,17 +201,17 @@ mkdir -p "$TMP_NOTARIZE_DIR/notarized"
 unzip -q "$SIGNED_ZIP_PATH" -d "$TMP_NOTARIZE_DIR/notarized"
 
 # Move excluded items back into c8run
-echo "  -> Re-inserting excluded items into c8run"
+echo "  -> Re-inserting excluded items into ${C8RUN_BASENAME}"
 find "$TMP_EXCLUDE_DIR" -mindepth 1 -maxdepth 1 -print0 | while IFS= read -r -d '' excluded; do
   base="$(basename "$excluded")"
   echo "    -> $base"
-  rsync --ignore-existing -ar "$excluded" "$TMP_NOTARIZE_DIR/notarized/c8run/"
+  rsync --ignore-existing -ar "$excluded" "$TMP_NOTARIZE_DIR/notarized/$C8RUN_BASENAME/"
 done
 
 # Build c8run_complete.zip
 (
   cd "$TMP_NOTARIZE_DIR/notarized"
-  /usr/bin/ditto -c -k --keepParent c8run c8run_complete.zip
+  /usr/bin/ditto -c -k --keepParent "$C8RUN_BASENAME" c8run_complete.zip
 )
 FINAL_ZIP="$(dirname "$C8RUN_DIR")/c8run_complete.zip"
 mv "$TMP_NOTARIZE_DIR/notarized/c8run_complete.zip" "$FINAL_ZIP"
@@ -226,4 +227,3 @@ cat <<EOM
 Note: c8run_complete.zip includes the previously excluded items, which remain
 unsigned/unnotarized if they contain Mach-O. Apple only notarized c8run_signed.zip.
 EOM
-

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -155,12 +155,21 @@ jobs:
           JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
 
       - name: MacOS - Extract package
+        id: macos-extract
         if: startsWith(matrix.os.name, 'MacOS')
         run: |
-          mkdir tmp
+          mkdir -p tmp
           mv "$C8RUN_NAME_ORIGINAL" tmp
           cd tmp
           unzip "$C8RUN_NAME_ORIGINAL"
+          extracted_dir="$(find . -mindepth 1 -maxdepth 1 -type d ! -name '__MACOSX' -print -quit)"
+          if [ -z "$extracted_dir" ]; then
+            echo "Unable to locate extracted directory"
+            exit 1
+          fi
+          extracted_dir="${extracted_dir#./}"
+          echo "Extracted directory: $extracted_dir"
+          echo "extracted_dir=./c8run/tmp/$extracted_dir" >> "$GITHUB_OUTPUT"
         shell: bash
         working-directory: ./c8run
         env:
@@ -176,7 +185,7 @@ jobs:
           apple-id: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
           app-password: ${{ steps.secrets.outputs.APPLE_DEVELOPER_PASSWORD }}
           team-id: ${{ steps.secrets.outputs.APPLE_TEAM_ID }}
-          path: ./c8run/tmp/c8run
+          path: ${{ steps.macos-extract.outputs.extracted_dir }}
 
       - name: MacOS - Replace old artifact with codesigned artifact
         if: startsWith(matrix.os.name, 'MacOS')


### PR DESCRIPTION
Due to this task: https://github.com/camunda/camunda/issues/38318
We changed folder to be not static "c8run" always, but versioned, it requires to change for signing also "versioned" version instead of static/hardcoded "c8run"
