### PR TITLE
Adjust load test updating to reset then reuse values

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -307,7 +307,7 @@ jobs:
         run: >
           helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
-          --reuse-values
+          --reset-then-reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set orchestration.image.registry=gcr.io


### PR DESCRIPTION
## Description

* We allow updating our load tests
* As we now directly make use of the Platform chart from the GitHub repo (main branch), this means changes can happen in between on the Helm chart
* We need to reset the values and then reuse the previously used values
* Otherwise, templates might fail with weird nil errors, as reuse values wouldn't correctly reference the new values 

Example error:

```
Error: UPGRADE FAILED: template: camunda-platform/templates/orchestration/statefulset.yaml:29:28: executing "camunda-platform/templates/orchestration/statefulset.yaml" at <include (print $.Template.BasePath "/orchestration/configmap-unified.yaml") .>: error calling include: template: camunda-platform/templates/orchestration/configmap-unified.yaml:26:9: executing "camunda-platform/templates/orchestration/configmap-unified.yaml" at <include (print $.Template.BasePath "/orchestration/files/_application-unified.yaml") $>: error calling include: template: camunda-platform/templates/orchestration/files/_application-unified.yaml:24:16: executing "camunda-platform/templates/orchestration/files/_application-unified.yaml" at <.Values.orchestration.exporters.rdbms.enabled>: nil pointer evaluating interface {}.enabled
```

See for reference https://camunda.slack.com/archives/C06UWQNCU7M/p1764859482651549?thread_ts=1764768507.104179&cid=C06UWQNCU7M where our release load test update failed
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

See related thread https://camunda.slack.com/archives/C06UWQNCU7M/p1764768507104179
Or failed recreation of weekly load tests https://camunda.slack.com/archives/C013MEVQ4M9/p1765179568960569
