### PR TITLE
ci: move GitHub release step to end of workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -350,7 +350,7 @@ jobs:
         uses: octokit/request-action@v2.3.1
         with:
           route: POST /repos/camunda/camunda/releases
-          draft: true
+          draft: false
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
           generate_release_notes: true

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -245,19 +245,6 @@ jobs:
             git push origin :refs/tags/${TAG}
           fi
 
-      - name: Create a GitHub release
-        if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: octokit/request-action@v2.3.1
-        with:
-          route: POST /repos/camunda/camunda/releases
-          draft: true
-          name: ${{ env.TAG }}
-          tag_name: ${{ env.TAG }}
-          generate_release_notes: true
-          make_latest: \"false\"
-
       - name: Auto-update previous version
         run: |
           if [ "$IS_PATCH" = "false" ]; then
@@ -355,6 +342,19 @@ jobs:
           version: ${{ env.RELEASE_VERSION }}
           date: ${{ env.DATE }}
           revision: ${{ env.REVISION }}
+
+      - name: Create a GitHub release
+        if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.3.1
+        with:
+          route: POST /repos/camunda/camunda/releases
+          draft: true
+          name: ${{ env.TAG }}
+          tag_name: ${{ env.TAG }}
+          generate_release_notes: true
+          make_latest: \"false\"
 
       - name: Docker log dump
         if: always()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Moves the GitHub release creation step to the end of the workflow to prevent duplicate releases when a job is retried after docker image build fails.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
