### PR TITLE
fix: changed springdoc settings to use local storage for csrf

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -106,6 +106,7 @@ management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
-springdoc.swagger-ui.csrf.use-session-storage=true
+springdoc.swagger-ui.csrf.use-session-storage=false
+springdoc.swagger-ui.csrf.use-local-storage=true
 
 camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}


### PR DESCRIPTION
## Description

**Context**

Swagger UI uses a CSRF header for non-GET requests when Spring Security CSRF protection is enabled.
Previously, the CSRF token was stored in sessionStorage, which is scoped to a single browser tab.

**As a result:**

- Opening Swagger in a second tab did not have access to the CSRF token
- This is a known limitation of sessionStorage

**Root cause**
`sessionStorage` is not shared between browser tabs.
Swagger UI was therefore unable to reuse the CSRF token when navigating or reopening Swagger in another tab.

**Solution**

Configured SpringDoc Swagger UI to use localStorage instead of sessionStorage for CSRF token storage.

```
springdoc.swagger-ui.csrf.use-session-storage=false
springdoc.swagger-ui.csrf.use-local-storage=true

```

This allows `CSRF tokens` to be shared across Swagger tabs on the same origin

**Security considerations**

- The CSRF token is not an authentication secret
- It is only valid in combination with a valid session cookie
- Tokens are **invalidated** when the session expires

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38326
