### PR TITLE
refactor: align audit log result enum with openapi spec values

### DIFF
--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapperTest.java
@@ -87,7 +87,7 @@ public class AuditLogEntityMapperTest {
             .actorId(null)
             .tenantId(null)
             .tenantScope(null)
-            .result(AuditLogOperationResult.FAILURE)
+            .result(AuditLogOperationResult.FAIL)
             .annotation(null)
             .category(AuditLogOperationCategory.USER_TASK)
             .processDefinitionId(null)

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AuditLogDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AuditLogDbModelTest.java
@@ -307,10 +307,10 @@ class AuditLogDbModelTest {
             .operationType(AuditLogOperationType.CANCEL)
             .timestamp(OffsetDateTime.now())
             .actorType(AuditLogActorType.USER)
-            .result(AuditLogOperationResult.FAILURE)
+            .result(AuditLogOperationResult.FAIL)
             .build();
 
-    assertThat(auditLog.result()).isEqualTo(AuditLogOperationResult.FAILURE);
+    assertThat(auditLog.result()).isEqualTo(AuditLogOperationResult.FAIL);
   }
 
   @Test

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationResult.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationResult.java
@@ -9,5 +9,5 @@ package io.camunda.webapps.schema.entities.auditlog;
 
 public enum AuditLogOperationResult {
   SUCCESS,
-  FAILURE
+  FAIL
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
@@ -131,7 +131,7 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
   }
 
   private void setRejectionData(final AuditLogEntity entity, final Record<R> record) {
-    entity.setResult(AuditLogOperationResult.FAILURE);
+    entity.setResult(AuditLogOperationResult.FAIL);
     // TODO: set rejection type and reason to AuditLogEntity#details
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/AuditLogExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/AuditLogExportHandler.java
@@ -88,7 +88,7 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
   }
 
   private void setRejectionData(final AuditLogDbModel.Builder builder, final Record<R> record) {
-    builder.result(AuditLogOperationResult.FAILURE);
+    builder.result(AuditLogOperationResult.FAIL);
     // TODO: set rejection type and reason to AuditLogEntity#details
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Align the webapp-schema `AuditLogResult` Enum values with the OpenApi spec values.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #41116
