### PR TITLE
[Backport stable/8.8] fix: fix broken serialisation of offsetdatetime in document stores

### DIFF
--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -75,6 +75,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
@@ -10,6 +10,7 @@ package io.camunda.document.store.localstorage;
 import static io.camunda.zeebe.util.VersionUtil.LOG;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
@@ -27,7 +28,8 @@ public class LocalStorageDocumentStoreProvider implements DocumentStoreProvider 
 
     LOG.info("Storage path created at {}", storagePath);
 
-    return new LocalStorageDocumentStore(storagePath, new ObjectMapper(), executor);
+    return new LocalStorageDocumentStore(
+        storagePath, new ObjectMapper().registerModule(new JavaTimeModule()), executor);
   }
 
   private Path getStoragePath(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
@@ -20,7 +20,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class InMemoryDocumentStoreTest {
 
@@ -184,13 +188,12 @@ public class InMemoryDocumentStoreTest {
         .isInstanceOf(DocumentError.OperationNotSupported.class);
   }
 
-  @Test
-  public void shouldStoreContentType() {
+  @ParameterizedTest
+  @MethodSource("metadataSingleParamProvider")
+  public void shouldHandleMetadataParamsCorrectly(final DocumentMetadataModel metadata) {
     // given
     final InMemoryDocumentStore store = new InMemoryDocumentStore();
     final String id = "key";
-    final DocumentMetadataModel metadata =
-        new DocumentMetadataModel("application/json", null, null, null, null, null, null);
 
     // when
     final var request =
@@ -202,5 +205,25 @@ public class InMemoryDocumentStoreTest {
     assertThat(result).isInstanceOf(Either.Right.class);
     final var reference = ((Either.Right<DocumentError, DocumentReference>) result).value();
     assertThat(reference).isNotNull();
+    assertThat(reference.metadata()).isEqualTo(metadata);
+  }
+
+  public static Stream<Arguments> metadataSingleParamProvider() {
+    // Filename is always set here to prevent it from being overridden with the id in the store to
+    // simplify assertions
+    return Stream.of(
+        Arguments.of(
+            new DocumentMetadataModel("text/plain", "fileName", null, null, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, null, null, null, null)),
+        Arguments.of(
+            new DocumentMetadataModel(
+                null, "fileName", OffsetDateTime.now(), null, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, 1L, null, null, null)),
+        Arguments.of(
+            new DocumentMetadataModel(null, "fileName", null, null, "definitionId", null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, null, null, 2L, null)),
+        Arguments.of(
+            new DocumentMetadataModel(
+                null, "fileName", null, null, null, null, Map.of("key", "value"))));
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
@@ -12,8 +12,16 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.document.api.*;
-import io.camunda.document.api.DocumentError.*;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
+import io.camunda.document.api.DocumentError.DocumentHashMismatch;
+import io.camunda.document.api.DocumentError.DocumentNotFound;
+import io.camunda.document.api.DocumentError.InvalidInput;
+import io.camunda.document.api.DocumentError.OperationNotSupported;
+import io.camunda.document.api.DocumentMetadataModel;
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -21,13 +29,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 
@@ -41,7 +53,9 @@ class LocalStorageDocumentStoreTest {
     storagePath = Files.createTempDirectory(UUID.randomUUID().toString());
     documentStore =
         new LocalStorageDocumentStore(
-            storagePath, new ObjectMapper(), Executors.newSingleThreadExecutor());
+            storagePath,
+            new ObjectMapper().registerModule(new JavaTimeModule()),
+            Executors.newSingleThreadExecutor());
   }
 
   @AfterEach
@@ -68,6 +82,7 @@ class LocalStorageDocumentStoreTest {
     assertThat(documentReference.documentId()).isEqualTo(documentId);
     assertThat(documentReference.contentHash())
         .isEqualTo("577bac45ad58fe5ee4e7f50d2d39a955d65baa825a61a970ba790d579f78e40e");
+    assertThat(documentReference.metadata()).isEqualTo(metadata);
     assertThat(Files.exists(storagePath.resolve(documentId))).isTrue();
     assertThat(
             Files.exists(
@@ -224,7 +239,61 @@ class LocalStorageDocumentStoreTest {
   }
 
   @Test
-  void verifyContentHashShouldFailIfHashDoesNotMatch() throws IOException {
+  void shouldSerializeOffsetDateTimeWhenCreatedViaProvider() throws IOException {
+    // given
+    final byte[] content = "test content".getBytes();
+    final Path tempPath = Files.createTempDirectory("test");
+    final DocumentStoreConfigurationRecord config =
+        new DocumentStoreConfigurationRecord(
+            "localstorage",
+            LocalStorageDocumentStoreProvider.class,
+            Map.of("PATH", tempPath.toString()));
+
+    final LocalStorageDocumentStoreProvider provider = new LocalStorageDocumentStoreProvider();
+    final DocumentStore store =
+        provider.createDocumentStore(config, Executors.newSingleThreadExecutor());
+
+    final DocumentMetadataModel metadata =
+        new DocumentMetadataModel(
+            "text/plain",
+            "test.txt",
+            OffsetDateTime.now(),
+            (long) content.length,
+            null,
+            null,
+            null);
+
+    // when - store document with OffsetDateTime
+    final DocumentCreationRequest request =
+        new DocumentCreationRequest(
+            UUID.randomUUID().toString(), new ByteArrayInputStream(content), metadata);
+    final var result = store.createDocument(request).join();
+
+    // then - should succeed without serialization errors
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("metadataSingleParamProvider")
+  public void shouldHandleMetadataParamsCorrectly(final DocumentMetadataModel metadata) {
+    // given
+    final String documentId = UUID.randomUUID().toString();
+    final byte[] content = "test content".getBytes();
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
+    final DocumentCreationRequest request =
+        new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    final var documentReference = result.get();
+    assertThat(documentReference.metadata()).isEqualTo(metadata);
+  }
+
+  @Test
+  void verifyContentHashShouldFailIfHashDoesNotMatch() {
     // given
     final String documentId = UUID.randomUUID().toString();
     final byte[] content = "test-content".getBytes();
@@ -298,6 +367,19 @@ class LocalStorageDocumentStoreTest {
   private DocumentMetadataModel givenMetadata(final byte[] content) {
     return new DocumentMetadataModel(
         "text/plain", "test-file.txt", null, (long) content.length, null, null, null);
+  }
+
+  public static Stream<Arguments> metadataSingleParamProvider() {
+    return Stream.of(
+        Arguments.of(new DocumentMetadataModel("text/plain", null, null, null, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, "fileName", null, null, null, null, null)),
+        Arguments.of(
+            new DocumentMetadataModel(null, null, OffsetDateTime.now(), null, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, null, null, 1L, null, null, null)),
+        Arguments.of(new DocumentMetadataModel(null, null, null, null, "definitionId", null, null)),
+        Arguments.of(new DocumentMetadataModel(null, null, null, null, null, 2L, null)),
+        Arguments.of(
+            new DocumentMetadataModel(null, null, null, null, null, null, Map.of("key", "value"))));
   }
 
   private static List<String> provideInvalidDocumentId() {


### PR DESCRIPTION
# Description
Backport of #42046 to `stable/8.8`.

relates to #41327