### PR TITLE
fix: OpenSearch ISM URL

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -24,10 +24,8 @@ import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @HistoryMultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class HistoryCleanupIT {
 
   static final String RESOURCE_NAME = "process/process_with_assigned_user_task.bpmn";

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -69,11 +69,11 @@ import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplate
 import org.slf4j.LoggerFactory;
 
 public class OpensearchEngineClient implements SearchEngineClient {
+  public static final String ISM_POLICIES_ENDPOINT = "/_plugins/_ism/policies";
   private static final SuppressLogger LOG =
       new SuppressLogger(LoggerFactory.getLogger(OpensearchEngineClient.class));
   private static final String OPERATE_DELETE_ARCHIVED_POLICY =
       "/schema/opensearch/create/policy/operate_delete_archived_indices.json";
-  private static final String ISM_POLICIES_ENDPOINT = "_plugins/_ism/policies";
   private static final long AUTO_SLICES = 0; // see OS docs; 0 means auto
   private final ObjectReader objectReader;
   private final ObjectWriter objectWriter;

--- a/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
@@ -505,7 +505,11 @@ public class OpensearchEngineClientIT {
 
   private String getPolicyMinAge(final String policyName) throws IOException {
     final var request =
-        Requests.builder().method("GET").endpoint("_plugins/_ism/policies/" + policyName).build();
+        Requests.builder()
+            .method("GET")
+            .endpoint(
+                String.format("%s/%s", OpensearchEngineClient.ISM_POLICIES_ENDPOINT, policyName))
+            .build();
 
     final var policyJsonNode =
         objectMapper.readTree(openSearchClient.generic().execute(request).getBody().get().body());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -395,7 +395,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
     final AddPolicyRequestBody value = new AddPolicyRequestBody(policyName);
     final var request =
-        Requests.builder().method("POST").endpoint("_plugins/_ism/add/" + indexNamePattern);
+        Requests.builder().method("POST").endpoint("/_plugins/_ism/add/" + indexNamePattern);
     return sendRequestAsync(
             () ->
                 genericClient.executeAsync(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -713,7 +713,7 @@ final class OpenSearchArchiverRepositoryIT {
         .untilAsserted(() -> verify(genericClientSpy, times(1)).executeAsync(captor.capture()));
 
     final var request = captor.getValue();
-    assertThat(request.getEndpoint()).isEqualTo("_plugins/_ism/add/" + indexName2);
+    assertThat(request.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName2);
     reset(genericClientSpy);
 
     // setting policy first time for srcIndexName but second time for indexName2, it
@@ -730,7 +730,7 @@ final class OpenSearchArchiverRepositoryIT {
 
     final Request request2 = captor2.getValue();
 
-    assertThat(request2.getEndpoint()).isEqualTo("_plugins/_ism/add/" + indexName1);
+    assertThat(request2.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName1);
   }
 
   @Test
@@ -767,7 +767,7 @@ final class OpenSearchArchiverRepositoryIT {
     final var requests = captor.getAllValues();
     assertThat(requests)
         .map(Request::getEndpoint)
-        .containsExactly("_plugins/_ism/add/" + indexName1, "_plugins/_ism/add/" + indexName2);
+        .containsExactly("/_plugins/_ism/add/" + indexName1, "/_plugins/_ism/add/" + indexName2);
 
     // we reset the spy to ensure that we only capture the next calls
     reset(genericClientSpy);
@@ -780,7 +780,7 @@ final class OpenSearchArchiverRepositoryIT {
     final var captor2 = ArgumentCaptor.forClass(Request.class);
     verify(genericClientSpy, times(1)).executeAsync(captor2.capture());
     final var request2 = captor2.getValue();
-    assertThat(request2.getEndpoint()).isEqualTo("_plugins/_ism/add/" + indexName1);
+    assertThat(request2.getEndpoint()).isEqualTo("/_plugins/_ism/add/" + indexName1);
   }
 
   @Test
@@ -820,7 +820,7 @@ final class OpenSearchArchiverRepositoryIT {
         .allSatisfy(
             request -> {
               final var indexPattern =
-                  request.getEndpoint().substring("_plugins/_ism/add/".length());
+                  request.getEndpoint().substring("/_plugins/_ism/add/".length());
               final String[] split = indexPattern.split(",");
               assertThat(split)
                   .hasSize(3); // 3 patterns (wildcard + runtime exclusion + alias exclusion)


### PR DESCRIPTION

## Description

The AWS OpenSearch ISM calls are failing as the AWS varient require a '/' prefix to the URL, where as the OSS version does not. We use the same HTTP client, so not sure how it can even happen. I'm assuming somewhere in the HTTP client the HOST & Endpoint URL's are concatenated to make the API call. Eitherway, this fixed it.

This probably is one of the reasons some of our AWS OS ITs are failing too.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42335
