### PR TITLE
[Backport stable/8.8] ci: move GitHub release step to end of workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -275,20 +275,6 @@ jobs:
             git push origin :refs/tags/"${TAG}"
           fi
 
-      - name: Create a GitHub release
-        if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: octokit/request-action@v2.4.0
-        with:
-          route: POST /repos/camunda/camunda/releases
-          draft: true
-          name: ${{ env.TAG }}
-          tag_name: ${{ env.TAG }}
-          make_latest: \"false\"
-          body: |
-            Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
-
       - name: Auto-update previous version
         run: |
           if [ "$IS_PATCH" = "false" ]; then
@@ -387,6 +373,20 @@ jobs:
           version: ${{ env.RELEASE_VERSION }}
           date: ${{ env.DATE }}
           revision: ${{ env.REVISION }}
+
+      - name: Create a GitHub release
+              if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              uses: octokit/request-action@v2.4.0
+              with:
+                route: POST /repos/camunda/camunda/releases
+                draft: false
+                name: ${{ env.TAG }}
+                tag_name: ${{ env.TAG }}
+                make_latest: \"false\"
+                body: |
+                  Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
 
       - name: Docker log dump
         if: always()

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -375,18 +375,18 @@ jobs:
           revision: ${{ env.REVISION }}
 
       - name: Create a GitHub release
-              if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              uses: octokit/request-action@v2.4.0
-              with:
-                route: POST /repos/camunda/camunda/releases
-                draft: false
-                name: ${{ env.TAG }}
-                tag_name: ${{ env.TAG }}
-                make_latest: \"false\"
-                body: |
-                  Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
+        if: ${{ env.IS_RC == 'false' && env.IS_DRY_RUN == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.4.0
+        with:
+          route: POST /repos/camunda/camunda/releases
+          draft: false
+          name: ${{ env.TAG }}
+          tag_name: ${{ env.TAG }}
+          make_latest: \"false\"
+          body: |
+            Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
 
       - name: Docker log dump
         if: always()


### PR DESCRIPTION
# Description
Backport of #42283 to `stable/8.8`.

relates to 
original author: @tsedekey