### PR TITLE
test: e2e test for adhoc subprocess migration

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_1.bpmn
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+  exporterVersion="eda7bab" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -29,7 +38,8 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment"
+      targetRef="ExclusiveGateway_1qqmrb8" />
     <bpmn:serviceTask id="requestForPayment" name="Request for payment">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
@@ -37,11 +47,14 @@
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid"
+      sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment"
+      targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8"
+      targetRef="shipArticles">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_18wek8y" sourceRef="Gateway_2" targetRef="checkPayment" />
@@ -94,7 +107,8 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting"
+      cancelActivity="false" attachedToRef="TaskC">
       <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_3mvm2pn" />
     </bpmn:boundaryEvent>
@@ -131,7 +145,8 @@
       <bpmn:outgoing>Flow_1i7pkzb</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1i7pkzb" sourceRef="TaskD" targetRef="Gateway_3" />
-    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting"
+      cancelActivity="false" attachedToRef="TaskD">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
@@ -154,7 +169,8 @@
     <bpmn:sequenceFlow id="Flow_0e569q0" sourceRef="TaskA" targetRef="Gateway_3" />
     <bpmn:sequenceFlow id="Flow_08ahq87" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch" />
     <bpmn:sequenceFlow id="Flow_1wxn661" sourceRef="MessageIntermediateCatch" targetRef="Gateway_3" />
-    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
       </bpmn:endEvent>
@@ -169,10 +185,12 @@
       </bpmn:serviceTask>
       <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
         <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_2u2g7tt" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx"
+          messageRef="Message_2u2g7tt" />
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
       </bpmn:endEvent>
@@ -194,7 +212,8 @@
     </bpmn:subProcess>
     <bpmn:sequenceFlow id="Flow_1jeea8a" sourceRef="Gateway_2" targetRef="MessageReceiveTask" />
     <bpmn:sequenceFlow id="Flow_17dl770" sourceRef="MessageReceiveTask" targetRef="Gateway_3" />
-    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_14us09o">
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task"
+      messageRef="Message_14us09o">
       <bpmn:incoming>Flow_1jeea8a</bpmn:incoming>
       <bpmn:outgoing>Flow_17dl770</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -233,7 +252,8 @@
       <bpmn:incoming>Flow_1fo0rfs</bpmn:incoming>
       <bpmn:outgoing>Flow_126yu9s</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway" targetRef="Gateway_1cs756a">
+    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway"
+      targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_1cs756a">
@@ -253,21 +273,26 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway" targetRef="TimerIntermediateCatchB" />
-    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB" targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway"
+      targetRef="TimerIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
     <bpmn:intermediateCatchEvent id="MessageIntermediateCatchB" name="Message intermediate catch B">
       <bpmn:incoming>Flow_0v8bsdg</bpmn:incoming>
       <bpmn:outgoing>Flow_17zq5s0</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_17s00ai" messageRef="Message_2530hhv" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway" targetRef="MessageIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway"
+      targetRef="MessageIntermediateCatchB" />
     <bpmn:exclusiveGateway id="Gateway_0ftzss1">
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:incoming>Flow_0j0qeck</bpmn:incoming>
       <bpmn:outgoing>Flow_17m3xiv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB" targetRef="Gateway_0ftzss1" />
-    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process" triggeredByEvent="true">
+    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
+    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process"
+      triggeredByEvent="true">
       <bpmn:sequenceFlow id="Flow_189mrto" sourceRef="SignalStartEvent" targetRef="TaskH" />
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
@@ -284,7 +309,8 @@
         <bpmn:outgoing>Flow_189mrto</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_19nq2lq" signalRef="Signal_3r9rbp1" />
       </bpmn:startEvent>
-      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event" attachedToRef="TaskH">
+      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event"
+        attachedToRef="TaskH">
         <bpmn:outgoing>Flow_0bfr615</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_0o1z67o" signalRef="Signal_104j77q" />
       </bpmn:boundaryEvent>
@@ -298,7 +324,8 @@
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0biu2sq" signalRef="Signal_3r9rbp1" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch" />
+    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow"
+      targetRef="SignalIntermediateCatch" />
     <bpmn:intermediateCatchEvent id="SignalIntermediateCatch" name="Signal intermediate catch">
       <bpmn:incoming>Flow_1359yom</bpmn:incoming>
       <bpmn:outgoing>Flow_0g97m5r</bpmn:outgoing>
@@ -310,7 +337,8 @@
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_1w9iwsx</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process"
+        triggeredByEvent="true">
         <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
           <bpmn:outgoing>Flow_1ic0jav</bpmn:outgoing>
           <bpmn:errorEventDefinition id="ErrorEventDefinition_094930e" errorRef="Error_13vdeq4" />
@@ -332,7 +360,8 @@
         <bpmn:incoming>Flow_1w9iwsx</bpmn:incoming>
         <bpmn:errorEventDefinition id="ErrorEventDefinition_0663p22" errorRef="Error_00pqgg4" />
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_1w9iwsx" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
+      <bpmn:sequenceFlow id="Flow_1w9iwsx" sourceRef="SubProcessStartEvent"
+        targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
     <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
       <bpmn:incoming>Flow_1nydbto</bpmn:incoming>
@@ -377,7 +406,8 @@
       <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
         <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
         <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_1v2o7l5" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il"
+          escalationRef="Escalation_1v2o7l5" />
       </bpmn:intermediateThrowEvent>
       <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
       <bpmn:serviceTask id="EscalationTask" name="Escalation task">
@@ -388,9 +418,11 @@
         <bpmn:outgoing>Flow_0bbhalt</bpmn:outgoing>
       </bpmn:serviceTask>
     </bpmn:subProcess>
-    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event" attachedToRef="EscalationSubProcess">
+    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event"
+      attachedToRef="EscalationSubProcess">
       <bpmn:outgoing>Flow_0xejz9b</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_16t2gpe" sourceRef="Gateway_1" targetRef="Gateway_2" />
     <bpmn:parallelGateway id="Gateway_1">
@@ -398,6 +430,7 @@
       <bpmn:outgoing>Flow_16t2gpe</bpmn:outgoing>
       <bpmn:outgoing>Flow_0vm1c0b</bpmn:outgoing>
       <bpmn:outgoing>Flow_0u3kipb</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1krp4hz</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_0vm1c0b</bpmn:incoming>
@@ -437,12 +470,15 @@
       <bpmn:incoming>Flow_1dzoyo4</bpmn:incoming>
       <bpmn:incoming>Flow_1bo0sui</bpmn:incoming>
       <bpmn:incoming>Flow_0383azr</bpmn:incoming>
+      <bpmn:incoming>Flow_0v0pz7s</bpmn:incoming>
       <bpmn:outgoing>Flow_1nlysp1</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1bo0sui" sourceRef="Gateway_3" targetRef="Gateway_6" />
     <bpmn:sequenceFlow id="Flow_0xejz9b" sourceRef="EscalationBoundaryEvent" targetRef="Gateway_5" />
-    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
-      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent" targetRef="EscalationEventTask" />
+    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process"
+      triggeredByEvent="true">
+      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent"
+        targetRef="EscalationEventTask" />
       <bpmn:endEvent id="Event_1cmlzk4">
         <bpmn:incoming>Flow_0of03mm</bpmn:incoming>
       </bpmn:endEvent>
@@ -454,16 +490,20 @@
         <bpmn:incoming>Flow_0vd8mzp</bpmn:incoming>
         <bpmn:outgoing>Flow_0of03mm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event" isInterrupting="false">
+      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event"
+        isInterrupting="false">
         <bpmn:outgoing>Flow_0vd8mzp</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s" escalationRef="Escalation_1v2o7l5" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s"
+          escalationRef="Escalation_1v2o7l5" />
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1rdc672" sourceRef="EscalationThrowEvent" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1rdc672" sourceRef="EscalationThrowEvent"
+      targetRef="EscalationSubProcess" />
     <bpmn:intermediateThrowEvent id="EscalationThrowEvent">
       <bpmn:incoming>Flow_1e1hjfq</bpmn:incoming>
       <bpmn:outgoing>Flow_1rdc672</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1nfw7gz" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1nfw7gz"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:intermediateThrowEvent>
     <bpmn:sequenceFlow id="Flow_0u3kipb" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:task id="UndoTask" name="Undo" isForCompensation="true" />
