### PR TITLE
Add history deletion scheduler for `CamundaExporter`

### DIFF
--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
@@ -74,6 +74,9 @@ public abstract class SearchDBExtension implements BeforeAllCallback, AfterAllCa
   public static final BatchOperationTemplate BATCH_OPERATION_INDEX =
       new BatchOperationTemplate(IDX_BATCH_OPERATION_PREFIX, true);
 
+  public static final String HISTORY_DELETION_ID_PREFIX =
+      "historydeletion" + RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
+
   public static final String TEST_INTEGRATION_OPENSEARCH_AWS_URL =
       "test.integration.opensearch.aws.url";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/HistoryDeletionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/HistoryDeletionIndex.java
@@ -20,6 +20,7 @@ public class HistoryDeletionIndex extends AbstractIndexDescriptor implements Pri
   public static final String RESOURCE_KEY = "resourceKey";
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PARTITION_ID = "partitionId";
 
   public HistoryDeletionIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/HistoryDeletionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/HistoryDeletionEntity.java
@@ -24,6 +24,9 @@ public class HistoryDeletionEntity implements ExporterEntity<HistoryDeletionEnti
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private long batchOperationKey;
 
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private long partitionId;
+
   @Override
   public String getId() {
     return id;
@@ -62,6 +65,20 @@ public class HistoryDeletionEntity implements ExporterEntity<HistoryDeletionEnti
     return this;
   }
 
+  public long getPartitionId() {
+    return partitionId;
+  }
+
+  public HistoryDeletionEntity setPartitionId(final long partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, resourceKey, resourceType, batchOperationKey, partitionId);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (o == null || getClass() != o.getClass()) {
@@ -71,12 +88,8 @@ public class HistoryDeletionEntity implements ExporterEntity<HistoryDeletionEnti
     return resourceKey == that.resourceKey
         && batchOperationKey == that.batchOperationKey
         && Objects.equals(id, that.id)
-        && Objects.equals(resourceType, that.resourceType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(id, resourceKey, resourceType, batchOperationKey);
+        && Objects.equals(resourceType, that.resourceType)
+        && partitionId == that.partitionId;
   }
 
   @Override
@@ -92,6 +105,8 @@ public class HistoryDeletionEntity implements ExporterEntity<HistoryDeletionEnti
         + '\''
         + ", batchOperationKey="
         + batchOperationKey
+        + ", partitionId="
+        + partitionId
         + '}';
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-history-deletion.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-history-deletion.json
@@ -13,6 +13,9 @@
       },
       "batchOperationKey": {
         "type": "long"
+      },
+      "partitionId": {
+        "type": "integer"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-history-deletion.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-history-deletion.json
@@ -13,6 +13,9 @@
       },
       "batchOperationKey": {
         "type": "long"
+      },
+      "partitionId": {
+        "type": "integer"
       }
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandler.java
@@ -60,6 +60,7 @@ public class HistoryDeletionDeletedHandler
     entity.setBatchOperationKey(record.getBatchOperationReference());
     entity.setResourceKey(value.getResourceKey());
     entity.setResourceType(value.getResourceType());
