### PR TITLE
feat: support cluster checkpoint state request

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -102,8 +102,10 @@ public final class BackupEndpoint {
   @ReadOperation
   public WebEndpointResponse<?> query(
       @Selector(match = Match.ALL_REMAINING) final String[] arguments) {
-    if (arguments.length != 1) {
-      return listAll();
+    if (arguments.length > 1) {
+      return new WebEndpointResponse<>(
+          new Error().message("Invalid arguments provided."),
+          WebEndpointResponse.STATUS_BAD_REQUEST);
     }
     final String argument = arguments[0];
     if (BackupApi.STATE.equals(argument)) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -136,7 +136,7 @@ public final class BackupEndpoint {
     try {
       final var cpType =
           BackupApi.BACKUP.equals(type) ? CheckpointType.SCHEDULED_BACKUP : CheckpointType.MARKER;
-      final var checkpointState = api.getLatestCheckpointState(cpType).toCompletableFuture().join();
+      final var checkpointState = api.getCheckpointState(cpType).toCompletableFuture().join();
       return new WebEndpointResponse<>(checkpointState);
     } catch (final Exception e) {
       return mapErrorResponse(e);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.shared.profiles.ProfileStandaloneBrokerOrGateway;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.Selector.Match;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
@@ -43,8 +44,9 @@ public final class BackupEndpointStandalone {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> query(@Selector final String prefixOrIdOrType) {
-    return backupEndpoint.query(prefixOrIdOrType);
+  public WebEndpointResponse<?> query(
+      @Selector(match = Match.ALL_REMAINING) final String[] arguments) {
+    return backupEndpoint.query(arguments);
   }
 
   @DeleteOperation

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -43,8 +43,8 @@ public final class BackupEndpointStandalone {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> query(@Selector final String prefixOrId) {
-    return backupEndpoint.query(prefixOrId);
+  public WebEndpointResponse<?> query(@Selector final String prefixOrIdOrType) {
+    return backupEndpoint.query(prefixOrIdOrType);
   }
 
   @DeleteOperation

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -111,6 +111,17 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
+  /backupRuntime/state/{type}:
+    get:
+      summary: Get latest checkpoint state
+      description: Information about the latest checkpoint of the given type.
+      parameters:
+        - $ref: '#/components/parameters/CheckpointType'
+      responses:
+        '200':
+          description: OK
+          $ref: '#/components/responses/CheckpointState'
+
 
   # Section on historic backups
   /backupHistory:
@@ -228,6 +239,15 @@ components:
           - $ref: '#/components/schemas/BackupId'
           - $ref: '#/components/schemas/BackupIdPrefix'
 
+    CheckpointType:
+      description: The type of the latest checkpoint.
+      in: path
+      required: true
+      example: backup
+      name: type
+      schema:
+        $ref: '#/components/schemas/CheckpointRequestType'
+
   responses:
     Error:
       description: Generic error response
@@ -246,7 +266,7 @@ components:
               - $ref: '#/components/schemas/BackupInfo'
     BackupList:
       description: |
-       List of all available backups.
+        List of all available backups.
       content:
         application/json:
           schema:
@@ -286,6 +306,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/TakeBackupHistoryResponse'
+
+    CheckpointState:
+      description: Response for checkpoint state request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CheckpointState'
   schemas:
     Error:
       title: Error response
@@ -356,6 +383,33 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/BackupInfo'
+    CheckpointRequestType:
+      title: Checkpoint Request Type
+      description: The type of checkpoint to query.
+      type: string
+      enum:
+        - backup
+        - checkpoint
+      example: backup
+    CheckpointType:
+      title: Checkpoint Type
+      description: The type of the checkpoint.
+      type: string
+      enum:
+        - MANUAL_BACKUP
+        - SCHEDULED_BACKUP
+        - MARKER
+      example: SCHEDULED_BACKUP
+    CheckpointId:
+      title: Checkpoint ID
+      description: |
+        The ID of the latest checkpoint. The ID of the checkpoint must be a positive numerical value.
+        As checkpoints are logically ordered by their IDs (ascending), each successive checkpoint
+        must use a higher ID than the previous one.
+      type: integer
+      format: int64
+      example: 1
+      minimum: 0
 
     BackupInfo:
       title: Backup Info
@@ -468,8 +522,8 @@ components:
       type: object
       properties:
         message:
-           description: A message indicating backup has been triggered
-           type: string
+          description: A message indicating backup has been triggered
+          type: string
 
     TakeBackupHistoryRequest:
       title: TakeBackupRequest
@@ -545,3 +599,37 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/HistoryBackupInfo'
+
+    CheckpointState:
+      title: Checkpoint State
+      description: |
+        Detailed information about the latest state of the cluster in regards to checkpoints. This
+        can either be in terms of backups or just logstream checkpoints.
+      type: object
+      properties:
+        checkpointId:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/CheckpointId'
+        checkpointType:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/CheckpointType'
+        partitionId:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/PartitionId'
+        checkpointPosition:
+          readOnly: true
+          type: integer
+          format: int64
+          example: 1500
+        checkpointTimestamp:
+          readOnly: true
+          type: string
+          format: date-time
+          example: "2022-09-15T13:10:38.176514094Z"
+      required:
+        - backupId
+        - state
+        - details

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -70,15 +70,15 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
-  /backupRuntime/{backupIdOrPrefix}:
+  /backupRuntime/{backupIdOrPrefixOrCheckpointType}:
     get:
       summary: Get information of a runtime backup
       description: A detailed information of the backup with the give backup id.
       parameters:
-        - $ref: '#/components/parameters/BackupIdOrPrefix'
+        - $ref: '#/components/parameters/BackupIdOrPrefixOrCheckpointType'
       responses:
         '200':
-          $ref: '#/components/responses/BackupStatusOrList'
+          $ref: '#/components/responses/BackupStatusOrListOrCheckpointState'
         '400':
           description: Backup is not enabled or configured on the brokers
           $ref: '#/components/responses/Error'
@@ -111,17 +111,6 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
-  /backupRuntime/state/{type}:
-    get:
-      summary: Get latest checkpoint state
-      description: Information about the latest checkpoint of the given type.
-      parameters:
-        - $ref: '#/components/parameters/CheckpointType'
-      responses:
-        '200':
-          description: OK
-          $ref: '#/components/responses/CheckpointState'
-
 
   # Section on historic backups
   /backupHistory:
@@ -229,24 +218,18 @@ components:
       description: Id of the backup
       schema:
         $ref: '#/components/schemas/BackupId'
-    BackupIdOrPrefix:
-      name: backupIdOrPrefix
+    BackupIdOrPrefixOrCheckpointType:
+      name: backupIdOrPrefixOrCheckpointType
       required: true
       in: path
-      description: A prefix of ids ending with '*', or a full backup id. Defaults to '*', matching all backup ids.
+      description: |
+        A prefix of ids ending with '*', or a full backup id. Defaults to '*', matching all backup ids.
+        Alternatively, the value can be 'backup' or 'checkpoint' to query for the checkpoint state.
       schema:
         oneOf:
           - $ref: '#/components/schemas/BackupId'
           - $ref: '#/components/schemas/BackupIdPrefix'
-
-    CheckpointType:
-      description: The type of the latest checkpoint.
-      in: path
-      required: true
-      example: backup
-      name: type
-      schema:
-        $ref: '#/components/schemas/CheckpointRequestType'
+          - $ref: '#/components/schemas/CheckpointRequestType'
 
   responses:
     Error:
@@ -255,15 +238,18 @@ components:
         application/json:
           schema:
             "$ref": "#/components/schemas/Error"
-    BackupStatusOrList:
+    BackupStatusOrListOrCheckpointState:
       description: |
-        Status of a single backup or list of statuses when querying for multiple backups
+        Status of a single backup or list of statuses when querying for multiple backups. When querying
+        for a checkpoint state, the response contains the the earliest checkpoint in the cluster, alongside
+        the checkpoint state per partition.
       content:
         application/json:
           schema:
             oneOf:
               - $ref: '#/components/schemas/BackupList'
               - $ref: '#/components/schemas/BackupInfo'
+              - $ref: '#/components/schemas/CheckpointState'
     BackupList:
       description: |
         List of all available backups.
@@ -603,33 +589,37 @@ components:
     CheckpointState:
       title: Checkpoint State
       description: |
-        Detailed information about the latest state of the cluster in regards to checkpoints. This
-        can either be in terms of backups or just logstream checkpoints.
+        Information about the checkpoint state for the cluster.
+      type: object
+      properties:
+          checkpointState:
+            $ref: '#/components/schemas/PartitionCheckpointState'
+          checkpointStates:
+            type: array
+            description: List of checkpoint states per partition
+            items:
+              $ref: '#/components/schemas/PartitionCheckpointState'
+
+    PartitionCheckpointState:
+      title: Partition Checkpoint State
+      description: |
+        Detailed information about the checkpoint state for a given partition.
       type: object
       properties:
         checkpointId:
-          readOnly: true
           allOf:
             - $ref: '#/components/schemas/CheckpointId'
         checkpointType:
-          readOnly: true
           allOf:
             - $ref: '#/components/schemas/CheckpointType'
         partitionId:
-          readOnly: true
           allOf:
             - $ref: '#/components/schemas/PartitionId'
         checkpointPosition:
-          readOnly: true
           type: integer
           format: int64
           example: 1500
         checkpointTimestamp:
-          readOnly: true
-          type: string
-          format: date-time
-          example: "2022-09-15T13:10:38.176514094Z"
-      required:
-        - backupId
-        - state
-        - details
+          type: integer
+          format: int64
+          example: 1765208671134

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -94,6 +94,23 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete a runtime backup
+      description: Delete a backup with the given id
+      parameters:
+        - $ref: '#/components/parameters/BackupId'
+      responses:
+        '204':
+          description: Backup is deleted
+        '500':
+          description: Internal error
+          $ref: '#/components/responses/Error'
+        '502':
+          description: Gateway failed to send request to the broker.
+          $ref: '#/components/responses/Error'
+        '504':
+          description: Request from gateway to broker timed out
+          $ref: '#/components/responses/Error'
   /backupRuntime/state:
     get:
       summary: Get information about the current checkpoint and backup state of the cluster
@@ -113,23 +130,7 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
-    delete:
-      summary: Delete a runtime backup
-      description: Delete a backup with the given id
-      parameters:
-        - $ref: '#/components/parameters/BackupId'
-      responses:
-        '204':
-          description: Backup is deleted
-        '500':
-          description: Internal error
-          $ref: '#/components/responses/Error'
-        '502':
-          description: Gateway failed to send request to the broker.
-          $ref: '#/components/responses/Error'
-        '504':
-          description: Request from gateway to broker timed out
-          $ref: '#/components/responses/Error'
+
 
   # Section on historic backups
   /backupHistory:

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -588,7 +588,7 @@ components:
             type: array
             description: List of partition backup states
             items:
-              $ref: '#/components/schemas/PartitionCheckpointState'
+              $ref: '#/components/schemas/PartitionBackupState'
 
     PartitionCheckpointState:
       title: Partition Checkpoint State

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -70,20 +70,39 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
-  /backupRuntime/{backupIdOrPrefixOrCheckpointType}:
+  /backupRuntime/{backupIdOrPrefix}:
     get:
       summary: Get information of a runtime backup
       description: A detailed information of the backup with the give backup id.
       parameters:
-        - $ref: '#/components/parameters/BackupIdOrPrefixOrCheckpointType'
+        - $ref: '#/components/parameters/BackupIdOrPrefix'
       responses:
         '200':
-          $ref: '#/components/responses/BackupStatusOrListOrCheckpointState'
+          $ref: '#/components/responses/BackupStatusOrList'
         '400':
           description: Backup is not enabled or configured on the brokers
           $ref: '#/components/responses/Error'
         '404':
           description: A backup with given backupId does not exist
+          $ref: '#/components/responses/Error'
+        '500':
+          description: Internal Error
+          $ref: '#/components/responses/Error'
+        '502':
+          description: Gateway failed to send request to the broker.
+          $ref: '#/components/responses/Error'
+        '504':
+          description: Request from gateway to broker timed out
+          $ref: '#/components/responses/Error'
+  /backupRuntime/state:
+    get:
+      summary: Get information about the current checkpoint and backup state of the cluster
+      description: A detailed information of the backup with the give backup id.
+      responses:
+        '200':
+          $ref: '#/components/responses/CheckpointState'
+        '400':
+          description: Backup is not enabled or configured on the brokers
           $ref: '#/components/responses/Error'
         '500':
           description: Internal Error
@@ -218,18 +237,15 @@ components:
       description: Id of the backup
       schema:
         $ref: '#/components/schemas/BackupId'
-    BackupIdOrPrefixOrCheckpointType:
-      name: backupIdOrPrefixOrCheckpointType
+    BackupIdOrPrefix:
+      name: backupIdOrPrefix
       required: true
       in: path
-      description: |
-        A prefix of ids ending with '*', or a full backup id. Defaults to '*', matching all backup ids.
-        Alternatively, the value can be 'backup' or 'checkpoint' to query for the checkpoint state.
+      description: A prefix of ids ending with '*', or a full backup id. Defaults to '*', matching all backup ids.
       schema:
         oneOf:
           - $ref: '#/components/schemas/BackupId'
           - $ref: '#/components/schemas/BackupIdPrefix'
-          - $ref: '#/components/schemas/CheckpointRequestType'
 
   responses:
     Error:
@@ -238,21 +254,18 @@ components:
         application/json:
           schema:
             "$ref": "#/components/schemas/Error"
-    BackupStatusOrListOrCheckpointState:
+    BackupStatusOrList:
       description: |
-        Status of a single backup or list of statuses when querying for multiple backups. When querying
-        for a checkpoint state, the response contains the the earliest checkpoint in the cluster, alongside
-        the checkpoint state per partition.
+        Status of a single backup or list of statuses when querying for multiple backups
       content:
         application/json:
           schema:
             oneOf:
               - $ref: '#/components/schemas/BackupList'
               - $ref: '#/components/schemas/BackupInfo'
-              - $ref: '#/components/schemas/CheckpointState'
     BackupList:
       description: |
-        List of all available backups.
+       List of all available backups.
       content:
         application/json:
           schema:
@@ -369,33 +382,6 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/BackupInfo'
-    CheckpointRequestType:
-      title: Checkpoint Request Type
-      description: The type of checkpoint to query.
-      type: string
-      enum:
-        - backup
-        - checkpoint
-      example: backup
-    CheckpointType:
-      title: Checkpoint Type
-      description: The type of the checkpoint.
-      type: string
-      enum:
-        - MANUAL_BACKUP
-        - SCHEDULED_BACKUP
-        - MARKER
-      example: SCHEDULED_BACKUP
-    CheckpointId:
-      title: Checkpoint ID
-      description: |
-        The ID of the latest checkpoint. The ID of the checkpoint must be a positive numerical value.
-        As checkpoints are logically ordered by their IDs (ascending), each successive checkpoint
-        must use a higher ID than the previous one.
-      type: integer
-      format: int64
-      example: 1
-      minimum: 0
 
     BackupInfo:
       title: Backup Info
@@ -592,11 +578,14 @@ components:
         Information about the checkpoint state for the cluster.
       type: object
       properties:
-          checkpointState:
-            $ref: '#/components/schemas/PartitionCheckpointState'
           checkpointStates:
             type: array
-            description: List of checkpoint states per partition
+            description: List of partition checkpoint states
+            items:
+              $ref: '#/components/schemas/PartitionCheckpointState'
+          backupStates:
+            type: array
+            description: List of partition backup states
             items:
               $ref: '#/components/schemas/PartitionCheckpointState'
 
@@ -623,3 +612,53 @@ components:
           type: integer
           format: int64
           example: 1765208671134
+
+    PartitionBackupState:
+      title: Partition Checkpoint State
+      description: |
+        Detailed information about the Backup state for a given partition.
+      type: object
+      properties:
+        checkpointId:
+          allOf:
+            - $ref: '#/components/schemas/CheckpointId'
+        checkpointType:
+          allOf:
+            - $ref: '#/components/schemas/BackupType'
+        partitionId:
+          allOf:
+            - $ref: '#/components/schemas/PartitionId'
+        checkpointPosition:
+          type: integer
+          format: int64
+          example: 1500
+        checkpointTimestamp:
+          type: integer
+          format: int64
+          example: 1765208671134
+
+    BackupType:
+      title: Backup Type
+      description: The type of the backup.
+      type: string
+      enum:
+        - MANUAL_BACKUP
+        - SCHEDULED_BACKUP
+      example: SCHEDULED_BACKUP
+    CheckpointType:
+      title: Checkpoint Type
+      description: The type of the checkpoint.
+      type: string
+      enum:
+        - MARKER
+      example: MARKER
+    CheckpointId:
+      title: Checkpoint ID
+      description: |
+        The ID of the latest checkpoint. The ID of the checkpoint must be a positive numerical value.
+        As checkpoints are logically ordered by their IDs (ascending), each successive checkpoint
+        must use a higher ID than the previous one.
+      type: integer
+      format: int64
+      example: 1
+      minimum: 0

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -69,7 +69,7 @@ public abstract class BackupEndpointStandaloneTest {
   }
 
   @Test
-  public void shouldCallStateWhenIsStandalone() {
+  public void shouldCallQueryWhenIsStandalone() {
     // when
     backupEndpointStandalone.query("checkpoint");
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.shared.management;
 
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.gateway.admin.backup.BackupApi;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,10 +54,10 @@ public abstract class BackupEndpointStandaloneTest {
   @Test
   public void shouldCallGetWhenIsStandalone() {
     // when
-    backupEndpointStandalone.query("11");
+    backupEndpointStandalone.query(new String[] {"11"});
 
     // then
-    verify(backupEndpoint).query("11");
+    verify(backupEndpoint).query(new String[] {"11"});
   }
 
   @Test
@@ -71,9 +72,9 @@ public abstract class BackupEndpointStandaloneTest {
   @Test
   public void shouldCallQueryWhenIsStandalone() {
     // when
-    backupEndpointStandalone.query("checkpoint");
+    backupEndpointStandalone.query(new String[] {BackupApi.STATE});
 
     // then
-    verify(backupEndpoint).query("checkpoint");
+    verify(backupEndpoint).query(new String[] {BackupApi.STATE});
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -71,9 +71,9 @@ public abstract class BackupEndpointStandaloneTest {
   @Test
   public void shouldCallStateWhenIsStandalone() {
     // when
-    backupEndpointStandalone.state("checkpoint");
+    backupEndpointStandalone.query("checkpoint");
 
     // then
-    verify(backupEndpoint).state("checkpoint");
+    verify(backupEndpoint).query("checkpoint");
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -67,4 +67,13 @@ public abstract class BackupEndpointStandaloneTest {
     // then
     verify(backupEndpoint).delete(11L);
   }
+
+  @Test
+  public void shouldCallStateWhenIsStandalone() {
+    // when
+    backupEndpointStandalone.state("checkpoint");
+
+    // then
+    verify(backupEndpoint).state("checkpoint");
+  }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -679,7 +679,8 @@ final class BackupEndpointTest {
     void shouldReturnCheckpointState() {
       // given
       final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
+      final var config = mock(BackupCfg.class);
+      final var endpoint = new BackupEndpoint(api, config);
 
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setCheckpointStates(
@@ -700,7 +701,8 @@ final class BackupEndpointTest {
     void shouldReturnBackupOnDifferentTypeState() {
       // given
       final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
+      final var config = mock(BackupCfg.class);
+      final var endpoint = new BackupEndpoint(api, config);
 
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setBackupStates(
@@ -721,7 +723,8 @@ final class BackupEndpointTest {
     void shouldReturnBothCheckpointAndBackupState() {
       // given
       final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
+      final var config = mock(BackupCfg.class);
+      final var endpoint = new BackupEndpoint(api, config);
 
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setBackupStates(
@@ -743,7 +746,8 @@ final class BackupEndpointTest {
     void shouldReturnEmptyState() {
       // given
       final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
+      final var config = mock(BackupCfg.class);
+      final var endpoint = new BackupEndpoint(api, config);
 
       final var stateResponse = new CheckpointStateResponse();
 
@@ -762,7 +766,8 @@ final class BackupEndpointTest {
     void shouldReturnAllPartitionsState() {
       // given
       final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
+      final var config = mock(BackupCfg.class);
+      final var endpoint = new BackupEndpoint(api, config);
 
       final var stateResponse = new CheckpointStateResponse();
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -682,11 +682,8 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
 
       final var stateResponse = new CheckpointStateResponse();
-      stateResponse.setCheckpointType(CheckpointType.MARKER);
-      stateResponse.setCheckpointId(1L);
-      stateResponse.setPartitionId(1);
-      stateResponse.setCheckpointPosition(10L);
-      stateResponse.setCheckpointTimestamp(20L);
+      stateResponse.setCheckpointStates(
+          Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
 
       when(api.getCheckpointState(CheckpointType.MARKER))
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
@@ -707,11 +704,8 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
 
       final var stateResponse = new CheckpointStateResponse();
-      stateResponse.setCheckpointType(CheckpointType.MANUAL_BACKUP);
-      stateResponse.setCheckpointId(1L);
-      stateResponse.setPartitionId(1);
-      stateResponse.setCheckpointPosition(10L);
-      stateResponse.setCheckpointTimestamp(20L);
+      stateResponse.setBackupStates(
+          Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
 
       when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
@@ -726,18 +720,16 @@ final class BackupEndpointTest {
     }
 
     @Test
-    void shouldReturnBackupState() {
+    void shouldReturnBothCheckpointAndBackupState() {
       // given
       final var api = mock(BackupApi.class);
       final var endpoint = new BackupEndpoint(api);
 
       final var stateResponse = new CheckpointStateResponse();
-      stateResponse.setCheckpointType(CheckpointType.SCHEDULED_BACKUP);
-      stateResponse.setCheckpointId(1L);
-      stateResponse.setPartitionId(1);
-      stateResponse.setCheckpointPosition(10L);
-      stateResponse.setCheckpointTimestamp(20L);
-
+      stateResponse.setBackupStates(
+          Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
+      stateResponse.setCheckpointStates(
+          Set.of(new PartitionCheckpointState(1, 2L, CheckpointType.MARKER, 30L, 50L)));
       when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
 
@@ -777,20 +769,23 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
 
       final var stateResponse = new CheckpointStateResponse();
-      stateResponse.setCheckpointType(CheckpointType.SCHEDULED_BACKUP);
-      stateResponse.setCheckpointId(1L);
-      stateResponse.setPartitionId(1);
-      stateResponse.setCheckpointPosition(10L);
-      stateResponse.setCheckpointTimestamp(20L);
 
       final PartitionCheckpointState p1State =
-          new PartitionCheckpointState(1, 1L, CheckpointType.SCHEDULED_BACKUP, 20L, 10L);
+          new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L);
       final PartitionCheckpointState p2State =
-          new PartitionCheckpointState(2, 1L, CheckpointType.SCHEDULED_BACKUP, 20L, 20L);
+          new PartitionCheckpointState(2, 1L, CheckpointType.MARKER, 20L, 20L);
       final PartitionCheckpointState p3State =
-          new PartitionCheckpointState(3, 1L, CheckpointType.SCHEDULED_BACKUP, 30L, 40L);
+          new PartitionCheckpointState(3, 1L, CheckpointType.MARKER, 30L, 40L);
+
+      final PartitionCheckpointState p1BackupState =
+          new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L);
+      final PartitionCheckpointState p2BackupState =
+          new PartitionCheckpointState(2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L);
+      final PartitionCheckpointState p3BackupState =
+          new PartitionCheckpointState(3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L);
 
       stateResponse.setCheckpointStates(Set.of(p1State, p2State, p3State));
+      stateResponse.setBackupStates(Set.of(p1BackupState, p2BackupState, p3BackupState));
 
       when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
           .thenReturn(CompletableFuture.completedFuture(stateResponse));

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -274,7 +274,7 @@ final class BackupEndpointTest {
       doThrow(failure).when(api).getStatus(anyLong());
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("1");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
 
       // then
       assertThat(response.getBody())
@@ -294,7 +294,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.completedFuture(backupStatus)).when(api).getStatus(anyLong());
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("1");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
 
       // then
       assertThat(response.getStatus()).isEqualTo(404);
@@ -314,7 +314,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.failedFuture(error)).when(api).getStatus(anyLong());
 
       // when
-      final var response = endpoint.query("1");
+      final var response = endpoint.query(new String[] {"1"});
 
       // then
       assertThat(response.getStatus()).isEqualTo(expectedCode);
@@ -369,7 +369,7 @@ final class BackupEndpointTest {
       final BackupInfo expectedResponse = mapper.readValue(expectedJson, BackupInfo.class);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("1");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
 
       // then
       assertThat(response.getBody())
@@ -417,7 +417,7 @@ final class BackupEndpointTest {
       final BackupInfo expectedResponse = mapper.readValue(expectedJson, BackupInfo.class);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("1");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {"1"});
 
       // then
       assertThat(response.getBody())
@@ -685,11 +685,10 @@ final class BackupEndpointTest {
       stateResponse.setCheckpointStates(
           Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
 
-      when(api.getCheckpointState(CheckpointType.MARKER))
-          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("checkpoint");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
@@ -707,11 +706,10 @@ final class BackupEndpointTest {
       stateResponse.setBackupStates(
           Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
 
-      when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
-          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("backup");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
@@ -730,11 +728,10 @@ final class BackupEndpointTest {
           Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
       stateResponse.setCheckpointStates(
           Set.of(new PartitionCheckpointState(1, 2L, CheckpointType.MARKER, 30L, 50L)));
-      when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
-          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("backup");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
@@ -750,11 +747,10 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
 
-      when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
-          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("backup");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
@@ -787,11 +783,10 @@ final class BackupEndpointTest {
       stateResponse.setCheckpointStates(Set.of(p1State, p2State, p3State));
       stateResponse.setBackupStates(Set.of(p1BackupState, p2BackupState, p3BackupState));
 
-      when(api.getCheckpointState(CheckpointType.SCHEDULED_BACKUP))
-          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.query("backup");
+      final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -690,7 +690,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.state("checkpoint");
+      final WebEndpointResponse<?> response = endpoint.query("checkpoint");
 
       // then
       assertThat(response.getBody())
@@ -715,7 +715,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.state("backup");
+      final WebEndpointResponse<?> response = endpoint.query("backup");
 
       // then
       assertThat(response.getBody())
@@ -740,7 +740,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.state("backup");
+      final WebEndpointResponse<?> response = endpoint.query("backup");
 
       // then
       assertThat(response.getBody())
@@ -760,7 +760,7 @@ final class BackupEndpointTest {
           .thenReturn(CompletableFuture.completedFuture(stateResponse));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.state("backup");
+      final WebEndpointResponse<?> response = endpoint.query("backup");
 
       // then
       assertThat(response.getBody())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
@@ -59,11 +60,14 @@ public final class BackupApiRequestHandlerStep implements PartitionTransitionSte
       final LogStreamWriter logStreamWriter) {
     final var isBackupEnabled =
         !context.getBrokerCfg().getData().getBackup().getStore().equals(BackupStoreType.NONE);
+    final var checkpointState =
+        new DbCheckpointState(context.getZeebeDb(), context.getZeebeDb().createContext());
     final var requestHandler =
         new BackupApiRequestHandler(
             context.getGatewayBrokerTransport(),
             logStreamWriter,
             context.getBackupManager(),
+            checkpointState,
             context.getPartitionId(),
             isBackupEnabled);
     context.getActorSchedulingService().submitActor(requestHandler).onComplete(installed);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -223,11 +223,23 @@ public final class BackupApiRequestHandler
     final var response = new CheckpointStateResponse();
     response.setPartitionId(requestReader.partitionId());
     if (type == CheckpointType.MANUAL_BACKUP || type == CheckpointType.SCHEDULED_BACKUP) {
+      if (checkpointState.getLatestBackupId() == CheckpointState.NO_CHECKPOINT) {
+        errorWriter.errorCode(ErrorCode.NO_CHECKPOINT_PRESENT).errorMessage("No backup present");
+        result.complete(Either.left(errorWriter));
+        return result;
+      }
       response.setCheckpointId(checkpointState.getLatestBackupId());
       response.setCheckpointTimestamp(checkpointState.getLatestBackupTimestamp());
       response.setCheckpointType(checkpointState.getLatestBackupType());
       response.setCheckpointPosition(checkpointState.getLatestBackupPosition());
     } else {
+      if (checkpointState.getLatestCheckpointId() == CheckpointState.NO_CHECKPOINT) {
+        errorWriter
+            .errorCode(ErrorCode.NO_CHECKPOINT_PRESENT)
+            .errorMessage("No checkpoint present");
+        result.complete(Either.left(errorWriter));
+        return result;
+      }
       response.setCheckpointId(checkpointState.getLatestCheckpointId());
       response.setCheckpointTimestamp(checkpointState.getLatestCheckpointTimestamp());
       response.setCheckpointType(checkpointState.getLatestCheckpointType());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -99,7 +99,7 @@ public final class BackupApiRequestHandler
       case QUERY_STATUS -> handleQueryStatusRequest(requestReader, responseWriter, errorWriter);
       case LIST -> handleListBackupRequest(requestReader, responseWriter, errorWriter);
       case DELETE -> handleDeleteBackupRequest(requestReader, responseWriter, errorWriter);
-      case QUERY_STATE -> handleQueryStateRequest(requestReader, responseWriter, errorWriter);
+      case QUERY_STATE -> handleQueryStateRequest(responseWriter);
       default ->
           CompletableActorFuture.completed(unknownRequest(errorWriter, requestReader.type()));
     };
@@ -215,21 +215,9 @@ public final class BackupApiRequestHandler
   }
 
   private ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> handleQueryStateRequest(
-      final BackupApiRequestReader requestReader,
-      final BackupApiResponseWriter responseWriter,
-      final ErrorResponseWriter errorWriter) {
+      final BackupApiResponseWriter responseWriter) {
     final ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> result =
         new CompletableActorFuture<>();
-
-    if (checkpointState.getLatestCheckpointId() == CheckpointState.NO_CHECKPOINT
-        && checkpointState.getLatestBackupId() == CheckpointState.NO_CHECKPOINT) {
-      errorWriter
-          .errorCode(ErrorCode.NO_CHECKPOINT_PRESENT)
-          .errorMessage("No checkpoint or backup found for partition " + partitionId);
-      result.complete(Either.left(errorWriter));
-      return result;
-    }
-
     final var response = new CheckpointStateResponse();
 
     if (checkpointState.getLatestBackupId() != CheckpointState.NO_CHECKPOINT) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.protocol.management.BackupRequestDecoder;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import org.agrona.DirectBuffer;
 
 public final class BackupApiRequestReader implements RequestReader {
@@ -42,5 +43,12 @@ public final class BackupApiRequestReader implements RequestReader {
 
   public BackupRequestType type() {
     return messageDecoder.type();
+  }
+
+  public CheckpointType checkpointType() {
+    if (messageDecoder.checkpointType() != BackupRequestDecoder.checkpointTypeNullValue()) {
+      return CheckpointType.valueOf(messageDecoder.checkpointType());
+    }
+    return CheckpointType.MANUAL_BACKUP;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.transport.backupapi;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
 import java.util.function.BiConsumer;
@@ -39,6 +40,12 @@ public final class BackupApiResponseWriter implements ResponseWriter {
   BackupApiResponseWriter noResponse() {
     hasResponse = false;
     lengthSupplier = () -> 0;
+    return this;
+  }
+
+  BackupApiResponseWriter withCheckpointState(final CheckpointStateResponse response) {
+    responseWriter = response::write;
+    lengthSupplier = response::getLength;
     return this;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -43,6 +44,7 @@ final class BackupApiRequestHandlerStepTest {
   @Mock DiskSpaceUsageMonitor diskSpaceUsageMonitor;
 
   @Mock ActorSchedulingService actorSchedulingService;
+  @Mock ZeebeDb zeebeDb;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   BrokerCfg brokerCfg;
@@ -59,6 +61,7 @@ final class BackupApiRequestHandlerStepTest {
     transitionContext.setDiskSpaceUsageMonitor(diskSpaceUsageMonitor);
     transitionContext.setActorSchedulingService(actorSchedulingService);
     transitionContext.setBrokerCfg(brokerCfg);
+    transitionContext.setZeebeDb(zeebeDb);
 
     step = new BackupApiRequestHandlerStep();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -516,7 +516,7 @@ final class BackupApiRequestHandlerTest {
   }
 
   @Test
-  void shouldReturnErrorWhenNoCheckpointAndBackupArePresent() {
+  void shouldReturnEmptyWhenNoCheckpointAndBackupArePresent() {
     // given
     when(checkpointState.getLatestCheckpointId()).thenReturn(-1L);
     when(checkpointState.getLatestBackupId()).thenReturn(-1L);
@@ -529,12 +529,9 @@ final class BackupApiRequestHandlerTest {
     handleRequest(request);
 
     // then
-    assertThat(responseFuture)
-        .succeedsWithin(Duration.ofMinutes(1))
-        .matches(Either::isLeft)
-        .extracting(Either::getLeft)
-        .extracting(ErrorResponse::getErrorCode)
-        .isEqualTo(ErrorCode.NO_CHECKPOINT_PRESENT);
+    assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+    assertThat(stateResponse.getCheckpointStates()).isEmpty();
+    assertThat(stateResponse.getBackupStates()).isEmpty();
   }
 
   private void handleRequest(final BackupRequest request) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -20,12 +20,14 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
@@ -69,6 +71,7 @@ final class BackupApiRequestHandlerTest {
   LogStreamWriter logStreamWriter;
 
   @Mock BackupManager backupManager;
+  @Mock CheckpointState checkpointState;
 
   BackupApiRequestHandler handler;
   private ResponseReader serverOutput;
@@ -76,7 +79,9 @@ final class BackupApiRequestHandlerTest {
 
   @BeforeEach
   void setup() {
-    handler = new BackupApiRequestHandler(transport, logStreamWriter, backupManager, 1, true);
+    handler =
+        new BackupApiRequestHandler(
+            transport, logStreamWriter, backupManager, checkpointState, 1, true);
     scheduler.submitActor(handler);
     scheduler.workUntilDone();
 
@@ -415,6 +420,58 @@ final class BackupApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .returns(ErrorCode.INTERNAL_ERROR, ErrorResponse::getErrorCode)
         .returns("Expected failure", error -> BufferUtil.bufferAsString(error.getErrorData()));
+  }
+
+  @Test
+  void shouldReturnCheckpointState() {
+    when(checkpointState.getLatestCheckpointId()).thenReturn(10L);
+    when(checkpointState.getLatestCheckpointType()).thenReturn(CheckpointType.SCHEDULED_BACKUP);
+    when(checkpointState.getLatestCheckpointTimestamp()).thenReturn(100L);
+    when(checkpointState.getLatestCheckpointPosition()).thenReturn(20L);
+
+    final var request =
+        new BackupRequest()
+            .setType(BackupRequestType.QUERY_STATE)
+            .setPartitionId(1)
+            .setCheckpointType(CheckpointType.MARKER);
+
+    final var stateResponse = new CheckpointStateResponse();
+    serverOutput.setResponseObject(stateResponse);
+    handleRequest(request);
+
+    assertThat(responseFuture).succeedsWithin(Duration.ofMillis(100)).matches(Either::isRight);
+    assertThat(stateResponse)
+        .returns(10L, CheckpointStateResponse::getCheckpointId)
+        .returns(1, CheckpointStateResponse::getPartitionId)
+        .returns(CheckpointType.SCHEDULED_BACKUP, CheckpointStateResponse::getCheckpointType)
+        .returns(100L, CheckpointStateResponse::getCheckpointTimestamp)
+        .returns(20L, CheckpointStateResponse::getCheckpointPosition);
+  }
+
+  @Test
+  void shouldReturnBackupState() {
+    when(checkpointState.getLatestBackupId()).thenReturn(10L);
+    when(checkpointState.getLatestBackupType()).thenReturn(CheckpointType.SCHEDULED_BACKUP);
+    when(checkpointState.getLatestBackupTimestamp()).thenReturn(100L);
+    when(checkpointState.getLatestBackupPosition()).thenReturn(20L);
+
+    final var request =
+        new BackupRequest()
+            .setType(BackupRequestType.QUERY_STATE)
+            .setPartitionId(1)
+            .setCheckpointType(CheckpointType.MANUAL_BACKUP);
+
+    final var stateResponse = new CheckpointStateResponse();
+    serverOutput.setResponseObject(stateResponse);
+    handleRequest(request);
+
+    assertThat(responseFuture).succeedsWithin(Duration.ofMillis(100)).matches(Either::isRight);
+    assertThat(stateResponse)
+        .returns(10L, CheckpointStateResponse::getCheckpointId)
+        .returns(1, CheckpointStateResponse::getPartitionId)
+        .returns(CheckpointType.SCHEDULED_BACKUP, CheckpointStateResponse::getCheckpointType)
+        .returns(100L, CheckpointStateResponse::getCheckpointTimestamp)
+        .returns(20L, CheckpointStateResponse::getCheckpointPosition);
   }
 
   private void handleRequest(final BackupRequest request) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -59,7 +59,7 @@ public interface BackupApi {
    *     CheckpointType#SCHEDULED_BACKUP} as "the latest backup of any type".
    * @return the latest checkpoint state for the given type
    */
-  CompletionStage<CheckpointStateResponse> getLatestCheckpointState(CheckpointType type);
+  CompletionStage<CheckpointStateResponse> getCheckpointState(CheckpointType type);
 
   /**
    * @return a list of available backups

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -8,14 +8,12 @@
 package io.camunda.zeebe.gateway.admin.backup;
 
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
-import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 public interface BackupApi {
   String WILDCARD = "*";
-  String CHECKPOINT = "checkpoint";
-  String BACKUP = "backup";
+  String STATE = "state";
 
   /**
    * Triggers backup on all partitions. Returned future is completed successfully after all
@@ -51,15 +49,9 @@ public interface BackupApi {
   CompletionStage<BackupStatus> getStatus(long backupId);
 
   /**
-   * Returns the latest checkpoint info for the given type amongst all partitions.
-   *
-   * @param type {@link CheckpointType} of which the latest checkpoint state is requested. This
-   *     argument is aggregated in the meaning that {@link CheckpointType#MARKER} is interpreted as
-   *     "the latest checkpoint of any type" and {@link CheckpointType#MANUAL_BACKUP} or {@link
-   *     CheckpointType#SCHEDULED_BACKUP} as "the latest backup of any type".
-   * @return the latest checkpoint state for the given type
+   * @return the latest checkpoint and state for all partitions
    */
-  CompletionStage<CheckpointStateResponse> getCheckpointState(CheckpointType type);
+  CompletionStage<CheckpointStateResponse> getCheckpointState();
 
   /**
    * @return a list of available backups

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 public interface BackupApi {
   String WILDCARD = "*";
+  String CHECKPOINT = "checkpoint";
+  String BACKUP = "backup";
 
   /**
    * Triggers backup on all partitions. Returned future is completed successfully after all
@@ -45,6 +49,17 @@ public interface BackupApi {
    * @return the status of the backup
    */
   CompletionStage<BackupStatus> getStatus(long backupId);
+
+  /**
+   * Returns the latest checkpoint info for the given type amongst all partitions.
+   *
+   * @param type {@link CheckpointType} of which the latest checkpoint state is requested. This
+   *     argument is aggregated in the meaning that {@link CheckpointType#MARKER} is interpreted as
+   *     "the latest checkpoint of any type" and {@link CheckpointType#MANUAL_BACKUP} or {@link
+   *     CheckpointType#SCHEDULED_BACKUP} as "the latest backup of any type".
+   * @return the latest checkpoint state for the given type
+   */
+  CompletionStage<CheckpointStateResponse> getLatestCheckpointState(CheckpointType type);
 
   /**
    * @return a list of available backups

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -134,7 +134,7 @@ public final class BackupRequestHandler implements BackupApi {
   }
 
   @Override
-  public CompletionStage<CheckpointStateResponse> getCheckpointState(final CheckpointType type) {
+  public CompletionStage<CheckpointStateResponse> getCheckpointState() {
     return checkTopologyComplete()
         .thenCompose(
             topology -> {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -144,8 +144,8 @@ public final class BackupRequestHandler implements BackupApi {
                       .toList();
 
               return CompletableFuture.allOf(statusesReceived.toArray(CompletableFuture[]::new))
-                  .handle(
-                      (ignored, error) ->
+                  .thenApply(
+                      ignored ->
                           statusesReceived.stream()
                               .map(response -> response.join().getResponse())
                               .collect(Collectors.toSet()))

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -147,7 +147,6 @@ public final class BackupRequestHandler implements BackupApi {
                   .handle(
                       (ignored, error) ->
                           statusesReceived.stream()
-                              .filter(f -> !f.isCompletedExceptionally() && f.join().isResponse())
                               .map(response -> response.join().getResponse())
                               .collect(Collectors.toSet()))
                   .thenApply(this::aggregateCheckpointResponses);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerCheckpointStateRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerCheckpointStateRequest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
+import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateResponse> {
+
+  private final BackupRequest request = new BackupRequest();
+  private final CheckpointStateResponse response = new CheckpointStateResponse();
+
+  public BrokerCheckpointStateRequest() {
+    super(ExecuteCommandResponseDecoder.SCHEMA_ID, ExecuteCommandResponseDecoder.TEMPLATE_ID);
+    request.setType(BackupRequestType.QUERY_STATE);
+  }
+
+  public CheckpointType getCheckpointType() {
+    return request.getCheckpointType();
+  }
+
+  public void setCheckpointType(final CheckpointType checkpointType) {
+    request.setCheckpointType(checkpointType);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<CheckpointStateResponse> readResponse() {
+    return new BrokerResponse<>(response, response.getPartitionId(), -1);
+  }
+
+  @Override
+  protected CheckpointStateResponse toResponseDto(final DirectBuffer buffer) {
+    return response;
+  }
+
+  @Override
+  public String getType() {
+    return "Backup#state";
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.BACKUP;
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerCheckpointStateRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerCheckpointStateRequest.java
@@ -74,7 +74,7 @@ public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateR
 
   @Override
   protected BrokerResponse<CheckpointStateResponse> readResponse() {
-    return new BrokerResponse<>(response, response.getCheckpointState().partitionId(), -1);
+    return new BrokerResponse<>(response);
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerCheckpointStateRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerCheckpointStateRequest.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
-import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
+import io.camunda.zeebe.protocol.management.CheckpointStateResponseDecoder;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -25,7 +25,7 @@ public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateR
   private final CheckpointStateResponse response = new CheckpointStateResponse();
 
   public BrokerCheckpointStateRequest() {
-    super(ExecuteCommandResponseDecoder.SCHEMA_ID, ExecuteCommandResponseDecoder.TEMPLATE_ID);
+    super(CheckpointStateResponseDecoder.SCHEMA_ID, CheckpointStateResponseDecoder.TEMPLATE_ID);
     request.setType(BackupRequestType.QUERY_STATE);
   }
 
@@ -74,7 +74,7 @@ public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateR
 
   @Override
   protected BrokerResponse<CheckpointStateResponse> readResponse() {
-    return new BrokerResponse<>(response, response.getPartitionId(), -1);
+    return new BrokerResponse<>(response, response.getCheckpointState().partitionId(), -1);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.management.BackupRequestEncoder;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
@@ -27,6 +28,7 @@ public class BackupRequest implements BufferReader, BufferWriter {
   private int partitionId;
   private long backupId;
   private String pattern;
+  private CheckpointType checkpointType;
 
   public BackupRequest reset() {
     type = BackupRequestType.NULL_VAL;
@@ -72,6 +74,15 @@ public class BackupRequest implements BufferReader, BufferWriter {
     return this;
   }
 
+  public CheckpointType getCheckpointType() {
+    return checkpointType;
+  }
+
+  public BackupRequest setCheckpointType(final CheckpointType checkpointType) {
+    this.checkpointType = checkpointType;
+    return this;
+  }
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
@@ -79,6 +90,9 @@ public class BackupRequest implements BufferReader, BufferWriter {
     type = bodyDecoder.type();
     backupId = bodyDecoder.backupId();
     pattern = bodyDecoder.pattern();
+    if (bodyDecoder.checkpointType() != BackupRequestEncoder.checkpointTypeNullValue()) {
+      checkpointType = CheckpointType.valueOf(bodyDecoder.checkpointType());
+    }
   }
 
   @Override
@@ -97,5 +111,9 @@ public class BackupRequest implements BufferReader, BufferWriter {
         .type(type)
         .backupId(backupId)
         .pattern(pattern);
+
+    if (checkpointType != null) {
+      bodyEncoder.checkpointType(checkpointType.getValue());
+    }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import io.camunda.zeebe.protocol.management.CheckpointStateResponseDecoder;
+import io.camunda.zeebe.protocol.management.CheckpointStateResponseEncoder;
+import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class CheckpointStateResponse implements BufferReader, BufferWriter {
+
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final CheckpointStateResponseEncoder bodyEncoder = new CheckpointStateResponseEncoder();
+  private final CheckpointStateResponseDecoder bodyDecoder = new CheckpointStateResponseDecoder();
+
+  private int partitionId;
+  private long checkpointId;
+  private CheckpointType checkpointType;
+  private long checkpointTimestamp;
+  private long checkpointPosition;
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength()
+        + bodyEncoder.sbeBlockLength()
+        + CheckpointStateResponseEncoder.partitionIdEncodingLength()
+        + CheckpointStateResponseEncoder.checkpointTypeEncodingLength()
+        + CheckpointStateResponseEncoder.checkpointIdEncodingLength()
+        + CheckpointStateResponseEncoder.checkpointTimestampEncodingLength()
+        + CheckpointStateResponseEncoder.checkpointPositionEncodingLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    bodyEncoder
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
+        .partitionId(partitionId)
+        .checkpointId(checkpointId)
+        .checkpointType(checkpointType.getValue())
+        .checkpointTimestamp(checkpointTimestamp)
+        .checkpointPosition(checkpointPosition);
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    partitionId = bodyDecoder.partitionId();
+    checkpointId = bodyDecoder.checkpointId();
+    checkpointType = CheckpointType.valueOf(bodyDecoder.checkpointType());
+    checkpointTimestamp = bodyDecoder.checkpointTimestamp();
+    checkpointPosition = bodyDecoder.checkpointPosition();
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public long getCheckpointId() {
+    return checkpointId;
+  }
+
+  public void setCheckpointId(final long checkpointId) {
+    this.checkpointId = checkpointId;
+  }
+
+  public CheckpointType getCheckpointType() {
+    return checkpointType;
+  }
+
+  public void setCheckpointType(final CheckpointType checkpointType) {
+    this.checkpointType = checkpointType;
+  }
+
+  public long getCheckpointTimestamp() {
+    return checkpointTimestamp;
+  }
+
+  public void setCheckpointTimestamp(final long checkpointTimestamp) {
+    this.checkpointTimestamp = checkpointTimestamp;
+  }
+
+  public long getCheckpointPosition() {
+    return checkpointPosition;
+  }
+
+  public void setCheckpointPosition(final long checkpointPosition) {
+    this.checkpointPosition = checkpointPosition;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
@@ -57,34 +57,26 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
   public void write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
-    if (checkpointStates.isEmpty()) {
-      bodyEncoder.checkpointStatesCount(0);
-    } else {
-      final var checkpointStateEncoder = bodyEncoder.checkpointStatesCount(checkpointStates.size());
-      for (final PartitionCheckpointState partitionState : checkpointStates) {
-        checkpointStateEncoder
-            .next()
-            .partitionId(partitionState.partitionId)
-            .checkpointId(partitionState.checkpointId)
-            .checkpointType(partitionState.checkpointType.getValue())
-            .checkpointTimestamp(partitionState.checkpointTimestamp)
-            .checkpointPosition(partitionState.checkpointPosition);
-      }
+    final var checkpointStateEncoder = bodyEncoder.checkpointStatesCount(checkpointStates.size());
+    for (final PartitionCheckpointState partitionState : checkpointStates) {
+      checkpointStateEncoder
+          .next()
+          .partitionId(partitionState.partitionId)
+          .checkpointId(partitionState.checkpointId)
+          .checkpointType(partitionState.checkpointType.getValue())
+          .checkpointTimestamp(partitionState.checkpointTimestamp)
+          .checkpointPosition(partitionState.checkpointPosition);
     }
 
-    if (backupStates.isEmpty()) {
-      bodyEncoder.backupStatesCount(0);
-    } else {
-      final var backupStateEncoder = bodyEncoder.backupStatesCount(backupStates.size());
-      for (final PartitionCheckpointState partitionState : backupStates) {
-        backupStateEncoder
-            .next()
-            .partitionId(partitionState.partitionId)
-            .checkpointId(partitionState.checkpointId)
-            .checkpointType(partitionState.checkpointType.getValue())
-            .checkpointTimestamp(partitionState.checkpointTimestamp)
-            .checkpointPosition(partitionState.checkpointPosition);
-      }
+    final var backupStateEncoder = bodyEncoder.backupStatesCount(backupStates.size());
+    for (final PartitionCheckpointState partitionState : backupStates) {
+      backupStateEncoder
+          .next()
+          .partitionId(partitionState.partitionId)
+          .checkpointId(partitionState.checkpointId)
+          .checkpointType(partitionState.checkpointType.getValue())
+          .checkpointTimestamp(partitionState.checkpointTimestamp)
+          .checkpointPosition(partitionState.checkpointPosition);
     }
   }
 

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -95,12 +95,14 @@
   </sbe:message>
 
   <sbe:message name="CheckpointStateResponse" id="6">
-    <field name="partitionId" id="1" type="uint16"/>
-    <field name="checkpointId" id="2"  type="int64"/>
-    <field name="checkpointType" id="3"  type="uint8"/>
-    <field name="checkpointTimestamp" id="4"  type="uint64"/>
-    <field name="checkpointPosition" id="5"  type="uint64"/>
-    <group name="state" id="6">
+    <group name="checkpointStates" id="1">
+      <field name="partitionId" id="1" type="uint16"/>
+      <field name="checkpointId" id="2"  type="int64"/>
+      <field name="checkpointType" id="3"  type="uint8"/>
+      <field name="checkpointPosition" id="4"  type="uint64"/>
+      <field name="checkpointTimestamp" id="5"  type="uint64"/>
+    </group>
+    <group name="backupStates" id="2">
       <field name="partitionId" id="1" type="uint16"/>
       <field name="checkpointId" id="2"  type="int64"/>
       <field name="checkpointType" id="3"  type="uint8"/>
@@ -108,7 +110,6 @@
       <field name="checkpointTimestamp" id="5"  type="uint64"/>
     </group>
   </sbe:message>
-
 </sbe:messageSchema>
 
 

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -98,8 +98,15 @@
     <field name="partitionId" id="1" type="uint16"/>
     <field name="checkpointId" id="2"  type="int64"/>
     <field name="checkpointType" id="3"  type="uint8"/>
-    <field name="checkpointPosition" id="4"  type="uint64"/>
-    <field name="checkpointTimestamp" id="5"  type="uint64"/>
+    <field name="checkpointTimestamp" id="4"  type="uint64"/>
+    <field name="checkpointPosition" id="5"  type="uint64"/>
+    <group name="state" id="6">
+      <field name="partitionId" id="1" type="uint16"/>
+      <field name="checkpointId" id="2"  type="int64"/>
+      <field name="checkpointType" id="3"  type="uint8"/>
+      <field name="checkpointPosition" id="4"  type="uint64"/>
+      <field name="checkpointTimestamp" id="5"  type="uint64"/>
+    </group>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.protocol.management"
-  id="1" version="0" semanticVersion="${project.version}"
+  id="1" version="1" semanticVersion="${project.version}"
   description="Zeebe Cluster Management Protocol" byteOrder="littleEndian">
 
   <xi:include href="common-types.xml"/>
@@ -22,6 +22,7 @@
       <validValue name="QUERY_STATUS">1</validValue>
       <validValue name="LIST">2</validValue>
       <validValue name="DELETE">3</validValue>
+      <validValue name="QUERY_STATE">4</validValue>
     </enum>
 
     <enum name="BackupStatusCode" encodingType="uint8">
@@ -57,6 +58,7 @@
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="BackupRequestType"/>
     <field name="backupId" id="3" type="int64"/>
+    <field name="checkpointType" id="5"  type="uint8" sinceVersion="1"/>
     <data name="pattern" id="4" type="varDataEncoding"/>
   </sbe:message>
 
@@ -91,6 +93,15 @@
       <data name="brokerVersion" id="11" type="varDataEncoding"/>
     </group>
   </sbe:message>
+
+  <sbe:message name="CheckpointStateResponse" id="6">
+    <field name="partitionId" id="1" type="uint16"/>
+    <field name="checkpointId" id="2"  type="int64"/>
+    <field name="checkpointType" id="3"  type="uint8"/>
+    <field name="checkpointPosition" id="4"  type="uint64"/>
+    <field name="checkpointTimestamp" id="5"  type="uint64"/>
+  </sbe:message>
+
 </sbe:messageSchema>
 
 

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -19,6 +19,7 @@
       <validValue name="PROCESS_NOT_FOUND">7</validValue>
       <validValue name="RESOURCE_EXHAUSTED">8</validValue>
       <validValue name="PARTITION_UNAVAILABLE">9</validValue>
+      <validValue name="NO_CHECKPOINT_PRESENT">10</validValue>
     </enum>
 
     <enum name="ValueType" encodingType="uint8" description="The type of a record value">

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -19,7 +19,6 @@
       <validValue name="PROCESS_NOT_FOUND">7</validValue>
       <validValue name="RESOURCE_EXHAUSTED">8</validValue>
       <validValue name="PARTITION_UNAVAILABLE">9</validValue>
-      <validValue name="NO_CHECKPOINT_PRESENT">10</validValue>
     </enum>
 
     <enum name="ValueType" encodingType="uint8" description="The type of a record value">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupAcceptance.java
@@ -15,6 +15,8 @@ import io.camunda.management.backups.BackupInfo;
 import io.camunda.management.backups.PartitionBackupInfo;
 import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import java.time.Duration;
@@ -123,6 +125,41 @@ public interface BackupAcceptance {
                     .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
                     .extracting(FeignException::status)
                     .isEqualTo(404));
+  }
+
+  @Test
+  default void shouldRetrieveState() {
+    // given
+    final TestCluster cluster = getTestCluster();
+    final var actuator = BackupActuator.of(cluster.availableGateway());
+    final long backupId = 1;
+    actuator.take(backupId);
+    waitUntilBackupIsCompleted(actuator, backupId);
+
+    // when
+    final var response = actuator.state();
+
+    // then
+    assertThat(response.getBackupStates()).hasSize(cluster.partitionsCount());
+    assertThat(response.getCheckpointStates()).hasSize(cluster.partitionsCount());
+
+    assertThat(response.getBackupStates())
+        .allSatisfy(
+            state ->
+                assertThat(state)
+                    .extracting(
+                        PartitionCheckpointState::checkpointId,
+                        PartitionCheckpointState::checkpointType)
+                    .containsExactly(backupId, CheckpointType.MANUAL_BACKUP));
+
+    assertThat(response.getCheckpointStates())
+        .allSatisfy(
+            state ->
+                assertThat(state)
+                    .extracting(
+                        PartitionCheckpointState::checkpointId,
+                        PartitionCheckpointState::checkpointType)
+                    .containsExactly(backupId, CheckpointType.MANUAL_BACKUP));
   }
 
   private static void waitUntilBackupIsCompleted(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupErrorResponseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupErrorResponseTest.java
@@ -132,7 +132,7 @@ class BackupErrorResponseTest {
     @Test
     void shouldReturn400() {
       // when - then
-      assertThat(backupEndpoint.query("1").getStatus()).isEqualTo(400);
+      assertThat(backupEndpoint.query(new String[] {"1"}).getStatus()).isEqualTo(400);
     }
   }
 
@@ -163,7 +163,7 @@ class BackupErrorResponseTest {
       clusteringRule.disconnect(clusteringRule.getBroker(0));
 
       // when - then
-      assertThat(backupEndpoint.query("1").getStatus()).isEqualTo(504);
+      assertThat(backupEndpoint.query(new String[] {"1"}).getStatus()).isEqualTo(504);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -389,7 +389,7 @@ class BackupMultiPartitionTest {
   private CheckpointStateResponse getCheckpointState()
       throws InterruptedException, ExecutionException, TimeoutException {
     return backupRequestHandler
-        .getCheckpointState(CheckpointType.MANUAL_BACKUP)
+        .getCheckpointState()
         .toCompletableFuture()
         .get(30, TimeUnit.SECONDS);
   }

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -245,5 +245,10 @@
       <artifactId>opensearch-java</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -24,8 +24,8 @@ import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.management.backups.BackupInfo;
-import io.camunda.management.backups.CheckpointState;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator.ErrorResponse.Payload;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.zeebe.containers.ZeebeNode;
@@ -129,9 +129,9 @@ public interface BackupActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void delete(@Param final long id);
 
-  @RequestLine("GET /state/{type}")
+  @RequestLine("GET /state")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  CheckpointState state(@Param final String type);
+  CheckpointStateResponse state();
 
   /**
    * Custom error handler, mapping errors with body to custom types for easier

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -24,6 +24,7 @@ import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.CheckpointState;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator.ErrorResponse.Payload;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
@@ -127,6 +128,10 @@ public interface BackupActuator {
   @RequestLine("DELETE /{id}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void delete(@Param final long id);
+
+  @RequestLine("GET /state/{type}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  CheckpointState state(@Param final String type);
 
   /**
    * Custom error handler, mapping errors with body to custom types for easier


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Support retrieving the checkpoint state per partition from RocksDB. This can be done either for `Checkpoints` or `Backups`. This functionality will be required when the checkpoint/backup schedulers are implemented, as during broker _handover of the service_ the next broker needs to determine when was the last successful tick. To do this, apart from the per partition state, we also return the _earliest checkpoint/backup_ from the aggregated partitions.

The API is exposed from the actuator under `GET /backupRuntime/state`, that will return the respective checkpoint and backup aggregate state. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42243 
