### PR TITLE
[Backport stable/8.7] fix: bail out when processing results were written but not committed

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -81,17 +81,14 @@ import org.slf4j.Logger;
  *           ^                    |     updateState()    |
  *           +--------------------|                      |
  *                                +----------------------+
- *                                       ^      |
- *                                       |      | exception
- *                                       |      |
+ *                                              |
+ *                                              | exception
+ *                                              |
  *                                    +---------v----+
  *                                    |              |
- *                                    |   onError()  |
+ *                                    |   FAILED     |
  *                                    |              |
  *                                    +--------------+
- *                                       ^     |
- *                                       |     |  exception
- *                                       +-----+
  *
  * </pre>
  */

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -106,8 +106,6 @@ public final class ProcessingStateMachine {
       "Expected to roll back the current transaction for record '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
       "Expected to execute side effects for record '{} {}' successfully, but exception was thrown.";
-  private static final String ERROR_MESSAGE_UPDATE_STATE_FAILED =
-      "Expected to successfully update state for record '{} {}', but caught an exception. Retry.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
       "Expected to process record '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_UNRECOVERABLE =

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncommittedStateException.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncommittedStateException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+public final class UncommittedStateException extends UnrecoverableException {
+  public UncommittedStateException(final Throwable cause) {
+    super("Processing result was written but state changes were not committed", cause);
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTransactionErrorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTransactionErrorTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.DbKey;
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.TransactionOperation;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.ZeebeDbTransaction;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.util.DefaultZeebeDbFactory;
+import io.camunda.zeebe.stream.util.RecordToWrite;
+import io.camunda.zeebe.stream.util.Records;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.File;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class StreamProcessorTransactionErrorTest {
+
+  @RegisterExtension
+  private final StreamPlatformExtension streamPlatformExtension =
+      new StreamPlatformExtension(
+          new ErrorProneDbFactory(new RuntimeException("Unexpected exception")));
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  private StreamProcessor streamProcessor;
+
+  @Test
+  void shouldShutDownStreamProcessorOnUncommittedStateException() {
+    // given
+    streamProcessor = streamPlatform.startStreamProcessorNotAwaitOpening();
+
+    // when -- processing something to trigger a commit
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    Awaitility.await("wait to become unhealthy")
+        .until(() -> streamProcessor.getHealthReport().isUnhealthy());
+
+    Assertions.assertThat(streamProcessor.isFailed()).isTrue();
+  }
+
+  private static final class ErrorProneTransactionConext implements TransactionContext {
+    final TransactionContext delegate;
+    final Exception commitException;
+
+    public ErrorProneTransactionConext(
+        final TransactionContext delegate, final Exception commitException) {
+      this.delegate = delegate;
+      this.commitException = commitException;
+    }
+
+    @Override
+    public void runInTransaction(final TransactionOperation operations) {
+      delegate.runInTransaction(operations);
+    }
+
+    @Override
+    public ZeebeDbTransaction getCurrentTransaction() {
+      // we need to use a spy here, as the transaction class and column families depend on
+      // internal implementations (and casting) which doesn't work to override here
+      final ZeebeDbTransaction spy = spy(delegate.getCurrentTransaction());
+      try {
+        doThrow(commitException).when(spy).commit();
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+      return spy;
+    }
+  }
+
+  private static final class ErrorProneDbFactory implements ZeebeDbFactory<ZbColumnFamilies> {
+
+    final ZeebeDbFactory<ZbColumnFamilies> delegate = DefaultZeebeDbFactory.defaultFactory();
+
+    final Exception commitException;
+
+    private ErrorProneDbFactory(final Exception commitException) {
+      this.commitException = commitException;
+    }
+
+    @Override
+    public ZeebeDb<ZbColumnFamilies> createDb(final File pathName) {
+      return new ErrorProneZeebeDb(delegate.createDb(pathName), commitException);
+    }
+
+    @Override
+    public ZeebeDb<ZbColumnFamilies> openSnapshotOnlyDb(final File path) {
+      return delegate.openSnapshotOnlyDb(path);
+    }
+  }
+
+  private static final class ErrorProneZeebeDb implements ZeebeDb<ZbColumnFamilies> {
+
+    private final ZeebeDb<ZbColumnFamilies> delegate;
+    private final Exception commitException;
+
+    private ErrorProneZeebeDb(
+        final ZeebeDb<ZbColumnFamilies> delegate, final Exception commitException) {
+      this.delegate = delegate;
+      this.commitException = commitException;
+    }
+
+    @Override
+    public <KeyType extends DbKey, ValueType extends DbValue>
+        ColumnFamily<KeyType, ValueType> createColumnFamily(
+            final ZbColumnFamilies columnFamily,
+            final TransactionContext context,
+            final KeyType keyInstance,
+            final ValueType valueInstance) {
+      return delegate.createColumnFamily(columnFamily, context, keyInstance, valueInstance);
+    }
+
+    @Override
+    public void createSnapshot(final File snapshotDir) {
+      delegate.createSnapshot(snapshotDir);
+    }
+
+    @Override
+    public Optional<String> getProperty(final String propertyName) {
+      return delegate.getProperty(propertyName);
+    }
+
+    @Override
+    public TransactionContext createContext() {
+      return new ErrorProneTransactionConext(delegate.createContext(), commitException);
+    }
+
+    @Override
+    public boolean isEmpty(final ZbColumnFamilies column, final TransactionContext context) {
+      return delegate.isEmpty(column, context);
+    }
+
+    @Override
+    public MeterRegistry getMeterRegistry() {
+      return delegate.getMeterRegistry();
+    }
+
+    @Override
+    public void exportMetrics() {
+      delegate.exportMetrics();
+    }
+
+    @Override
+    public void close() throws Exception {
+      delegate.close();
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #31459 to `stable/8.7`.

relates to #24675