+    entity.setPartitionId(record.getPartitionId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks;
 
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
+import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -26,6 +27,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
   private final ArchiverRepository archiverRepository;
   private final IncidentUpdateRepository incidentRepository;
   private final BatchOperationUpdateRepository batchOperationUpdateRepository;
+  private final HistoryDeletionRepository historyDeletionRepository;
   private final Logger logger;
   private final ScheduledThreadPoolExecutor executor;
   private final List<RunnableTask> tasks;
@@ -39,6 +41,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
       final @WillCloseWhenClosed ArchiverRepository archiverRepository,
       final @WillCloseWhenClosed IncidentUpdateRepository incidentRepository,
       final @WillCloseWhenClosed BatchOperationUpdateRepository batchOperationUpdateRepository,
+      final @WillCloseWhenClosed HistoryDeletionRepository historyDeletionRepository,
       final Logger logger,
       final @WillCloseWhenClosed ScheduledThreadPoolExecutor executor,
       final List<RunnableTask> tasks,
@@ -51,6 +54,9 @@ public final class BackgroundTaskManager implements CloseableSilently {
     this.batchOperationUpdateRepository =
         Objects.requireNonNull(
             batchOperationUpdateRepository, "must specify a batch operation update repository");
+    this.historyDeletionRepository =
+        Objects.requireNonNull(
+            historyDeletionRepository, "must specify a history deletion repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
     this.tasks = Objects.requireNonNull(tasks, "must specify tasks");
@@ -76,7 +82,8 @@ public final class BackgroundTaskManager implements CloseableSilently {
         error -> logger.warn("Failed to close resource for partition {}", partitionId, error),
         archiverRepository,
         incidentRepository,
-        batchOperationUpdateRepository);
+        batchOperationUpdateRepository,
+        historyDeletionRepository);
   }
 
   public void start() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -264,13 +264,14 @@ public final class BackgroundTaskManagerFactory {
 
   private OpenSearchHistoryDeletionRepository createHistoryDeletionRepository(
       final OpenSearchAsyncClient asyncClient) {
-    return new OpenSearchHistoryDeletionRepository(resourceProvider, asyncClient, executor, logger);
+    return new OpenSearchHistoryDeletionRepository(
+        resourceProvider, asyncClient, executor, logger, partitionId);
   }
 
   private ElasticsearchHistoryDeletionRepository createHistoryDeletionRepository(
       final ElasticsearchAsyncClient asyncClient) {
     return new ElasticsearchHistoryDeletionRepository(
-        resourceProvider, asyncClient, executor, logger);
+        resourceProvider, asyncClient, executor, logger, partitionId);
   }
 
   private ReschedulingTask buildRolloverPeriodJob() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -30,6 +30,10 @@ import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
 import io.camunda.exporter.tasks.batchoperations.ElasticsearchBatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.batchoperations.OpensearchBatchOperationUpdateRepository;
+import io.camunda.exporter.tasks.historydeletion.ElasticsearchHistoryDeletionRepository;
+import io.camunda.exporter.tasks.historydeletion.HistoryDeletionJob;
+import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository;
+import io.camunda.exporter.tasks.historydeletion.OpenSearchHistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.ElasticsearchIncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
@@ -72,6 +76,7 @@ public final class BackgroundTaskManagerFactory {
   private ArchiverRepository archiverRepository;
   private IncidentUpdateRepository incidentRepository;
   private BatchOperationUpdateRepository batchOperationUpdateRepository;
+  private HistoryDeletionRepository historyDeletionRepository;
   private final ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache;
 
   public BackgroundTaskManagerFactory(
@@ -108,6 +113,7 @@ public final class BackgroundTaskManagerFactory {
       archiverRepository = createArchiverRepository(asyncClient, genericClient);
       incidentRepository = createIncidentUpdateRepository(asyncClient);
       batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
+      historyDeletionRepository = createHistoryDeletionRepository(asyncClient);
     } else {
       final var connector = new ElasticsearchConnector(config.getConnect());
       final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
@@ -115,6 +121,7 @@ public final class BackgroundTaskManagerFactory {
       archiverRepository = createArchiverRepository(asyncClient);
       incidentRepository = createIncidentUpdateRepository(asyncClient);
       batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
+      historyDeletionRepository = createHistoryDeletionRepository(asyncClient);
     }
 
     final List<RunnableTask> tasks = buildTasks();
@@ -124,6 +131,7 @@ public final class BackgroundTaskManagerFactory {
         archiverRepository,
         incidentRepository,
         batchOperationUpdateRepository,
+        historyDeletionRepository,
         logger,
         executor,
         tasks,
@@ -248,8 +256,21 @@ public final class BackgroundTaskManagerFactory {
       }
     }
 
+    tasks.add(buildHistoryDeletionJob());
+
     executor.setCorePoolSize(tasks.size());
     return tasks;
+  }
+
+  private OpenSearchHistoryDeletionRepository createHistoryDeletionRepository(
+      final OpenSearchAsyncClient asyncClient) {
+    return new OpenSearchHistoryDeletionRepository(resourceProvider, asyncClient, executor, logger);
+  }
+
+  private ElasticsearchHistoryDeletionRepository createHistoryDeletionRepository(
+      final ElasticsearchAsyncClient asyncClient) {
+    return new ElasticsearchHistoryDeletionRepository(
+        resourceProvider, asyncClient, executor, logger);
   }
 
   private ReschedulingTask buildRolloverPeriodJob() {
@@ -371,6 +392,22 @@ public final class BackgroundTaskManagerFactory {
         config.getHistory().getMaxDelayBetweenRuns(),
         executor,
         logger);
+  }
+
+  private ReschedulingTask buildHistoryDeletionJob() {
+    final var dependantTemplates = new ArrayList<ProcessInstanceDependant>();
+    resourceProvider.getIndexTemplateDescriptors().stream()
+        .filter(ProcessInstanceDependant.class::isInstance)
+        .map(ProcessInstanceDependant.class::cast)
+        .forEach(dependantTemplates::add);
+
+    return buildHistoryDeletionTask(
+        new HistoryDeletionJob(dependantTemplates, executor, historyDeletionRepository, logger));
+  }
+
+  private ReschedulingTask buildHistoryDeletionTask(final BackgroundTask task) {
+    // TODO make hardcoded values configurable
+    return new ReschedulingTask(task, 1, 1000, 60000, executor, logger);
   }
 
   private ScheduledThreadPoolExecutor buildExecutor() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.tasks.util.ElasticsearchRepository;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.annotation.WillCloseWhenClosed;
+import org.slf4j.Logger;
+
+/**
+ * Elasticsearch implementation of {@link HistoryDeletionRepository} that queries the
+ * history-deletion index for resources marked for deletion, filtering by partition ID.
+ */
+public class ElasticsearchHistoryDeletionRepository extends ElasticsearchRepository
+    implements HistoryDeletionRepository {
+
+  private final IndexDescriptor indexDescriptor;
+
+  public ElasticsearchHistoryDeletionRepository(
+      final ExporterResourceProvider resourceProvider,
+      @WillCloseWhenClosed final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final Logger logger) {
+    super(client, executor, logger);
+    indexDescriptor =
+        resourceProvider.getIndexDescriptors().stream()
+            .filter(HistoryDeletionIndex.class::isInstance)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException("No HistoryDeletionIndex descriptor found"));
+  }
+
+  @Override
+  public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
+    final var searchRequest = createSearchRequest();
+
+    return client
+        .search(searchRequest, Object.class)
+        .thenComposeAsync(
+            (response) -> {
+              final var hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
+              }
+              final var ids = hits.stream().map(Hit::id).toList();
+              return CompletableFuture.completedFuture(new HistoryDeletionBatch(ids));
+            },
+            executor);
+  }
+
+  private SearchRequest createSearchRequest() {
+    return createSearchRequest(indexDescriptor.getFullQualifiedName());
+  }
+
+  private SearchRequest createSearchRequest(final String indexName) {
+    logger.trace("Create search request against index '{}'", indexName);
+
+    return new SearchRequest.Builder()
+        .index(indexName)
+        .requestCache(false)
+        .source(source -> source.fetch(false))
+        .size(100) // TODO add configurable values
+        .sort(s -> s.field(f -> f.field("id").order(SortOrder.Asc)))
+        .build();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
-import java.util.List;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import java.util.Map;
 
 /**
  * Represents a batch of resource IDs to be deleted from the history.
  *
- * @param ids list of resource IDs marked for deletion
+ * @param ids Map of resource IDs marked for deletion and their corresponding deletion type.
  */
-public record HistoryDeletionBatch(List<String> ids) {}
+public record HistoryDeletionBatch(Map<String, HistoryDeletionType> ids) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import java.util.List;
+
+/**
+ * Represents a batch of resource IDs to be deleted from the history.
+ *
+ * @param ids list of resource IDs marked for deletion
+ */
+public record HistoryDeletionBatch(List<String> ids) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import io.camunda.exporter.tasks.BackgroundTask;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+/**
+ * Background task that queries the history-deletion index for resources marked for deletion and
+ * deletes the corresponding data from secondary storage. Work is distributed across partitions to
+ * balance the deletion load.
+ *
+ * <p>The job interacts with the history-deletion index to identify resources scheduled for
+ * deletion, and executes deletion requests in batches, partitioned by partition ID to ensure
+ * balanced processing.
+ */
+public class HistoryDeletionJob implements BackgroundTask {
+  private final List<ProcessInstanceDependant> processInstanceDependants;
+  private final Executor executor;
+  private final HistoryDeletionRepository deleterRepository;
+  private final Logger logger;
+
+  public HistoryDeletionJob(
+      final List<ProcessInstanceDependant> processInstanceDependants,
+      final Executor executor,
+      final HistoryDeletionRepository historyDeletionRepository,
+      final Logger logger) {
+    this.processInstanceDependants =
+        processInstanceDependants.stream()
+            .sorted(Comparator.comparing(ProcessInstanceDependant::getFullQualifiedName))
+            .toList(); // sort to ensure the execution order is stable
+    this.executor = executor;
+    deleterRepository = historyDeletionRepository;
+    this.logger = logger;
+  }
+
+  @Override
+  public CompletionStage<Integer> execute() {
+    return deleterRepository.getNextBatch().thenComposeAsync(this::deleteBatch, executor);
+  }
+
+  private CompletionStage<Integer> deleteBatch(final HistoryDeletionBatch batch) {
+    logger.debug("Deleting history for process instances with ids: {}", batch.ids());
+    // TODO perform actual deletion
+    //  ES: https://github.com/camunda/camunda/issues/41105
+    //  OS: https://github.com/camunda/camunda/issues/41109
+    return CompletableFuture.completedFuture(0);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -51,7 +51,7 @@ public class HistoryDeletionJob implements BackgroundTask {
   }
 
   private CompletionStage<Integer> deleteBatch(final HistoryDeletionBatch batch) {
-    logger.debug("Deleting history for process instances with ids: {}", batch.ids());
+    logger.trace("Deleting history for process instances with ids: {}", batch.ids());
     // TODO perform actual deletion
     //  ES: https://github.com/camunda/camunda/issues/41105
     //  OS: https://github.com/camunda/camunda/issues/41109

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** Repository for querying and managing history deletion requests. */
@@ -28,7 +28,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
     public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
-      return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
+      return CompletableFuture.completedFuture(new HistoryDeletionBatch(Map.of()));
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/** Repository for querying and managing history deletion requests. */
+public interface HistoryDeletionRepository extends AutoCloseable {
+
+  /**
+   * Retrieves the next batch of resource IDs to be deleted.
+   *
+   * <p>The batch should be sorted by id and filtered by partition id. The sorting ensures older
+   * deletion requests are handled first. The filter ensures that the deletion load is distributed
+   * fairly amongst partitions.
+   *
+   * @return a {@link CompletableFuture} containing a {@link HistoryDeletionBatch} of resource IDs,
+   *     or an empty batch if none are available
+   */
+  CompletableFuture<HistoryDeletionBatch> getNextBatch();
+
+  class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
+    @Override
+    public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
+      return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
+    }
+
+    @Override
+    public void close() throws Exception {}
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.tasks.util.OpensearchRepository;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.zeebe.exporter.api.ExporterException;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.annotation.WillCloseWhenClosed;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.slf4j.Logger;
+
+/**
+ * OpenSearch implementation of {@link HistoryDeletionRepository} that queries the history-deletion
+ * index for resources marked for deletion, filtering by partition ID.
+ */
+public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
+    implements HistoryDeletionRepository {
+
+  private final IndexDescriptor indexDescriptor;
+
+  public OpenSearchHistoryDeletionRepository(
+      final ExporterResourceProvider resourceProvider,
+      @WillCloseWhenClosed final OpenSearchAsyncClient client,
+      final Executor executor,
+      final Logger logger) {
+    super(client, executor, logger);
+    indexDescriptor =
+        resourceProvider.getIndexDescriptors().stream()
+            .filter(HistoryDeletionIndex.class::isInstance)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException("No HistoryDeletionIndex descriptor found"));
+  }
+
+  @Override
+  public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
+    final var searchRequest = createSearchRequest();
+
+    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
+        .thenComposeAsync(
+            (response) -> {
+              final var hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
+              }
+              final var ids = hits.stream().map(Hit::id).toList();
+              return CompletableFuture.completedFuture(new HistoryDeletionBatch(ids));
+            },
+            executor);
+  }
+
+  private SearchRequest createSearchRequest() {
+    return createSearchRequest(indexDescriptor.getFullQualifiedName());
+  }
+
+  private SearchRequest createSearchRequest(final String indexName) {
+    logger.trace("Create search request against index '{}'", indexName);
+
+    return new SearchRequest.Builder()
+        .index(indexName)
+        .requestCache(false)
+        .source(source -> source.fetch(false))
+        .size(100) // TODO add configurable values
+        .sort(s -> s.field(f -> f.field("id").order(SortOrder.Asc)))
+        .build();
+  }
+
+  private <T> CompletableFuture<T> sendRequestAsync(final RequestSender<T> sender) {
+    try {
+      return sender.sendRequest();
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(
+          new ExporterException(
+              "Failed to send request, likely because we failed to parse the request", e));
+    }
+  }
+
+  @FunctionalInterface
+  private interface RequestSender<T> {
+    CompletableFuture<T> sendRequest() throws IOException;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -22,6 +22,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,8 +64,11 @@ final class CamundaExporterTest {
     mockedClientAdapterFactory
         .when(() -> ClientAdapter.of(configuration.getConnect()))
         .thenReturn(stubbedClientAdapterInUse);
-    doReturn(emptyList()).when(resourceProvider).getIndexDescriptors();
+    doReturn(List.of(new HistoryDeletionIndex("", true)))
+        .when(resourceProvider)
+        .getIndexDescriptors();
     doReturn(emptyList()).when(resourceProvider).getIndexTemplateDescriptors();
+    configuration.setCreateSchema(false);
   }
 
   @AfterEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -22,6 +22,7 @@ import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricTUArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
+import io.camunda.exporter.tasks.historydeletion.HistoryDeletionJob;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
@@ -164,14 +165,15 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should always schedule incident and usage metrics tasks regardless of PI config")
-        .hasSize(7)
+        .hasSize(8)
         .anyMatch(task -> isTaskOfType(task, IncidentUpdateTask.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricTUArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, StandaloneDecisionArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, BatchOperationArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, BatchOperationUpdateTask.class))
-        .anyMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
+        .anyMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class))
+        .anyMatch(task -> isTaskOfType(task, HistoryDeletionJob.class));
   }
 
   @Test
@@ -186,7 +188,7 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should not schedule ApplyRolloverPeriodJob when retention is disabled")
-        .hasSize(8)
+        .hasSize(9)
         .noneMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
   }
 
