### PR TITLE
feat: support user task process instance migration in zeebe

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -414,13 +414,16 @@ public class ProcessInstanceMigrationMigrateProcessor
     if (isUserTaskConversion) {
       final ProcessInstanceMigrationUserTaskBehavior migrationUserTaskBehavior =
           new ProcessInstanceMigrationUserTaskBehavior(
+              processInstanceKey,
               elementInstance,
               sourceProcessDefinition,
               targetProcessDefinition,
+              bpmnBehaviors,
               targetElementId,
+              updatedElementInstanceRecord,
               stateWriter,
               jobState);
-      migrationUserTaskBehavior.tryMigrateJobWorkerToCamundaUserTask(processInstanceKey); // TODO
+      migrationUserTaskBehavior.tryMigrateJobWorkerToCamundaUserTask();
     }
 
     if (elementInstance.getUserTaskKey() > 0) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -573,8 +573,9 @@ public final class ProcessInstanceMigrationPreconditions {
    * @param targetElementId target element id
    * @param elementInstance element instance to do the check
    * @param processInstanceKey process instance key to be logged
+   * @return whether the migration is to a different user task implementation
    */
-  public static void requireSupportedUserTaskImplementation(
+  public static boolean requireSupportedUserTaskImplementation(
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
@@ -582,14 +583,14 @@ public final class ProcessInstanceMigrationPreconditions {
       final long processInstanceKey) {
     final ProcessInstanceRecord elementInstanceRecord = elementInstance.getValue();
     if (elementInstanceRecord.getBpmnElementType() != BpmnElementType.USER_TASK) {
-      return;
+      return false;
     }
 
     final AbstractFlowElement targetElement =
         targetProcessDefinition.getProcess().getElementById(targetElementId);
     final BpmnElementType targetElementType = targetElement.getElementType();
     if (targetElementType != BpmnElementType.USER_TASK) {
-      return;
+      return false;
     }
 
     final ExecutableUserTask targetUserTask =
@@ -623,6 +624,8 @@ public final class ProcessInstanceMigrationPreconditions {
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_STATE);
     }
+    return sourceUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)
+        && targetUserTaskType.equals(ZEEBE_USER_TASK_IMPLEMENTATION);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -7,51 +7,95 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior.UserTaskProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.ProcessInstanceMigrationPreconditionFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
 
 public class ProcessInstanceMigrationUserTaskBehavior {
 
+  private static final String ERROR_JOB_NOT_FOUND =
+      """
+                  Expected to migrate a job for process instance with key '%d', \
+                  but could not find job with key '%d'. \
+                  Please report this as a bug""";
+
+  private static final String ERROR_TARGET_FORM_EVALUATION =
+      """
+                  Expected to migrate form of user task with id '%s' \
+                  to %s form with reference '%s' \
+                  defined in target element '%s', \
+                  but reference evaluation failed with message: %s""";
+
+  private static final String WARN_EMBEDDED_FORM_MIGRATION =
+      """
+                  Migrated embedded form of user task with id '%s' \
+                  to target element '%s' with Camunda user task implementation and no form reference \
+                  for process instance with key '%s'.
+                  """;
+
+  private static final Logger LOGGER = Loggers.ENGINE_PROCESSING_LOGGER;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final long processInstanceKey;
   private final ElementInstance elementInstance;
   private final DeployedProcess sourceProcessDefinition;
   private final DeployedProcess targetProcessDefinition;
   private final String targetElementId;
+  private final ProcessInstanceRecord updatedElementInstanceRecord;
   private final StateWriter stateWriter;
+  private final BpmnUserTaskBehavior userTaskBehavior;
   private final JobState jobState;
 
   public ProcessInstanceMigrationUserTaskBehavior(
+      final long processInstanceKey,
       final ElementInstance elementInstance,
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
+      final BpmnBehaviors bpmnBehaviors,
       final String targetElementId,
+      final ProcessInstanceRecord updatedElementInstanceRecord,
       final StateWriter stateWriter,
       final JobState jobState) {
+    this.processInstanceKey = processInstanceKey;
     this.elementInstance = elementInstance;
     this.sourceProcessDefinition = sourceProcessDefinition;
     this.targetProcessDefinition = targetProcessDefinition;
     this.targetElementId = targetElementId;
+    this.updatedElementInstanceRecord = updatedElementInstanceRecord;
     this.stateWriter = stateWriter;
     this.jobState = jobState;
+    userTaskBehavior = bpmnBehaviors.userTaskBehavior();
   }
 
-  public void tryMigrateJobWorkerToCamundaUserTask(final long processInstanceKey) {
+  public void tryMigrateJobWorkerToCamundaUserTask() {
     final var jobKey = elementInstance.getJobKey();
 
     final var job = jobState.getJob(jobKey);
     if (job == null) {
       throw new SafetyCheckFailedException(
-          String.format(
-              """
-                  Expected to migrate a job for process instance with key '%d', \
-                  but could not find job with key '%d'. \
-                  Please report this as a bug""",
-              processInstanceKey, jobKey));
+          String.format(ERROR_JOB_NOT_FOUND, processInstanceKey, jobKey));
     }
 
     final String elementId = elementInstance.getValue().getElementId();
@@ -64,7 +108,164 @@ public class ProcessInstanceMigrationUserTaskBehavior {
             .getProcess()
             .getElementById(targetElementId, ExecutableUserTask.class);
 
+    // Create new user task properties
+    final Map<String, String> customHeaders = job.getCustomHeaders();
+    final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+        targetProperties = targetElement.getUserTaskProperties();
+    final var userTaskProperties = mapUserTaskProperties(customHeaders, targetProperties);
+
+    // Create new Zeebe user task
+    final var context = new BpmnElementContextImpl();
+    context.init(
+        elementInstance.getKey(), updatedElementInstanceRecord, elementInstance.getState());
+
+    migrateForm(sourceElement, customHeaders, targetProperties, context, userTaskProperties);
+
+    final var userTaskRecord =
+        createNewUserTask(targetProperties, context, userTaskProperties, targetElement);
+
+    assignUser(userTaskProperties, userTaskRecord);
+
     // Cancel previous job worker job
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
+  }
+
+  private void assignUser(
+      final UserTaskProperties userTaskProperties, final UserTaskRecord userTaskRecord) {
+    final var assignee = userTaskProperties.getAssignee();
+    if (StringUtils.isNotEmpty(assignee)) {
+      userTaskBehavior.userTaskAssigning(userTaskRecord, assignee);
+      userTaskBehavior.userTaskAssigned(userTaskRecord, assignee);
+    }
+  }
+
+  private UserTaskRecord createNewUserTask(
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          newProperties,
+      final BpmnElementContextImpl context,
+      final UserTaskProperties userTaskProperties,
+      final ExecutableUserTask targetElement) {
+    userTaskBehavior
+        .evaluatePriorityExpression(
+            newProperties.getPriority(),
+            context.getFlowScopeKey(),
+            targetProcessDefinition.getTenantId())
+        .ifRight(userTaskProperties::priority);
+
+    final var userTaskRecord =
+        userTaskBehavior.createNewUserTask(context, targetElement, userTaskProperties);
+    userTaskBehavior.userTaskCreated(userTaskRecord);
+    elementInstance.setUserTaskKey(userTaskRecord.getUserTaskKey());
+    return userTaskRecord;
+  }
+
+  private void migrateForm(
+      final ExecutableJobWorkerElement sourceElement,
+      final Map<String, String> customHeaders,
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          targetElementProperties,
+      final BpmnElementContextImpl context,
+      final UserTaskProperties userTaskProperties) {
+    final String jobFormKey = customHeaders.get(Protocol.USER_TASK_FORM_KEY_HEADER_NAME);
+    final Expression workerFormId = sourceElement.getJobWorkerProperties().getFormId();
+
+    if (jobFormKey != null) {
+      if (jobFormKey.toLowerCase().contains("bpmn:usertaskform")) {
+        if (targetElementProperties.getExternalFormReference() != null) {
+          // external form
+          userTaskBehavior
+              .evaluateExternalFormReferenceExpression(
+                  targetElementProperties.getExternalFormReference(),
+                  context.getFlowScopeKey(),
+                  targetProcessDefinition.getTenantId())
+              .ifRightOrLeft(
+                  userTaskProperties::externalFormReference,
+                  failure -> {
+                    throw new ProcessInstanceMigrationPreconditionFailedException(
+                        ERROR_TARGET_FORM_EVALUATION.formatted(
+                            sourceElement.getId(),
+                            "external",
+                            targetElementProperties.getExternalFormReference(),
+                            targetElementId,
+                            failure.getMessage()),
+                        RejectionType.INVALID_STATE);
+                  });
+        } else if (targetElementProperties.getFormId() != null) {
+          // internal form
+          userTaskBehavior
+              .evaluateFormIdExpressionToFormKey(
+                  targetElementProperties.getFormId(),
+                  targetElementProperties.getFormBindingType(),
+                  targetElementProperties.getFormVersionTag(),
+                  context,
+                  context.getFlowScopeKey(),
+                  targetProcessDefinition.getTenantId())
+              .ifRightOrLeft(
+                  userTaskProperties::formKey,
+                  failure -> {
+                    throw new ProcessInstanceMigrationPreconditionFailedException(
+                        ERROR_TARGET_FORM_EVALUATION.formatted(
+                            sourceElement.getId(),
+                            "internal",
+                            targetElementProperties.getFormId().getExpression(),
+                            targetElementId,
+                            failure.getMessage()),
+                        RejectionType.INVALID_STATE);
+                  });
+        } else {
+          // none
+          LOGGER.warn(
+              WARN_EMBEDDED_FORM_MIGRATION.formatted(
+                  sourceElement.getId(), targetElementId, processInstanceKey));
+        }
+      } else if (workerFormId == null) {
+        // external form
+        userTaskProperties.externalFormReference(jobFormKey);
+      } else {
+        // internal form
+        userTaskProperties.formKey(Long.parseLong(jobFormKey));
+      }
+    }
+  }
+
+  private static UserTaskProperties mapUserTaskProperties(
+      final Map<String, String> customHeaders,
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          targetProperties) {
+    final UserTaskProperties userTaskProperties = new UserTaskProperties();
+
+    if (targetProperties.getAssignee() != null) {
+      userTaskProperties.assignee(targetProperties.getAssignee().getExpression());
+    }
+    final String candidateGroups =
+        customHeaders.get(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME);
+    if (candidateGroups != null) {
+      try {
+        userTaskProperties.candidateGroups(
+            OBJECT_MAPPER.readValue(candidateGroups, new TypeReference<>() {}));
+      } catch (final JsonProcessingException e) {
+        throw new ProcessInstanceMigrationPreconditionFailedException(
+            "Failed to parse candidate groups: " + e.getMessage(), RejectionType.INVALID_STATE);
+      }
+    }
+    final String candidateUsers = customHeaders.get(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME);
+    if (candidateUsers != null) {
+      try {
+        userTaskProperties.candidateUsers(
+            OBJECT_MAPPER.readValue(candidateUsers, new TypeReference<>() {}));
+      } catch (final JsonProcessingException e) {
+        throw new ProcessInstanceMigrationPreconditionFailedException(
+            "Failed to parse candidate users: " + e.getMessage(), RejectionType.INVALID_STATE);
+      }
+    }
+    final String dueDate = customHeaders.get(Protocol.USER_TASK_DUE_DATE_HEADER_NAME);
+    if (dueDate != null) {
+      userTaskProperties.dueDate(dueDate);
+    }
+    final String followUpDate = customHeaders.get(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME);
+    if (followUpDate != null) {
+      userTaskProperties.followUpDate(followUpDate);
+    }
+    return userTaskProperties;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public class ProcessInstanceMigrationUserTaskBehavior {
+
+  private final ElementInstance elementInstance;
+  private final DeployedProcess sourceProcessDefinition;
+  private final DeployedProcess targetProcessDefinition;
+  private final String targetElementId;
+  private final StateWriter stateWriter;
+  private final JobState jobState;
+
+  public ProcessInstanceMigrationUserTaskBehavior(
+      final ElementInstance elementInstance,
+      final DeployedProcess sourceProcessDefinition,
+      final DeployedProcess targetProcessDefinition,
+      final String targetElementId,
+      final StateWriter stateWriter,
+      final JobState jobState) {
+    this.elementInstance = elementInstance;
+    this.sourceProcessDefinition = sourceProcessDefinition;
+    this.targetProcessDefinition = targetProcessDefinition;
+    this.targetElementId = targetElementId;
+    this.stateWriter = stateWriter;
+    this.jobState = jobState;
+  }
+
+  public void tryMigrateJobWorkerToCamundaUserTask(final long processInstanceKey) {
+    final var jobKey = elementInstance.getJobKey();
+
+    final var job = jobState.getJob(jobKey);
+    if (job == null) {
+      throw new SafetyCheckFailedException(
+          String.format(
+              """
+                  Expected to migrate a job for process instance with key '%d', \
+                  but could not find job with key '%d'. \
+                  Please report this as a bug""",
+              processInstanceKey, jobKey));
+    }
+
+    final String elementId = elementInstance.getValue().getElementId();
+    final ExecutableJobWorkerElement sourceElement =
+        sourceProcessDefinition
+            .getProcess()
+            .getElementById(elementId, ExecutableJobWorkerElement.class);
+    final ExecutableUserTask targetElement =
+        targetProcessDefinition
+            .getProcess()
+            .getElementById(targetElementId, ExecutableUserTask.class);
+
+    // Cancel previous job worker job
+    stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Implemented the migration of job worker user tasks to Camunda user task record creation.

**Reviewer note**: I mostly took the [PoC implementation](https://github.com/camunda/camunda/pull/39747) and fixed the parts that were mentioned in the review of it. I added comments to the more significant parts that I changed, as well as parts where I have some uncertainty about the implementation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/29266 and https://github.com/camunda/camunda/issues/29272