@@ -480,11 +520,86 @@
       <bpmn:incoming>Flow_0u3kipb</bpmn:incoming>
       <bpmn:outgoing>Flow_0ejrzsk</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
-    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event" attachedToRef="CompensationTask">
+    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask"
+      targetRef="CompensationThrowEvent" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event"
+      attachedToRef="CompensationTask">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a309d0" />
     </bpmn:boundaryEvent>
-    <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess" name="Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskI&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16j5w5f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1atp6z8</bpmn:outgoing>
+      <bpmn:serviceTask id="TaskI" name="Task I">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:parallelGateway id="Gateway_18qbndw">
+      <bpmn:incoming>Flow_1krp4hz</bpmn:incoming>
+      <bpmn:outgoing>Flow_16j5w5f</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0m41222</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1q6776b</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1krp4hz" sourceRef="Gateway_1" targetRef="Gateway_18qbndw" />
+    <bpmn:sequenceFlow id="Flow_16j5w5f" sourceRef="Gateway_18qbndw" targetRef="AdHocSubProcess" />
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess"
+      name="Parallel multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0m41222</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nj16xx</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskJ" name="Task J">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess"
+      name="Sequential multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskK&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1q6776b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ektns0</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskK" name="Task K">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0m41222" sourceRef="Gateway_18qbndw"
+      targetRef="ParallelMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1q6776b" sourceRef="Gateway_18qbndw"
+      targetRef="SequentialMultiInstanceAdHocSubProcess" />
+    <bpmn:parallelGateway id="Gateway_01n2aj8">
+      <bpmn:incoming>Flow_1ektns0</bpmn:incoming>
+      <bpmn:incoming>Flow_1nj16xx</bpmn:incoming>
+      <bpmn:incoming>Flow_1atp6z8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0v0pz7s</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0v0pz7s" sourceRef="Gateway_01n2aj8" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_1ektns0" sourceRef="SequentialMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_01n2aj8" />
+    <bpmn:sequenceFlow id="Flow_1nj16xx" sourceRef="ParallelMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_01n2aj8" />
+    <bpmn:sequenceFlow id="Flow_1atp6z8" sourceRef="AdHocSubProcess" targetRef="Gateway_01n2aj8" />
+    <bpmn:association id="Association_0xok9ld" associationDirection="One"
+      sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -541,7 +656,14 @@
       <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
         <dc:Bounds x="773" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="3202" y="1652" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
+        isMarkerVisible="true">
         <dc:Bounds x="609" y="175" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="600" y="147" width="69" height="14" />
@@ -592,6 +714,58 @@
           <dc:Bounds x="715" y="760" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2770" y="140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="3032" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="2890" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="2810" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2794" y="265" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="2846" y="240" />
+        <di:waypoint x="2890" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="2990" y="240" />
+        <di:waypoint x="3032" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2770" y="390" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="3032" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="2890" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="2810" y="472" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2787" y="515" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="2846" y="490" />
+        <di:waypoint x="2890" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="2990" y="490" />
+        <di:waypoint x="3032" y="490" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
         <dc:Bounds x="440" y="1212" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -607,7 +781,8 @@
         <dc:Bounds x="440" y="1542" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway"
+        isMarkerVisible="true">
         <dc:Bounds x="1205" y="175" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1207" y="233" width="47" height="27" />
@@ -637,6 +812,45 @@
       <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
         <dc:Bounds x="1585" y="285" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2770" y="640" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="3062" y="722" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="2900" y="700" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="2810" y="722" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2786" y="765" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="3062" y="792" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="2952" y="762" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2931" y="805" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="2846" y="740" />
+        <di:waypoint x="2900" y="740" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="3000" y="740" />
+        <di:waypoint x="3062" y="740" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="2970" y="798" />
+        <di:waypoint x="2970" y="810" />
+        <di:waypoint x="3062" y="810" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
         <dc:Bounds x="1212" y="502" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -649,29 +863,6 @@
           <dc:Bounds x="1386" y="545" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1j4ljfk_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2075" y="1645" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2692" y="1652" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="270" width="90" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="1930" y="280" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="1992" y="182" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1975" y="225" width="71" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="1810" y="160" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1lb6pou_di" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1122" y="610" width="423" height="350" />
         <bpmndi:BPMNLabel />
@@ -679,7 +870,8 @@
       <bpmndi:BPMNShape id="BPMNShape_1v2yf5g" bpmnElement="SubProcessStartEvent">
         <dc:Bounds x="1199" y="652" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cqp75h_di" bpmnElement="ErrorEventSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_0cqp75h_di" bpmnElement="ErrorEventSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1160" y="733" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -711,7 +903,8 @@
         <di:waypoint x="1235" y="670" />
         <di:waypoint x="1412" y="670" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1199" y="1020" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -733,7 +926,8 @@
         <di:waypoint x="1275" y="1120" />
         <di:waypoint x="1327" y="1120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1199" y="1270" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -771,127 +965,90 @@
       <bpmndi:BPMNShape id="Gateway_1tdy0d3_di" bpmnElement="Gateway_5">
         <dc:Bounds x="1675" y="1557" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1dvyj5q_di" bpmnElement="EscalationThrowEvent">
-        <dc:Bounds x="1102" y="1352" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_1j4ljfk_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="2585" y="1645" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="1880" y="258" />
-        <di:waypoint x="1880" y="320" />
-        <di:waypoint x="1930" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="140" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2522" y="222" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="2380" y="200" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2300" y="222" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2284" y="265" width="70" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2480" y="240" />
-        <di:waypoint x="2522" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2336" y="240" />
-        <di:waypoint x="2380" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="390" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2522" y="472" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="2380" y="450" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2300" y="472" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2277" y="515" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2480" y="490" />
-        <di:waypoint x="2522" y="490" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2336" y="490" />
-        <di:waypoint x="2380" y="490" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="640" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2552" y="722" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2390" y="700" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2300" y="722" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2276" y="765" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2552" y="792" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="2442" y="762" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2420" y="805" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2490" y="740" />
-        <di:waypoint x="2552" y="740" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2336" y="740" />
-        <di:waypoint x="2390" y="740" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2460" y="798" />
-        <di:waypoint x="2460" y="810" />
-        <di:waypoint x="2552" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="894" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2770" y="894" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2552" y="976" width="36" height="36" />
+        <dc:Bounds x="3062" y="976" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2390" y="954" width="100" height="80" />
+        <dc:Bounds x="2900" y="954" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2300" y="976" width="36" height="36" />
+        <dc:Bounds x="2810" y="976" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2282" y="1019" width="76" height="27" />
+          <dc:Bounds x="2792" y="1019" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2490" y="994" />
-        <di:waypoint x="2552" y="994" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vd8mzp_di" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2336" y="994" />
-        <di:waypoint x="2390" y="994" />
+        <di:waypoint x="2846" y="994" />
+        <di:waypoint x="2900" y="994" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
+        <di:waypoint x="3000" y="994" />
+        <di:waypoint x="3062" y="994" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1dvyj5q_di" bpmnElement="EscalationThrowEvent">
+        <dc:Bounds x="1102" y="1352" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
+        <dc:Bounds x="2440" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="2502" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2485" y="225" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
+        <dc:Bounds x="2320" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0le8k76_di" bpmnElement="AdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="1940" y="390" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y4ytky_di" bpmnElement="TaskI">
+        <dc:Bounds x="2060" y="455" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_15ql81k_di" bpmnElement="Gateway_18qbndw">
+        <dc:Bounds x="1815" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1uz6s9v" bpmnElement="ParallelMultiInstanceAdHocSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="1940" y="715" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_00amvs8" bpmnElement="TaskJ">
+        <dc:Bounds x="2050" y="780" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1j0wcvz" bpmnElement="SequentialMultiInstanceAdHocSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="1940" y="1050" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_14x23bu" bpmnElement="TaskK">
+        <dc:Bounds x="2060" y="1110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wuhuhy_di" bpmnElement="Gateway_01n2aj8">
+        <dc:Bounds x="2415" y="1557" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="2372" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2352" y="265" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
         <dc:Bounds x="1362" y="1452" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -920,12 +1077,6 @@
         <dc:Bounds x="492" y="756" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="788" width="86" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="1862" y="222" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1842" y="265" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1159,7 +1310,7 @@
       <bpmndi:BPMNEdge id="Flow_1dzoyo4_di" bpmnElement="Flow_1dzoyo4">
         <di:waypoint x="1700" y="1607" />
         <di:waypoint x="1700" y="1670" />
