### PR TITLE
[CPT: DSL] Create JUnit extension to read and execute test scenario files

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -947,6 +947,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-dsl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- sibling projects -->
 
       <dependency>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -24,6 +24,11 @@
   <dependencies>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-dsl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
     </dependency>
@@ -41,6 +46,11 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
     </dependency>
 
     <dependency>
@@ -121,12 +131,6 @@
     </dependency>
 
     <!--  test scope  -->
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -18,12 +18,14 @@ package io.camunda.process.test.api;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConfiguration;
 import io.camunda.process.test.impl.coverage.ProcessCoverage;
 import io.camunda.process.test.impl.coverage.ProcessCoverageBuilder;
 import io.camunda.process.test.impl.deployment.TestDeploymentService;
+import io.camunda.process.test.impl.dsl.CamundaTestScenarioRunner;
 import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestContainerRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
@@ -240,6 +242,10 @@ public class CamundaProcessTestExtension
       injectField(context, CamundaClient.class, camundaProcessTestContext::createClient);
       injectField(context, ZeebeClient.class, camundaProcessTestContext::createZeebeClient);
       injectField(context, CamundaProcessTestContext.class, () -> camundaProcessTestContext);
+      injectField(
+          context,
+          TestScenarioRunner.class,
+          () -> new CamundaTestScenarioRunner(camundaProcessTestContext));
     } catch (final Exception e) {
       closeCreatedClients();
       runtime.close();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioArgumentProvider.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioArgumentProvider.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+import io.camunda.process.test.impl.dsl.TestScenarioReader;
+import io.camunda.process.test.impl.extension.SourceTestCase;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+
+/**
+ * A JUnit argument provider that reads test scenarios from files in a given directory or from
+ * specific files. The test scenarios are parsed and each test case is provided as an argument of
+ * the type {@link TestCase} to the parameterized test. The name of the source file is provided as a
+ * second argument.
+ *
+ * <p>The provider reads the configuration from the {@link TestScenarioSource} annotation on the
+ * parameterized test method.
+ */
+public class TestScenarioArgumentProvider
+    implements ArgumentsProvider, AnnotationConsumer<TestScenarioSource> {
+
+  private static final FilenameFilter ACCEPT_ALL_FILES_FILTER = (dir, name) -> true;
+
+  private final TestScenarioReader testScenarioReader = new TestScenarioReader();
+
+  private String sourceDirectory;
+  private List<String> sourceFileNames;
+  private String sourceFileExtension;
+
+  @Override
+  public void accept(final TestScenarioSource testScenarioSource) {
+    sourceDirectory = testScenarioSource.directory();
+    sourceFileNames = Arrays.asList(testScenarioSource.fileNames());
+    sourceFileExtension = testScenarioSource.fileExtension();
+  }
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(
+      final ParameterDeclarations parameters, final ExtensionContext context) {
+
+    final File directory = readDirectory(context.getRequiredTestClass());
+    final List<File> files = readFiles(directory);
+
+    return files.stream()
+        .flatMap(
+            file ->
+                parseTestScenario(file).getTestCases().stream()
+                    .map(testCase -> asArguments(testCase, file)));
+  }
+
+  private File readDirectory(final Class<?> testClass) {
+    final URL resource = testClass.getResource(sourceDirectory);
+    if (resource == null) {
+      throw new TestScenarioReadException(
+          String.format("The directory '%s' does not exist.", sourceDirectory));
+    }
+
+    final File directory = new File(resource.getFile());
+
+    // validate the directory
+    if (!directory.isDirectory()) {
+      throw new TestScenarioReadException(
+          String.format("The path '%s' is not a directory.", sourceDirectory));
+    }
+    if (!directory.canRead()) {
+      throw new TestScenarioReadException(
+          String.format("The directory '%s' is not readable.", sourceDirectory));
+    }
+    return directory;
+  }
+
+  private List<File> readFiles(final File directory) {
+    final FilenameFilter fileExtensionFilter = (dir, name) -> name.endsWith(sourceFileExtension);
+    final FilenameFilter filenameFilter =
+        sourceFileNames.isEmpty() ? fileExtensionFilter : ACCEPT_ALL_FILES_FILTER;
+
+    final List<File> files =
+        Optional.ofNullable(directory.listFiles(filenameFilter))
+            .map(Arrays::asList)
+            .filter(filesInDirectory -> !filesInDirectory.isEmpty())
+            .orElseThrow(
+                () ->
+                    new TestScenarioReadException(
+                        String.format(
+                            "No files found with extension '%s' in directory '%s'.",
+                            sourceFileExtension, sourceDirectory)));
+
+    if (sourceFileNames.isEmpty()) {
+      return files;
+    }
+
+    // filter files by the specified names in the source annotation
+    final List<File> existingSourceFiles =
+        files.stream()
+            .filter(file -> sourceFileNames.contains(file.getName()))
+            .collect(Collectors.toList());
+
+    if (existingSourceFiles.size() < sourceFileNames.size()) {
+      final List<String> existingSourceFileNames =
+          existingSourceFiles.stream().map(File::getName).collect(Collectors.toList());
+
+      final List<String> missingSourceFileNames = new ArrayList<>(sourceFileNames);
+      missingSourceFileNames.removeAll(existingSourceFileNames);
+
+      if (!missingSourceFileNames.isEmpty()) {
+        throw new TestScenarioReadException(
+            String.format(
+                "The directory '%s' doesn't contain the files: %s",
+                sourceDirectory, missingSourceFileNames));
+      }
+    }
+    return existingSourceFiles;
+  }
+
+  private TestScenario parseTestScenario(final File testScenarioFile) {
+    try (final InputStream inputStream = Files.newInputStream(testScenarioFile.toPath())) {
+      return testScenarioReader.read(inputStream);
+
+    } catch (final Exception e) {
+      throw new TestScenarioReadException(
+          String.format("The file '%s' is not a valid test scenario.", testScenarioFile.getName()),
+          e);
+    }
+  }
+
+  private static Arguments asArguments(final TestCase testCase, final File file) {
+    return Arguments.of(new SourceTestCase(testCase), file.getName());
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioArgumentProvider.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioArgumentProvider.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -56,6 +57,13 @@ public class TestScenarioArgumentProvider
 
   @Override
   public void accept(final TestScenarioSource testScenarioSource) {
+    Objects.requireNonNull(
+        testScenarioSource.directory(), "The source directory must not be null.");
+    Objects.requireNonNull(
+        testScenarioSource.fileNames(), "The source file names must not be null.");
+    Objects.requireNonNull(
+        testScenarioSource.fileExtension(), "The source file extension must not be null.");
+
     sourceDirectory = testScenarioSource.directory();
     sourceFileNames = Arrays.asList(testScenarioSource.fileNames());
     sourceFileExtension = testScenarioSource.fileExtension();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioReadException.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioReadException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+/** Exception indicating that a test scenario could not be read or parsed. */
+public final class TestScenarioReadException extends IllegalArgumentException {
+
+  public TestScenarioReadException(final String message) {
+    super(message);
+  }
+
+  public TestScenarioReadException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioRunner.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+/** Runs a test scenario represented by a {@link TestCase}. */
+public interface TestScenarioRunner {
+
+  /**
+   * Runs the given {@link TestCase} by executing its instructions. If an assertion instruction
+   * fails, the assertion error is thrown to the caller. If the test case is executed without
+   * errors, it is considered successful and all assertions have passed.
+   *
+   * @param testCase the test case to run
+   * @throws AssertionError if an assertion instruction fails
+   */
+  void run(TestCase testCase);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/dsl/TestScenarioSource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+/**
+ * Defines the source for scenario test cases to be used in a parameterized JUnit test. The argument
+ * provider reads the scenarios from the given directory or from the given files.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ *   &#064;ParameterizedTest
+ *   &#064;TestScenarioSource
+ *   void shouldPass(final TestCase testCase, final String scenarioFile) {
+ *     // given - when - then
+ *     testScenarioRunner.run(testCase);
+ *   }
+ * </pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ArgumentsSource(TestScenarioArgumentProvider.class)
+public @interface TestScenarioSource {
+
+  /**
+   * The classpath directory to read the scenario files from. Defaults to "/scenarios".
+   *
+   * @return the directory path
+   */
+  String directory() default "/scenarios";
+
+  /**
+   * The names of the scenario files in the directory to read. If no files are given, all files in
+   * the directory are read.
+   *
+   * @return the file names
+   */
+  String[] fileNames() default {};
+
+  /**
+   * The file extension of the scenario files to read. Only used if no specific files are given.
+   * Defaults to ".json".
+   *
+   * @return the file extension
+   */
+  String fileExtension() default ".json";
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestCaseInstruction;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import io.camunda.process.test.impl.dsl.instructions.CreateProcessInstanceInstructionHandler;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CamundaTestScenarioRunner implements TestScenarioRunner {
+
+  private static final Map<Class<? extends TestCaseInstruction>, TestCaseInstructionHandler<?>>
+      INSTRUCTION_HANDLERS = new HashMap<>();
+
+  static {
+    // register instruction handlers here
+    registerHandler(new CreateProcessInstanceInstructionHandler());
+  }
+
+  private final CamundaProcessTestContext context;
+
+  public CamundaTestScenarioRunner(final CamundaProcessTestContext context) {
+    this.context = context;
+  }
+
+  private static void registerHandler(
+      final TestCaseInstructionHandler<? extends TestCaseInstruction> handler) {
+    INSTRUCTION_HANDLERS.put(handler.getInstructionType(), handler);
+  }
+
+  @Override
+  public void run(final TestCase testCase) {
+    try (final CamundaClient camundaClient = context.createClient()) {
+
+      testCase
+          .getInstructions()
+          .forEach(instruction -> executeInstruction(instruction, camundaClient));
+    }
+  }
+
+  private void executeInstruction(
+      final TestCaseInstruction instruction, final CamundaClient camundaClient) {
+    //noinspection rawtypes
+    final TestCaseInstructionHandler instructionHandler = getInstructionHandler(instruction);
+
+    try {
+      //noinspection unchecked
+      instructionHandler.execute(instruction, context, camundaClient);
+
+    } catch (final Exception e) {
+      throw new TestScenarioRunException(
+          String.format(
+              "Failed to execute instruction '%s': %s", instruction.getType(), instruction),
+          e);
+    }
+  }
+
+  private static TestCaseInstructionHandler<?> getInstructionHandler(
+      final TestCaseInstruction instruction) {
+    final Class<?> instructionInterface = getInstructionInterface(instruction);
+    return Optional.ofNullable(INSTRUCTION_HANDLERS.get(instructionInterface))
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "No handler found for instruction: " + instruction.getClass()));
+  }
+
+  private static Class<?> getInstructionInterface(final TestCaseInstruction instruction) {
+    return Arrays.stream(instruction.getClass().getInterfaces())
+        .filter(TestCaseInstruction.class::isAssignableFrom)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "Could not determine instruction interface of: " + instruction));
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/TestCaseInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/TestCaseInstructionHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.dsl.TestCaseInstruction;
+
+/**
+ * Implements the behavior of a specific {@link TestCaseInstruction}.
+ *
+ * @param <T> the type of the instruction
+ */
+public interface TestCaseInstructionHandler<T extends TestCaseInstruction> {
+
+  /**
+   * Executes the given instruction using the provided context and the Camunda client.
+   *
+   * @param instruction the instruction to execute
+   * @param context the test context with utilities
+   * @param camundaClient the Camunda client to send commands
+   */
+  void execute(T instruction, CamundaProcessTestContext context, final CamundaClient camundaClient);
+
+  /**
+   * Gets the type of instruction this handler can execute.
+   *
+   * @return the class of the instruction type
+   */
+  Class<T> getInstructionType();
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/TestScenarioRunException.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/TestScenarioRunException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+/** Exception indicating that a test scenario could not be executed. */
+public class TestScenarioRunException extends RuntimeException {
+  public TestScenarioRunException(final String message) {
+    super(message);
+  }
+
+  public TestScenarioRunException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/instructions/CreateProcessInstanceInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/instructions/CreateProcessInstanceInstructionHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl.instructions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruction;
+import io.camunda.process.test.impl.dsl.TestCaseInstructionHandler;
+
+public class CreateProcessInstanceInstructionHandler
+    implements TestCaseInstructionHandler<CreateProcessInstanceInstruction> {
+
+  @Override
+  public void execute(
+      final CreateProcessInstanceInstruction instruction,
+      final CamundaProcessTestContext context,
+      final CamundaClient camundaClient) {
+
+    // dummy implementation as a placeholder
+    camundaClient.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+  }
+
+  @Override
+  public Class<CreateProcessInstanceInstruction> getInstructionType() {
+    return CreateProcessInstanceInstruction.class;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/SourceTestCase.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/SourceTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.extension;
+
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestCaseInstruction;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A test case delegate with a modified toString implementation that returns only the name of the
+ * test case.
+ */
+public final class SourceTestCase implements TestCase {
+
+  private final TestCase delegate;
+
+  public SourceTestCase(final TestCase delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
+  public Optional<String> getDescription() {
+    return delegate.getDescription();
+  }
+
+  @Override
+  public List<TestCaseInstruction> getInstructions() {
+    return delegate.getInstructions();
+  }
+
+  @Override
+  public String toString() {
+    return getName();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.coverage.ProcessCoverage;
 import io.camunda.process.test.impl.coverage.ProcessCoverageBuilder;
@@ -80,6 +81,7 @@ public class JunitExtensionTest {
   private CamundaClient client;
   private ZeebeClient zeebeClient;
   private CamundaProcessTestContext camundaProcessTestContext;
+  private TestScenarioRunner testScenarioRunner;
 
   @BeforeEach
   void configureMocks() {
@@ -142,6 +144,20 @@ public class JunitExtensionTest {
     assertThat(camundaProcessTestContext.getCamundaRestAddress()).isEqualTo(REST_API_ADDRESS);
     assertThat(camundaProcessTestContext.getConnectorsAddress())
         .isEqualTo(connectorsRestApiAddress);
+  }
+
+  @Test
+  void shouldInjectTestScenarioRunner() throws Exception {
+    // given
+    final CamundaProcessTestExtension extension =
+        new CamundaProcessTestExtension(camundaRuntimeBuilder, processCoverageBuilder, NOOP);
+
+    // when
+    extension.beforeAll(extensionContext);
+    extension.beforeEach(extensionContext);
+
+    // then
+    assertThat(testScenarioRunner).isNotNull();
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/TestScenarioIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/TestScenarioIT.java
@@ -15,10 +15,11 @@
  */
 package io.camunda.process.test.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byProcessId;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
 import io.camunda.process.test.api.dsl.TestScenarioSource;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -27,22 +28,27 @@ import org.junit.jupiter.params.ParameterizedTest;
 @CamundaProcessTest
 public class TestScenarioIT {
 
-  // to be injected
   private CamundaClient client;
-  private CamundaProcessTestContext processTestContext;
+  private TestScenarioRunner testScenarioRunner;
 
   @ParameterizedTest
   @TestScenarioSource
-  void shouldPass(final TestCase testCase) {
+  void shouldPass(final TestCase testCase, final String scenarioFile) {
     // given
     final BpmnModelInstance process =
-        Bpmn.createExecutableProcess("process").startEvent("start").name("end").done();
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .name("Start")
+            .endEvent("end")
+            .name("End")
+            .done();
 
     client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
 
     // when
+    testScenarioRunner.run(testCase);
 
     // then
-    assertThat(testCase).isNotNull();
+    CamundaAssert.assertThatProcessInstance(byProcessId("process")).isCreated();
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/TestScenarioIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/TestScenarioIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenarioSource;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+
+@CamundaProcessTest
+public class TestScenarioIT {
+
+  // to be injected
+  private CamundaClient client;
+  private CamundaProcessTestContext processTestContext;
+
+  @ParameterizedTest
+  @TestScenarioSource
+  void shouldPass(final TestCase testCase) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process").startEvent("start").name("end").done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    // when
+
+    // then
+    assertThat(testCase).isNotNull();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/TestScenarioRunnerTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/TestScenarioRunnerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.dsl.ImmutableTestCase;
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestCaseInstruction;
+import io.camunda.process.test.api.dsl.TestCaseInstructionType;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import io.camunda.process.test.api.dsl.instructions.ImmutableCreateProcessInstanceInstruction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TestScenarioRunnerTest {
+
+  @Mock private CamundaProcessTestContext processTestContext;
+
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private CamundaClient camundaClient;
+
+  @Test
+  void shouldExecuteInstruction() {
+    // given
+    final TestScenarioRunner runner = new CamundaTestScenarioRunner(processTestContext);
+    when(processTestContext.createClient()).thenReturn(camundaClient);
+
+    final TestCase testCase =
+        createTestCase(
+            ImmutableCreateProcessInstanceInstruction.builder()
+                .type(TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
+                .build());
+
+    // when
+    runner.run(testCase);
+
+    // then
+    verify(camundaClient).newCreateInstanceCommand();
+  }
+
+  @Test
+  void shouldIgnoreEmptyInstructions() {
+    // given
+    final TestScenarioRunner runner = new CamundaTestScenarioRunner(processTestContext);
+
+    final TestCase testCaseWithoutInstructions = ImmutableTestCase.builder().name("test").build();
+
+    // when/then
+    assertThatCode(() -> runner.run(testCaseWithoutInstructions)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailIfInstructionIsUnknown() {
+    // given
+    final TestScenarioRunner runner = new CamundaTestScenarioRunner(processTestContext);
+
+    final TestCaseInstruction unknownInstruction = mock(TestCaseInstruction.class);
+    final TestCase testCase = createTestCase(unknownInstruction);
+
+    // when/then
+    assertThatThrownBy(() -> runner.run(testCase))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining(
+            "No handler found for instruction: %s", unknownInstruction.getClass());
+  }
+
+  @Test
+  void shouldFailIfInstructionExecutionThrowsException() {
+    // given
+    final TestScenarioRunner runner = new CamundaTestScenarioRunner(processTestContext);
+
+    when(processTestContext.createClient()).thenReturn(camundaClient);
+    final ClientException clientException = new ClientException("expected");
+    when(camundaClient.newCreateInstanceCommand()).thenThrow(clientException);
+
+    final TestCaseInstruction instruction =
+        ImmutableCreateProcessInstanceInstruction.builder()
+            .type(TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
+            .build();
+    final TestCase testCase = createTestCase(instruction);
+
+    // when/then
+    assertThatThrownBy(() -> runner.run(testCase))
+        .isInstanceOf(TestScenarioRunException.class)
+        .hasMessageContaining(
+            "Failed to execute instruction '%s': %s", instruction.getType(), instruction.toString())
+        .hasCause(clientException);
+  }
+
+  private static TestCase createTestCase(final TestCaseInstruction instruction) {
+    return ImmutableTestCase.builder().name("test").addInstructions(instruction).build();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/TestScenarioArgumentProviderTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/TestScenarioArgumentProviderTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenarioArgumentProvider;
+import io.camunda.process.test.api.dsl.TestScenarioReadException;
+import io.camunda.process.test.api.dsl.TestScenarioSource;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TestScenarioArgumentProviderTest {
+
+  private static final String SCENARIO_DIRECTORY = "/testScenarioArgumentProviderTest";
+  private static final String DEFAULT_FILE_EXTENSION = ".json";
+
+  @Mock private ExtensionContext extensionContext;
+  @Mock private ParameterDeclarations parameterDeclarations;
+
+  @Mock private TestScenarioSource testScenarioSource;
+
+  @BeforeEach
+  void configureMocks() {
+    //noinspection unchecked,rawtypes
+    when(extensionContext.getRequiredTestClass()).thenReturn((Class) ProcessTest.class);
+  }
+
+  @Test
+  void shouldProvideScenarioArguments() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {});
+    when(testScenarioSource.fileExtension()).thenReturn(DEFAULT_FILE_EXTENSION);
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when
+    final Stream<? extends Arguments> argumentStream =
+        argumentProvider.provideArguments(parameterDeclarations, extensionContext);
+
+    // then
+    assertThat(argumentStream)
+        .hasSize(3)
+        .extracting(Arguments::get)
+        .allSatisfy(args -> assertThat(args).hasSize(2))
+        .extracting(args -> ((TestCase) args[0]).getName(), args -> args[1])
+        .contains(
+            tuple("Scenario 1: Test Case 1", "scenario1.json"),
+            tuple("Scenario 1: Test Case 2", "scenario1.json"),
+            tuple("Scenario 2: Test Case 1", "scenario2.json"));
+  }
+
+  @Test
+  void shouldFilterByFileNames() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {"scenario1.json"});
+    when(testScenarioSource.fileExtension()).thenReturn(DEFAULT_FILE_EXTENSION);
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when
+    final Stream<? extends Arguments> argumentStream =
+        argumentProvider.provideArguments(parameterDeclarations, extensionContext);
+
+    // then
+    assertThat(argumentStream)
+        .hasSize(2)
+        .extracting(Arguments::get)
+        .allSatisfy(args -> assertThat(args).hasSize(2))
+        .extracting(args -> ((TestCase) args[0]).getName(), args -> args[1])
+        .contains(
+            tuple("Scenario 1: Test Case 1", "scenario1.json"),
+            tuple("Scenario 1: Test Case 2", "scenario1.json"));
+  }
+
+  @Test
+  void shouldFilterByFileExtension() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {});
+    when(testScenarioSource.fileExtension()).thenReturn(".scenario");
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when
+    final Stream<? extends Arguments> argumentStream =
+        argumentProvider.provideArguments(parameterDeclarations, extensionContext);
+
+    // then
+    assertThat(argumentStream)
+        .hasSize(1)
+        .extracting(Arguments::get)
+        .allSatisfy(args -> assertThat(args).hasSize(2))
+        .extracting(args -> ((TestCase) args[0]).getName(), args -> args[1])
+        .contains(tuple("Scenario 3: Test Case 1", "scenario3.scenario"));
+  }
+
+  @Test
+  void shouldFilterByFileNamesAndIgnoreFileExtension() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {"scenario1.json"});
+    when(testScenarioSource.fileExtension()).thenReturn(".fun");
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when
+    final Stream<? extends Arguments> argumentStream =
+        argumentProvider.provideArguments(parameterDeclarations, extensionContext);
+
+    // then
+    assertThat(argumentStream)
+        .hasSize(2)
+        .extracting(Arguments::get)
+        .allSatisfy(args -> assertThat(args).hasSize(2))
+        .extracting(args -> ((TestCase) args[0]).getName(), args -> args[1])
+        .contains(
+            tuple("Scenario 1: Test Case 1", "scenario1.json"),
+            tuple("Scenario 1: Test Case 2", "scenario1.json"));
+  }
+
+  @Test
+  void shouldFailIfDirectoryDoesntExist() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    final String directory = SCENARIO_DIRECTORY + "/non-existing";
+
+    when(testScenarioSource.directory()).thenReturn(directory);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {});
+    when(testScenarioSource.fileExtension()).thenReturn(DEFAULT_FILE_EXTENSION);
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when/then
+    assertThatThrownBy(
+            () -> argumentProvider.provideArguments(parameterDeclarations, extensionContext))
+        .isInstanceOf(TestScenarioReadException.class)
+        .hasMessageContaining("The directory '%s' does not exist.", directory);
+  }
+
+  @Test
+  void shouldFailIfDirectoryIsEmpty() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    final String fileExtension = ".fun";
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {});
+    when(testScenarioSource.fileExtension()).thenReturn(fileExtension);
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when/then
+    assertThatThrownBy(
+            () -> argumentProvider.provideArguments(parameterDeclarations, extensionContext))
+        .isInstanceOf(TestScenarioReadException.class)
+        .hasMessageContaining(
+            "No files found with extension '%s' in directory '%s'.",
+            fileExtension, SCENARIO_DIRECTORY);
+  }
+
+  @Test
+  void shouldFailIfFilesDoesntExist() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames())
+        .thenReturn(new String[] {"scenario1.json", "non-existing.json"});
+    when(testScenarioSource.fileExtension()).thenReturn(DEFAULT_FILE_EXTENSION);
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when/then
+    assertThatThrownBy(
+            () -> argumentProvider.provideArguments(parameterDeclarations, extensionContext))
+        .hasMessageContaining(
+            "The directory '%s' doesn't contain the files: %s",
+            SCENARIO_DIRECTORY, "[non-existing.json]");
+  }
+
+  @Test
+  void shouldFailIfFileIsInvalid() {
+    // given
+    final TestScenarioArgumentProvider argumentProvider = new TestScenarioArgumentProvider();
+
+    when(testScenarioSource.directory()).thenReturn(SCENARIO_DIRECTORY);
+    when(testScenarioSource.fileNames()).thenReturn(new String[] {"scenario4.invalid"});
+    when(testScenarioSource.fileExtension()).thenReturn(DEFAULT_FILE_EXTENSION);
+
+    argumentProvider.accept(testScenarioSource);
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                argumentProvider
+                    .provideArguments(parameterDeclarations, extensionContext)
+                    .collect(Collectors.toList()))
+        .hasMessageContaining("The file '%s' is not a valid test scenario.", "scenario4.invalid");
+  }
+
+  private static final class ProcessTest {}
+}

--- a/testing/camunda-process-test-java/src/test/resources/scenarios/example-test-scenario.json
+++ b/testing/camunda-process-test-java/src/test/resources/scenarios/example-test-scenario.json
@@ -1,0 +1,17 @@
+{
+  "testCases": [
+    {
+      "name": "Happy path order processing",
+      "description": "The order should be processed successfully from creation to shipping with tracking code received.",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario1.json
+++ b/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario1.json
@@ -1,0 +1,30 @@
+{
+  "testCases": [
+    {
+      "name": "Scenario 1: Test Case 1",
+      "description": "Test case description",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Scenario 1: Test Case 2",
+      "description": "Test case description",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario2.json
+++ b/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario2.json
@@ -1,0 +1,17 @@
+{
+  "testCases": [
+    {
+      "name": "Scenario 2: Test Case 1",
+      "description": "Test case description",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario3.scenario
+++ b/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario3.scenario
@@ -1,0 +1,17 @@
+{
+  "testCases": [
+    {
+      "name": "Scenario 3: Test Case 1",
+      "description": "Test case description",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario4.invalid
+++ b/testing/camunda-process-test-java/src/test/resources/testScenarioArgumentProviderTest/scenario4.invalid
@@ -1,0 +1,14 @@
+{
+  "testCases": [
+    {
+      "name": "Scenario 4: Test Case 1",
+      "description": "Invalid test case",
+      "instructions": [
+        {
+          "type": "UNKNOWN_INSTRUCTION",
+          "isValid": false
+        }
+      ]
+    }
+  ]
+}

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -26,6 +26,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-dsl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-starter</artifactId>
     </dependency>
 
@@ -136,6 +141,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -205,6 +216,7 @@
             <dependency>org.awaitility:awaitility</dependency>
             <dependency>org.apache.httpcomponents.client5:httpclient5</dependency>
             <dependency>org.apache.httpcomponents.core5:httpcore5</dependency>
+            <dependency>io.camunda:camunda-process-test-dsl</dependency>
           </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -28,9 +28,11 @@ import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConf
 import io.camunda.process.test.impl.coverage.ProcessCoverage;
 import io.camunda.process.test.impl.coverage.ProcessCoverageBuilder;
 import io.camunda.process.test.impl.deployment.TestDeploymentService;
+import io.camunda.process.test.impl.dsl.CamundaTestScenarioRunner;
 import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.proxy.CamundaClientProxy;
 import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
+import io.camunda.process.test.impl.proxy.TestScenarioRunnerProxy;
 import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestContainerRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
@@ -160,6 +162,10 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
         .getApplicationContext()
         .getBean(CamundaProcessTestContextProxy.class)
         .setContext(camundaProcessTestContext);
+    testContext
+        .getApplicationContext()
+        .getBean(TestScenarioRunnerProxy.class)
+        .setRunner(new CamundaTestScenarioRunner(camundaProcessTestContext));
 
     // publish Zeebe client
     testContext
@@ -214,6 +220,7 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
         .getApplicationContext()
         .getBean(CamundaProcessTestContextProxy.class)
         .removeContext();
+    testContext.getApplicationContext().getBean(TestScenarioRunnerProxy.class).removeRunner();
 
     // final steps: reset the time and delete data
     // It's important that the runtime clock is reset before the purge is started, as doing it

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestProxyConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestProxyConfiguration.java
@@ -17,8 +17,10 @@ package io.camunda.process.test.impl.configuration;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
 import io.camunda.process.test.impl.proxy.CamundaClientProxy;
 import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
+import io.camunda.process.test.impl.proxy.TestScenarioRunnerProxy;
 import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
 import io.camunda.zeebe.client.ZeebeClient;
 import java.lang.reflect.Proxy;
@@ -66,5 +68,20 @@ public class CamundaProcessTestProxyConfiguration {
             getClass().getClassLoader(),
             new Class[] {CamundaProcessTestContext.class},
             camundaProcessTestContextProxy);
+  }
+
+  @Bean
+  public TestScenarioRunnerProxy testScenarioRunnerProxy() {
+    return new TestScenarioRunnerProxy();
+  }
+
+  @Bean
+  public TestScenarioRunner proxiedTestScenarioRunner(
+      final TestScenarioRunnerProxy testScenarioRunnerProxy) {
+    return (TestScenarioRunner)
+        Proxy.newProxyInstance(
+            getClass().getClassLoader(),
+            new Class[] {TestScenarioRunner.class},
+            testScenarioRunnerProxy);
   }
 }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/TestScenarioRunnerProxy.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/TestScenarioRunnerProxy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.proxy;
+
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import java.lang.reflect.Method;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Dynamic proxy to delegate to a {@link TestScenarioRunner} which allows to swap the object under
+ * the hood.
+ */
+public class TestScenarioRunnerProxy extends AbstractInvocationHandler {
+
+  private TestScenarioRunner delegate;
+
+  public void setRunner(final TestScenarioRunner testScenarioRunner) {
+    delegate = testScenarioRunner;
+  }
+
+  public void removeRunner() {
+    delegate = null;
+  }
+
+  @Override
+  protected Object handleInvocation(
+      final Object proxy, final Method method, @Nullable final Object[] args) throws Throwable {
+    if (delegate == null) {
+      throw new RuntimeException(
+          "Cannot invoke "
+              + method
+              + " on TestScenarioRunner, as TestScenarioRunner is currently not initialized. Maybe you run outside of a testcase?");
+    }
+    return method.invoke(delegate, args);
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringTestScenarioIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringTestScenarioIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byProcessId;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import io.camunda.process.test.api.dsl.TestScenarioSource;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {SpringTestScenarioIT.class})
+@CamundaSpringProcessTest
+public class SpringTestScenarioIT {
+
+  @Autowired private CamundaClient client;
+  @Autowired private TestScenarioRunner testScenarioRunner;
+
+  @ParameterizedTest
+  @TestScenarioSource
+  void shouldPass(final TestCase testCase, final String scenarioFile) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .name("Start")
+            .endEvent("end")
+            .name("End")
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    // when
+    testScenarioRunner.run(testCase);
+
+    // then
+    CamundaAssert.assertThatProcessInstance(byProcessId("process")).isCreated();
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/resources/scenarios/example-test-scenario.json
+++ b/testing/camunda-process-test-spring/src/test/resources/scenarios/example-test-scenario.json
@@ -1,0 +1,17 @@
+{
+  "testCases": [
+    {
+      "name": "Happy path order processing",
+      "description": "The order should be processed successfully from creation to shipping with tracking code received.",
+      "instructions": [
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionId": "order-process",
+          "variables": {
+            "order_id": "order-1"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- Create a JUnit argument provider to read and parse the DSL for parameterized tests
- Create a runner to execute the DSL
- Inject the runner in JUnit and Spring process tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41207 
