### PR TITLE
[stable/8.8] feat: spring boot 4.0 support via dedicated modules

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -29,7 +29,10 @@
     <version.spring>7.0.1</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
     <version.junit>6.0.1</version.junit>
+    <version.roaster>2.30.3.Final</version.roaster>
     <version.aspectjweaver>1.9.24</version.aspectjweaver>
+    <generated.test.sources.path>${project.build.directory}/generated-test-sources/java</generated.test.sources.path>
+    <camunda-spring-boot-starter.sourcedir>${project.basedir}/../camunda-spring-boot-starter/src</camunda-spring-boot-starter.sourcedir>
   </properties>
 
   <dependencies>
@@ -48,6 +51,13 @@
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.forge.roaster</groupId>
+      <artifactId>roaster-api</artifactId>
+      <version>${version.roaster}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -74,6 +84,88 @@
       <artifactId>spring-boot-health</artifactId>
     </dependency>
 
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>${version.aspectjweaver}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -156,17 +248,106 @@
         </configuration>
       </plugin>
 
-      <!--
-        Note: Tests are skipped because test-jar tests from camunda-spring-boot-starter
-        were compiled with JUnit 5.x which is binary incompatible with JUnit 6.x
-        (required by Spring Boot 4). Test coverage is provided by the base module.
-        This is acceptable as this module is a temporary solution for the 8.8 branch.
-      -->
+      <!-- Add test re-/sources from the base module -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-generator-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sources>
+                <!-- Include test generator utility classes (compiled as main sources in base module) -->
+                <source>${camunda-spring-boot-starter.sourcedir}/test/test-source-generator</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <sources>
+                <source>${camunda-spring-boot-starter.sourcedir}/test/java</source>
+                <source>${generated.test.sources.path}</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-resources</id>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${camunda-spring-boot-starter.sourcedir}/test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <dependencies>
+          <!-- Needed for the roaster generator used -->
+          <dependency>
+            <groupId>org.jboss.forge.roaster</groupId>
+            <artifactId>roaster-jdt</artifactId>
+            <version>${version.roaster}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <!-- This executed the test generator classes -->
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <mainClass>io.camunda.client.spring.test.util.JobWorkerPermutationsGenerator</mainClass>
+              <arguments>
+                <argument>${generated.test.sources.path}</argument>
+              </arguments>
+              <classpathScope>provided</classpathScope>
+              <includePluginDependencies>true</includePluginDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <!-- As the test generator classes end up among main classes, they have to be excluded again -->
+          <excludes>
+            <exclude>**/test/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <!-- Run tests compiled from base module sources -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skipTests>true</skipTests>
+          <!-- Exclude tests that require file system access to configuration metadata in JAR -->
+          <!-- Low risk on those, given they are not tightly coupled to spring classes -->
+          <excludes>
+            <exclude>**/configurationMetadata/AlignmentTest.java</exclude>
+            <exclude>**/configurationMetadata/FormattingTest.java</exclude>
+          </excludes>
         </configuration>
       </plugin>
     </plugins>

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-library-parent</artifactId>
+    <version>8.8.9-SNAPSHOT</version>
+    <relativePath>../../library-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-spring-boot-4-starter</artifactId>
+
+  <name>Camunda Spring Boot 4 Starter</name>
+  <description>Camunda Spring Boot Starter for Spring Boot 4.x</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <version.java>17</version.java>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
+    <!-- Override Spring Boot version for 4.x compatibility -->
+    <version.spring-boot>4.0.1</version.spring-boot>
+    <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
+    <version.spring>7.0.1</version.spring>
+    <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
+    <version.junit>6.0.1</version.junit>
+    <version.aspectjweaver>1.9.24</version.aspectjweaver>
+  </properties>
+
+  <dependencies>
+    <!-- Base Spring Boot starter - will be shaded -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <!-- New in Spring Boot 4: Jackson module is separate -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson</artifactId>
+    </dependency>
+    <!-- New in Spring Boot 4: Health module is separate -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-health</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <!-- Shade plugin to include and relocate classes from camunda-spring-boot-starter -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <!-- Only include the base starter module in the shaded jar -->
+                  <include>io.camunda:camunda-spring-boot-starter</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>io.camunda:camunda-spring-boot-starter</artifact>
+                  <excludes>
+                    <!-- Exclude classes that we override with Spring Boot 4 versions -->
+                    <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.class</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
+                    <!-- Exclude META-INF services that we override -->
+                    <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <!-- Merge service files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <!-- Keep manifest entries -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!--
+            Ignore all "used but undeclared" dependencies in this module.
+            This starter shades and reuses classes and tests from the base
+            camunda-spring-boot-starter module, which is where the actual
+            dependency declarations live. From the perspective of this POM,
+            many classes therefore appear as used but undeclared, even though
+            they are intentionally provided by the base module and by the
+            shaded artifact.
+            Using a wildcard here avoids having to duplicate and constantly
+            maintain the full dependency list of the base module. The trade-off
+            is that accidental missing dependencies in *this* module will not
+            be reported by maven-dependency-plugin. To mitigate this, dependency
+            analysis should be run primarily on the base module, where the
+            dependencies are actually declared, and changes here should be kept
+            minimal and aligned with that module.
+          -->
+          <ignoredUsedUndeclaredDependencies>*</ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <!--
+        Note: Tests are skipped because test-jar tests from camunda-spring-boot-starter
+        were compiled with JUnit 5.x which is binary incompatible with JUnit 6.x
+        (required by Spring Boot 4). Test coverage is provided by the base module.
+        This is acceptable as this module is a temporary solution for the 8.8 branch.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.actuator;
+
+import io.camunda.client.health.HealthCheck;
+import org.springframework.boot.health.contributor.AbstractHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+
+/**
+ * Spring Boot 4 compatible health indicator for Camunda Client. Uses the new package location for
+ * health classes in Spring Boot 4.x.
+ */
+public class CamundaClientHealthIndicator extends AbstractHealthIndicator {
+
+  private final HealthCheck healthCheck;
+
+  public CamundaClientHealthIndicator(final HealthCheck healthCheck) {
+    this.healthCheck = healthCheck;
+  }
+
+  @Override
+  protected void doHealthCheck(final Health.Builder builder) {
+    switch (healthCheck.health()) {
+      case UP -> builder.up();
+      case DOWN -> builder.down();
+      default -> throw new IllegalStateException("Unexpected value: " + healthCheck.health());
+    }
+  }
+}

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.health.HealthCheck;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.metrics.MicrometerMetricsRecorder;
+import io.camunda.client.spring.actuator.CamundaClientHealthIndicator;
+import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Spring Boot 4 compatible actuator configuration. Uses the new package location for
+ * HealthIndicator in Spring Boot 4.x.
+ */
+@AutoConfigureBefore(MetricsDefaultConfiguration.class)
+@ConditionalOnCamundaClientEnabled
+@ConditionalOnClass({
+  EndpointAutoConfiguration.class,
+  MeterRegistry.class
+}) // only if actuator is on classpath
+public class CamundaActuatorConfiguration {
+  @Bean
+  @ConditionalOnMissingBean
+  public MetricsRecorder micrometerMetricsRecorder(@Lazy final MeterRegistry meterRegistry) {
+    return new MicrometerMetricsRecorder(meterRegistry);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public HealthCheck camundaHealthCheck(final CamundaClient client) {
+    return new HealthCheck(client);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "management.health.camunda",
+      name = "enabled",
+      matchIfMissing = true)
+  @ConditionalOnClass(HealthIndicator.class)
+  @ConditionalOnMissingBean(name = "camundaClientHealthIndicator")
+  public CamundaClientHealthIndicator camundaClientHealthIndicator(final HealthCheck healthCheck) {
+    return new CamundaClientHealthIndicator(healthCheck);
+  }
+}

--- a/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaAutoConfiguration.java
+++ b/clients/camunda-spring-boot-4-starter/src/main/java/io/camunda/client/spring/configuration/CamundaAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
+import io.camunda.client.spring.event.CamundaLifecycleEventProducer;
+import io.camunda.client.spring.testsupport.CamundaSpringProcessTestContext;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot 4 compatible auto-configuration. Uses the new package location for
+ * JacksonAutoConfiguration in Spring Boot 4.x.
+ *
+ * <p>Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients
+ */
+@Configuration
+@ConditionalOnCamundaClientEnabled
+@ImportAutoConfiguration({
+  CamundaClientProdAutoConfiguration.class,
+  CamundaClientAllAutoConfiguration.class,
+  CamundaActuatorConfiguration.class,
+  MetricsDefaultConfiguration.class,
+  JsonMapperConfiguration.class,
+  ZeebeClientProdAutoConfiguration.class
+})
+@AutoConfigureAfter(JacksonAutoConfiguration.class)
+public class CamundaAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(
+      CamundaSpringProcessTestContext
+          .class) // only run if we are not running in a test case - as otherwise the lifecycle
+  // is controlled by the test
+  public CamundaLifecycleEventProducer camundaLifecycleEventProducer(
+      final CamundaClient client, final ApplicationEventPublisher publisher) {
+    return new CamundaLifecycleEventProducer(client, publisher);
+  }
+}