-        <di:waypoint x="2075" y="1670" />
+        <di:waypoint x="2585" y="1670" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01ogvlh_di" bpmnElement="Flow_01ogvlh">
         <di:waypoint x="1495" y="200" />
@@ -1192,13 +1343,13 @@
         <di:waypoint x="1700" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nlysp1_di" bpmnElement="Flow_1nlysp1">
-        <di:waypoint x="2125" y="1670" />
-        <di:waypoint x="2692" y="1670" />
+        <di:waypoint x="2635" y="1670" />
+        <di:waypoint x="3202" y="1670" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bo0sui_di" bpmnElement="Flow_1bo0sui">
         <di:waypoint x="970" y="1607" />
         <di:waypoint x="970" y="1670" />
-        <di:waypoint x="2075" y="1670" />
+        <di:waypoint x="2585" y="1670" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xejz9b_di" bpmnElement="Flow_0xejz9b">
         <di:waypoint x="1380" y="1488" />
@@ -1211,17 +1362,62 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0u3kipb_di" bpmnElement="Flow_0u3kipb">
         <di:waypoint x="355" y="110" />
-        <di:waypoint x="1860" y="110" />
-        <di:waypoint x="1860" y="160" />
+        <di:waypoint x="2370" y="110" />
+        <di:waypoint x="2370" y="160" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0383azr_di" bpmnElement="Flow_0383azr">
-        <di:waypoint x="2028" y="200" />
-        <di:waypoint x="2100" y="200" />
-        <di:waypoint x="2100" y="1645" />
+        <di:waypoint x="2538" y="200" />
+        <di:waypoint x="2610" y="200" />
+        <di:waypoint x="2610" y="1645" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="1910" y="200" />
-        <di:waypoint x="1992" y="200" />
+        <di:waypoint x="2420" y="200" />
+        <di:waypoint x="2502" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1krp4hz_di" bpmnElement="Flow_1krp4hz">
+        <di:waypoint x="355" y="110" />
+        <di:waypoint x="1840" y="110" />
+        <di:waypoint x="1840" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16j5w5f_di" bpmnElement="Flow_16j5w5f">
+        <di:waypoint x="1840" y="225" />
+        <di:waypoint x="1840" y="490" />
+        <di:waypoint x="1940" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m41222_di" bpmnElement="Flow_0m41222">
+        <di:waypoint x="1840" y="225" />
+        <di:waypoint x="1840" y="815" />
+        <di:waypoint x="1940" y="815" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q6776b_di" bpmnElement="Flow_1q6776b">
+        <di:waypoint x="1840" y="225" />
+        <di:waypoint x="1840" y="1150" />
+        <di:waypoint x="1940" y="1150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v0pz7s_di" bpmnElement="Flow_0v0pz7s">
+        <di:waypoint x="2440" y="1607" />
+        <di:waypoint x="2440" y="1670" />
+        <di:waypoint x="2585" y="1670" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ektns0_di" bpmnElement="Flow_1ektns0">
+        <di:waypoint x="2290" y="1150" />
+        <di:waypoint x="2440" y="1150" />
+        <di:waypoint x="2440" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nj16xx_di" bpmnElement="Flow_1nj16xx">
+        <di:waypoint x="2290" y="815" />
+        <di:waypoint x="2440" y="815" />
+        <di:waypoint x="2440" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1atp6z8_di" bpmnElement="Flow_1atp6z8">
+        <di:waypoint x="2290" y="490" />
+        <di:waypoint x="2440" y="490" />
+        <di:waypoint x="2440" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="2390" y="258" />
+        <di:waypoint x="2390" y="320" />
+        <di:waypoint x="2440" y="320" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="0782300" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -406,6 +406,7 @@
       <bpmn:outgoing>Flow_1d2ue2p</bpmn:outgoing>
       <bpmn:outgoing>Flow_00b9dxt</bpmn:outgoing>
       <bpmn:outgoing>Flow_0yepp52</bpmn:outgoing>
+      <bpmn:outgoing>Flow_12u9pvx</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_00b9dxt</bpmn:incoming>
@@ -446,6 +447,7 @@
       <bpmn:incoming>Flow_1xou7mm</bpmn:incoming>
       <bpmn:incoming>Flow_19y2492</bpmn:incoming>
       <bpmn:incoming>Flow_01xs1ek</bpmn:incoming>
+      <bpmn:incoming>Flow_1yfpso7</bpmn:incoming>
       <bpmn:outgoing>Flow_0whnivt</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
@@ -491,6 +493,72 @@
     <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
     <bpmn:sequenceFlow id="Flow_0yepp52" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:sequenceFlow id="Flow_01xs1ek" sourceRef="CompensationThrowEvent" targetRef="Gateway_6" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess" name="Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskI&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0v443hz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dx8hzz</bpmn:outgoing>
+      <bpmn:serviceTask id="TaskI" name="Task I">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess" name="Parallel multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0x38e96</bpmn:incoming>
+      <bpmn:outgoing>Flow_07bkx0g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskJ" name="Task J">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess" name="Sequential multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskK&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_14ntaal</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fuizf1</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskK" name="Task K">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:parallelGateway id="Gateway_14pehud">
+      <bpmn:incoming>Flow_12u9pvx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0v443hz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0x38e96</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14ntaal</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_00j3vbq">
+      <bpmn:incoming>Flow_0dx8hzz</bpmn:incoming>
+      <bpmn:incoming>Flow_1fuizf1</bpmn:incoming>
+      <bpmn:incoming>Flow_07bkx0g</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yfpso7</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_12u9pvx" sourceRef="Gateway_1" targetRef="Gateway_14pehud" />
+    <bpmn:sequenceFlow id="Flow_0v443hz" sourceRef="Gateway_14pehud" targetRef="AdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0x38e96" sourceRef="Gateway_14pehud" targetRef="ParallelMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_14ntaal" sourceRef="Gateway_14pehud" targetRef="SequentialMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0dx8hzz" sourceRef="AdHocSubProcess" targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_1fuizf1" sourceRef="SequentialMultiInstanceAdHocSubProcess" targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_07bkx0g" sourceRef="ParallelMultiInstanceAdHocSubProcess" targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_1yfpso7" sourceRef="Gateway_00j3vbq" targetRef="Gateway_6" />
     <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
@@ -554,7 +622,7 @@
         <dc:Bounds x="400" y="178" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2432" y="1712" width="36" height="36" />
+        <dc:Bounds x="2784" y="1680" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
@@ -616,6 +684,62 @@
           <dc:Bounds x="718" y="804" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1e1imfy_di" bpmnElement="Gateway_14pehud">
+        <dc:Bounds x="1925" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0vr8496_di" bpmnElement="Gateway_00j3vbq">
+        <dc:Bounds x="2425" y="1523" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="2662" y="178" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="2924" y="260" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="2782" y="238" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="2702" y="260" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2686" y="303" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="2882" y="278" />
+        <di:waypoint x="2924" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="2738" y="278" />
+        <di:waypoint x="2782" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="2662" y="428" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="2924" y="510" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="2782" y="488" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="2702" y="510" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2679" y="553" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="2882" y="528" />
+        <di:waypoint x="2924" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="2738" y="528" />
+        <di:waypoint x="2782" y="528" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
         <dc:Bounds x="400" y="1230" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -629,20 +753,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1f4kynw_di" bpmnElement="SendTask">
         <dc:Bounds x="400" y="1590" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2092" y="192" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2075" y="235" width="71" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="1910" y="170" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2030" y="290" width="100" height="80" />
