### PR TITLE
[Backport stable/8.8] fix: deprecated non supported github runner macos-13

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -184,7 +184,7 @@ runs:
       shell: bash
       working-directory: ./c8run
 
-    - if: ${{ inputs.os == 'macos-13' }}
+    - if: ${{ inputs.os == 'macos-15-intel' }}
       name: Set env
       shell: bash
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_21_X64)" >> $GITHUB_ENV

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -62,7 +62,7 @@ jobs:
   test_c8run_unittests:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
     name: C8Run Unit Tests ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 2
@@ -124,8 +124,8 @@ jobs:
   test_c8run_on_unix:
     strategy:
       matrix:
-        # macos-latest is ARM, mac os 13 will execute on x86 runner.
-        os: [ubuntu-latest, macos-latest, macos-13]
+        # macos-latest is ARM, macos-15-intel will execute on x86 runner.
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-latest is ARM, mac os 13 will execute on x86 runner.
+        # macos-latest is ARM, macos-15-intel will execute on x86 runner.
         os:
           - name: Ubuntu (AMD64)
             id: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
             command: ./c8run
             packagingCmd: ./packager
           - name: MacOS (AMD64)
-            id: macos-13
+            id: macos-15-intel
             artifactFileSuffix: darwin-x86_64.zip
             workingDir: ./c8run
             c8runArtifactName: c8run


### PR DESCRIPTION
# Description
Backport of #42272 to `stable/8.8`.

relates to camunda/team-distribution#670