### PR TITLE
[Backport stable/8.6] fix: deprecated non supported github runner macos-13

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -194,6 +194,7 @@ runs:
       shell: bash
       working-directory: ./c8run
 
+<<<<<<< HEAD
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
@@ -201,6 +202,10 @@ runs:
 
     - name: Set env
       if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-13' }}
+=======
+    - if: ${{ inputs.os == 'macos-15-intel' }}
+      name: Set env
+>>>>>>> 2ac4fce3 (fix: deprecated non supported github runner macos-13)
       shell: bash
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_22_X64)" >> $GITHUB_ENV
 

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -34,6 +34,50 @@ permissions:
   statuses: write
 
 jobs:
+<<<<<<< HEAD
+=======
+  linting:
+    name: C8Run linting
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION}}
+          cache: false # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          working-directory: ./c8run
+          skip-cache: true
+
+  test_c8run_unittests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+    name: C8Run Unit Tests ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 2
+    defaults:
+      run:
+        working-directory: ./c8run
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION}}
+          cache: false
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Unit tests
+        run: go test ./...
+
+>>>>>>> 2ac4fce3 (fix: deprecated non supported github runner macos-13)
   camunda-dist-build:
     name: Build camunda-dist
     runs-on: gcp-perf-core-16-default
@@ -74,8 +118,8 @@ jobs:
   test_c8run:
     strategy:
       matrix:
