### PR TITLE
refactor: remove zeebe container from optimize

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -731,12 +731,6 @@
       <artifactId>zeebe-broker</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-exporter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -731,6 +731,11 @@
       <artifactId>zeebe-broker</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -291,12 +291,6 @@
       <version>3.3</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-      <version>${version.zeebe-test-container}</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
@@ -398,6 +392,20 @@
       <artifactId>mockserver-core</artifactId>
       <version>${mockserver.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-models</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -701,6 +709,27 @@
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
       <version>${version.nimbus-jose-jwt}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.liquibase</groupId>
+          <artifactId>liquibase-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -278,7 +278,7 @@ public abstract class AbstractCCSMIT extends AbstractIT {
     final String expectedIndex = zeebeExtension.getZeebeRecordPrefix() + "-" + indexName;
     Awaitility.given()
         .ignoreExceptions()
-        .timeout(15, TimeUnit.SECONDS)
+        .timeout(30, TimeUnit.SECONDS)
         .untilAsserted(
             () ->
                 assertThat(databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex))

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -20,14 +20,19 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorker;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.exporter.CamundaExporter;
 import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.optimize.service.util.configuration.DatabaseType;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -38,60 +43,135 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.MountableFile;
 
 /** Embedded Zeebe Extension */
 public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
 
-  private static final String ZEEBE_CONFIG_PATH = "zeebe/zeebe-application.yml";
-  private static final String ZEEBE_VERSION =
-      IntegrationTestConfigurationUtil.getZeebeDockerVersion();
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ZeebeExtension.class);
 
-  private ZeebeContainer zeebeContainer;
+  private final TestStandaloneBroker standaloneBroker;
   private CamundaClient camundaClient;
 
   private String zeebeRecordPrefix;
 
   public ZeebeExtension() {
-    final int databasePort;
-    final String zeebeExporterClassName;
-    if (IntegrationTestConfigurationUtil.getDatabaseType().equals(DatabaseType.OPENSEARCH)) {
-      databasePort = 9200;
-      zeebeExporterClassName = ZEEBE_OPENSEARCH_EXPORTER;
-    } else {
-      databasePort = 9200;
-      zeebeExporterClassName = ZEEBE_ELASTICSEARCH_EXPORTER;
-    }
-    Testcontainers.exposeHostPorts(databasePort);
-    zeebeContainer =
-        new ZeebeContainer(DockerImageName.parse("camunda/zeebe:" + ZEEBE_VERSION))
-            .withEnv("ZEEBE_CLOCK_CONTROLLED", "true")
-            .withEnv("DATABASE_PORT", String.valueOf(databasePort))
-            .withEnv("ZEEBE_EXPORTER_CLASS_NAME", zeebeExporterClassName)
-            .withCopyFileToContainer(
-                MountableFile.forClasspathResource(ZEEBE_CONFIG_PATH),
-                "/usr/local/zeebe/config/application.yml");
-    if (!isZeebeVersionPre85()) {
-      zeebeContainer =
-          zeebeContainer
-              .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
-              .withAdditionalExposedPort(8080);
-    }
+
+    standaloneBroker =
+        new TestStandaloneBroker()
+            .withSecurityConfig(
+                cfg -> {
+                  cfg.getAuthentication().setUnprotectedApi(true);
+                  cfg.getAuthorizations().setEnabled(false);
+                  final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
+                  cfg.getInitialization().setUsers(List.of(user));
+                })
+            .withAdditionalProperties(
+                Map.of(
+                    "zeebe.log.level", "ERROR",
+                    "atomix.log.level", "ERROR",
+                    "zeebe.clock.controlled", "true",
+                    "zeebe.broker.gateway.enable", "true"));
   }
 
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
     zeebeRecordPrefix = ZeebeConstants.ZEEBE_RECORD_TEST_PREFIX + "-" + IdGenerator.getNextId();
+    final var dbType = IntegrationTestConfigurationUtil.getDatabaseType();
+    final String zeebeExporterClassName;
+
+    if (dbType.equals(DatabaseType.OPENSEARCH)) {
+      zeebeExporterClassName = ZEEBE_OPENSEARCH_EXPORTER;
+    } else {
+      zeebeExporterClassName = ZEEBE_ELASTICSEARCH_EXPORTER;
+    }
+    Testcontainers.exposeHostPorts(9200);
     setZeebeRecordPrefixForTest();
-    zeebeContainer.start();
+    standaloneBroker
+        .withUnifiedConfig(
+            cfg -> {
+              cfg.getCluster().setPartitionCount(2);
+              cfg.getData()
+                  .getSecondaryStorage()
+                  .setType(SecondaryStorageType.valueOf(dbType.getId()));
+              if (dbType.equals(DatabaseType.OPENSEARCH)) {
+                cfg.getData().getSecondaryStorage().getOpensearch().setUrl("http://localhost:9200");
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getOpensearch()
+                    .setIndexPrefix(zeebeRecordPrefix);
+              } else {
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setUrl("http://localhost:9200");
+                cfg.getData()
+                    .getSecondaryStorage()
+                    .getElasticsearch()
+                    .setIndexPrefix(zeebeRecordPrefix);
+              }
+            })
+        .withExporter(
+            CamundaExporter.class.getSimpleName().toLowerCase(),
+            cfg -> {
+              cfg.setClassName(CamundaExporter.class.getName());
+              cfg.setArgs(
+                  Map.of(
+                      "index",
+                      Map.of("prefix", zeebeRecordPrefix),
+                      "bulk",
+                      Map.of("size", 1),
+                      "connect",
+                      Map.of(
+                          "url",
+                          "http://localhost:9200",
+                          "type",
+                          dbType.toString(),
+                          "indexPrefix",
+                          zeebeRecordPrefix)));
+            })
+        .withExporter(
+            dbType.getId() + "exporter",
+            cfg -> {
+              cfg.setClassName(zeebeExporterClassName);
+              cfg.setArgs(
+                  Map.of(
+                      "index",
+                      Map.of("prefix", zeebeRecordPrefix),
+                      "bulk",
+                      Map.of("size", 1),
+                      "connect",
+                      Map.of(
+                          "url",
+                          "http://localhost:9200",
+                          "indexPrefix",
+                          zeebeRecordPrefix,
+                          "type",
+                          dbType.toString())));
+            })
+        .withCreateSchema(true)
+        .withAdditionalProperties(
+            Map.of(
+                "camunda.data.secondary-storage.type",
+                dbType.getId(),
+                "camunda.database.type",
+                dbType.getId(),
+                "camunda.database.url",
+                "http://localhost:9200",
+                "camunda.tasklist.database",
+                dbType.getId(),
+                "camunda.operate.database",
+                dbType.getId(),
+                "camunda.tasklist." + dbType.getId() + ".url",
+                "http://localhost:9200",
+                "camunda.operate." + dbType.getId() + ".url",
+                "http://localhost:9200"))
+        .start();
     createClient();
   }
 
   @Override
   public void afterEach(final ExtensionContext extensionContext) {
-    zeebeContainer.stop();
+    standaloneBroker.stop();
     destroyClient();
   }
 
