### PR TITLE
fix: Reduce OpenSearch Nightly Parallelisation

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -25,7 +25,10 @@ defaults:
 jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}. OS ver.${{ matrix.os_version }}"
-    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: write
+    timeout-minutes: 60
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -62,7 +65,7 @@ jobs:
             name: "Camunda QA Integration Module"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
             maven-build-threads: 2
-            maven-test-fork-count: 2
+            maven-test-fork-count: 7
             runs-on: aws-core-8-default
             owner: "General"
     steps:


### PR DESCRIPTION

## Description

This will reduce no of test files running at the same time and extend the overall run time. Given this is a nightly, the time limit does not really matter.

Also this will attempt to delete any existing indices prior to running tests to start from a clean slate.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
