### PR TITLE
[Backport stable/8.6] fix: deprecated non supported github runner macos-13

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -200,7 +200,7 @@ runs:
         java-version: '22'
 
     - name: Set env
-      if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-13' }}
+      if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-15-intel' }}
       shell: bash
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_22_X64)" >> $GITHUB_ENV
 

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -74,8 +74,8 @@ jobs:
   test_c8run:
     strategy:
       matrix:
-        # macos-latest is ARM, mac os 13 will execute on x86 runner.
-        os: [ubuntu-latest, macos-latest, macos-13]
+        # macos-latest is ARM, macos-15-intel will execute on x86 runner.
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15


### PR DESCRIPTION
Backport of https://github.com/camunda/camunda/pull/42272 to stable/8.6.

relates to https://github.com/camunda/team-distribution/issues/670

