### PR TITLE
deps: Ignore renovate Lucene updates on stable branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -161,6 +161,23 @@
       "enabled": false
     },
     {
+      "description": "Skip lucene minor and patch in stable branches to avoid breaking changes.",
+      "matchBaseBranches": [
+        "/^stable\\/8\\.[6-8]/"
+      ],
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.apache.lucene**"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "maven"
       ],


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Lucene is coupled to the ES7 version. As ES7 is out of support soon they won't upgrade their Lucene version anymore. As we already are on the highest supported version, any subsequent upgrades will fail.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to renovate PRs:
- #37782 
- #37850 
- #38020 