@@ -202,7 +204,7 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should schedule ApplyRolloverPeriodJob when retention is enabled")
-        .hasSize(9)
+        .hasSize(10)
         .anyMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NoopBatchOperationUpdateRepository;
+import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository.NoopHistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
 import java.time.Duration;
 import java.util.List;
@@ -38,6 +39,7 @@ final class BackgroundTaskManagerTest {
             new NoopArchiverRepository(),
             new NoopIncidentUpdateRepository(),
             new NoopBatchOperationUpdateRepository(),
+            new NoopHistoryDeletionRepository(),
             LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
             executor,
             // return unfinished futures to have a deterministic count of submitted tasks
@@ -97,6 +99,8 @@ final class BackgroundTaskManagerTest {
         new CloseableIncidentRepository();
     private final CloseableBatchOperationUpdateRepository batchOperationUpdateRepository =
         new CloseableBatchOperationUpdateRepository();
+    private final CloseableHistoryDeletionRepository historyDeletionRepository =
+        new CloseableHistoryDeletionRepository();
     private volatile boolean taskClosed = false;
     private volatile boolean keepRunningEvenIfClosed = false;
     private final RunnableTask task =
@@ -124,6 +128,7 @@ final class BackgroundTaskManagerTest {
             archiverRepository,
             incidentRepository,
             batchOperationUpdateRepository,
+            historyDeletionRepository,
             LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
             executor,
             tasks,
@@ -170,6 +175,7 @@ final class BackgroundTaskManagerTest {
       assertThat(archiverRepository.isClosed).isTrue();
       assertThat(incidentRepository.isClosed).isTrue();
       assertThat(batchOperationUpdateRepository.isClosed).isTrue();
+      assertThat(historyDeletionRepository.isClosed).isTrue();
     }
 
     @Test
@@ -194,6 +200,15 @@ final class BackgroundTaskManagerTest {
     void shouldNotThrowOnBatchOperationUpdateRepositoryCloseError() {
       // given
       batchOperationUpdateRepository.exception = new RuntimeException("foo");
+
+      // when
+      assertThatCode(taskManager::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowOnHistoryDeletionRepositoryCloseError() {
+      // given
+      historyDeletionRepository.exception = new RuntimeException("foo");
 
       // when
       assertThatCode(taskManager::close).doesNotThrowAnyException();
@@ -229,6 +244,21 @@ final class BackgroundTaskManagerTest {
 
     private static final class CloseableBatchOperationUpdateRepository
         extends NoopBatchOperationUpdateRepository {
+      private boolean isClosed;
+      private Exception exception;
+
+      @Override
+      public void close() throws Exception {
+        if (exception != null) {
+          throw exception;
+        }
+
+        isClosed = true;
+      }
+    }
+
+    private static final class CloseableHistoryDeletionRepository
+        extends NoopHistoryDeletionRepository {
       private boolean isClosed;
       private Exception exception;
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@DisabledIfSystemProperty(
+    named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+    matches = "^(?=\\s*\\S).*$",
+    disabledReason = "Excluding from AWS OS IT CI")
+public class ElasticsearchHistoryDeletionRepositoryIT extends HistoryDeletionRepositoryIT {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchHistoryDeletionRepositoryIT.class);
+  private final ElasticsearchAsyncClient client;
+
+  public ElasticsearchHistoryDeletionRepositoryIT() {
+    super("http://" + searchDB.esUrl(), true);
+    final var connector = new ElasticsearchConnector(config.getConnect());
+    client = connector.createAsyncClient();
+  }
+
+  @Override
+  protected HistoryDeletionRepository createRepository(
+      final String indexPrefix, final int partitionId) {
+    return new ElasticsearchHistoryDeletionRepository(
+        new TestExporterResourceProvider(indexPrefix, true),
+        client,
+        Runnable::run,
+        LOGGER,
+        partitionId);
+  }
+
+  @Override
+  protected void index(final HistoryDeletionEntity entity) {
+    client
+        .index(
+            b ->
+                b.index(historyDeletionIndex.getFullQualifiedName())
+                    .document(entity)
+                    .id(entity.getId()))
+        .join();
+    client.indices().refresh(r -> r.index(historyDeletionIndex.getFullQualifiedName())).join();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
@@ -18,6 +18,7 @@ import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
@@ -81,6 +82,7 @@ abstract class HistoryDeletionRepositoryIT {
     final var entity = new HistoryDeletionEntity();
     entity.setId(id);
     entity.setPartitionId(partitionId);
+    entity.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
     index(entity);
   }
 
@@ -97,7 +99,7 @@ abstract class HistoryDeletionRepositoryIT {
     assertThat(future)
         .succeedsWithin(REQUEST_TIMEOUT)
         .extracting(HistoryDeletionBatch::ids)
-        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
         .isEmpty();
   }
 
@@ -114,8 +116,9 @@ abstract class HistoryDeletionRepositoryIT {
     assertThat(future)
         .succeedsWithin(REQUEST_TIMEOUT)
         .extracting(HistoryDeletionBatch::ids)
-        .asInstanceOf(InstanceOfAssertFactories.LIST)
-        .containsExactly(entityId);
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .hasSize(1)
+        .containsEntry(entityId, HistoryDeletionType.PROCESS_INSTANCE);
   }
 
   @Test
@@ -131,7 +134,7 @@ abstract class HistoryDeletionRepositoryIT {
     assertThat(future)
         .succeedsWithin(REQUEST_TIMEOUT)
         .extracting(HistoryDeletionBatch::ids)
-        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
         .isEmpty();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import static io.camunda.search.test.utils.SearchDBExtension.HISTORY_DELETION_ID_PREFIX;
+import static io.camunda.search.test.utils.SearchDBExtension.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.schema.SearchEngineClient;
+import io.camunda.search.schema.config.IndexConfiguration;
+import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class HistoryDeletionRepositoryIT {
+
+  public static final int PARTITION_ID = 1;
+  @RegisterExtension protected static SearchDBExtension searchDB = create();
+  private static final Logger LOGGER = LoggerFactory.getLogger(HistoryDeletionRepositoryIT.class);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  protected final HistoryDeletionIndex historyDeletionIndex;
+  @AutoClose protected final ClientAdapter clientAdapter;
+  protected final SearchEngineClient engineClient;
+  protected final ExporterConfiguration config;
+  private HistoryDeletionRepository repository;
+  private final String indexPrefix;
+
+  public HistoryDeletionRepositoryIT(final String databaseUrl, final boolean isElastic) {
+    config = new ExporterConfiguration();
+    indexPrefix = HISTORY_DELETION_ID_PREFIX + UUID.randomUUID();
+    config.getConnect().setIndexPrefix(indexPrefix);
+    config.getConnect().setUrl(databaseUrl);
+    config.getConnect().setType(isElastic ? "elasticsearch" : "opensearch");
+    config.getConnect().setAwsEnabled(searchDB.isAws());
+
+    clientAdapter = ClientAdapter.of(config.getConnect());
+    engineClient = clientAdapter.getSearchEngineClient();
+
+    historyDeletionIndex = new HistoryDeletionIndex(indexPrefix, isElastic);
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    engineClient.createIndex(historyDeletionIndex, new IndexConfiguration());
+    repository = createRepository(indexPrefix, PARTITION_ID);
+  }
+
+  @AfterEach
+  void afterEach() {
+    engineClient.deleteIndex(historyDeletionIndex.getFullQualifiedName());
+    engineClient.createIndex(historyDeletionIndex, new IndexConfiguration());
+  }
+
+  protected abstract HistoryDeletionRepository createRepository(
+      final String indexPrefix, final int partitionId);
+
+  private void createHistoryDeletionEntity(final String id) throws IOException {
+    createHistoryDeletionEntity(id, PARTITION_ID);
+  }
+
+  private void createHistoryDeletionEntity(final String id, final int partitionId)
+      throws IOException {
+    final var entity = new HistoryDeletionEntity();
+    entity.setId(id);
+    entity.setPartitionId(partitionId);
+    index(entity);
+  }
+
+  protected abstract void index(final HistoryDeletionEntity entity) throws IOException;
+
+  @Test
+  void shouldGetEmptyListWhenNoEntitiesToDelete() {
+    // given - no entities
+
+    // when
+    final var future = repository.getNextBatch();
+
+    // then
+    assertThat(future)
+        .succeedsWithin(REQUEST_TIMEOUT)
+        .extracting(HistoryDeletionBatch::ids)
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .isEmpty();
+  }
+
+  @Test
+  void shouldGetEntitiesToDelete() throws IOException {
+    // given
+    final var entityId = UUID.randomUUID().toString();
+    createHistoryDeletionEntity(entityId);
+
+    // when
+    final var future = repository.getNextBatch();
+
+    // then
+    assertThat(future)
+        .succeedsWithin(REQUEST_TIMEOUT)
+        .extracting(HistoryDeletionBatch::ids)
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .containsExactly(entityId);
+  }
+
+  @Test
+  void shouldNotFindEntitiesForOtherPartitions() throws IOException {
+    // given
+    final var entityId = UUID.randomUUID().toString();
+    createHistoryDeletionEntity(entityId, 2);
+
+    // when
+    final var future = repository.getNextBatch();
+
+    // then
+    assertThat(future)
+        .succeedsWithin(REQUEST_TIMEOUT)
+        .extracting(HistoryDeletionBatch::ids)
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .isEmpty();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import java.io.IOException;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenSearchHistoryDeletionIT extends HistoryDeletionRepositoryIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchHistoryDeletionIT.class);
+  private final OpenSearchAsyncClient client;
+
+  public OpenSearchHistoryDeletionIT() {
+    super(searchDB.osUrl(), false);
+    final var connector = new OpensearchConnector(config.getConnect());
+    client = connector.createAsyncClient();
+  }
+
+  @Override
+  protected HistoryDeletionRepository createRepository(
+      final String indexPrefix, final int partitionId) {
+    return new OpenSearchHistoryDeletionRepository(
+        new TestExporterResourceProvider(indexPrefix, false),
+        client,
+        Runnable::run,
+        LOGGER,
+        partitionId);
+  }
+
+  @Override
+  protected void index(final HistoryDeletionEntity entity) throws IOException {
+    client
+        .index(
+            b ->
+                b.index(historyDeletionIndex.getFullQualifiedName())
+                    .document(entity)
+                    .id(entity.getId()))
+        .join();
+    client.indices().refresh(r -> r.index(historyDeletionIndex.getFullQualifiedName())).join();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The scheduler introduces here will query the history-deletion index for resources that need to be deleted, and will go on to delete this data from secondary storage. This is used when a user triggers a deletion request.

The job queries data from ES/OS, sorting it by id and filtering on partition id. The sorting is done so we delete the data that was requested for deletion earlier first. The partition id is to distribute the deletion load between the different partitions. Note that the deletion of the data itself is not within the scope of this PR.

❗As part of the issue the parameters surrounding the job scheduling should've been configurable. However, as the PR is already becoming quite large I will do this in a separate PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41516 