-        # macos-latest is ARM, mac os 13 will execute on x86 runner.
-        os: [ubuntu-latest, macos-latest, macos-13]
+        # macos-latest is ARM, macos-15-intel will execute on x86 runner.
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -1,0 +1,267 @@
+# type: Release
+# owner: @camunda/distribution
+---
+name: "C8Run: Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "release branch of c8run to release (e.g., main, stable/8.7, etc.)"
+        type: string
+        required: true
+        default: ""
+      camundaVersion:
+        description: "Camunda minor version in format x.y"
+        type: string
+        required: true
+        default: ""
+      camundaAppsRelease:
+        description: "Name of the Camunda apps GitHub release page (e.g., 8.7.1, 8.8.0-alpha4, etc.)"
+        type: string
+        required: true
+        default: ""
+      publishToCamundaAppsRelease:
+        description: "Publish C8Run artifact to Camunda apps GitHub release page"
+        type: boolean
+        default: true
+      publishToCamundaDownloadCenter:
+        description: "Publish C8Run artifact to Camunda Download Center"
+        type: boolean
+        default: true
+      typePrerelease:
+        description: "Mark the GitHub release as prerelease (used for alphas only)"
+        type: boolean
+        default: false
+      artifactVersionSuffix:
+        description: 'Add extra suffix for release artifacts like "-rc" (Note: the dash should be included)'
+        type: string
+        default: ""
+
+permissions:
+  actions: read
+  attestations: none
+  checks: read
+  contents: write
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    name: C8Run - ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.id }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-latest is ARM, macos-15-intel will execute on x86 runner.
+        os:
+          - name: Ubuntu (AMD64)
+            id: ubuntu-latest
+            artifactFileSuffix: linux-x86_64.tar.gz
+            workingDir: ./c8run
+            c8runArtifactName: c8run
+            packagerArtifactName: packager
+            command: ./c8run
+            packagingCmd: ./packager
+          - name: MacOS (ARM64)
+            id: macos-latest
+            artifactFileSuffix: darwin-aarch64.zip
+            workingDir: ./c8run
+            c8runArtifactName: c8run
+            packagerArtifactName: packager
+            command: ./c8run
+            packagingCmd: ./packager
+          - name: MacOS (AMD64)
+            id: macos-15-intel
+            artifactFileSuffix: darwin-x86_64.zip
+            workingDir: ./c8run
+            c8runArtifactName: c8run
+            packagerArtifactName: packager
+            command: ./c8run
+            packagingCmd: ./packager
+          - name: Windows (AMD64)
+            id: windows-latest
+            artifactFileSuffix: windows-x86_64.zip
+            workingDir: ./c8run
+            c8runArtifactName: c8run.exe
+            packagerArtifactName: packager.exe
+            command: ./c8run.exe
+            packagingCmd: ./packager.exe
+    env:
+      C8RUN_NAME_ARTIFACT_WITH_MINOR_VERSION: >-
+        camunda8-run-${{ inputs.camundaVersion }}${{ inputs.artifactVersionSuffix }}-${{ matrix.os.artifactFileSuffix }}
+      C8RUN_NAME_ARTIFACT_WITH_PATCH_VERSION: >-
+        camunda8-run-${{ inputs.camundaAppsRelease }}${{ inputs.artifactVersionSuffix }}-${{ matrix.os.artifactFileSuffix }}
+    steps:
+      - name: ℹ️ Print workflow inputs ℹ️
+        env:
+          WORKFLOW_INPUTS: ${{ toJson(inputs) }}
+        run: |
+          echo "Action Inputs:"
+          echo "${WORKFLOW_INPUTS}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+            secret/data/products/distribution/ci APPLE_CERTIFICATE;
+            secret/data/products/distribution/ci APPLE_CERTIFICATE_PASSWORD;
+            secret/data/products/distribution/ci APPLE_DEVELOPER_ID;
+            secret/data/products/distribution/ci APPLE_DEVELOPER_PASSWORD;
+            secret/data/products/distribution/ci APPLE_TEAM_ID;
+            secret/data/products/distribution/ci APPLE_COMMON_NAME;
+            secret/data/common/jenkins/downloads-camunda-cloud_google_sa_key DOWNLOAD_CENTER_GCLOUD_KEY_BYTES | GCP_CREDENTIALS_NAME;
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.23.1"
+          cache: false # disabling since not working anyways without a cache-dependency-path specified
+      - name: Build artifact runtime distro
+        working-directory: ${{ matrix.os.workingDir }}
+        run: go build -o ${{ matrix.os.c8runArtifactName }} ./cmd/c8run
+
+      - name: Build artifact packaging distro
+        working-directory: ${{ matrix.os.workingDir }}
+        run: go build -o ${{ matrix.os.packagerArtifactName }} ./cmd/packager
+
+      - name: Create artifact package
+        working-directory: ${{ matrix.os.workingDir }}
+        run: ${{ matrix.os.packagingCmd }} package
+        env:
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
+
+      - name: MacOS - Extract package
+        id: macos-extract
+        if: startsWith(matrix.os.name, 'MacOS')
+        run: |
+          mkdir -p tmp
+          mv "$C8RUN_NAME_ORIGINAL" tmp
+          cd tmp
+          unzip "$C8RUN_NAME_ORIGINAL"
+          extracted_dir="$(find . -mindepth 1 -maxdepth 1 -type d ! -name '__MACOSX' -print -quit)"
+          if [ -z "$extracted_dir" ]; then
+            echo "Unable to locate extracted directory"
+            exit 1
+          fi
+          extracted_dir="${extracted_dir#./}"
+          echo "Extracted directory: $extracted_dir"
+          echo "extracted_dir=./c8run/tmp/$extracted_dir" >> "$GITHUB_OUTPUT"
+        shell: bash
+        working-directory: ./c8run
+        env:
+          C8RUN_NAME_ORIGINAL: "camunda8-run-${{ inputs.camundaAppsRelease }}-${{ matrix.os.artifactFileSuffix }}"
+
+      - name: MacOS - Sign and notarize
+        if: startsWith(matrix.os.name, 'MacOS')
+        uses: ./.github/actions/sign-and-notarize
+        with:
+          p12-base64: ${{ steps.secrets.outputs.APPLE_CERTIFICATE }}
+          p12-password: ${{ steps.secrets.outputs.APPLE_CERTIFICATE_PASSWORD }}
+          developer-id-cert-name: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
+          apple-id: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
+          app-password: ${{ steps.secrets.outputs.APPLE_DEVELOPER_PASSWORD }}
+          team-id: ${{ steps.secrets.outputs.APPLE_TEAM_ID }}
+          path: ${{ steps.macos-extract.outputs.extracted_dir }}
+
+      - name: MacOS - Replace old artifact with codesigned artifact
+        if: startsWith(matrix.os.name, 'MacOS')
+        run: |
+          mv ./c8run/tmp/c8run_complete.zip ./c8run/"$C8RUN_NAME_ORIGINAL"
+        env:
+          C8RUN_NAME_ORIGINAL: "camunda8-run-${{ inputs.camundaAppsRelease }}-${{ matrix.os.artifactFileSuffix }}"
+
+      - name: Copy artifact
+        working-directory: ${{ matrix.os.workingDir }}
+        env:
+          C8RUN_NAME_ORIGINAL: "camunda8-run-${{ inputs.camundaAppsRelease }}-${{ matrix.os.artifactFileSuffix }}"
+          C8RUN_NAME_TMP: "${{ env.C8RUN_NAME_ORIGINAL }}.tmp"
+        run: |
+          ls -lsa
+          # Artifact.
+          cp -a "${{ env.C8RUN_NAME_ORIGINAL }}" "${{ env.C8RUN_NAME_TMP }}"
+          cp -a "${{ env.C8RUN_NAME_TMP }}" \
+            "${{ env.C8RUN_NAME_ARTIFACT_WITH_MINOR_VERSION }}"
+          cp -a "${{ env.C8RUN_NAME_TMP }}" \
+            "${{ env.C8RUN_NAME_ARTIFACT_WITH_PATCH_VERSION }}"
+
+      - name: GitHub - Upload artifact to Camunda apps release
+        if: inputs.publishToCamundaAppsRelease
+        working-directory: ${{ matrix.os.workingDir }}
+        run: |
+          gh release upload "${{ inputs.camundaAppsRelease }}" \
+            "${{ env.C8RUN_NAME_ARTIFACT_WITH_PATCH_VERSION }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Set GitHub release type
+        if: inputs.typePrerelease
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh release edit "${{ inputs.camundaAppsRelease }}" --prerelease
+
+      - name: Camunda Download Center - Upload artifact in own release
+        if: inputs.publishToCamundaDownloadCenter
+        uses: camunda/infra-global-github-actions/download-center-upload@main
+        with:
+          gcp_credentials: ${{ steps.secrets.outputs.GCP_CREDENTIALS_NAME }}
+          version: ${{ inputs.camundaVersion }}
+          artifact_file: ./c8run/${{ env.C8RUN_NAME_ARTIFACT_WITH_MINOR_VERSION }}
+          artifact_subpath: c8run
+
+      - name: Camunda Download Center - Upload artifact in Camunda apps version
+        if: inputs.publishToCamundaDownloadCenter
+        uses: camunda/infra-global-github-actions/download-center-upload@main
+        with:
+          gcp_credentials: ${{ steps.secrets.outputs.GCP_CREDENTIALS_NAME }}
+          version: ${{ inputs.camundaAppsRelease }}
+          artifact_file: ./c8run/${{ env.C8RUN_NAME_ARTIFACT_WITH_PATCH_VERSION }}
+          artifact_subpath: c8run
+
+  post:
+    needs: release
+    name: Add release summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Camunda Download Center - C8Run artifacts in own release
+        if: inputs.publishToCamundaDownloadCenter
+        run: |
+          c8run_release_url_dc="https://downloads.camunda.cloud/release/camunda/c8run/${{ inputs.camundaVersion }}/"
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          ⭐ Camunda Download Center - C8Run artifacts in own release ⭐
+          - Release URL: ${c8run_release_url_dc}
+          EOF
+
+      - name: Camunda Download Center - C8Run artifacts in Camunda apps release
+        if: inputs.publishToCamundaDownloadCenter
+        run: |
+          c8run_release_url_dc="https://downloads.camunda.cloud/release/camunda/c8run/${{ inputs.camundaAppsRelease }}/"
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          ⭐ Camunda Download Center - C8Run artifacts ⭐
+          - Release URL: ${c8run_release_url_dc}
+          EOF


### PR DESCRIPTION
# Description
Backport of #42272 to `stable/8.6`.

relates to camunda/team-distribution#670