### PR TITLE
Short-circuit RecordingExporter properly in ES/OS ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
@@ -199,8 +199,8 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
         assertThat(
                 RecordingExporter.resourceDeletionRecords(ResourceDeletionIntent.DELETED)
                     .withResourceKey(processDefinitionForDeletionKey)
-                    .count())
-            .isEqualTo(1L);
+                    .exists())
+            .isTrue();
         RecordingExporter.setMaximumWaitTime(5000);
       }
     }
@@ -232,9 +232,8 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
         assertThat(
                 RecordingExporter.resourceDeletionRecords(ResourceDeletionIntent.DELETED)
                     .withResourceKey(decisionRequirementsKey)
-                    .limit(1L)
-                    .count())
-            .isEqualTo(1L);
+                    .exists())
+            .isTrue();
         RecordingExporter.setMaximumWaitTime(5000);
       }
     }
@@ -275,12 +274,13 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
       if (expectedResponseCode == 200) {
         // if the request is successful, we expect the process instance to be modified
         RecordingExporter.setMaximumWaitTime(25_000L);
-        final var count =
-            RecordingExporter.processInstanceModificationRecords()
-                .withIntent(ProcessInstanceModificationIntent.MODIFIED)
-                .withProcessInstanceKey(processInstanceKey)
-                .count();
-        assertThat(count).isEqualTo(1);
+        assertThat(
+                RecordingExporter.processInstanceModificationRecords()
+                    .withIntent(ProcessInstanceModificationIntent.MODIFIED)
+                    .withProcessInstanceKey(processInstanceKey)
+                    .exists())
+            .isTrue();
+        RecordingExporter.setMaximumWaitTime(5000);
       }
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
@@ -194,8 +194,8 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
         assertThat(
                 RecordingExporter.resourceDeletionRecords(ResourceDeletionIntent.DELETED)
                     .withResourceKey(processDefinitionForDeletionKey)
-                    .count())
-            .isEqualTo(1L);
+                    .exists())
+            .isTrue();
         RecordingExporter.setMaximumWaitTime(5000);
       }
     }
@@ -227,9 +227,8 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
         assertThat(
                 RecordingExporter.resourceDeletionRecords(ResourceDeletionIntent.DELETED)
                     .withResourceKey(decisionRequirementsKey)
-                    .limit(1L)
-                    .count())
-            .isEqualTo(1L);
+                    .exists())
+            .isTrue();
         RecordingExporter.setMaximumWaitTime(5000);
       }
     }
@@ -274,8 +273,9 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
                 RecordingExporter.processInstanceModificationRecords()
                     .withIntent(ProcessInstanceModificationIntent.MODIFIED)
                     .withProcessInstanceKey(processInstanceKey)
-                    .count())
-            .isEqualTo(1L);
+                    .exists())
+            .isTrue();
+        RecordingExporter.setMaximumWaitTime(5000);
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

These tests did not all limit the RecordingExporter. As a result it would run for the full maximum wait time. Add to this that this was set to 25 seconds, it resulted in a very long runtime for these cases.

Note that the 25 seconds might be excessive anyway, but I don't consider this to be in scope for this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42314 