--- a/clients/camunda-spring-boot-4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/clients/camunda-spring-boot-4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,9 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+io.camunda.client.spring.configuration.CamundaAutoConfiguration
+

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <module>clients/java</module>
     <module>clients/java-deprecated</module>
     <module>clients/camunda-spring-boot-starter</module>
+    <module>clients/camunda-spring-boot-4-starter</module>
     <module>clients/spring-boot-starter-camunda-sdk-deprecated</module>
     <module>testing</module>
     <module>document</module>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-testing</artifactId>
+    <version>8.8.9-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-spring-4</artifactId>
+
+  <name>Camunda Process Test Spring Boot 4</name>
+  <description>Camunda's testing library for processes and process applications with Spring Boot 4.x support</description>
+
+  <properties>
+    <version.java>17</version.java>
+    <!-- Override Spring Boot version for 4.x compatibility -->
+    <version.spring-boot>4.0.1</version.spring-boot>
+    <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
+    <version.spring>7.0.1</version.spring>
+    <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
+    <version.junit>6.0.1</version.junit>
+  </properties>
+
+  <dependencies>
+
+    <!-- Base module - will be shaded -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <exclusions>
+        <!-- Exclude Spring Boot 3.x dependencies - we use 4.x versions -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-test</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-autoconfigure</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-configuration-processor</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-beans</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-test</artifactId>
+        </exclusion>
+        <!-- Exclude Spring Boot 3.x starter - we use 4.x version -->
+        <exclusion>
+          <groupId>io.camunda</groupId>
+          <artifactId>camunda-spring-boot-starter</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Use Spring Boot 4 starter instead -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-4-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Spring Boot 4 dependencies -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <!-- Shade plugin to include and relocate classes from camunda-process-test-spring -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <!-- Only include the base module in the shaded jar -->
+                  <include>io.camunda:camunda-process-test-spring</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <!-- Merge service files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <!-- Keep manifest entries -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!-- These dependencies are used by the shaded camunda-process-test-spring classes -->
+          <usedDependencies>
+            <dependency>org.springframework.boot:spring-boot-configuration-processor</dependency>
+            <dependency>io.camunda:camunda-spring-boot-4-starter</dependency>
+          </usedDependencies>
+          <!-- These are transitive dependencies from shaded module - used but not directly declared -->
+          <ignoredUsedUndeclaredDependencies>
+            <dependency>org.springframework:spring-beans</dependency>
+            <dependency>org.springframework:spring-core</dependency>
+            <dependency>org.springframework:spring-context</dependency>
+            <dependency>org.springframework.boot:spring-boot</dependency>
+            <dependency>org.springframework.boot:spring-boot-autoconfigure</dependency>
+          </ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <!--
+        Note: Tests are skipped because test-jar tests from camunda-process-test-spring
+        were compiled with JUnit 5.x which is binary incompatible with JUnit 6.x
+        (required by Spring Boot 4). Test coverage is provided by the base module.
+        This is acceptable as this module is a temporary solution for the 8.8 branch.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -37,39 +37,6 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
       <exclusions>
