### PR TITLE
feat: c8run default to H2 secondary storage and document ES opt-in

### DIFF
--- a/c8run/README.md
+++ b/c8run/README.md
@@ -24,13 +24,10 @@ Elasticsearch remains available, but it is no longer started automatically. The 
    ```
 
 2. Start Camunda 8 Run and instruct it to manage Elasticsearch:
-
    ```bash
    ./c8run start --disable-elasticsearch=false
    ```
-
 3. When stopping a stack that was started with Elasticsearch, pass the same flag to ensure the Elasticsearch processes are terminated:
-
    ```bash
    ./c8run stop --disable-elasticsearch=false
    ```

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -4,6 +4,37 @@ C8 Run is a packaged distribution of Camunda 8, which allows you to spin up Camu
 
 Please refer to the [local installation with Camunda 8 Run guide](https://docs.camunda.io/docs/next/self-managed/setup/deploy/local/c8run/) for further details.
 
+## Default secondary storage
+
+Camunda 8 Run now starts with H2 as the secondary storage backend. No additional configuration or flags are required—running `./c8run start` launches a full stack backed by an in-memory H2 database that is perfect for local development and testing scenarios. H2 is not supported for production workloads.
+
+Elasticsearch remains available, but it is no longer started automatically. The `--disable-elasticsearch` flag defaults to `true`, so Elasticsearch processes are skipped unless you explicitly re-enable them.
+
+### Running with Elasticsearch
+
+1. Update `c8run/configuration/application.yaml` so that the secondary storage type is `elasticsearch` and points to your cluster:
+
+   ```yaml
+   camunda:
+     data:
+       secondary-storage:
+         type: elasticsearch
+         elasticsearch:
+           url: http://localhost:9200
+   ```
+
+2. Start Camunda 8 Run and instruct it to manage Elasticsearch:
+
+   ```bash
+   ./c8run start --disable-elasticsearch=false
+   ```
+
+3. When stopping a stack that was started with Elasticsearch, pass the same flag to ensure the Elasticsearch processes are terminated:
+
+   ```bash
+   ./c8run stop --disable-elasticsearch=false
+   ```
+
 ## CI requirement for merging
 
 Only CI checks related to C8Run (those with "c8run" in the name) and CI runs marked as `required` are needed to merge. Non-C8Run-related CI checks can be ignored.

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -22,12 +22,13 @@ Elasticsearch remains available, but it is no longer started automatically. The 
          elasticsearch:
            url: http://localhost:9200
    ```
-
 2. Start Camunda 8 Run and instruct it to manage Elasticsearch:
+
    ```bash
    ./c8run start --disable-elasticsearch=false
    ```
 3. When stopping a stack that was started with Elasticsearch, pass the same flag to ensure the Elasticsearch processes are terminated:
+
    ```bash
    ./c8run stop --disable-elasticsearch=false
    ```

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -212,7 +212,7 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet.StringVar(&settings.Keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
 	startFlagSet.StringVar(&settings.KeystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
 	startFlagSet.StringVar(&settings.LogLevel, "log-level", "", "Adjust the log level of Camunda")
-	startFlagSet.BoolVar(&settings.DisableElasticsearch, "disable-elasticsearch", false, "Do not start or stop Elasticsearch (disabling will enable H2)")
+	startFlagSet.BoolVar(&settings.DisableElasticsearch, "disable-elasticsearch", true, "Skip managing Elasticsearch (default). Set to false (and configure the application) to run with Elasticsearch instead of H2.")
 	startFlagSet.BoolVar(&settings.Docker, "docker", false, "Run Camunda from docker-compose.")
 	startFlagSet.StringVar(&settings.Username, "username", "demo", "Change the first users username (default: demo)")
 	startFlagSet.StringVar(&settings.Password, "password", "demo", "Change the first users password (default: demo)")

--- a/c8run/configuration/application.yaml
+++ b/c8run/configuration/application.yaml
@@ -1,15 +1,13 @@
 camunda:
-  database:
-    clusterName: elasticsearch
-    type: elasticsearch
-    url: http://localhost:9200
-    index:
-      numberOfReplicas: 0
   data:
     secondary-storage:
-      type: elasticsearch
-      elasticsearch:
-        url: http://localhost:9200
+      type: rdbms
+      rdbms:
+        url: jdbc:h2:mem:camunda
+        username: sa
+        password:
+        flushInterval: PT0.5S
+        queueSize: 1000
   security:
     initialization:
       users:
@@ -30,17 +28,6 @@ camunda:
 
 zeebe:
   broker:
-    exporters:
-      camundaExporter:
-        args:
-          connect:
-            type: elasticsearch
-            url: http://localhost:9200
-          index:
-            shouldWaitForImporters: false
-          retention:
-            enabled: false
-        className: io.camunda.exporter.CamundaExporter
     network:
       host: localhost
       advertisedHost: localhost


### PR DESCRIPTION
## Description

Changed application config to support H2 by default.

About "--disable-elasticsearch":

**--disable-elasticsearch=true** just forces the default behavior (skipping Elasticsearch entirely). Since H2/RDBMS is now the out-of-the-box backend, nothing else happens—you’ll still get the lightweight setup, and no Elasticsearch
  processes or exporters are touched.

Setting **--disable-elasticsearch=false** keeps the old workflow:
  - Update c8run/configuration/application.yaml so camunda.data.secondary-storage.type is elasticsearch (and point it to your existing cluster).
  - Start with ./c8run start --disable-elasticsearch=false so Run manages Elasticsearch again.
  With those two pieces in place, the distro wires the Camunda exporter just like before, so you can keep using your existing Elasticsearch data after the upgrade.


closes #39961 