-        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
         <dc:Bounds x="1355" y="193" width="50" height="50" />
@@ -686,25 +796,43 @@
           <dc:Bounds x="1536" y="553" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0gmp7q3_di" bpmnElement="Gateway_1">
-        <dc:Bounds x="285" y="85" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
+        <dc:Bounds x="2662" y="678" width="350" height="200" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0sjq8dt_di" bpmnElement="Gateway_4">
-        <dc:Bounds x="1085" y="193" width="50" height="50" />
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="2954" y="760" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0o7tedy_di" bpmnElement="Gateway_5">
-        <dc:Bounds x="1805" y="1523" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="2792" y="738" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
-        <dc:Bounds x="1222" y="1370" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="2702" y="760" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2678" y="803" width="85" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_10o6pf2_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2285" y="1705" width="50" height="50" />
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="2954" y="830" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="1980" y="268" />
-        <di:waypoint x="1980" y="330" />
-        <di:waypoint x="2030" y="330" />
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="2844" y="800" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2823" y="843" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="2892" y="778" />
+        <di:waypoint x="2954" y="778" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="2738" y="778" />
+        <di:waypoint x="2792" y="778" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="2862" y="836" />
+        <di:waypoint x="2862" y="848" />
+        <di:waypoint x="2954" y="848" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1280" y="618" width="423" height="350" />
@@ -796,119 +924,96 @@
         <di:waypoint x="1464" y="1388" />
         <di:waypoint x="1496" y="1388" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="210" width="350" height="200" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Gateway_0gmp7q3_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="285" y="85" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2572" y="292" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_0sjq8dt_di" bpmnElement="Gateway_4">
+        <dc:Bounds x="1085" y="193" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="2430" y="270" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Gateway_0o7tedy_di" bpmnElement="Gateway_5">
+        <dc:Bounds x="1805" y="1523" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2350" y="292" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2334" y="335" width="70" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Gateway_10o6pf2_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="2637" y="1673" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2530" y="310" />
-        <di:waypoint x="2572" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2386" y="310" />
-        <di:waypoint x="2430" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="460" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2572" y="542" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="2430" y="520" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2350" y="542" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2327" y="585" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2530" y="560" />
-        <di:waypoint x="2572" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2386" y="560" />
-        <di:waypoint x="2430" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="710" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2602" y="792" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2440" y="770" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2350" y="792" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2326" y="835" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2602" y="862" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="2492" y="832" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2470" y="875" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2540" y="810" />
-        <di:waypoint x="2602" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2386" y="810" />
-        <di:waypoint x="2440" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2510" y="868" />
-        <di:waypoint x="2510" y="880" />
-        <di:waypoint x="2602" y="880" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="960" width="350" height="200" />
+        <dc:Bounds x="2662" y="928" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2602" y="1042" width="36" height="36" />
+        <dc:Bounds x="2954" y="1010" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2440" y="1020" width="100" height="80" />
+        <dc:Bounds x="2792" y="988" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2350" y="1042" width="36" height="36" />
+        <dc:Bounds x="2702" y="1010" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2332" y="1085" width="76" height="27" />
+          <dc:Bounds x="2684" y="1053" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2540" y="1060" />
-        <di:waypoint x="2602" y="1060" />
+        <di:waypoint x="2892" y="1028" />
+        <di:waypoint x="2954" y="1028" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vd8mzp_di" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2386" y="1060" />
-        <di:waypoint x="2440" y="1060" />
+        <di:waypoint x="2738" y="1028" />
+        <di:waypoint x="2792" y="1028" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
+        <dc:Bounds x="1222" y="1370" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="2444" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2427" y="203" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
+        <dc:Bounds x="2262" y="138" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
+        <dc:Bounds x="2382" y="258" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17mq8ma_di" bpmnElement="AdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="2040" y="428" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f56u0l_di" bpmnElement="TaskI">
+        <dc:Bounds x="2160" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_18hzbbj" bpmnElement="ParallelMultiInstanceAdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="2040" y="810" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0dibvk1" bpmnElement="TaskJ">
+        <dc:Bounds x="2160" y="862" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02upd8b" bpmnElement="SequentialMultiInstanceAdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="2040" y="1140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_18s5ceo" bpmnElement="TaskK">
+        <dc:Bounds x="2160" y="1192" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="2314" y="200" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2294" y="243" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
+        <dc:Bounds x="1568" y="1470" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1550" y="1513" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
         <dc:Bounds x="452" y="1121" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -931,18 +1036,6 @@
         <dc:Bounds x="452" y="639" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="402" y="666" width="56" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="1962" y="232" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1942" y="275" width="76" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
-        <dc:Bounds x="1568" y="1470" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1550" y="1513" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1029,8 +1122,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xou7mm_di" bpmnElement="Flow_1xou7mm">
         <di:waypoint x="1000" y="1655" />
-        <di:waypoint x="1000" y="1730" />
-        <di:waypoint x="2285" y="1730" />
+        <di:waypoint x="1000" y="1698" />
+        <di:waypoint x="2637" y="1698" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vp8yz2_di" bpmnElement="Flow_0vp8yz2">
         <di:waypoint x="500" y="779" />
@@ -1115,6 +1208,35 @@
         <di:waypoint x="500" y="1630" />
         <di:waypoint x="975" y="1630" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
+        <di:waypoint x="1405" y="218" />
+        <di:waypoint x="1595" y="218" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1492" y="200" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
+        <di:waypoint x="1405" y="328" />
+        <di:waypoint x="1562" y="328" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
+        <di:waypoint x="1380" y="353" />
+        <di:waypoint x="1380" y="428" />
+        <di:waypoint x="1562" y="428" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
+        <di:waypoint x="1598" y="328" />
+        <di:waypoint x="1735" y="328" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
+        <di:waypoint x="1598" y="428" />
+        <di:waypoint x="1760" y="428" />
+        <di:waypoint x="1760" y="353" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
+        <di:waypoint x="1398" y="528" />
+        <di:waypoint x="1562" y="528" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1d2ue2p_di" bpmnElement="Flow_1d2ue2p">
         <di:waypoint x="310" y="135" />
         <di:waypoint x="310" y="193" />
@@ -1153,66 +1275,14 @@
         <di:waypoint x="1110" y="1388" />
         <di:waypoint x="1222" y="1388" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0whnivt_di" bpmnElement="Flow_0whnivt">
-        <di:waypoint x="2335" y="1730" />
-        <di:waypoint x="2432" y="1730" />
+      <bpmndi:BPMNEdge id="Flow_1pu67u8_di" bpmnElement="Flow_1pu67u8">
+        <di:waypoint x="1586" y="1506" />
+        <di:waypoint x="1586" y="1548" />
+        <di:waypoint x="1805" y="1548" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19y2492_di" bpmnElement="Flow_19y2492">
-        <di:waypoint x="1830" y="1573" />
-        <di:waypoint x="1830" y="1730" />
-        <di:waypoint x="2285" y="1730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2010" y="210" />
-        <di:waypoint x="2092" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
-        <di:waypoint x="1405" y="218" />
-        <di:waypoint x="1595" y="218" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1492" y="200" width="16" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_186ylgv_di" bpmnElement="Flow_186ylgv">
-        <di:waypoint x="1645" y="218" />
-        <di:waypoint x="1830" y="218" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
-        <di:waypoint x="1405" y="328" />
-        <di:waypoint x="1562" y="328" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
-        <di:waypoint x="1380" y="353" />
-        <di:waypoint x="1380" y="428" />
-        <di:waypoint x="1562" y="428" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
-        <di:waypoint x="1598" y="328" />
-        <di:waypoint x="1735" y="328" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
-        <di:waypoint x="1598" y="428" />
-        <di:waypoint x="1760" y="428" />
-        <di:waypoint x="1760" y="353" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0brqydf_di" bpmnElement="Flow_0brqydf">
-        <di:waypoint x="1785" y="328" />
-        <di:waypoint x="1830" y="328" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
-        <di:waypoint x="1398" y="528" />
-        <di:waypoint x="1562" y="528" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1yhf88z_di" bpmnElement="Flow_1yhf88z">
-        <di:waypoint x="1598" y="528" />
-        <di:waypoint x="1830" y="528" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1fet2uy_di" bpmnElement="Flow_1fet2uy">
-        <di:waypoint x="1703" y="793" />
-        <di:waypoint x="1830" y="793" />
+      <bpmndi:BPMNEdge id="Flow_0tjifq7_di" bpmnElement="Flow_0tjifq7">
+        <di:waypoint x="1755" y="1388" />
+        <di:waypoint x="1830" y="1388" />
         <di:waypoint x="1830" y="1523" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bit3gk_di" bpmnElement="Flow_1bit3gk">
