### PR TITLE
[Backport stable/8.8] docs: fixed documentation of the v1 search endpoint.

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -93,7 +93,7 @@ public class TaskController extends ApiErrorController {
       summary = "Search tasks",
       description =
           "Returns the list of tasks that satisfy search request params.<br>"
-              + "<ul><li>If an empty body is provided, all tasks are returned.</li>"
+              + "<ul><li>If an empty body is provided, return all tasks except CANCELED.</li>"
               + "<li>Only one of `[searchAfter, searchAfterOrEqual, searchBefore, searchBeforeOrEqual]` search options must be present in request.</li></ul>",
       responses = {
         @ApiResponse(

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -93,7 +93,7 @@ public class TaskController extends ApiErrorController {
       summary = "Search tasks",
       description =
           "Returns the list of tasks that satisfy search request params.<br>"
-              + "<ul><li>If an empty body is provided, return all tasks except CANCELED.</li>"
+              + "<ul><li>If an empty body is provided, all tasks except CANCELED are returned.</li>"
               + "<li>Only one of `[searchAfter, searchAfterOrEqual, searchBefore, searchBeforeOrEqual]` search options must be present in request.</li></ul>",
       responses = {
         @ApiResponse(


### PR DESCRIPTION
# Description
Backport of #42085 to `stable/8.8`.

relates to #37785