@@ -100,14 +180,15 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
       camundaClient =
           CamundaClient.newClientBuilder()
               .defaultRequestTimeout(Duration.ofMillis(15000))
-              .grpcAddress(zeebeContainer.getGrpcAddress())
+              .grpcAddress(standaloneBroker.grpcAddress())
               .build();
     } else {
       camundaClient =
           CamundaClient.newClientBuilder()
+              .preferRestOverGrpc(false)
               .defaultRequestTimeout(Duration.ofMillis(15000))
-              .grpcAddress(zeebeContainer.getGrpcAddress())
-              .restAddress(zeebeContainer.getRestAddress())
+              .grpcAddress(standaloneBroker.grpcAddress())
+              .restAddress(standaloneBroker.restAddress())
               .build();
     }
   }
@@ -166,7 +247,7 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
 
   public void setClock(final Instant pinAt) throws IOException, InterruptedException {
     final ClockActuatorClient clockClient =
-        new ClockActuatorClient(zeebeContainer.getExternalMonitoringAddress());
+        new ClockActuatorClient(standaloneBroker.address(TestZeebePort.MONITORING));
     clockClient.pinZeebeTime(pinAt);
   }
 
@@ -274,9 +355,9 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
   }
 
   private void setZeebeRecordPrefixForTest() {
-    zeebeContainer =
-        zeebeContainer.withEnv(
-            "ZEEBE_BROKER_EXPORTERS_OPTIMIZE_ARGS_INDEX_PREFIX", zeebeRecordPrefix);
+    /*    standaloneBroker =
+    standaloneBroker.withEnv(
+        "ZEEBE_BROKER_EXPORTERS_OPTIMIZE_ARGS_INDEX_PREFIX", zeebeRecordPrefix);*/
   }
 
   private void destroyClient() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -54,6 +54,8 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
 
   public ZeebeExtension() {
 
+    System.setProperty("management.endpoints.web.exposure.include", "*");
+
     standaloneBroker =
         new TestStandaloneBroker()
             .withAdditionalProperties(
@@ -62,7 +64,7 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
                     "ERROR",
                     "atomix.log.level",
                     "ERROR",
-                    "camunda.system.clock-controlled",
+                    "zeebe.clock.controlled",
                     "true",
                     "zeebe.broker.gateway.enable",
                     "true"))