@@ -1220,30 +1290,98 @@
         <di:waypoint x="1830" y="1128" />
         <di:waypoint x="1830" y="1523" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fet2uy_di" bpmnElement="Flow_1fet2uy">
+        <di:waypoint x="1703" y="793" />
+        <di:waypoint x="1830" y="793" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yhf88z_di" bpmnElement="Flow_1yhf88z">
+        <di:waypoint x="1598" y="528" />
+        <di:waypoint x="1830" y="528" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0brqydf_di" bpmnElement="Flow_0brqydf">
+        <di:waypoint x="1785" y="328" />
+        <di:waypoint x="1830" y="328" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_186ylgv_di" bpmnElement="Flow_186ylgv">
+        <di:waypoint x="1645" y="218" />
+        <di:waypoint x="1830" y="218" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0whnivt_di" bpmnElement="Flow_0whnivt">
+        <di:waypoint x="2687" y="1698" />
+        <di:waypoint x="2784" y="1698" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19y2492_di" bpmnElement="Flow_19y2492">
+        <di:waypoint x="1830" y="1573" />
+        <di:waypoint x="1830" y="1698" />
+        <di:waypoint x="2637" y="1698" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yr2bpp_di" bpmnElement="Flow_0yr2bpp">
         <di:waypoint x="1258" y="1388" />
         <di:waypoint x="1405" y="1388" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tjifq7_di" bpmnElement="Flow_0tjifq7">
-        <di:waypoint x="1755" y="1388" />
-        <di:waypoint x="1830" y="1388" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1pu67u8_di" bpmnElement="Flow_1pu67u8">
-        <di:waypoint x="1586" y="1506" />
-        <di:waypoint x="1586" y="1548" />
-        <di:waypoint x="1805" y="1548" />
+      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
+        <di:waypoint x="2362" y="178" />
+        <di:waypoint x="2444" y="178" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yepp52_di" bpmnElement="Flow_0yepp52">
         <di:waypoint x="335" y="110" />
-        <di:waypoint x="1960" y="110" />
-        <di:waypoint x="1960" y="170" />
+        <di:waypoint x="2312" y="110" />
+        <di:waypoint x="2312" y="138" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01xs1ek_di" bpmnElement="Flow_01xs1ek">
-        <di:waypoint x="2128" y="210" />
-        <di:waypoint x="2200" y="210" />
-        <di:waypoint x="2200" y="1730" />
-        <di:waypoint x="2285" y="1730" />
+        <di:waypoint x="2480" y="178" />
+        <di:waypoint x="2552" y="178" />
+        <di:waypoint x="2552" y="1698" />
+        <di:waypoint x="2637" y="1698" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="2332" y="236" />
+        <di:waypoint x="2332" y="298" />
+        <di:waypoint x="2382" y="298" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12u9pvx_di" bpmnElement="Flow_12u9pvx">
+        <di:waypoint x="335" y="110" />
+        <di:waypoint x="1950" y="110" />
+        <di:waypoint x="1950" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v443hz_di" bpmnElement="Flow_0v443hz">
+        <di:waypoint x="1950" y="243" />
+        <di:waypoint x="1950" y="528" />
+        <di:waypoint x="2040" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x38e96_di" bpmnElement="Flow_0x38e96">
+        <di:waypoint x="1950" y="243" />
+        <di:waypoint x="1950" y="910" />
+        <di:waypoint x="2040" y="910" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14ntaal_di" bpmnElement="Flow_14ntaal">
+        <di:waypoint x="1950" y="243" />
+        <di:waypoint x="1950" y="1240" />
+        <di:waypoint x="2040" y="1240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dx8hzz_di" bpmnElement="Flow_0dx8hzz">
+        <di:waypoint x="2390" y="528" />
+        <di:waypoint x="2450" y="528" />
+        <di:waypoint x="2450" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fuizf1_di" bpmnElement="Flow_1fuizf1">
+        <di:waypoint x="2390" y="1240" />
+        <di:waypoint x="2450" y="1240" />
+        <di:waypoint x="2450" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07bkx0g_di" bpmnElement="Flow_07bkx0g">
+        <di:waypoint x="2390" y="910" />
+        <di:waypoint x="2450" y="910" />
+        <di:waypoint x="2450" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yfpso7_di" bpmnElement="Flow_1yfpso7">
+        <di:waypoint x="2450" y="1573" />
+        <di:waypoint x="2450" y="1698" />
+        <di:waypoint x="2637" y="1698" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_3.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_3.bpmn
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+  exporterVersion="eda7bab" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -21,7 +30,8 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment2" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment2"
+      targetRef="ExclusiveGateway_1qqmrb8" />
     <bpmn:serviceTask id="requestForPayment2" name="Request for payment 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
@@ -29,11 +39,14 @@
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment2">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid"
+      sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment2" targetRef="checkPayment2" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles2">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment2"
+      targetRef="checkPayment2" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8"
+      targetRef="shipArticles2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="shipArticles2" name="Ship Articles 2">
@@ -43,7 +56,8 @@
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles2" targetRef="notifyCustomer2" />
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles2"
+      targetRef="notifyCustomer2" />
     <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="notifyCustomer2" targetRef="checkDeliveryState2" />
     <bpmn:serviceTask id="notifyCustomer2" name="Notify Customer 2">
       <bpmn:extensionElements>
@@ -100,7 +114,8 @@
       <bpmn:incoming>Flow_1478njt</bpmn:incoming>
       <bpmn:outgoing>Flow_0279afj</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="MessageInterrupting2" name="Message interrupting 2" attachedToRef="TaskA2">
+    <bpmn:boundaryEvent id="MessageInterrupting2" name="Message interrupting 2"
+      attachedToRef="TaskA2">
       <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
     </bpmn:boundaryEvent>
@@ -110,11 +125,13 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="MessageNonInterrupting2" name="Message non-interrupting 2" cancelActivity="false" attachedToRef="TaskC2">
+    <bpmn:boundaryEvent id="MessageNonInterrupting2" name="Message non-interrupting 2"
+      cancelActivity="false" attachedToRef="TaskC2">
       <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_1xpzcw8" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="TimerNonInterrupting2" name="Timer non-interrupting 2" cancelActivity="false" attachedToRef="TaskD2">
+    <bpmn:boundaryEvent id="TimerNonInterrupting2" name="Timer non-interrupting 2"
+      cancelActivity="false" attachedToRef="TaskD2">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
@@ -175,7 +192,8 @@
     <bpmn:sequenceFlow id="Flow_0kfelct" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch2" />
     <bpmn:sequenceFlow id="Flow_1j5fksj" sourceRef="MessageIntermediateCatch2" targetRef="Gateway_3" />
     <bpmn:sequenceFlow id="Flow_0aheimq" sourceRef="TaskA2" targetRef="Gateway_3" />
-    <bpmn:subProcess id="TimerEventSubProcess2" name="Timer event sub process 2" triggeredByEvent="true">
+    <bpmn:subProcess id="TimerEventSubProcess2" name="Timer event sub process 2"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
       </bpmn:endEvent>
@@ -195,7 +213,8 @@
       <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF2" targetRef="Event_0lk89tk" />
       <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF2" />
     </bpmn:subProcess>
-    <bpmn:subProcess id="MessageEventSubProcess2" name="Message event sub process 2" triggeredByEvent="true">
+    <bpmn:subProcess id="MessageEventSubProcess2" name="Message event sub process 2"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
       </bpmn:endEvent>
@@ -208,12 +227,14 @@
       </bpmn:serviceTask>
       <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
         <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_312oin4" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx"
