### PR TITLE
[Backport main] ci: move GitHub release step to end of workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -380,7 +380,7 @@ jobs:
         if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: octokit/request-action@v2.3.1
+        uses: octokit/request-action@v2.4.0
         with:
           route: POST /repos/camunda/camunda/releases
           draft: false

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -383,7 +383,7 @@ jobs:
         uses: octokit/request-action@v2.3.1
         with:
           route: POST /repos/camunda/camunda/releases
-          draft: true
+          draft: false
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
           generate_release_notes: true

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -276,23 +276,6 @@ jobs:
             git push origin :refs/tags/"${TAG}"
           fi
 
-<<<<<<< HEAD
-      - name: Create a GitHub release
-        if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: octokit/request-action@v2.4.0
-        with:
-          route: POST /repos/camunda/camunda/releases
-          draft: true
-          name: ${{ env.TAG }}
-          tag_name: ${{ env.TAG }}
-          make_latest: \"false\"
-          body: |
-            Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
-
-=======
->>>>>>> 00067cdf (ci: move GitHub release step to end of workflow)
       - name: Auto-update previous version
         run: |
           POM_FILE="optimize/pom.xml"

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -276,6 +276,7 @@ jobs:
             git push origin :refs/tags/"${TAG}"
           fi
 
+<<<<<<< HEAD
       - name: Create a GitHub release
         if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
         env:
@@ -290,6 +291,8 @@ jobs:
           body: |
             Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
 
+=======
+>>>>>>> 00067cdf (ci: move GitHub release step to end of workflow)
       - name: Auto-update previous version
         run: |
           POM_FILE="optimize/pom.xml"
@@ -389,6 +392,19 @@ jobs:
           version: ${{ env.RELEASE_VERSION }}
           date: ${{ env.DATE }}
           revision: ${{ env.REVISION }}
+
+      - name: Create a GitHub release
+        if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.3.1
+        with:
+          route: POST /repos/camunda/camunda/releases
+          draft: true
+          name: ${{ env.TAG }}
+          tag_name: ${{ env.TAG }}
+          generate_release_notes: true
+          make_latest: \"false\"
 
       - name: Docker log dump
         if: always()


### PR DESCRIPTION
# Description
Backport of #42283 to `main`.

relates to 
original author: @tsedekey