### PR TITLE
ci: enable camunda-process-test IT CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,18 +605,16 @@ jobs:
             docker-file: Dockerfile
             owner: "Core Features"
             module: "Zeebe"
-# Disable for now until the issue is fixed.
-# See https://camunda.slack.com/archives/C071KP5BTHB/p1765350880999359?thread_ts=1765347090.334479&cid=C071KP5BTHB
-#          - group: qa-camunda-process-test
-#            name: "Camunda Process"
-#            maven-modules: "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example"
-#            maven-build-threads: 1
-#            maven-test-fork-count: 3
-#            runs-on: gcp-perf-core-8-default
-#            docker-repository: localhost:5000/camunda/camunda
-#            docker-file: camunda.Dockerfile
-#            owner: "CamundaEx"
-#            module: "Testing"
+          - group: qa-camunda-process-test
+            name: "Camunda Process"
+            maven-modules: "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example"
+            maven-build-threads: 1
+            maven-test-fork-count: 3
+            runs-on: gcp-perf-core-8-default
+            docker-repository: localhost:5000/camunda/camunda
+            docker-file: camunda.Dockerfile
+            owner: "CamundaEx"
+            module: "Testing"
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test


### PR DESCRIPTION
## Description

This reverts commit c8c6902bbae9043a42b0085bd84e31a36c12db52.

As the cause being the instable connectors:SNAPSHOT image is resolved with https://github.com/camunda/connectors/pull/5896

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
