### PR TITLE
ci: update release workflow, change job name in nightly workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Run tests
+      - name: Run API tests
         shell: bash
         env:
           LOCAL_TEST: "false"

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -82,6 +82,7 @@ jobs:
     permissions: {}
     steps:
       - name: Print release info
+        shell: bash
         run: |
           echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
           echo "Base branch: ${{ needs.validate-release.outputs.base }}"
@@ -91,6 +92,7 @@ jobs:
           ref: ${{ needs.validate-release.outputs.base }}
 
       - name: Update docker-compose with release version
+        shell: bash
         run: |
           release_version="${{ needs.validate-release.outputs.release_version }}"
           base="${{ needs.validate-release.outputs.base }}"
@@ -119,6 +121,7 @@ jobs:
           fi
       
       - name: Set NON_STANDALONE variable
+        shell: bash
         run: |
           base="${{ needs.validate-release.outputs.base }}"
           if [[ "$base" == "stable/8.6" || "$base" == "stable/8.7" ]]; then
@@ -128,6 +131,7 @@ jobs:
           fi
 
       - name: Start Camunda
+        shell: bash
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
             echo "Using single services for older branches (8.6/8.7)"
@@ -139,10 +143,12 @@ jobs:
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers
+        shell: bash
         run: docker ps -a
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: Wait for services to be ready
+        shell: bash
         id: wait-for-services
         run: |
           echo "Checking if services are up..."
@@ -181,6 +187,7 @@ jobs:
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: Print Docker logs before failing
+        shell: bash
         if: failure()
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
@@ -535,51 +542,51 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  # notify-result:
-  #   name: Send notification based on test results
-  #   runs-on: ubuntu-latest
-  #   needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
-  #   if: always()
-  #   timeout-minutes: 5
-  #   permissions: {}
-  #   steps:
-  #     - name: Import Secrets
-  #       id: secrets
-  #       uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
-  #       with:
-  #         url: ${{ secrets.VAULT_ADDR }}
-  #         method: approle
-  #         roleId: ${{ secrets.VAULT_ROLE_ID }}
-  #         secretId: ${{ secrets.VAULT_SECRET_ID }}
-  #         exportEnv: false
-  #         secrets: |
-  #           secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+  notify-result:
+    name: Send notification based on test results
+    runs-on: ubuntu-latest
+    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
 
-  #     - name: Send Slack notification
-  #       uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
-  #       with:
-  #         webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
-  #         webhook-type: incoming-webhook
-  #         payload: |
-  #           {
-  #             "blocks": [
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
-  #                 }
-  #               }
-  #             ]
-  #           }
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+                  }
+                }
+              ]
+            }
 
