### PR TITLE
build: Add Immutables annotation processor

### DIFF
--- a/testing/camunda-process-test-dsl/pom.xml
+++ b/testing/camunda-process-test-dsl/pom.xml
@@ -105,7 +105,39 @@
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <!-- required by javac detection logic in immutables -->
+            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+          </compilerArgs>
+          <fork>true</fork>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.immutables</groupId>
+                  <artifactId>value-processor</artifactId>
+                  <version>${version.immutables}</version>
+                </path>
+              </annotationProcessorPaths>
+              <annotationProcessors>
+                <processor>org.immutables.value.processor.Processor</processor>
+              </annotationProcessors>
+            </configuration>
+          </execution>
+        </executions>
+
+      </plugin>
+
     </plugins>
+
   </build>
 
 </project>


### PR DESCRIPTION
## Description

I added the Immutables annotation processor to generate the DSL. This is the same configuration as in `zeebe-protocol`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Fixes compile failures. 