+          messageRef="Message_312oin4" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE2" targetRef="Event_13rtwuo" />
       <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE2" />
     </bpmn:subProcess>
-    <bpmn:receiveTask id="MessageReceiveTask2" name="Message receive task 2" messageRef="Message_1r6tus3">
+    <bpmn:receiveTask id="MessageReceiveTask2" name="Message receive task 2"
+      messageRef="Message_1r6tus3">
       <bpmn:incoming>Flow_00bezny</bpmn:incoming>
       <bpmn:outgoing>Flow_16drwmj</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -266,7 +287,8 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:intermediateCatchEvent id="MessageIntermediateCatchB2" name="Message intermediate catch B2">
+    <bpmn:intermediateCatchEvent id="MessageIntermediateCatchB2"
+      name="Message intermediate catch B2">
       <bpmn:incoming>Flow_0v8bsdg</bpmn:incoming>
       <bpmn:outgoing>Flow_17zq5s0</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_17s00ai" messageRef="Message_0qjep2d" />
@@ -276,13 +298,18 @@
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:outgoing>Flow_0u9dvrj</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway2" targetRef="Gateway_1cs756a">
+    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway2"
+      targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway2" targetRef="TimerIntermediateCatchB2" />
-    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway2" targetRef="MessageIntermediateCatchB2" />
-    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB2" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB2" targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway2"
+      targetRef="TimerIntermediateCatchB2" />
+    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway2"
+      targetRef="MessageIntermediateCatchB2" />
+    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB2"
+      targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB2"
+      targetRef="Gateway_0ftzss1" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
       <bpmn:incoming>Flow_041w5kk</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
@@ -293,8 +320,10 @@
       <bpmn:outgoing>Flow_04ta31i</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_0j5das4" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch2" />
-    <bpmn:subProcess id="SignalEventSubProcess2" name="Signal event sub process 2" triggeredByEvent="true">
+    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow"
+      targetRef="SignalIntermediateCatch2" />
+    <bpmn:subProcess id="SignalEventSubProcess2" name="Signal event sub process 2"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
       </bpmn:endEvent>
@@ -312,7 +341,8 @@
       <bpmn:endEvent id="Event_049m1di">
         <bpmn:incoming>Flow_0bfr615</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:boundaryEvent id="SignalBoudaryEvent2" name="Signal boundary event 2" attachedToRef="TaskH">
+      <bpmn:boundaryEvent id="SignalBoudaryEvent2" name="Signal boundary event 2"
+        attachedToRef="TaskH">
         <bpmn:outgoing>Flow_0bfr615</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_0o1z67o" signalRef="Signal_0j5das4" />
       </bpmn:boundaryEvent>
@@ -330,7 +360,8 @@
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_04fbdug</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process"
+        triggeredByEvent="true">
         <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
           <bpmn:outgoing>Flow_1nc8qvq</bpmn:outgoing>
           <bpmn:errorEventDefinition id="ErrorEventDefinition_1jxc702" errorRef="Error_0guddpc" />
@@ -348,7 +379,8 @@
         <bpmn:sequenceFlow id="Flow_1nc8qvq" sourceRef="ErrorStartEvent" targetRef="TaskG" />
         <bpmn:sequenceFlow id="Flow_1n6hwxq" sourceRef="TaskG" targetRef="Event_12yeu6m" />
       </bpmn:subProcess>
-      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
+      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent"
+        targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
     <bpmn:subProcess id="MultiInstanceSubProcess2" name="Multi instance sub process 2">
       <bpmn:incoming>Flow_0nfno00</bpmn:incoming>
@@ -388,7 +420,8 @@
       <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
         <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
         <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_1fppfbl" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il"
+          escalationRef="Escalation_1fppfbl" />
       </bpmn:intermediateThrowEvent>
       <bpmn:startEvent id="Event_1vxuw3v">
         <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
@@ -404,9 +437,11 @@
       <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
       <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
     </bpmn:subProcess>
-    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event" attachedToRef="EscalationSubProcess">
+    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event"
+      attachedToRef="EscalationSubProcess">
       <bpmn:outgoing>Flow_19stf58</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1fppfbl" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l"
+        escalationRef="Escalation_1fppfbl" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_13zdve9" sourceRef="Gateway_1" targetRef="Gateway_2" />
     <bpmn:parallelGateway id="Gateway_1">
@@ -414,6 +449,7 @@
       <bpmn:outgoing>Flow_13zdve9</bpmn:outgoing>
       <bpmn:outgoing>Flow_1rs7xob</bpmn:outgoing>
       <bpmn:outgoing>Flow_1hxtfne</bpmn:outgoing>
+      <bpmn:outgoing>Flow_013v9pn</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_1rs7xob</bpmn:incoming>
@@ -453,10 +489,12 @@
       <bpmn:incoming>Flow_1ibxab9</bpmn:incoming>
       <bpmn:incoming>Flow_1c49dph</bpmn:incoming>
       <bpmn:incoming>Flow_0f4n4wb</bpmn:incoming>
+      <bpmn:incoming>Flow_0xe17zu</bpmn:incoming>
       <bpmn:outgoing>Flow_1tyhemw</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1c49dph" sourceRef="Gateway_5" targetRef="Gateway_6" />
-    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_1cmlzk4">
         <bpmn:incoming>Flow_0of03mm</bpmn:incoming>
       </bpmn:endEvent>
@@ -467,19 +505,24 @@
         <bpmn:incoming>Flow_0vd8mzp</bpmn:incoming>
         <bpmn:outgoing>Flow_0of03mm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event" isInterrupting="false">
+      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event"
+        isInterrupting="false">
         <bpmn:outgoing>Flow_0vd8mzp</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s" escalationRef="Escalation_1fppfbl" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s"
+          escalationRef="Escalation_1fppfbl" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_0of03mm" sourceRef="EscalationEventTask" targetRef="Event_1cmlzk4" />
-      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent" targetRef="EscalationEventTask" />
+      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent"
+        targetRef="EscalationEventTask" />
     </bpmn:subProcess>
     <bpmn:intermediateThrowEvent id="EscalationThrowEvent">
       <bpmn:incoming>Flow_0ykwgtn</bpmn:incoming>
       <bpmn:outgoing>Flow_0bhp20l</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025" escalationRef="Escalation_1fppfbl" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025"
+        escalationRef="Escalation_1fppfbl" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:sequenceFlow id="Flow_0bhp20l" sourceRef="EscalationThrowEvent" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0bhp20l" sourceRef="EscalationThrowEvent"
+      targetRef="EscalationSubProcess" />
     <bpmn:intermediateThrowEvent id="CompensationThrowEvent" name="Compensation throw event">
       <bpmn:incoming>Flow_0ejrzsk</bpmn:incoming>
       <bpmn:outgoing>Flow_0f4n4wb</bpmn:outgoing>
@@ -493,13 +536,88 @@
       <bpmn:outgoing>Flow_0ejrzsk</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:task id="UndoTask" name="Undo" isForCompensation="true" />
-    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event" attachedToRef="CompensationTask">
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event"
+      attachedToRef="CompensationTask">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a309d0" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
+    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask"
+      targetRef="CompensationThrowEvent" />
     <bpmn:sequenceFlow id="Flow_1hxtfne" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:sequenceFlow id="Flow_0f4n4wb" sourceRef="CompensationThrowEvent" targetRef="Gateway_6" />