@@ -248,8 +250,7 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
 
   public void setClock(final Instant pinAt) throws IOException, InterruptedException {
     final ClockActuatorClient clockClient =
-        new ClockActuatorClient(
-            "localhost:" + standaloneBroker.mappedPort(TestZeebePort.MONITORING));
+        new ClockActuatorClient(standaloneBroker.address(TestZeebePort.MONITORING));
     clockClient.pinZeebeTime(pinAt);
   }
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -21,7 +21,6 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.exporter.CamundaExporter;
 import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.optimize.service.util.configuration.DatabaseType;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
@@ -88,7 +87,7 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
       zeebeExporterClassName = ZEEBE_ELASTICSEARCH_EXPORTER;
     }
     Testcontainers.exposeHostPorts(9200);
-    setZeebeRecordPrefixForTest();
+
     standaloneBroker
         .withUnifiedConfig(
             cfg -> {
@@ -112,25 +111,6 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
                     .getElasticsearch()
                     .setIndexPrefix(zeebeRecordPrefix);
               }
-            })
-        .withExporter(
-            CamundaExporter.class.getSimpleName().toLowerCase(),
-            cfg -> {
-              cfg.setClassName(CamundaExporter.class.getName());
-              cfg.setArgs(
-                  Map.of(
-                      "index",
-                      Map.of("prefix", zeebeRecordPrefix),
-                      "bulk",
-                      Map.of("size", 1),
-                      "connect",
-                      Map.of(
-                          "url",
-                          "http://localhost:9200",
-                          "type",
-                          dbType.toString(),
-                          "indexPrefix",
-                          zeebeRecordPrefix)));
             })
         .withExporter(
             dbType.getId() + "exporter",
@@ -355,12 +335,6 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
             .open();
     Awaitility.await().timeout(10, TimeUnit.SECONDS).untilTrue(jobCompleted);
     jobWorker.close();
-  }
-
-  private void setZeebeRecordPrefixForTest() {
-    /*    standaloneBroker =
-    standaloneBroker.withEnv(
-        "ZEEBE_BROKER_EXPORTERS_OPTIMIZE_ARGS_INDEX_PREFIX", zeebeRecordPrefix);*/
   }
 
   private void destroyClient() {

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -50,7 +50,7 @@
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
     <identity.version>8.8.2</identity.version>
     <!-- We use this for the Zeebe test container version only -->
-    <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
+    <zeebe.docker.version>8.9</zeebe.docker.version>
 
     <!-- maven plugins -->
     <surefire-plugin.version>3.5.3</surefire-plugin.version>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Replace usage of `ZeebeContainer` in Optimize IT test suite with the `TestStandaloneBroker` spring application. Test suite is also more up to date as it was being tested against Zeebe 8.7 still.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41357 