-  #     - name: Observe build status
-  #       if: always()
-  #       continue-on-error: true
-  #       uses: ./.github/actions/observe-build-status
-  #       with:
-  #         build_status: ${{ job.status }}
-  #         job_name: c8-orchestration-cluster-e2e-tests-notify-result
-  #         secret_vault_address: ${{ secrets.VAULT_ADDR }}
-  #         secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-  #         secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-notify-result
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -74,6 +74,221 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  c8-orchestration-cluster-api-tests:
+    name: C8 Orchestration Cluster API Tests
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: {}
+    steps:
+      - name: Print release info
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch: ${{ needs.validate-release.outputs.base }}"
+    
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.base }}
+
+      - name: Update docker-compose with release version
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          base="${{ needs.validate-release.outputs.base }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker images to version: $release_version for base: $base"
+
+          if [[ "$base" == "stable/8.6" || "$base" == "stable/8.7" ]]; then
+            echo "Updating separate service images (zeebe, tasklist, operate)"
+            # Update zeebe image
+            sed -i.bak "s|image: camunda/zeebe:.*|image: camunda/zeebe:$release_version|g" "$compose_file"
+            # Update tasklist image  
+            sed -i.bak2 "s|image: camunda/tasklist:.*|image: camunda/tasklist:$release_version|g" "$compose_file"
+            # Update operate image
+            sed -i.bak3 "s|image: camunda/operate:.*|image: camunda/operate:$release_version|g" "$compose_file"
+            
+            echo "Updated docker-compose.yml with separate services:"
+            grep -E "image: camunda/(zeebe|tasklist|operate):" "$compose_file"
+          else
+            echo "Updating unified camunda service image"
+            # Replace the camunda image tag in docker-compose.yml
+            sed -i.bak "s|image: camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+            
+            echo "Updated docker-compose.yml with unified service:"
+            grep "image: camunda/camunda:" "$compose_file"
+          fi
+      
+      - name: Set NON_STANDALONE variable
+        run: |
+          base="${{ needs.validate-release.outputs.base }}"
+          if [[ "$base" == "stable/8.6" || "$base" == "stable/8.7" ]]; then
+            echo "NON_STANDALONE=true" >> "$GITHUB_ENV"
+          else
+            echo "NON_STANDALONE=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Start Camunda
+        run: |
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            echo "Using single services for older branches (8.6/8.7)"
+            DATABASE=elasticsearch docker compose up -d operate tasklist
+          else
+            echo "Using standalone camunda container"
+            DATABASE=elasticsearch docker compose up -d camunda
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: List running Docker containers
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        id: wait-for-services
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
+              operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")
+            else
+              tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+              operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+              identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
+            fi
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" ]]; then
+                echo "Services are ready!"
+                ready=true
+                break
+              fi
+            else
+              if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
+                echo "Services are ready!"
+                ready=true
+                break
+              fi
+            fi
+            echo "Waiting for services... ($i/90)"
+            sleep 10
+          done
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Print Docker logs before failing
+        if: failure()
+        run: |
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            docker compose logs zeebe
+            docker compose logs tasklist
+            docker compose logs operate
+          else
+            docker compose logs camunda
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run API tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
+        run: |
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            export CORE_APPLICATION_TASKLIST_URL="http://localhost:8080"
+            export CORE_APPLICATION_OPERATE_URL="http://localhost:8081"
+            export ZEEBE_REST_ADDRESS="http://localhost:8089"
+          else
+            export CORE_APPLICATION_URL="http://localhost:8080"
+            export ZEEBE_REST_ADDRESS="http://localhost:8080"
+          fi
+          
+          echo "Running API tests"
+          npm run test -- --project=api-tests
+          
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            parse_junit --suite-id 17050 \
+            --title "Release C8 Orchestration Cluster API Test Run Results - v${{ needs.validate-release.outputs.release_version }} - $(date '+%Y-%m-%d %H:%M:%S')" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: C8 Orchestration Cluster E2E API Test Result Release v${{ needs.validate-release.outputs.release_version }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-api-tests-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   c8-orchestration-cluster-e2e-tests:
     name: C8 Orchestration Cluster E2E Tests Release (Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:
@@ -320,51 +535,51 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  notify-result:
-    name: Send notification based on test results
-    runs-on: ubuntu-latest
-    needs: [validate-release, c8-orchestration-cluster-e2e-tests]
-    if: always()
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+  # notify-result:
+  #   name: Send notification based on test results
+  #   runs-on: ubuntu-latest
+  #   needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
+  #   if: always()
+  #   timeout-minutes: 5
+  #   permissions: {}
+  #   steps:
+  #     - name: Import Secrets
+  #       id: secrets
+  #       uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
+  #       with:
+  #         url: ${{ secrets.VAULT_ADDR }}
+  #         method: approle
+  #         roleId: ${{ secrets.VAULT_ROLE_ID }}
+  #         secretId: ${{ secrets.VAULT_SECRET_ID }}
+  #         exportEnv: false
+  #         secrets: |
+  #           secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
 
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
-        with:
-          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
-                  }
-                }
-              ]
-            }
+  #     - name: Send Slack notification
+  #       uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+  #       with:
+  #         webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+  #         webhook-type: incoming-webhook
+  #         payload: |
+  #           {
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+  #                 }
+  #               }
+  #             ]
+  #           }
 
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: c8-orchestration-cluster-e2e-tests-notify-result
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+  #     - name: Observe build status
+  #       if: always()
+  #       continue-on-error: true
+  #       uses: ./.github/actions/observe-build-status
+  #       with:
+  #         build_status: ${{ job.status }}
+  #         job_name: c8-orchestration-cluster-e2e-tests-notify-result
+  #         secret_vault_address: ${{ secrets.VAULT_ADDR }}
+  #         secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+  #         secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

This PR changes release workflow to separate UI and API tests, as done in [on demand workflow](https://github.com/camunda/camunda/issues/42021)

## Related issues
closes #42303

## Triggered run
[main](https://github.com/camunda/camunda/actions/runs/20064324166)
[8.8.0](https://github.com/camunda/camunda/actions/runs/20064329798)
[8.7.0](https://github.com/camunda/camunda/actions/runs/20064337518)
[8.6.0](https://github.com/camunda/camunda/actions/runs/20064348216)