-    <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess2" name="Ad hoc sub process 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskI2&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0rawrrz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1acta43</bpmn:outgoing>
+      <bpmn:serviceTask id="TaskI2" name="Task I2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess2"
+      name="Sequential multi instance Ad hoc sub process 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskK2&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1v1ohc8</bpmn:incoming>
+      <bpmn:outgoing>Flow_19ud3sr</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskK2" name="Task K2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess2"
+      name="Parallel multi instance Ad hoc sub process 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ2&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0cowwuj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xki2u7</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskJ2" name="Task J2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:parallelGateway id="Gateway_1wrnxon">
+      <bpmn:incoming>Flow_013v9pn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rawrrz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0cowwuj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1v1ohc8</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_1azg5ns">
+      <bpmn:incoming>Flow_19ud3sr</bpmn:incoming>
+      <bpmn:incoming>Flow_1xki2u7</bpmn:incoming>
+      <bpmn:incoming>Flow_1acta43</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xe17zu</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_19ud3sr" sourceRef="SequentialMultiInstanceAdHocSubProcess2"
+      targetRef="Gateway_1azg5ns" />
+    <bpmn:sequenceFlow id="Flow_1xki2u7" sourceRef="ParallelMultiInstanceAdHocSubProcess2"
+      targetRef="Gateway_1azg5ns" />
+    <bpmn:sequenceFlow id="Flow_1acta43" sourceRef="AdHocSubProcess2" targetRef="Gateway_1azg5ns" />
+    <bpmn:sequenceFlow id="Flow_013v9pn" sourceRef="Gateway_1" targetRef="Gateway_1wrnxon" />
+    <bpmn:sequenceFlow id="Flow_0rawrrz" sourceRef="Gateway_1wrnxon" targetRef="AdHocSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_0cowwuj" sourceRef="Gateway_1wrnxon"
+      targetRef="ParallelMultiInstanceAdHocSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_1v1ohc8" sourceRef="Gateway_1wrnxon"
+      targetRef="SequentialMultiInstanceAdHocSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_0xe17zu" sourceRef="Gateway_1azg5ns" targetRef="Gateway_6" />
+    <bpmn:association id="Association_0xok9ld" associationDirection="One"
+      sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -567,7 +685,14 @@
         <dc:Bounds x="360" y="168" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="3072" y="1651" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
+        isMarkerVisible="true">
         <dc:Bounds x="529" y="183" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="519" y="159" width="69" height="14" />
@@ -635,12 +760,58 @@
           <dc:Bounds x="745" y="795" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2662" y="1662" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2900" y="419" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="3162" y="501" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
+        <dc:Bounds x="3020" y="479" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="2940" y="501" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="270" width="90" height="12" />
+          <dc:Bounds x="2917" y="544" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="3120" y="519" />
+        <di:waypoint x="3162" y="519" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="2976" y="519" />
+        <di:waypoint x="3020" y="519" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2900" y="169" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="3162" y="251" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
+        <dc:Bounds x="3020" y="229" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="2940" y="251" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2924" y="294" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="3120" y="269" />
+        <di:waypoint x="3162" y="269" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="2976" y="269" />
+        <di:waypoint x="3020" y="269" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask2">
         <dc:Bounds x="360" y="1220" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -656,7 +827,8 @@
         <dc:Bounds x="360" y="1550" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway2" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway2"
+        isMarkerVisible="true">
         <dc:Bounds x="1427" y="183" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1427" y="241" width="51" height="27" />
@@ -698,23 +870,45 @@
           <dc:Bounds x="1608" y="563" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2242" y="190" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2900" y="669" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="3192" y="751" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="3030" y="729" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="2940" y="751" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2227" y="233" width="71" height="27" />
+          <dc:Bounds x="2916" y="794" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="2060" y="168" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="3192" y="821" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2180" y="288" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
+        <dc:Bounds x="3082" y="791" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3063" y="834" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2365" y="1655" width="50" height="50" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="3130" y="769" />
+        <di:waypoint x="3192" y="769" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="2976" y="769" />
+        <di:waypoint x="3030" y="769" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="3100" y="827" />
+        <di:waypoint x="3100" y="839" />
+        <di:waypoint x="3192" y="839" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1402" y="628" width="423" height="350" />
         <bpmndi:BPMNLabel />
@@ -754,7 +948,8 @@
         <di:waypoint x="1515" y="688" />
         <di:waypoint x="1692" y="688" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess2" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess2"
+        isExpanded="true">
         <dc:Bounds x="1412" y="1018" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -776,7 +971,8 @@
         <di:waypoint x="1640" y="1118" />
         <di:waypoint x="1692" y="1118" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1412" y="1248" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -814,127 +1010,90 @@
       <bpmndi:BPMNShape id="Gateway_06z2xtb_di" bpmnElement="Gateway_5">
         <dc:Bounds x="1905" y="1565" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
-        <dc:Bounds x="1342" y="1330" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="2775" y="1644" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="2130" y="266" />
-        <di:waypoint x="2130" y="328" />
-        <di:waypoint x="2180" y="328" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="2490" y="430" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2752" y="512" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
-        <dc:Bounds x="2610" y="490" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2530" y="512" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2507" y="555" width="83" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2710" y="530" />
-        <di:waypoint x="2752" y="530" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2566" y="530" />
-        <di:waypoint x="2610" y="530" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="2490" y="180" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2752" y="262" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
-        <dc:Bounds x="2610" y="240" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2530" y="262" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2514" y="305" width="70" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2710" y="280" />
-        <di:waypoint x="2752" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2566" y="280" />
-        <di:waypoint x="2610" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="2490" y="680" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2782" y="762" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2620" y="740" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2530" y="762" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2506" y="805" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2782" y="832" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
-        <dc:Bounds x="2672" y="802" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2652" y="845" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2720" y="780" />
-        <di:waypoint x="2782" y="780" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2566" y="780" />
-        <di:waypoint x="2620" y="780" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2690" y="838" />
-        <di:waypoint x="2690" y="850" />
-        <di:waypoint x="2782" y="850" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="BPMNShape_0bwi9k5" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2490" y="930" width="350" height="200" />
+      <bpmndi:BPMNShape id="BPMNShape_0bwi9k5" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2900" y="919" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2782" y="1012" width="36" height="36" />
+        <dc:Bounds x="3192" y="1001" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2620" y="990" width="100" height="80" />
+        <dc:Bounds x="3030" y="979" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2530" y="1012" width="36" height="36" />
+        <dc:Bounds x="2940" y="1001" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2510" y="1055" width="76" height="27" />
+          <dc:Bounds x="2920" y="1044" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2720" y="1030" />
-        <di:waypoint x="2782" y="1030" />
+        <di:waypoint x="3130" y="1019" />
+        <di:waypoint x="3192" y="1019" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_095dl4e" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2566" y="1030" />
-        <di:waypoint x="2620" y="1030" />
+        <di:waypoint x="2976" y="1019" />
+        <di:waypoint x="3030" y="1019" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
+        <dc:Bounds x="1342" y="1330" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="2652" y="179" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2637" y="222" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
+        <dc:Bounds x="2470" y="157" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
+        <dc:Bounds x="2590" y="277" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jfa5hv_di" bpmnElement="AdHocSubProcess2" isExpanded="true">
+        <dc:Bounds x="2190" y="507" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ep6491_di" bpmnElement="TaskI2">
+        <dc:Bounds x="2310" y="570" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0r5e346" bpmnElement="SequentialMultiInstanceAdHocSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2190" y="1110" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ppj71p" bpmnElement="TaskK2">
+        <dc:Bounds x="2310" y="1173" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0a2uyvl" bpmnElement="ParallelMultiInstanceAdHocSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2190" y="800" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0zv29h9" bpmnElement="TaskJ2">
+        <dc:Bounds x="2310" y="863" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0fi1sa1_di" bpmnElement="Gateway_1wrnxon">
+        <dc:Bounds x="2065" y="183" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0rftrqi_di" bpmnElement="Gateway_1azg5ns">
+        <dc:Bounds x="2615" y="1565" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="2522" y="219" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2502" y="262" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
         <dc:Bounds x="1575" y="1430" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -963,12 +1122,6 @@
         <dc:Bounds x="412" y="629" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="358" y="656" width="65" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="2112" y="230" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2092" y="273" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1069,8 +1222,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ibxab9_di" bpmnElement="Flow_1ibxab9">
         <di:waypoint x="1130" y="1615" />
-        <di:waypoint x="1130" y="1680" />
-        <di:waypoint x="2365" y="1680" />
+        <di:waypoint x="1130" y="1669" />
+        <di:waypoint x="2775" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lyxcbw_di" bpmnElement="Flow_0lyxcbw">
         <di:waypoint x="460" y="769" />