-        <!-- Exclude Spring Boot 3.x dependencies - we use 4.x versions -->
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-test</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-autoconfigure</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-configuration-processor</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-test</artifactId>
-        </exclusion>
         <!-- Exclude Spring Boot 3.x starter - we use 4.x version -->
         <exclusion>
           <groupId>io.camunda</groupId>
@@ -85,46 +52,122 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Spring Boot 4 dependencies -->
+    <!-- Test dependencies -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
+      <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <optional>true</optional>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>
@@ -164,11 +207,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.revapi</groupId>
-        <artifactId>revapi-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
@@ -177,34 +215,52 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <!-- These dependencies are used by the shaded camunda-process-test-spring classes -->
-          <usedDependencies>
-            <dependency>org.springframework.boot:spring-boot-configuration-processor</dependency>
+          <!-- Base module compile dependencies -->
+          <ignoredNonTestScopedDependencies>
+            <dependency>io.camunda:camunda-process-test-spring</dependency>
             <dependency>io.camunda:camunda-spring-boot-4-starter</dependency>
-          </usedDependencies>
-          <!-- These are transitive dependencies from shaded module - used but not directly declared -->
-          <ignoredUsedUndeclaredDependencies>
-            <dependency>org.springframework:spring-beans</dependency>
-            <dependency>org.springframework:spring-core</dependency>
-            <dependency>org.springframework:spring-context</dependency>
-            <dependency>org.springframework.boot:spring-boot</dependency>
-            <dependency>org.springframework.boot:spring-boot-autoconfigure</dependency>
-          </ignoredUsedUndeclaredDependencies>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
 
