### PR TITLE
Refactor: expand on NavigatedViewer to display flownodes

### DIFF
--- a/operate/client/src/__mocks__/bpmn-js/lib/NavigatedViewer.ts
+++ b/operate/client/src/__mocks__/bpmn-js/lib/NavigatedViewer.ts
@@ -7,10 +7,49 @@
  */
 
 const diObject = {set: vi.fn()};
+const BPMN_NODES = [
+  'bpmn\\:startEvent',
+  'bpmn\\:endEvent',
+  'bpmn\\:userTask',
+  'bpmn\\:task',
+  'bpmn\\:scriptTask',
+  'bpmn\\:subProcess',
+].join(',');
 
-const createMockedModules = (
-  container: HTMLElement,
-): {[module: string]: unknown} => ({
+type Listener = (event: unknown) => void;
+
+class EventBusMock {
+  private listeners = new Map<string, Listener[]>();
+
+  on = vi.fn((event: string, cb: Listener) => {
+    const list = this.listeners.get(event) ?? [];
+    list.push(cb);
+    this.listeners.set(event, list);
+  });
+
+  off = vi.fn((event: string, cb: Listener) => {
+    this.listeners.set(
+      event,
+      (this.listeners.get(event) ?? []).filter((listener) => listener !== cb),
+    );
+  });
+
+  emit(event: string, payload: unknown) {
+    this.listeners.get(event)?.forEach((cb) => cb(payload));
+  }
+}
+
+const createMockFlowNode = (id: string) => ({
+  id,
+  type: 'bpmn:Task',
+  di: diObject,
+  businessObject: {
+    id,
+    $instanceOf: (type: string) => type === 'bpmn:FlowNode',
+  },
+});
+
+const createMockedModules = (container: HTMLElement) => ({
   canvas: {
     zoom: vi.fn(),
     addMarker: vi.fn(),
@@ -32,12 +71,12 @@ const createMockedModules = (
       })),
       getBBox: vi.fn(() => ({x: 0, y: 0, height: 0, width: 0})),
     })),
-    get: vi.fn((id) => ({di: diObject, businessObject: {name: id}})),
+    get: vi.fn((id: string) => createMockFlowNode(id)),
     forEach: vi.fn(() => {}),
     filter: vi.fn(() => []),
   },
   graphicsFactory: {update: vi.fn(() => {})},
-  eventBus: {on: vi.fn()},
+  eventBus: new EventBusMock(),
   overlays: {
     add: vi.fn(
       (_: string, __: string, {html: children}: {html: HTMLElement}) => {
@@ -49,9 +88,19 @@ const createMockedModules = (
   },
 });
 
+function extractFlowNodes(xml: string) {
+  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  return Array.from(doc.querySelectorAll(BPMN_NODES))
+    .map((el) => el.getAttribute('id'))
+    .filter((id): id is string => id !== null)
+    .map((id) => ({id}));
+}
+
 class Viewer {
   bpmnRenderer: unknown;
   container: HTMLElement;
+  modules: ReturnType<typeof createMockedModules>;
+
   constructor(
     {
       container,
@@ -63,19 +112,41 @@ class Viewer {
   ) {
     this.container = container;
     this.bpmnRenderer = bpmnRenderer;
+    this.modules = createMockedModules(container);
   }
 
   importDefinitions = vi.fn(() => Promise.resolve({}));
-  importXML = vi.fn(() => {
+
+  importXML = vi.fn((xml: string) => {
     this.container.innerHTML = 'Diagram mock';
+    const flowNodes = extractFlowNodes(xml);
+    flowNodes.forEach(({id}) => {
+      const element = createMockFlowNode(id);
+      const node = document.createElement('div');
+      node.setAttribute('data-testid', id);
+
+      node.addEventListener('click', () => {
+        this.modules.eventBus.emit('element.click', {element});
+      });
+
+      this.container.appendChild(node);
+    });
+
     return Promise.resolve({});
   });
+
   detach = vi.fn();
   destroy = vi.fn();
-  on = vi.fn();
-  off = vi.fn();
+  on = (event: string, cb: Listener) => {
+    this.modules.eventBus.on(event, cb);
+  };
 
-  get = (module: string) => createMockedModules(this.container)[module];
+  off = (event: string, cb: Listener) => {
+    this.modules.eventBus.off(event, cb);
+  };
+
+  get = (module: keyof ReturnType<typeof createMockedModules>) =>
+    this.modules[module];
 }
 
 export default Viewer;


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR improves the MockedNavigatedViewer used in component tests by making BPMN flow nodes interactive and easier to test without exposing internal viewer APIs.


* Updated `importXML` mock to:

  * Parse provided BPMN XML.
  * Extract flow nodes (e.g., user tasks, script tasks, sub-processes).
  * Create corresponding DOM elements (`div`s) for each flow node inside the mock viewer container.
* Each flow node element now has a `click` event listener that emits the `'element.click'` event via the mocked `eventBus`.
* This allows React Testing Library tests to simulate flow node clicks directly on the DOM, triggering component handlers such as `onFlowNodeSelection`.
* No internal APIs (`triggerElementClick`) are exposed; tests interact naturally with DOM elements.
* Supports multi-instance and nested BPMN elements in the mock.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #41519 
