### PR TITLE
Short circuit recording exporter for Zeebe Engine QA ITs

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
@@ -18,8 +18,6 @@ import io.camunda.client.api.response.Process;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -165,25 +163,18 @@ public final class CreateDeploymentTest {
             .startEvent()
             .documentation("x".repeat((1046900)))
             .done();
-    final var command =
-        getCommand(client, false)
-            .addProcessModel(modelThatFitsJustWithinMaxMessageSize, "too_large_process.bpmn")
-            .send();
+    getCommand(client, false)
+        .addProcessModel(modelThatFitsJustWithinMaxMessageSize, "too_large_process.bpmn")
+        .send();
 
     // then
-    final var rejectedRecords =
-        RecordingExporter.records()
-            .filter(record -> RecordType.COMMAND_REJECTION.equals(record.getRecordType()))
-            .toList();
-
-    rejectedRecords.stream()
-        .map(Record::getValue)
-        .forEach(
-            recordValue -> {
-              if (recordValue instanceof DeploymentRecord) {
-                assertThat(((DeploymentRecord) recordValue).getResources()).isEmpty();
-              }
-            });
+    assertThat(
+            RecordingExporter.deploymentRecords()
+                .filter(record -> RecordType.COMMAND_REJECTION.equals(record.getRecordType()))
+                .getFirst()
+                .getValue()
+                .getResources())
+        .isEmpty();
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateDeploymentTest.java
@@ -18,7 +18,6 @@ import io.camunda.client.api.response.Process;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -170,7 +169,7 @@ public final class CreateDeploymentTest {
     // then
     assertThat(
             RecordingExporter.deploymentRecords()
-                .filter(record -> RecordType.COMMAND_REJECTION.equals(record.getRecordType()))
+                .onlyCommandRejections()
                 .getFirst()
                 .getValue()
                 .getResources())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/JobWorkerTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/JobWorkerTest.java
@@ -422,14 +422,12 @@ final class JobWorkerTest {
       final var startedPiKeys = new CopyOnWriteArrayList<Long>();
 
       // when
-      RecordingExporter.setMaximumWaitTime(100);
-      Awaitility.await("until transport is suspended and jobs are yielded")
+      RecordingExporter.await()
           .untilAsserted(
               () -> {
                 startedPiKeys.add(createProcessInstance(uniqueId, payload));
-                assertThat(RecordingExporter.jobRecords(JobIntent.YIELDED).limit(1)).hasSize(1);
+                assertThat(RecordingExporter.jobRecords(JobIntent.YIELDED).exists()).isTrue();
               });
-      RecordingExporter.setMaximumWaitTime(5000);
 
       final var firstYieldedPi =
           RecordingExporter.jobRecords(JobIntent.YIELDED)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/RejectLargeDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/RejectLargeDeploymentTest.java
@@ -46,7 +46,10 @@ public class RejectLargeDeploymentTest {
     }
 
     // then -- The rejection can be exported
-    assertThat(RecordingExporter.deploymentRecords().withRecordType(RecordType.COMMAND_REJECTION))
-        .isNotEmpty();
+    assertThat(
+            RecordingExporter.deploymentRecords()
+                .withRecordType(RecordType.COMMAND_REJECTION)
+                .exists())
+        .isTrue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a utility method to wrap awaitility withing the `RecordingExporter`. This prevents having to set the maximum wait time of the exporter and reverting it back. It also uses this in relevant test cases and ensures some others are properly short-circuited.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42315 
