### PR TITLE
feat: add rootProcessInstanceKey property to userTask/job/evaluatedDecision records

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -151,6 +151,11 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     return tags;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return -1L; // not used in Optimize
+  }
+
   public void setTags(final Set<String> tags) {
     this.tags = tags;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -178,7 +178,8 @@ public final class BpmnDecisionBehavior {
         .setBpmnProcessId(context.getBpmnProcessId())
         .setProcessInstanceKey(context.getProcessInstanceKey())
         .setElementInstanceKey(context.getElementInstanceKey())
-        .setElementId(context.getElementId());
+        .setElementId(context.getElementId())
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
 
     stateWriter.appendFollowUpEvent(
         newDecisionEvaluationKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -450,7 +450,8 @@ public final class BpmnJobBehavior {
         .setElementId(context.getElementId())
         .setElementInstanceKey(context.getElementInstanceKey())
         .setTenantId(context.getTenantId())
-        .setTags(getTagsFromProcessInstance(context));
+        .setTags(getTagsFromProcessInstance(context))
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -177,7 +177,8 @@ public final class BpmnUserTaskBehavior {
             .setTenantId(context.getTenantId())
             .setPriority(userTaskProperties.getPriority())
             .setCreationTimestamp(clock.millis())
-            .setTags(getTagsFromProcessInstance(context));
+            .setTags(getTagsFromProcessInstance(context))
+            .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
     return userTaskRecord;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -339,7 +339,8 @@ public final class BusinessRuleTaskTest {
         .hasBpmnProcessId(businessRuleTaskActivated.getValue().getBpmnProcessId())
         .hasProcessInstanceKey(businessRuleTaskActivated.getValue().getProcessInstanceKey())
         .hasElementInstanceKey(businessRuleTaskActivated.getKey())
-        .hasElementId(businessRuleTaskActivated.getValue().getElementId());
+        .hasElementId(businessRuleTaskActivated.getValue().getElementId())
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     final var evaluatedDecisions = decisionEvaluationValue.getEvaluatedDecisions();
     assertThat(evaluatedDecisions).hasSize(2);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -163,7 +163,8 @@ public final class CamundaUserTaskTest {
         .hasElementId(taskActivated.getValue().getElementId())
         .hasProcessDefinitionKey(taskActivated.getValue().getProcessDefinitionKey())
         .hasBpmnProcessId(taskActivated.getValue().getBpmnProcessId())
-        .hasProcessDefinitionVersion(taskActivated.getValue().getVersion());
+        .hasProcessDefinitionVersion(taskActivated.getValue().getVersion())
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     assertThat(userTask.getValue().getUserTaskKey()).isGreaterThan(0L);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
@@ -129,6 +129,7 @@ public class ServiceTaskTest {
             .getFirst();
 
     assertThat(jobCreated.getValue().getCustomHeaders()).containsKey("linkedResources");
+    assertThat(jobCreated.getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
     final List<LinkedResourceProps> resourcePropsList =
         MAPPER.readValue(
             jobCreated.getValue().getCustomHeaders().get("linkedResources"),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationRootProcessInstanceKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationRootProcessInstanceKeyTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.dmn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Set;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class DecisionEvaluationRootProcessInstanceKeyTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
+  private static final String PROCESS_ID = "process";
+  private static final String CHILD_PROCESS_ID = "child-process";
+  private static final String GRANDCHILD_PROCESS_ID = "grandchild-process";
+  private static final String RESULT_VARIABLE = "result";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance simpleProcessWithBusinessRuleTask() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .businessRuleTask(
+            "task",
+            t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable(RESULT_VARIABLE))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance parentProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .callActivity("call", c -> c.zeebeProcessId(CHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithBusinessRuleTask() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .businessRuleTask(
+            "child-task",
+            t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable(RESULT_VARIABLE))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .callActivity("child-call", c -> c.zeebeProcessId(GRANDCHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance grandchildProcessWithBusinessRuleTask() {
+    return Bpmn.createExecutableProcess(GRANDCHILD_PROCESS_ID)
+        .startEvent()
+        .businessRuleTask(
+            "grandchild-task",
+            t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable(RESULT_VARIABLE))
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToProcessInstanceKeyForSimpleProcess() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_DECISION_TABLE)
+        .withXmlResource(simpleProcessWithBusinessRuleTask())
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then
+    final Record<DecisionEvaluationRecordValue> decisionEvaluated =
+        RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(decisionEvaluated.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToTopLevelParentForNestedCallActivities() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_DECISION_TABLE)
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithCallActivity())
+        .withXmlResource("grandchild.bpmn", grandchildProcessWithBusinessRuleTask())
+        .deploy();
+
+    // when
+    final long rootProcessInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then - get the child process instance
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    // get the grandchild process instance
+    final Record<ProcessInstanceRecordValue> grandchildProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(childProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long grandchildProcessInstanceKey = grandchildProcessInstance.getKey();
+
+    // Verify all three process instances are different
+    assertThat(
+            Set.of(rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
+        .hasSize(3);
+
+    // get the decision evaluation in the grandchild process
+    final Record<DecisionEvaluationRecordValue> decisionEvaluated =
+        RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+            .withProcessInstanceKey(grandchildProcessInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(decisionEvaluated.getValue())
+        .hasProcessInstanceKey(grandchildProcessInstanceKey)
+        .hasRootProcessInstanceKey(rootProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldPropagateRootProcessInstanceKeyThroughAllDecisionEvaluationIntents() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_DECISION_TABLE)
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithBusinessRuleTask())
+        .deploy();
+
+    // when
+    final long rootProcessInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    // then - verify all decision evaluation events have the correct rootProcessInstanceKey
+    assertThat(
+            RecordingExporter.decisionEvaluationRecords()
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .limit(1))
+        .extracting(Record::getIntent, r -> r.getValue().getRootProcessInstanceKey())
+        .containsExactly(tuple(DecisionEvaluationIntent.EVALUATED, rootProcessInstanceKey));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationRootProcessInstanceKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationRootProcessInstanceKeyTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -154,8 +154,9 @@ public final class DecisionEvaluationRootProcessInstanceKeyTest {
 
     // Verify all three process instances are different
     assertThat(
-            Set.of(rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
-        .hasSize(3);
+            Stream.of(
+                rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
+        .doesNotHaveDuplicates();
 
     // get the decision evaluation in the grandchild process
     final Record<DecisionEvaluationRecordValue> decisionEvaluated =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobRootProcessInstanceKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobRootProcessInstanceKeyTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -135,8 +135,9 @@ public final class JobRootProcessInstanceKeyTest {
 
     // Verify all three process instances are different
     assertThat(
-            Set.of(rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
-        .hasSize(3);
+            Stream.of(
+                rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
+        .doesNotHaveDuplicates();
 
     // get the job created in the grandchild process
     final Record<JobRecordValue> jobCreated =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobRootProcessInstanceKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobRootProcessInstanceKeyTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Set;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JobRootProcessInstanceKeyTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String CHILD_PROCESS_ID = "child-process";
+  private static final String GRANDCHILD_PROCESS_ID = "grandchild-process";
+  private static final String JOB_TYPE = "test-job";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance simpleProcessWithServiceTask() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance parentProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .callActivity("call", c -> c.zeebeProcessId(CHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithServiceTask() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .serviceTask("child-task", t -> t.zeebeJobType(JOB_TYPE))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .callActivity("child-call", c -> c.zeebeProcessId(GRANDCHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance grandchildProcessWithServiceTask() {
+    return Bpmn.createExecutableProcess(GRANDCHILD_PROCESS_ID)
+        .startEvent()
+        .serviceTask("grandchild-task", t -> t.zeebeJobType(JOB_TYPE))
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToProcessInstanceKeyForSimpleProcess() {
+    // given
+    ENGINE.deployment().withXmlResource(simpleProcessWithServiceTask()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(jobCreated.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToTopLevelParentForNestedCallActivities() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithCallActivity())
+        .withXmlResource("grandchild.bpmn", grandchildProcessWithServiceTask())
+        .deploy();
+
+    // when
+    final long rootProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then - get the child process instance
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    // get the grandchild process instance
+    final Record<ProcessInstanceRecordValue> grandchildProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(childProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long grandchildProcessInstanceKey = grandchildProcessInstance.getKey();
+
+    // Verify all three process instances are different
+    assertThat(
+            Set.of(rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
+        .hasSize(3);
+
+    // get the job created in the grandchild process
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(grandchildProcessInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(jobCreated.getValue())
+        .hasProcessInstanceKey(grandchildProcessInstanceKey)
+        .hasRootProcessInstanceKey(rootProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldPropagateRootProcessInstanceKeyThroughAllJobIntents() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithServiceTask())
+        .deploy();
+
+    // when
+    final long rootProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(childProcessInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // Complete the job
+    ENGINE.job().withKey(jobKey).complete();
+
+    // then - verify all job events have the correct rootProcessInstanceKey
+    assertThat(
+            RecordingExporter.jobRecords().withProcessInstanceKey(childProcessInstanceKey).limit(2))
+        .extracting(Record::getIntent, r -> r.getValue().getRootProcessInstanceKey())
+        .containsExactly(
+            tuple(JobIntent.CREATED, rootProcessInstanceKey),
+            tuple(JobIntent.COMPLETED, rootProcessInstanceKey));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -119,7 +119,7 @@ public final class CreateProcessInstanceTest {
     final ProcessInstanceRecordValue value = process.getValue();
     assertThat(value.getCallingElementPath()).isEmpty();
     assertThat(value.getElementInstancePath()).hasSize(1);
-    final List<Long> elementInstances = value.getElementInstancePath().get(0);
+    final List<Long> elementInstances = value.getElementInstancePath().getFirst();
     assertThat(elementInstances).containsExactly(processInstanceKey);
     assertThat(value.getProcessDefinitionPath()).containsExactly(value.getProcessDefinitionKey());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRootProcessInstanceKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRootProcessInstanceKeyTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Set;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class UserTaskRootProcessInstanceKeyTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String CHILD_PROCESS_ID = "child-process";
+  private static final String GRANDCHILD_PROCESS_ID = "grandchild-process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance simpleProcessWithUserTask() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .userTask("task")
+        .zeebeUserTask()
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance parentProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .callActivity("call", c -> c.zeebeProcessId(CHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithUserTask() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .userTask("child-task")
+        .zeebeUserTask()
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .callActivity("child-call", c -> c.zeebeProcessId(GRANDCHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance grandchildProcessWithUserTask() {
+    return Bpmn.createExecutableProcess(GRANDCHILD_PROCESS_ID)
+        .startEvent()
+        .userTask("grandchild-task")
+        .zeebeUserTask()
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToProcessInstanceKeyForSimpleProcess() {
+    // given
+    ENGINE.deployment().withXmlResource(simpleProcessWithUserTask()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<UserTaskRecordValue> userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(userTaskCreated.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // rootProcessInstanceKey should equal processInstanceKey for simple processes
+    assertThat(userTaskCreated.getValue().getRootProcessInstanceKey())
+        .isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToTopLevelParentForNestedCallActivities() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithCallActivity())
+        .withXmlResource("grandchild.bpmn", grandchildProcessWithUserTask())
+        .deploy();
+
+    // when
+    final long rootProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then - get the child process instance
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    // get the grandchild process instance
+    final Record<ProcessInstanceRecordValue> grandchildProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(childProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long grandchildProcessInstanceKey = grandchildProcessInstance.getKey();
+
+    // Verify all three process instances are different
+    assertThat(
+            Set.of(rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
+        .hasSize(3);
+
+    // get the user task created in the grandchild process
+    final Record<UserTaskRecordValue> userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(grandchildProcessInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(userTaskCreated.getValue())
+        .hasProcessInstanceKey(grandchildProcessInstanceKey)
+        .hasRootProcessInstanceKey(rootProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldPropagateRootProcessInstanceKeyThroughAllUserTaskIntents() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithUserTask())
+        .deploy();
+
+    // when
+    final long rootProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(childProcessInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // Complete the user task
+    ENGINE.userTask().withKey(userTaskKey).complete();
+
+    // then - verify all user task events have the correct rootProcessInstanceKey
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .limit(4))
+        .extracting(Record::getIntent, r -> r.getValue().getRootProcessInstanceKey())
+        .containsExactly(
+            tuple(UserTaskIntent.CREATING, rootProcessInstanceKey),
+            tuple(UserTaskIntent.CREATED, rootProcessInstanceKey),
+            tuple(UserTaskIntent.COMPLETING, rootProcessInstanceKey),
+            tuple(UserTaskIntent.COMPLETED, rootProcessInstanceKey));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRootProcessInstanceKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRootProcessInstanceKeyTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -140,8 +140,9 @@ public final class UserTaskRootProcessInstanceKeyTest {
 
     // Verify all three process instances are different
     assertThat(
-            Set.of(rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
-        .hasSize(3);
+            Stream.of(
+                rootProcessInstanceKey, childProcessInstanceKey, grandchildProcessInstanceKey))
+        .doesNotHaveDuplicates();
 
     // get the user task created in the grandchild process
     final Record<UserTaskRecordValue> userTaskCreated =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -108,4 +108,32 @@ public class UserTaskCreatingV2ApplierTest {
         .describedAs("Expect initial assignee to not be present")
         .isEmpty();
   }
+
+  @Test
+  public void shouldStoreRootProcessInstanceKeyWhenCreatingUserTask() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+    final long processInstanceKey = new Random().nextLong();
+    final long rootProcessInstanceKey = new Random().nextLong();
+
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setRootProcessInstanceKey(rootProcessInstanceKey);
+
+    // when
+    userTaskCreatingV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    // ensure the user task has the correct rootProcessInstanceKey
+    assertThat(userTaskState.getUserTask(userTaskKey).getRootProcessInstanceKey())
+        .isEqualTo(rootProcessInstanceKey);
+    // ensure the intermediate state has the correct rootProcessInstanceKey
+    assertThat(
+            userTaskState.getIntermediateState(userTaskKey).getRecord().getRootProcessInstanceKey())
+        .isEqualTo(rootProcessInstanceKey);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -128,12 +128,12 @@ public class UserTaskCreatingV2ApplierTest {
     userTaskCreatingV2Applier.applyState(userTaskKey, userTaskRecord);
 
     // then
-    // ensure the user task has the correct rootProcessInstanceKey
     assertThat(userTaskState.getUserTask(userTaskKey).getRootProcessInstanceKey())
+        .describedAs("Expect user task to have the correct rootProcessInstanceKey")
         .isEqualTo(rootProcessInstanceKey);
-    // ensure the intermediate state has the correct rootProcessInstanceKey
     assertThat(
             userTaskState.getIntermediateState(userTaskKey).getRecord().getRootProcessInstanceKey())
+        .describedAs("Expect intermediate state to have the correct rootProcessInstanceKey")
         .isEqualTo(rootProcessInstanceKey);
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -15,12 +15,15 @@ import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -47,9 +50,11 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
-          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
+          .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(JobRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(ProcessInstanceRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(
@@ -59,6 +64,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
+          .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -130,6 +130,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -160,6 +160,9 @@
                       "type": "boolean"
                     }
                   }
+                },
+                "rootProcessInstanceKey": {
+                  "type": "long"
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -141,6 +141,9 @@
                   "type": "boolean"
                 }
               }
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -90,6 +90,9 @@
             },
             "listenersConfigKey": {
               "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -15,12 +15,15 @@ import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -47,9 +50,11 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
-          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
+          .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(JobRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
@@ -59,6 +64,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
+          .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -130,6 +130,9 @@
                   }
                 }
               }
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -160,6 +160,9 @@
                       "type": "boolean"
                     }
                   }
+                },
+                "rootProcessInstanceKey": {
+                  "type": "long"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -141,6 +141,9 @@
                   "type": "boolean"
                 }
               }
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -90,6 +90,9 @@
             },
             "listenersConfigKey": {
               "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -60,9 +60,11 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   private final StringProperty failedDecisionIdProp = new StringProperty("failedDecisionId", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", -1L);
 
   public DecisionEvaluationRecord() {
-    super(17);
+    super(18);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -79,7 +81,8 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
         .declareProperty(evaluatedDecisionsProp)
         .declareProperty(evaluationFailureMessageProp)
         .declareProperty(failedDecisionIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   @Override
@@ -330,6 +333,16 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -75,24 +75,21 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue TAGS = new StringValue("tags");
   private static final StringValue IS_JOB_TO_USERTASK_MIGRATION_KEY =
       new StringValue("isUserTaskMigration");
-
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
-
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
   private final LongProperty timeoutProp = new LongProperty(TIMEOUT_KEY, -1);
   private final IntegerProperty retriesProp = new IntegerProperty(RETRIES_KEY, -1);
   private final LongProperty retryBackoffProp = new LongProperty(RETRY_BACKOFF_KEY, 0);
   private final LongProperty recurringTimeProp = new LongProperty(RECURRING_TIME_KEY, -1);
-
   private final PackedProperty customHeadersProp =
       new PackedProperty(CUSTOM_HEADERS_KEY, NO_HEADERS);
   private final DocumentProperty variableProp = new DocumentProperty(VARIABLES_KEY);
-
   private final StringProperty errorMessageProp =
       new StringProperty(ERROR_MESSAGE_KEY, EMPTY_STRING);
   private final StringProperty errorCodeProp = new StringProperty(ERROR_CODE_KEY, EMPTY_STRING);
-
   private final LongProperty processInstanceKeyProp =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProp =
@@ -120,6 +117,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>(TAGS, StringValue::new);
   private final BooleanProperty isJobToUserTaskMigrationProp =
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public JobRecord() {
     super(24);
@@ -146,7 +145,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(changedAttributesProp)
         .declareProperty(resultProp)
         .declareProperty(tagsProp)
-        .declareProperty(isJobToUserTaskMigrationProp);
+        .declareProperty(isJobToUserTaskMigrationProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -175,6 +175,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     isJobToUserTaskMigrationProp.setValue(record.isJobToUserTaskMigration());
 
     setTags(record.getTags());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   public void wrap(final JobRecord record) {
@@ -343,6 +344,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public boolean isJobToUserTaskMigration() {
     return isJobToUserTaskMigrationProp.getValue();
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
   }
 
   public JobRecord setProcessDefinitionVersion(final int version) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -56,6 +56,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue FOLLOW_UP_DATE_VALUE = new StringValue(FOLLOW_UP_DATE);
   private static final StringValue PRIORITY_VALUE = new StringValue(PRIORITY);
   private static final StringValue VARIABLES_VALUE = new StringValue(VARIABLES);
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_VALUE =
+      new StringValue("rootProcessInstanceKey");
 
   /**
    * Defines the mapping between names of attributes that may be modified (updated or corrected) and
@@ -107,6 +109,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_VALUE, -1L);
 
   /**
    * Tracks the names of user task attributes that are intended to be modified (e.g. on `UPDATE`),
@@ -151,7 +155,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(24);
+    super(25);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -175,7 +179,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(priorityProp)
         .declareProperty(deniedReasonProp)
         .declareProperty(tagsProp)
-        .declareProperty(listenersConfigKeyProp);
+        .declareProperty(listenersConfigKeyProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
@@ -204,6 +209,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     deniedReasonProp.setValue(record.getDeniedReason());
     setTags(record.getTags());
     listenersConfigKeyProp.setValue(record.getListenersConfigKey());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   /**
@@ -444,6 +450,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     if (tags != null) {
       tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
     }
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public UserTaskRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -759,6 +759,7 @@ final class JsonSerializableToJsonTest {
               final int processDefinitionKey = 13;
               final int processDefinitionVersion = 12;
               final int processInstanceKey = 1234;
+              final int rootProcessInstanceKey = 4321;
               final String activityId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
@@ -808,6 +809,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setProcessDefinitionVersion(processDefinitionVersion)
                   .setProcessInstanceKey(processInstanceKey)
+                  .setRootProcessInstanceKey(rootProcessInstanceKey)
                   .setElementId(wrapString(activityId))
                   .setElementInstanceKey(activityInstanceKey)
                   .setChangedAttributes(changedAttributes)
@@ -850,6 +852,7 @@ final class JsonSerializableToJsonTest {
                       "deadline": 1000,
                       "timeout": -1,
                       "tenantId": "<default>",
+                      "rootProcessInstanceKey": 4321,
                       "changedAttributes": ["bar", "foo"],
                       "tags": ["tag1", "tag2"],
                       "jobToUserTaskMigration": true,
@@ -941,6 +944,7 @@ final class JsonSerializableToJsonTest {
               final int processDefinitionKey = 13;
               final int processDefinitionVersion = 12;
               final int processInstanceKey = 1234;
+              final int rootProcessInstanceKey = 4321;
               final String elementId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
@@ -1000,6 +1004,7 @@ final class JsonSerializableToJsonTest {
                       .setChangedAttributes(changedAttributes)
                       .setResult(result)
                       .setTags(Set.of("tag1", "tag2"))
+                      .setRootProcessInstanceKey(rootProcessInstanceKey)
                       .setIsJobToUserTaskMigration(true);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
@@ -1031,6 +1036,7 @@ final class JsonSerializableToJsonTest {
                   "deadline": 13,
                   "timeout": 14,
                   "tenantId": "<default>",
+                  "rootProcessInstanceKey": 4321,
                   "tags": ["tag1", "tag2"],
                   "jobToUserTaskMigration": true,
                   "changedAttributes": ["bar", "foo"],
@@ -1105,6 +1111,7 @@ final class JsonSerializableToJsonTest {
                   "deadline": -1,
                   "timeout": -1,
                   "tenantId": "<default>",
+                  "rootProcessInstanceKey": -1,
                   "tags": [],
                   "jobToUserTaskMigration": false,
                   "changedAttributes": [],
@@ -1164,6 +1171,7 @@ final class JsonSerializableToJsonTest {
                   "processDefinitionVersion": -1,
                   "customHeaders": {},
                   "tenantId": "<default>",
+                  "rootProcessInstanceKey": -1,
                   "tags": [],
                   "jobToUserTaskMigration": false,
                   "changedAttributes": [],
@@ -2065,7 +2073,8 @@ final class JsonSerializableToJsonTest {
                       .setElementInstanceKey(5L)
                       .setElementId("element-id")
                       .setEvaluationFailureMessage("evaluation-failure-message")
-                      .setFailedDecisionId("failed-decision-id");
+                      .setFailedDecisionId("failed-decision-id")
+                      .setRootProcessInstanceKey(6L);
 
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
@@ -2146,7 +2155,8 @@ final class JsonSerializableToJsonTest {
                   ],
                   "evaluationFailureMessage":"evaluation-failure-message",
                   "failedDecisionId":"failed-decision-id",
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": 6
                 }
                 """
       },
@@ -2174,7 +2184,8 @@ final class JsonSerializableToJsonTest {
                       .setElementId("element-id")
                       .setEvaluationFailureMessage("evaluation-failure-message")
                       .setFailedDecisionId("failed-decision-id")
-                      .setTenantId("tenant-test");
+                      .setTenantId("tenant-test")
+                      .setRootProcessInstanceKey(6L);
 
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
@@ -2256,7 +2267,8 @@ final class JsonSerializableToJsonTest {
                   ],
                   "evaluationFailureMessage":"evaluation-failure-message",
                   "failedDecisionId":"failed-decision-id",
-                  "tenantId": "tenant-test"
+                  "tenantId": "tenant-test",
+                  "rootProcessInstanceKey": 6
                 }
                 """
       },
@@ -2287,7 +2299,8 @@ final class JsonSerializableToJsonTest {
                   "evaluatedDecisions":[],
                   "evaluationFailureMessage":"",
                   "failedDecisionId":"",
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },
@@ -2729,7 +2742,8 @@ final class JsonSerializableToJsonTest {
                     .setElementInstanceKey(5678)
                     .setPriority(80)
                     .setDeniedReason("Reason to deny lifecycle transition")
-                    .setListenersConfigKey(42L),
+                    .setListenersConfigKey(42L)
+                    .setRootProcessInstanceKey(4321L),
         """
                 {
                   "bpmnProcessId": "test-process",
@@ -2759,7 +2773,8 @@ final class JsonSerializableToJsonTest {
                   "priority": 80,
                   "tags": [],
                   "deniedReason": "Reason to deny lifecycle transition",
-                  "listenersConfigKey": 42
+                  "listenersConfigKey": 42,
+                  "rootProcessInstanceKey": 4321
                 }
                 """
       },
@@ -2797,7 +2812,8 @@ final class JsonSerializableToJsonTest {
                   "priority": 50,
                   "tags": [],
                   "deniedReason": "",
-                  "listenersConfigKey": -1
+                  "listenersConfigKey": -1,
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },
@@ -2840,7 +2856,8 @@ final class JsonSerializableToJsonTest {
                   "priority": 50,
                   "tags": [],
                   "deniedReason": "",
-                  "listenersConfigKey": -1
+                  "listenersConfigKey": -1,
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
@@ -60,9 +60,11 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   private final StringProperty failedDecisionIdProp = new StringProperty("failedDecisionId", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", -1L);
 
   public DecisionEvaluationRecord() {
-    super(17);
+    super(18);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -79,7 +81,8 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
         .declareProperty(evaluatedDecisionsProp)
         .declareProperty(evaluationFailureMessageProp)
         .declareProperty(failedDecisionIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   @Override
@@ -330,6 +333,16 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -75,24 +75,21 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue TAGS = new StringValue("tags");
   private static final StringValue IS_JOB_TO_USERTASK_MIGRATION_KEY =
       new StringValue("isUserTaskMigration");
-
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
-
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
   private final LongProperty timeoutProp = new LongProperty(TIMEOUT_KEY, -1);
   private final IntegerProperty retriesProp = new IntegerProperty(RETRIES_KEY, -1);
   private final LongProperty retryBackoffProp = new LongProperty(RETRY_BACKOFF_KEY, 0);
   private final LongProperty recurringTimeProp = new LongProperty(RECURRING_TIME_KEY, -1);
-
   private final PackedProperty customHeadersProp =
       new PackedProperty(CUSTOM_HEADERS_KEY, NO_HEADERS);
   private final DocumentProperty variableProp = new DocumentProperty(VARIABLES_KEY);
-
   private final StringProperty errorMessageProp =
       new StringProperty(ERROR_MESSAGE_KEY, EMPTY_STRING);
   private final StringProperty errorCodeProp = new StringProperty(ERROR_CODE_KEY, EMPTY_STRING);
-
   private final LongProperty processInstanceKeyProp =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProp =
@@ -120,6 +117,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>(TAGS, StringValue::new);
   private final BooleanProperty isJobToUserTaskMigrationProp =
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public JobRecord() {
     super(24);
@@ -146,7 +145,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(changedAttributesProp)
         .declareProperty(resultProp)
         .declareProperty(tagsProp)
-        .declareProperty(isJobToUserTaskMigrationProp);
+        .declareProperty(isJobToUserTaskMigrationProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -175,6 +175,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     isJobToUserTaskMigrationProp.setValue(record.isJobToUserTaskMigration());
 
     setTags(record.getTags());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   public void wrap(final JobRecord record) {
@@ -343,6 +344,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public boolean isJobToUserTaskMigration() {
     return isJobToUserTaskMigrationProp.getValue();
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
   }
 
   public JobRecord setProcessDefinitionVersion(final int version) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
@@ -56,6 +56,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue FOLLOW_UP_DATE_VALUE = new StringValue(FOLLOW_UP_DATE);
   private static final StringValue PRIORITY_VALUE = new StringValue(PRIORITY);
   private static final StringValue VARIABLES_VALUE = new StringValue(VARIABLES);
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_VALUE =
+      new StringValue("rootProcessInstanceKey");
 
   /**
    * Defines the mapping between names of attributes that may be modified (updated or corrected) and
@@ -107,6 +109,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_VALUE, -1L);
 
   /**
    * Tracks the names of user task attributes that are intended to be modified (e.g. on `UPDATE`),
@@ -151,7 +155,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(24);
+    super(25);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -175,7 +179,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(priorityProp)
         .declareProperty(deniedReasonProp)
         .declareProperty(tagsProp)
-        .declareProperty(listenersConfigKeyProp);
+        .declareProperty(listenersConfigKeyProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
@@ -204,6 +209,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     deniedReasonProp.setValue(record.getDeniedReason());
     setTags(record.getTags());
     listenersConfigKeyProp.setValue(record.getListenersConfigKey());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   /**
@@ -431,6 +437,32 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
+  @Override
+  public Set<String> getTags() {
+    return StreamSupport.stream(tagsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .collect(Collectors.toSet());
+  }
+
+  public UserTaskRecord setTags(final Set<String> tags) {
+    tagsProp.reset();
+    if (tags != null) {
+      tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
+    }
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public UserTaskRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
   public UserTaskRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -555,8 +587,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return listenersConfigKeyProp.getValue();
   }
 
-  public UserTaskRecord setListenersConfigKey(final long versionKey) {
-    listenersConfigKeyProp.setValue(versionKey);
+  public UserTaskRecord setListenersConfigKey(final long listenersConfigKey) {
+    listenersConfigKeyProp.setValue(listenersConfigKey);
     return this;
   }
 
@@ -756,22 +788,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord resetChangedAttributes() {
     changedAttributesProp.reset();
-    return this;
-  }
-
-  @Override
-  public Set<String> getTags() {
-    return StreamSupport.stream(tagsProp.spliterator(), false)
-        .map(StringValue::getValue)
-        .map(BufferUtil::bufferAsString)
-        .collect(Collectors.toSet());
-  }
-
-  public UserTaskRecord setTags(final Set<String> tags) {
-    tagsProp.reset();
-    if (tags != null) {
-      tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
-    }
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -115,4 +115,15 @@ public interface DecisionEvaluationRecordValue
    *     the evaluation was successful
    */
   String getFailedDecisionId();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For decisions evaluated in
+   * top-level process instances, this is equal to {@link #getProcessInstanceKey()}. For decisions
+   * in child process instances (created via call activities), this is the key of the topmost parent
+   * process instance.
+   *
+   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
+   *     8.9
+   */
+  long getRootProcessInstanceKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -141,6 +141,17 @@ public interface JobRecordValue
    */
   boolean isJobToUserTaskMigration();
 
+  /**
+   * Returns the key of the root process instance in the hierarchy. For jobs in top-level process
+   * instances, this is equal to {@link #getProcessInstanceKey()}. For jobs in child process
+   * instances (created via call activities), this is the key of the topmost parent process
+   * instance.
+   *
+   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
+   *     8.9
+   */
+  long getRootProcessInstanceKey();
+
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableJobResultValue.Builder.class)
   interface JobResultValue {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -88,4 +88,15 @@ public interface UserTaskRecordValue
    * @return the tags that were set for this user task.
    */
   Set<String> getTags();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For user tasks in top-level
+   * process instances, this is equal to {@link #getProcessInstanceKey()}. For user tasks in child
+   * process instances (created via call activities), this is the key of the topmost parent process
+   * instance.
+   *
+   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
+   *     8.9
+   */
+  long getRootProcessInstanceKey();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request introduces the concept of a "rootProcessInstanceKey" into jobs, user tasks, and decision evaluations records, to consistently reference the top-level process instance, allowing downstream consumers to access this information (exporters):

* Set the rootProcessInstanceKey from the `BpmnElementContext.getRootProcessInstanceKey()`,  on UserTask `CREATING`, Job `CREATED`, and DecisionEvaluation `EVALUATED`/`FAILED` records.
* Updated the `zeebe-record` index templates to include this field, the field is excluded from serialization for the previous version's records for backward compatibility

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41655
depends on https://github.com/camunda/camunda/pull/42708
