### PR TITLE
feat: add audit log export handlers for batch creation

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent.MODIFIED;
@@ -19,6 +20,9 @@ import java.util.Set;
 public class AuditLogTransformerConfigs {
   public static final TransformerConfig PROCESS_INSTANCE_MODIFICATION_CONFIG =
       TransformerConfig.with(PROCESS_INSTANCE_MODIFICATION).withIntents(MODIFIED);
+
+  public static final TransformerConfig BATCH_OPERATION_CREATION_CONFIG =
+      TransformerConfig.with(BATCH_OPERATION_CREATION).withIntents(BatchOperationIntent.CREATED);
 
   public static final TransformerConfig BATCH_OPERATION_LIFECYCLE_MANAGEMENT_CONFIG =
       new TransformerConfig(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -67,6 +67,7 @@ import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
+import io.camunda.exporter.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.ProcessInstanceModificationAuditLogTransformer;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedHandler;
@@ -448,6 +449,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
 
       AuditLogHandler.builder(indexName, auditLog)
           .addHandler(new ProcessInstanceModificationAuditLogTransformer())
+          .addHandler(new BatchOperationCreationAuditLogTransformer())
           .addHandler(new BatchOperationLifecycleManagementAuditLogTransformer())
           .build()
           .forEach(exportHandlers::add);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/BatchOperationCreationAuditLogTransformer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/BatchOperationCreationAuditLogTransformer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+
+public class BatchOperationCreationAuditLogTransformer
+    implements AuditLogTransformer<BatchOperationCreationRecordValue, AuditLogEntity> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.BATCH_OPERATION_CREATION_CONFIG;
+  }
+
+  @Override
+  public void transform(
+      final Record<BatchOperationCreationRecordValue> record, final AuditLogEntity entity) {
+    final var value = record.getValue();
+    entity
+        .setBatchOperationType(value.getBatchOperationType())
+        .setTenantScope(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -19,10 +19,13 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -154,9 +157,25 @@ public class DefaultExporterResourceProviderTest {
     final var auditLogHandlers =
         provider.getExportHandlers().stream().filter(AuditLogHandler.class::isInstance).toList();
 
+    final Set<ValueType> expectedValueTypes =
+        Set.of(
+            ValueType.BATCH_OPERATION_CREATION,
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            ValueType.PROCESS_INSTANCE_MODIFICATION);
+
+    // Verify that all expected AuditLogHandler value types are present
+    assertThat(
+            auditLogHandlers.stream()
+                .map(ExportHandler::getHandledValueType)
+                .collect(Collectors.toSet()))
+        .isEqualTo(expectedValueTypes);
+
     assertThat(auditLogHandlers)
-        .as("Should have exactly 2 AuditLogHandler instances added by addAuditLogHandlers method")
-        .hasSize(2);
+        .as(
+            "Should have exactly "
+                + expectedValueTypes.size()
+                + " AuditLogHandler instances added by addAuditLogHandlers method")
+        .hasSize(expectedValueTypes.size());
   }
 
   static Stream<ExporterConfiguration> configProvider() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/BatchOperationCreationAuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/BatchOperationCreationAuditLogHandlerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationCreationAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final BatchOperationCreationAuditLogTransformer transformer =
+      new BatchOperationCreationAuditLogTransformer();
+
+  @Test
+  void shouldTransformBatchOperationCreationRecord() {
+    // given
+    final BatchOperationCreationRecordValue recordValue =
+        ImmutableBatchOperationCreationRecordValue.builder()
+            .from(factory.generateObject(BatchOperationCreationRecordValue.class))
+            .withBatchOperationType(BatchOperationType.MODIFY_PROCESS_INSTANCE)
+            .build();
+
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MODIFICATION,
+            r -> r.withIntent(BatchOperationIntent.CREATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getBatchOperationType())
+        .isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
+    assertThat(entity.getTenantScope()).isEqualTo(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/BatchOperationCreationAuditLogTransformer.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/BatchOperationCreationAuditLogTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import static io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs.BATCH_OPERATION_CREATION_CONFIG;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel.Builder;
+import io.camunda.search.entities.BatchOperationType;
+import io.camunda.util.EnumUtil;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+
+public class BatchOperationCreationAuditLogTransformer
+    implements AuditLogTransformer<BatchOperationCreationRecordValue, Builder> {
+
+  @Override
+  public TransformerConfig config() {
+    return BATCH_OPERATION_CREATION_CONFIG;
+  }
+
+  @Override
+  public void transform(
+      final Record<BatchOperationCreationRecordValue> record, final Builder entity) {
+    final var value = record.getValue();
+    entity
+        .batchOperationType(
+            EnumUtil.convert(value.getBatchOperationType(), BatchOperationType.class))
+        .tenantScope(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/BatchOperationCreationAuditLogExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/BatchOperationCreationAuditLogExportHandlerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationCreationAuditLogExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final BatchOperationCreationAuditLogTransformer transformer =
+      new BatchOperationCreationAuditLogTransformer();
+
+  @Test
+  void shouldTransformBatchOperationCreationRecord() {
+    // given
+    final BatchOperationCreationRecordValue recordValue =
+        ImmutableBatchOperationCreationRecordValue.builder()
+            .from(factory.generateObject(BatchOperationCreationRecordValue.class))
+            .withBatchOperationType(BatchOperationType.MODIFY_PROCESS_INSTANCE)
+            .build();
+
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_MODIFICATION,
+            r -> r.withIntent(BatchOperationIntent.CREATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.batchOperationType())
+        .isEqualTo(io.camunda.search.entities.BatchOperationType.MODIFY_PROCESS_INSTANCE);
+    assertThat(entity.tenantScope()).isEqualTo(AuditLogTenantScope.GLOBAL);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add audit log export handlers for batch creation and streamline the creation of audit log handlers within the respective exporter wrapper/resource provider.

As the `webapps-schema` is currently being refactored, this PR will need to wait for #42270 to go out first before being rebased and modified from there.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41146