-      <!--
-        Note: Tests are skipped because test-jar tests from camunda-process-test-spring
-        were compiled with JUnit 5.x which is binary incompatible with JUnit 6.x
-        (required by Spring Boot 4). Test coverage is provided by the base module.
-        This is acceptable as this module is a temporary solution for the 8.8 branch.
-      -->
+      <!-- Add test re-/sources from the base module -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-source</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <sources>
+                <source>${project.basedir}/../camunda-process-test-spring/src/test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-resource</id>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../camunda-process-test-spring/src/test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Run tests compiled from base module sources -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
       </plugin>
 
     </plugins>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -23,6 +23,7 @@
   <modules>
     <module>camunda-process-test-java</module>
     <module>camunda-process-test-spring</module>
+    <module>camunda-process-test-spring-4</module>
     <module>camunda-process-test-example</module>
   </modules>
 


### PR DESCRIPTION
## Description

This PR adds Spring Boot 4.0 compatibility by introducing parallel modules that share code with the existing Spring Boot 3.x modules.

### New Modules
* clients/camunda-spring-boot-starter-4 - Spring Boot 4.0 compatible starter
* testing/camunda-process-test-spring-4 - Spring Boot 4.0 compatible process testing support

### Approach
The Spring Boot 4 modules use maven-shade-plugin to include classes from the base Spring Boot 3.x modules, selectively excluding and replacing classes that require Spring Boot 4 specific implementations. This approach provides a single source of truth for bug fixes and features for the majority of the code base, while producing separate artifacts with correct Spring Boot version dependencies and minimal POM-only differences between versions.

### Test Setup
Tests are shared using build-helper-maven-plugin with add-test-source and add-test-resource goals instead of a test-jar dependency. This is necessary because Spring Boot 4.0 upgrades from JUnit 5 to JUnit 6—a test-jar compiled against JUnit 5 would fail at runtime with ClassNotFoundException. Using add-test-source ensures tests are recompiled against the correct JUnit version for each Spring Boot variant.

### Motivation
I favor this approach as:
* it has no risk of breaking 3.5 compatibility in the default original module - and is aligned with [Spring discouraging supporting both 3.x and 4.0 with one starter](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide#considerations-for-projects-building-their-own-starters)
* users can opt-in to make use of `camunda-spring-boot-starter-4` at will on 8.8 by swapping the artifactid. With 8.9 where the default will be spring-boot 4 though, we could then just relocate this special artifactid to the default one. This could be a general pattern we use going forward whenever we face breaking changes from spring. `camunda-spring-boot-starter` will always be stay compatible with the boot version used in the initial minor release, support for new spring boot versions with breaking changes may be added with dedicated modules in a future patch

So in overall we keep the risk for existing users that stay on the initial spring-boot version as low as possible, while providing a clear path for users that need to migrate motivated by the closing support window of a spring-boot release or are just eager early adopters.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #42077
