### PR TITLE
fix: fix operation progressbar

### DIFF
--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState, useLayoutEffect} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 import {
   render,
@@ -36,24 +35,6 @@ function createWrapper() {
 
   return Wrapper;
 }
-
-const FinishingOperationsEntry: React.FC = () => {
-  const [completedCount, setCompletedCount] = useState(0);
-
-  useLayoutEffect(() => {
-    setCompletedCount(5);
-  }, []);
-
-  return (
-    <OperationsEntry
-      operation={{
-        ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
-        operationsTotalCount: 5,
-        operationsCompletedCount: completedCount,
-      }}
-    />
-  );
-};
 
 const OPERATIONS_TIMESTAMP = '2023-11-22 08:03:29';
 
@@ -359,7 +340,40 @@ describe('OperationsEntry', () => {
 
   it('should render 100% progress and hide progress bar', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
-    render(<FinishingOperationsEntry />, {wrapper: createWrapper()});
+    const {rerender} = render(
+      <OperationsEntry
+        operation={{
+          ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          endDate: undefined,
+          operationsTotalCount: 5,
+          operationsCompletedCount: 0,
+        }}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    vi.runOnlyPendingTimersAsync();
+    await waitFor(() =>
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuenow',
+        '10',
+      ),
+    );
+
+    expect(screen.queryByText(OPERATIONS_TIMESTAMP)).not.toBeInTheDocument();
+
+    rerender(
+      <OperationsEntry
+        operation={{
+          ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          endDate: OPERATIONS_TIMESTAMP,
+          operationsTotalCount: 5,
+          operationsCompletedCount: 5,
+        }}
+      />,
+    );
+
+    vi.runOnlyPendingTimersAsync();
 
     await waitFor(() =>
       expect(screen.getByRole('progressbar')).toHaveAttribute(
@@ -368,12 +382,27 @@ describe('OperationsEntry', () => {
       ),
     );
 
-    expect(screen.queryByText(OPERATIONS_TIMESTAMP)).not.toBeInTheDocument();
-
-    vi.runOnlyPendingTimersAsync();
     await waitForElementToBeRemoved(screen.queryByRole('progressbar'));
     expect(screen.getByText(OPERATIONS_TIMESTAMP)).toBeInTheDocument();
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  it('should not show progress bar when operation is finished but counts do not match', () => {
+    render(
+      <OperationsEntry
+        {...mockProps}
+        operation={{
+          ...OPERATIONS.CANCEL_PROCESS_INSTANCE,
+          endDate: '2023-11-22T09:03:29.564+0100',
+          operationsTotalCount: 8,
+          operationsCompletedCount: 8,
+          operationsFailedCount: 2,
+        }}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
@@ -25,8 +25,8 @@ const useLoadingProgress = ({
   isFinished: boolean;
 }) => {
   const [fakeProgressPercentage, setFakeProgressPercentage] = useState(0);
-  const [isComplete, setIsComplete] = useState(totalCount === processedCount);
-  const initialCompleteRef = useRef(totalCount === processedCount);
+  const [isComplete, setIsComplete] = useState(isFinished);
+  const initialCompleteRef = useRef(isFinished);
   const fakeTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
   const completedTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fakeStartPercentage = 10;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

For some reasons the backend is sending diverging processed and total item counts so the loading spinner were always loading for finished operatons

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42280
