### PR TITLE
Remove Slack Reporter From Stateless WF

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -147,8 +147,6 @@ jobs:
           CAMUNDA_AUTH_STRATEGY: "BASIC"
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
-          INCLUDE_SLACK_REPORTER: true
-          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           VERSION: ${{ matrix.branch }}
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
           CORE_APPLICATION_URL: "http://localhost:8080"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The V2 REST API stateless testing will no longer be under QA ownership, so we can remove the slack reporter from the nightly test run.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
