### PR TITLE
[Backport stable/8.7] fix: fix broken serialisation of offsetdatetime in document stores

### DIFF
--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -75,6 +75,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
@@ -10,6 +10,7 @@ package io.camunda.document.store.localstorage;
 import static io.camunda.zeebe.util.VersionUtil.LOG;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
@@ -27,7 +28,8 @@ public class LocalStorageDocumentStoreProvider implements DocumentStoreProvider 
 
     LOG.info("Storage path created at {}", storagePath);
 
-    return new LocalStorageDocumentStore(storagePath, new ObjectMapper(), executor);
+    return new LocalStorageDocumentStore(
+        storagePath, new ObjectMapper().registerModule(new JavaTimeModule()), executor);
   }
 
   private Path getStoragePath(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
@@ -20,7 +20,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class InMemoryDocumentStoreTest {
 
@@ -184,13 +188,12 @@ public class InMemoryDocumentStoreTest {
         .isInstanceOf(DocumentError.OperationNotSupported.class);
   }
 
-  @Test
-  public void shouldStoreContentType() {
+  @ParameterizedTest
+  @MethodSource("metadataSingleParamProvider")
+  public void shouldHandleMetadataParamsCorrectly(final DocumentMetadataModel metadata) {
     // given
     final InMemoryDocumentStore store = new InMemoryDocumentStore();
     final String id = "key";
-    final DocumentMetadataModel metadata =
-        new DocumentMetadataModel("application/json", null, null, null, null, null, null);
 
     // when
     final var request =
@@ -202,5 +205,25 @@ public class InMemoryDocumentStoreTest {
     assertThat(result).isInstanceOf(Either.Right.class);
     final var reference = ((Either.Right<DocumentError, DocumentReference>) result).value();
     assertThat(reference).isNotNull();
+    assertThat(reference.metadata()).isEqualTo(metadata);
+  }
+
+  public static Stream<Arguments> metadataSingleParamProvider() {
+    // Filename is always set here to prevent it from being overridden with the id in the store to
+    // simplify assertions
+    return Stream.of(
+        Arguments.of(
+            new DocumentMetadataModel("text/plain", "fileName", null, null, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, null, null, null, null)),
+        Arguments.of(
+            new DocumentMetadataModel(
+                null, "fileName", OffsetDateTime.now(), null, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, 1L, null, null, null)),
+        Arguments.of(
+            new DocumentMetadataModel(null, "fileName", null, null, "definitionId", null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, null, null, 2L, null)),
+        Arguments.of(
+            new DocumentMetadataModel(
+                null, "fileName", null, null, null, null, Map.of("key", "value"))));
   }
 }


### PR DESCRIPTION
# Description
Backport of #42046 to `stable/8.7`.

relates to #41327