### PR TITLE
[Backport stable/optimize-8.7] fix: removing superficial dependency from Optimize

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
@@ -130,10 +130,10 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
-import org.apache.tika.utils.StringUtils;
 import org.elasticsearch.client.Request;
 import org.mockserver.integration.ClientAndServer;
 

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -122,11 +122,7 @@
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-      <version>2.9.2</version>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseClient.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.FailsafeExecutor;
 import net.jodah.failsafe.RetryPolicy;
-import org.apache.tika.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public abstract class DatabaseClient implements ConfigurationReloadable {


### PR DESCRIPTION
# Description
Backport of #42246 to `stable/optimize-8.7`.

relates to #42245