### PR TITLE
refactor: move CamundaUserDetailsService from Camunda Authentication to Zeebe Distribution

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -10,7 +10,6 @@ package io.camunda.authentication.config;
 import static io.camunda.security.configuration.headers.ContentSecurityPolicyConfig.DEFAULT_SAAS_SECURITY_POLICY;
 import static io.camunda.security.configuration.headers.ContentSecurityPolicyConfig.DEFAULT_SM_SECURITY_POLICY;
 
-import io.camunda.authentication.CamundaUserDetailsService;
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.ConditionalOnProtectedApi;
 import io.camunda.authentication.ConditionalOnUnprotectedApi;
@@ -41,7 +40,6 @@ import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.service.UserServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import jakarta.annotation.PostConstruct;
@@ -60,7 +58,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -80,7 +77,6 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
@@ -456,12 +452,6 @@ public class WebSecurityConfig {
         final TenantServices tenantServices) {
       return new UsernamePasswordAuthenticationTokenConverter(
           roleServices, groupServices, tenantServices);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(UserDetailsService.class)
-    public CamundaUserDetailsService camundaUserDetailsService(final UserServices userServices) {
-      return new CamundaUserDetailsService(userServices);
     }
 
     @Bean

--- a/authentication/src/test/resources/camunda-bar-realm.json
+++ b/authentication/src/test/resources/camunda-bar-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "NONE",
   "registrationAllowed": false,
   "registrationEmailAsUsername": false,
   "rememberMe": false,

--- a/authentication/src/test/resources/camunda-foo-realm.json
+++ b/authentication/src/test/resources/camunda-foo-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "NONE",
   "registrationAllowed": false,
   "registrationEmailAsUsername": false,
   "rememberMe": false,

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -31,6 +31,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
@@ -7,15 +7,26 @@
  */
 package io.camunda.application.commons.identity;
 
+import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.authentication"})
 @ConfigurationPropertiesScan(basePackages = {"io.camunda.authentication"})
 @Profile("consolidated-auth")
 @ConditionalOnRestGatewayEnabled
-public class AuthenticationConfiguration {}
+public class AuthenticationConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(UserDetailsService.class)
+  public CamundaUserDetailsService camundaUserDetailsService(final UserServices userServices) {
+    return new CamundaUserDetailsService(userServices);
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/identity/CamundaUserDetailsService.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/CamundaUserDetailsService.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication;
+package io.camunda.application.commons.identity;
 
 import io.camunda.search.entities.UserEntity;
 import io.camunda.security.auth.CamundaAuthentication;

--- a/dist/src/test/java/io/camunda/application/commons/identity/CamundaUserDetailsServiceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/CamundaUserDetailsServiceTest.java
@@ -17,8 +17,8 @@ import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.UserServices;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -30,7 +30,7 @@ public class CamundaUserDetailsServiceTest {
   @Mock private UserServices userService;
   private CamundaUserDetailsService userDetailsService;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     userDetailsService = new CamundaUserDetailsService(userService);

--- a/dist/src/test/java/io/camunda/application/commons/identity/CamundaUserDetailsServiceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/CamundaUserDetailsServiceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication;
+package io.camunda.application.commons.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
## Description

Refactoring.
Move CamundaUserDetailsService from `camunda-authentication` to "dist" - `camunda-zeebe`.
The class implements Spring's `UserDetailsService` so the interface already "exists" in `camunda-zeebe`.
It also depends on UserServices, which is a bean instantiated in `camunda-zeebe` as well.

closes #42191 
