### PR TITLE
[Backport stable/8.8] Don't apply `group id` restrictions when BYOGroups is enabled

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -8,13 +8,10 @@
 package io.camunda.security.configuration;
 
 import io.camunda.security.entity.AuthenticationMethod;
-import java.util.regex.Pattern;
 
 public class AuthenticationConfiguration {
   public static final AuthenticationMethod DEFAULT_METHOD = AuthenticationMethod.BASIC;
   public static final boolean DEFAULT_UNPROTECTED_API = false;
-
-  public static final Pattern DEFAULT_EXTERNAL_ID_REGEX = Pattern.compile(".*", Pattern.DOTALL);
 
   private AuthenticationMethod method = DEFAULT_METHOD;
   private String authenticationRefreshInterval = "PT30S";
@@ -62,10 +59,5 @@ public class AuthenticationConfiguration {
 
   public void setProviders(final ProvidersConfiguration providers) {
     this.providers = providers;
-  }
-
-  public boolean areGroupsManagedExternally() {
-    final var groupsClaim = getOidc().getGroupsClaim();
-    return groupsClaim != null && !groupsClaim.isEmpty();
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -8,10 +8,13 @@
 package io.camunda.security.configuration;
 
 import io.camunda.security.entity.AuthenticationMethod;
+import java.util.regex.Pattern;
 
 public class AuthenticationConfiguration {
   public static final AuthenticationMethod DEFAULT_METHOD = AuthenticationMethod.BASIC;
   public static final boolean DEFAULT_UNPROTECTED_API = false;
+
+  public static final Pattern DEFAULT_EXTERNAL_ID_REGEX = Pattern.compile(".*", Pattern.DOTALL);
 
   private AuthenticationMethod method = DEFAULT_METHOD;
   private String authenticationRefreshInterval = "PT30S";

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -60,4 +60,9 @@ public class AuthenticationConfiguration {
   public void setProviders(final ProvidersConfiguration providers) {
     this.providers = providers;
   }
+
+  public boolean areGroupsManagedExternally() {
+    final var groupsClaim = getOidc().getGroupsClaim();
+    return groupsClaim != null && !groupsClaim.isEmpty();
+  }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -15,6 +15,8 @@ public class SecurityConfiguration {
   /** 1 or more alphanumeric characters, '_', '@', '.', '+', '-' or '~'. */
   public static final String DEFAULT_ID_REGEX = "^[a-zA-Z0-9_~@.+-]+$";
 
+  public static final Pattern DEFAULT_EXTERNAL_ID_REGEX = Pattern.compile(".*", Pattern.DOTALL);
+
   private AuthenticationConfiguration authentication = new AuthenticationConfiguration();
   private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();
   private InitializationConfiguration initialization = new InitializationConfiguration();
@@ -108,5 +110,13 @@ public class SecurityConfiguration {
       compiledIdValidationPattern = Pattern.compile(idValidationPattern);
     }
     return compiledIdValidationPattern;
+  }
+
+  public Pattern getCompiledGroupIdValidationPattern() {
+    final var groupsClaim = getAuthentication().getOidc().getGroupsClaim();
+    if (groupsClaim != null && !groupsClaim.isEmpty()) {
+      return DEFAULT_EXTERNAL_ID_REGEX;
+    }
+    return getCompiledIdValidationPattern();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.tenant;
 
-import static io.camunda.security.configuration.AuthenticationConfiguration.DEFAULT_EXTERNAL_ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.GroupQuery;
@@ -170,15 +169,11 @@ public class TenantController {
   @CamundaPutMapping(path = "/{tenantId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
       @PathVariable final String tenantId, @PathVariable final String groupId) {
-    final boolean areGroupsManagedExternally =
-        securityConfiguration.getAuthentication().areGroupsManagedExternally();
     return RequestMapper.toTenantMemberRequest(
             tenantId,
             groupId,
             EntityType.GROUP,
-            areGroupsManagedExternally
-                ? DEFAULT_EXTERNAL_ID_REGEX
-                : securityConfiguration.getCompiledIdValidationPattern())
+            securityConfiguration.getCompiledGroupIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -249,7 +249,7 @@ public class TenantController {
             tenantId,
             groupId,
             EntityType.GROUP,
-            securityConfiguration.getCompiledIdValidationPattern())
+            securityConfiguration.getCompiledGroupIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -170,7 +170,8 @@ public class TenantController {
   @CamundaPutMapping(path = "/{tenantId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
       @PathVariable final String tenantId, @PathVariable final String groupId) {
-    final boolean areGroupsManagedExternally = areGroupsManagedExternally();
+    final boolean areGroupsManagedExternally =
+        securityConfiguration.getAuthentication().areGroupsManagedExternally();
     return RequestMapper.toTenantMemberRequest(
             tenantId,
             groupId,
@@ -476,18 +477,5 @@ public class TenantController {
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .updateTenant(tenantRequest),
         ResponseMapper::toTenantUpdateResponse);
-  }
-
-  private boolean areGroupsManagedExternally() {
-    final var authentication = securityConfiguration.getAuthentication();
-    if (authentication == null) {
-      return false;
-    }
-    final var oidcConfiguration = authentication.getOidc();
-    if (oidcConfiguration == null) {
-      return false;
-    }
-    final var groupsClaim = oidcConfiguration.getGroupsClaim();
-    return groupsClaim != null && !groupsClaim.isEmpty();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryResponseMapper;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -169,11 +170,14 @@ public class TenantController {
   @CamundaPutMapping(path = "/{tenantId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
       @PathVariable final String tenantId, @PathVariable final String groupId) {
+    final boolean areGroupsManagedExternally = areGroupsManagedExternally();
     return RequestMapper.toTenantMemberRequest(
             tenantId,
             groupId,
             EntityType.GROUP,
-            securityConfiguration.getCompiledIdValidationPattern())
+            areGroupsManagedExternally
+                ? Pattern.compile(".*", Pattern.DOTALL)
+                : securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -472,5 +476,18 @@ public class TenantController {
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .updateTenant(tenantRequest),
         ResponseMapper::toTenantUpdateResponse);
+  }
+
+  private boolean areGroupsManagedExternally() {
+    final var authentication = securityConfiguration.getAuthentication();
+    if (authentication == null) {
+      return false;
+    }
+    final var oidcConfiguration = authentication.getOidc();
+    if (oidcConfiguration == null) {
+      return false;
+    }
+    final var groupsClaim = oidcConfiguration.getGroupsClaim();
+    return groupsClaim != null && !groupsClaim.isEmpty();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.tenant;
 
+import static io.camunda.security.configuration.AuthenticationConfiguration.DEFAULT_EXTERNAL_ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.GroupQuery;
@@ -53,7 +54,6 @@ import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryResponseMapper;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Pattern;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -177,7 +177,7 @@ public class TenantController {
             groupId,
             EntityType.GROUP,
             areGroupsManagedExternally
-                ? Pattern.compile(".*", Pattern.DOTALL)
+                ? DEFAULT_EXTERNAL_ID_REGEX
                 : securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -327,7 +327,8 @@ public class RoleController {
             roleId,
             groupId,
             EntityType.GROUP,
-            securityConfiguration.getCompiledIdValidationPattern())
+            securityConfiguration.getCompiledIdValidationPattern(),
+            securityConfiguration.getCompiledGroupIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
+import static io.camunda.security.configuration.AuthenticationConfiguration.DEFAULT_EXTERNAL_ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.MappingRuleQuery;
@@ -43,7 +44,6 @@ import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryResponseMapper;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Pattern;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -266,7 +266,7 @@ public class RoleController {
             groupId,
             EntityType.GROUP,
             areGroupsManagedExternally
-                ? Pattern.compile(".*", Pattern.DOTALL)
+                ? DEFAULT_EXTERNAL_ID_REGEX
                 : securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -259,7 +259,8 @@ public class RoleController {
   @CamundaPutMapping(path = "/{roleId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
-    final boolean areGroupsManagedExternally = areGroupsManagedExternally();
+    final boolean areGroupsManagedExternally =
+        securityConfiguration.getAuthentication().areGroupsManagedExternally();
     return RequestMapper.toRoleMemberRequest(
             roleId,
             groupId,
@@ -367,18 +368,5 @@ public class RoleController {
             roleServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .removeMember(request));
-  }
-
-  private boolean areGroupsManagedExternally() {
-    final var authentication = securityConfiguration.getAuthentication();
-    if (authentication == null) {
-      return false;
-    }
-    final var oidcConfiguration = authentication.getOidc();
-    if (oidcConfiguration == null) {
-      return false;
-    }
-    final var groupsClaim = oidcConfiguration.getGroupsClaim();
-    return groupsClaim != null && !groupsClaim.isEmpty();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -259,12 +259,12 @@ public class RoleController {
   @CamundaPutMapping(path = "/{roleId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
-    final boolean hasGroupClaimConfigured = hasGroupClaimConfigured();
+    final boolean areGroupsManagedExternally = areGroupsManagedExternally();
     return RequestMapper.toRoleMemberRequest(
             roleId,
             groupId,
             EntityType.GROUP,
-            hasGroupClaimConfigured
+            areGroupsManagedExternally
                 ? Pattern.compile(".*", Pattern.DOTALL)
                 : securityConfiguration.getCompiledIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
@@ -369,7 +369,7 @@ public class RoleController {
                 .removeMember(request));
   }
 
-  private boolean hasGroupClaimConfigured() {
+  private boolean areGroupsManagedExternally() {
     final var authentication = securityConfiguration.getAuthentication();
     if (authentication == null) {
       return false;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -13,13 +13,11 @@ import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
-import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleClientSearchQueryRequest;
@@ -60,9 +58,7 @@ public class RoleController {
 
   public RoleController(
       final RoleServices roleServices,
-      final UserServices userServices,
       final MappingRuleServices mappingServices,
-      final GroupServices groupServices,
       final CamundaAuthenticationProvider authenticationProvider,
       final SecurityConfiguration securityConfiguration) {
     this.roleServices = roleServices;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
-import static io.camunda.security.configuration.AuthenticationConfiguration.DEFAULT_EXTERNAL_ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.MappingRuleQuery;
@@ -259,15 +258,12 @@ public class RoleController {
   @CamundaPutMapping(path = "/{roleId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToGroup(
       @PathVariable final String roleId, @PathVariable final String groupId) {
-    final boolean areGroupsManagedExternally =
-        securityConfiguration.getAuthentication().areGroupsManagedExternally();
     return RequestMapper.toRoleMemberRequest(
             roleId,
             groupId,
             EntityType.GROUP,
-            areGroupsManagedExternally
-                ? DEFAULT_EXTERNAL_ID_REGEX
-                : securityConfiguration.getCompiledIdValidationPattern())
+            securityConfiguration.getCompiledIdValidationPattern(),
+            securityConfiguration.getCompiledGroupIdValidationPattern())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/RequestMapper.java
@@ -336,7 +336,20 @@ public class RequestMapper {
       final EntityType entityType,
       final Pattern identifierPattern) {
     return getResult(
-        RoleRequestValidator.validateMemberRequest(roleId, memberId, entityType, identifierPattern),
+        RoleRequestValidator.validateMemberRequest(
+            roleId, memberId, entityType, identifierPattern, identifierPattern),
+        () -> new RoleMemberRequest(roleId, memberId, entityType));
+  }
+
+  public static Either<ProblemDetail, RoleMemberRequest> toRoleMemberRequest(
+      final String roleId,
+      final String memberId,
+      final EntityType entityType,
+      final Pattern roleIdentifierPattern,
+      final Pattern memberIdentifierPattern) {
+    return getResult(
+        RoleRequestValidator.validateMemberRequest(
+            roleId, memberId, entityType, roleIdentifierPattern, memberIdentifierPattern),
         () -> new RoleMemberRequest(roleId, memberId, entityType));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RoleRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RoleRequestValidator.java
@@ -42,11 +42,12 @@ public final class RoleRequestValidator {
       final String roleId,
       final String memberId,
       final EntityType memberType,
-      final Pattern identifierPattern) {
+      final Pattern roleIdentifierPattern,
+      final Pattern memberIdentifierPattern) {
     return validate(
         violations -> {
-          validateRoleId(roleId, violations, identifierPattern);
-          validateMemberId(memberId, memberType, violations, identifierPattern);
+          validateRoleId(roleId, violations, roleIdentifierPattern);
+          validateMemberId(memberId, memberType, violations, memberIdentifierPattern);
         });
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.tenant;
 
+import static io.camunda.security.configuration.SecurityConfiguration.DEFAULT_EXTERNAL_ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration.TENANTS_API_DISABLED_ERROR_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -16,8 +17,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.AuthenticationConfiguration;
-import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
@@ -76,7 +75,6 @@ public class TenantControllerTest {
     @MockitoBean private RoleServices roleServices;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
     @MockitoBean private SecurityConfiguration securityConfiguration;
-    private AuthenticationConfiguration authenticationConfiguration;
 
     @BeforeEach
     void setup() {
@@ -85,8 +83,7 @@ public class TenantControllerTest {
       when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(tenantServices);
       when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
-      authenticationConfiguration = new AuthenticationConfiguration();
-      when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+      when(securityConfiguration.getCompiledGroupIdValidationPattern()).thenReturn(ID_PATTERN);
     }
 
     @ParameterizedTest
@@ -638,10 +635,8 @@ public class TenantControllerTest {
       final var groupId = "group id";
       final var request = new TenantMemberRequest(tenantId, groupId, EntityType.GROUP);
 
-      final var oidcConfiguration = new OidcAuthenticationConfiguration();
-      oidcConfiguration.setGroupsClaim("groups");
-      authenticationConfiguration.setOidc(oidcConfiguration);
-
+      when(securityConfiguration.getCompiledGroupIdValidationPattern())
+          .thenReturn(DEFAULT_EXTERNAL_ID_REGEX);
       when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
       // when

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -76,6 +76,7 @@ public class TenantControllerTest {
     @MockitoBean private RoleServices roleServices;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
     @MockitoBean private SecurityConfiguration securityConfiguration;
+    private AuthenticationConfiguration authenticationConfiguration;
 
     @BeforeEach
     void setup() {
@@ -84,6 +85,8 @@ public class TenantControllerTest {
       when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(tenantServices);
       when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
+      authenticationConfiguration = new AuthenticationConfiguration();
+      when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
     }
 
     @ParameterizedTest
@@ -635,12 +638,10 @@ public class TenantControllerTest {
       final var groupId = "group id";
       final var request = new TenantMemberRequest(tenantId, groupId, EntityType.GROUP);
 
-      final var authenticationConfiguration = new AuthenticationConfiguration();
       final var oidcConfiguration = new OidcAuthenticationConfiguration();
       oidcConfiguration.setGroupsClaim("groups");
       authenticationConfiguration.setOidc(oidcConfiguration);
 
-      when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
       when(tenantServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
       // when

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -58,6 +58,7 @@ public class RoleControllerTest extends RestControllerTest {
   @MockitoBean private GroupServices groupServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean private SecurityConfiguration securityConfiguration;
+  private AuthenticationConfiguration authenticationConfiguration;
 
   @BeforeEach
   void setup() {
@@ -72,6 +73,8 @@ public class RoleControllerTest extends RestControllerTest {
     when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(groupServices);
     when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
+    authenticationConfiguration = new AuthenticationConfiguration();
+    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
   }
 
   @ParameterizedTest
@@ -951,12 +954,10 @@ public class RoleControllerTest extends RestControllerTest {
 
     final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
 
-    final var authenticationConfiguration = new AuthenticationConfiguration();
     final var oidcConfiguration = new OidcAuthenticationConfiguration();
     oidcConfiguration.setGroupsClaim("groups");
     authenticationConfiguration.setOidc(oidcConfiguration);
 
-    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
     when(roleServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
     // when

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
+import static io.camunda.security.configuration.SecurityConfiguration.DEFAULT_EXTERNAL_ID_REGEX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,8 +16,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.AuthenticationConfiguration;
-import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
@@ -58,7 +57,6 @@ public class RoleControllerTest extends RestControllerTest {
   @MockitoBean private GroupServices groupServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean private SecurityConfiguration securityConfiguration;
-  private AuthenticationConfiguration authenticationConfiguration;
 
   @BeforeEach
   void setup() {
@@ -73,8 +71,7 @@ public class RoleControllerTest extends RestControllerTest {
     when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(groupServices);
     when(securityConfiguration.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
-    authenticationConfiguration = new AuthenticationConfiguration();
-    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+    when(securityConfiguration.getCompiledGroupIdValidationPattern()).thenReturn(ID_PATTERN);
   }
 
   @ParameterizedTest
@@ -951,13 +948,10 @@ public class RoleControllerTest extends RestControllerTest {
     final var roleId = "roleId";
     // group id containing special characters to simulate external groups
     final var groupId = "group Id";
-
     final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
 
-    final var oidcConfiguration = new OidcAuthenticationConfiguration();
-    oidcConfiguration.setGroupsClaim("groups");
-    authenticationConfiguration.setOidc(oidcConfiguration);
-
+    when(securityConfiguration.getCompiledGroupIdValidationPattern())
+        .thenReturn(DEFAULT_EXTERNAL_ID_REGEX);
     when(roleServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
     // when

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -942,11 +942,14 @@ public class RoleControllerTest extends RestControllerTest {
     verify(roleServices, times(1)).addMember(request);
   }
 
+  /**
+   * Test for the group ID that contains special characters to simulate external groups that does
+   * not match the default regex {@link SecurityConfiguration#DEFAULT_ID_REGEX}
+   */
   @Test
-  void shouldAssignExternalGroupToRoleAndReturnNoContentWhenGroupClaimIsPresent() {
+  void shouldAssignExternalGroupToRoleAndReturnNoContentWhenGroupsAreExternallyManaged() {
     // given
     final var roleId = "roleId";
-    // group id containing special characters to simulate external groups
     final var groupId = "group Id";
     final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
 
@@ -965,6 +968,34 @@ public class RoleControllerTest extends RestControllerTest {
 
     // then
     verify(roleServices, times(1)).addMember(request);
+  }
+
+  /**
+   * Test for the group ID that contains special characters to simulate external groups that does
+   * not match the default regex {@link SecurityConfiguration#DEFAULT_ID_REGEX}
+   */
+  @Test
+  void shouldUnassignExternalGroupFromRoleAndReturnNoContentWhenGroupsAreExternallyManaged() {
+    // given
+    final var roleId = "roleId";
+    final var groupId = "group Id";
+    final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
+
+    when(securityConfiguration.getCompiledGroupIdValidationPattern())
+        .thenReturn(DEFAULT_EXTERNAL_ID_REGEX);
+    when(roleServices.removeMember(request)).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    webClient
+        .delete()
+        .uri("%s/%s/groups/%s".formatted(ROLE_BASE_URL, roleId, groupId))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // then
+    verify(roleServices, times(1)).removeMember(request);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #42062 to `stable/8.8`.

relates to #41096