@@ -1248,31 +1401,76 @@
         <di:waypoint x="1905" y="1590" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tyhemw_di" bpmnElement="Flow_1tyhemw">
-        <di:waypoint x="2415" y="1680" />
-        <di:waypoint x="2662" y="1680" />
+        <di:waypoint x="2825" y="1669" />
+        <di:waypoint x="3072" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1c49dph_di" bpmnElement="Flow_1c49dph">
         <di:waypoint x="1930" y="1615" />
-        <di:waypoint x="1930" y="1680" />
-        <di:waypoint x="2365" y="1680" />
+        <di:waypoint x="1930" y="1669" />
+        <di:waypoint x="2775" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bhp20l_di" bpmnElement="Flow_0bhp20l">
         <di:waypoint x="1378" y="1348" />
         <di:waypoint x="1412" y="1348" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2160" y="208" />
-        <di:waypoint x="2242" y="208" />
+        <di:waypoint x="2570" y="197" />
+        <di:waypoint x="2652" y="197" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hxtfne_di" bpmnElement="Flow_1hxtfne">
         <di:waypoint x="315" y="110" />
-        <di:waypoint x="2110" y="110" />
-        <di:waypoint x="2110" y="168" />
+        <di:waypoint x="2520" y="110" />
+        <di:waypoint x="2520" y="157" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0f4n4wb_di" bpmnElement="Flow_0f4n4wb">
-        <di:waypoint x="2278" y="208" />
-        <di:waypoint x="2390" y="208" />
-        <di:waypoint x="2390" y="1655" />
+        <di:waypoint x="2688" y="197" />
+        <di:waypoint x="2800" y="197" />
+        <di:waypoint x="2800" y="1644" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ud3sr_di" bpmnElement="Flow_19ud3sr">
+        <di:waypoint x="2540" y="1210" />
+        <di:waypoint x="2640" y="1210" />
+        <di:waypoint x="2640" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xki2u7_di" bpmnElement="Flow_1xki2u7">
+        <di:waypoint x="2540" y="900" />
+        <di:waypoint x="2640" y="900" />
+        <di:waypoint x="2640" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1acta43_di" bpmnElement="Flow_1acta43">
+        <di:waypoint x="2540" y="607" />
+        <di:waypoint x="2640" y="607" />
+        <di:waypoint x="2640" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_013v9pn_di" bpmnElement="Flow_013v9pn">
+        <di:waypoint x="315" y="110" />
+        <di:waypoint x="2090" y="110" />
+        <di:waypoint x="2090" y="183" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rawrrz_di" bpmnElement="Flow_0rawrrz">
+        <di:waypoint x="2090" y="233" />
+        <di:waypoint x="2090" y="607" />
+        <di:waypoint x="2190" y="607" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cowwuj_di" bpmnElement="Flow_0cowwuj">
+        <di:waypoint x="2090" y="233" />
+        <di:waypoint x="2090" y="900" />
+        <di:waypoint x="2190" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v1ohc8_di" bpmnElement="Flow_1v1ohc8">
+        <di:waypoint x="2090" y="233" />
+        <di:waypoint x="2090" y="1210" />
+        <di:waypoint x="2190" y="1210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xe17zu_di" bpmnElement="Flow_0xe17zu">
+        <di:waypoint x="2640" y="1615" />
+        <di:waypoint x="2640" y="1669" />
+        <di:waypoint x="2775" y="1669" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="2540" y="255" />
+        <di:waypoint x="2540" y="317" />
+        <di:waypoint x="2590" y="317" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -243,6 +243,23 @@ test.describe.serial('Process Instance Migration', () => {
           label: 'target element for message start event',
           targetValue: 'MessageStartEvent',
         },
+        {
+          label: 'target element for ad hoc sub process',
+          targetValue: 'AdHocSubProcess',
+        },
+        {label: 'target element for task i', targetValue: 'TaskI'},
+        {
+          label:
+            'target element for parallel multi instance ad hoc sub process',
+          targetValue: 'ParallelMultiInstanceAdHocSubProcess',
+        },
+        {label: 'target element for task j', targetValue: 'TaskJ'},
+        {
+          label:
+            'target element for sequential multi instance ad hoc sub process',
+          targetValue: 'SequentialMultiInstanceAdHocSubProcess',
+        },
+        {label: 'target element for task k', targetValue: 'TaskK'},
       ]);
 
       await operateProcessMigrationModePage.completeProcessInstanceMigration();
@@ -318,6 +335,44 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
+  test('Migrated ad hoc sub processes', async ({
+    page,
+    operateFiltersPanelPage,
+    operateProcessesPage,
+    operateOperationPanelPage,
+  }) => {
+    const targetBpmnProcessId = testProcesses.processV2.bpmnProcessId;
+    const targetVersion = testProcesses.processV2.version.toString();
+
+    await test.step('Navigate to processes and expand operations panel', async () => {
+      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(targetVersion);
+
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
+        timeout: 30000,
+      });
+
+      await operateOperationPanelPage.expandOperationIdField();
+    });
+
+    const tasksToVerify = ['TaskI', 'TaskJ', 'TaskK'];
+    for (const taskId of tasksToVerify) {
+      await test.step(`Get migration operation ID and verify ${taskId} instances`, async () => {
+        const operationId =
+          await operateOperationPanelPage.getMigrationOperationId();
+
+        await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
+        await operateFiltersPanelPage.selectVersion(targetVersion);
+
+        await page.goto(
+          `operate/processes?active=true&incidents=true&process=${targetBpmnProcessId}&version=${targetVersion}&operationId=${operationId}&flowNodeId=${taskId}`,
+        );
+
+        await expect(page.getByText('6 results')).toBeVisible({timeout: 90000});
+      });
+    }
+  });
+
   test('Manual mapping migration', async ({
     page,
     operateFiltersPanelPage,
@@ -369,6 +424,9 @@ test.describe.serial('Process Instance Migration', () => {
       await operateProcessMigrationModePage.mapFlowNode('Task B', 'Task B2');
       await operateProcessMigrationModePage.mapFlowNode('Task C', 'Task A2');
       await operateProcessMigrationModePage.mapFlowNode('Task D', 'Task D2');
+      await operateProcessMigrationModePage.mapFlowNode('Task I', 'Task I2');
+      await operateProcessMigrationModePage.mapFlowNode('Task J', 'Task J2');
+      await operateProcessMigrationModePage.mapFlowNode('Task K', 'Task K2');
 
       await operateProcessMigrationModePage.mapFlowNode(
         'Message interrupting',
@@ -469,6 +527,18 @@ test.describe.serial('Process Instance Migration', () => {
       await operateProcessMigrationModePage.mapFlowNode(
         'Multi instance task',
         'Multi instance task 2',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'Ad hoc sub process',
+        'Ad hoc sub process 2',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'Parallel multi instance Ad hoc sub process',
+        'Parallel multi instance Ad hoc sub process 2',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'Sequential multi instance Ad hoc sub process',
+        'Sequential multi instance Ad hoc sub process 2',
       );
     });
 


### PR DESCRIPTION
## Description

This pull request enhances the process instance migration end-to-end tests by expanding coverage for ad hoc sub processes and related tasks. The changes introduce new test cases and mappings to ensure that migration scenarios involving ad hoc sub processes, including their multi-instance variants and associated tasks, are thoroughly validated.

**Expanded test coverage for ad hoc sub processes:**

* Added new test case to verify the migration of ad hoc sub processes and their associated tasks (`TaskI`, `TaskJ`, `TaskK`) by checking that the expected number of instances exist after migration.
* Included additional mapping options for ad hoc sub processes and their multi-instance variants in the migration mapping steps, ensuring these elements are correctly handled during migration. [[1]](diffhunk://#diff-73e2c9a6d566ea33694863f9a90bd5dd71e61a02bd416b2f9da08e8ffc8e819eR246-R262) [[2]](diffhunk://#diff-73e2c9a6d566ea33694863f9a90bd5dd71e61a02bd416b2f9da08e8ffc8e819eR568-R579)

**Additional flow node mappings:**

* Added mappings for tasks `Task I`, `Task J`, and `Task K` as part of the manual mapping migration test, increasing the test's comprehensiveness for different flow node types.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
