### PR TITLE
test: migrate operation.spec.ts to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -10,6 +10,7 @@ import {Page, Locator, expect} from '@playwright/test';
 import {OperateDiagramPage} from './OperateDiagramPage';
 import {sleep} from '../utils/sleep';
 import {checkUpdateOnVersion} from 'utils/zeebeClient';
+import {time} from 'console';
 
 class OperateProcessesPage {
   private page: Page;
@@ -34,7 +35,7 @@ class OperateProcessesPage {
   readonly continueMigrationDialogButton: Locator;
   readonly cancelProcessInstanceButton: Locator;
   readonly cancelProcessInstanceDialogButton: Locator;
-  readonly singleCancellationSpinner: Locator;
+  readonly singleOperationSpinner: Locator;
   readonly diagram: InstanceType<typeof OperateDiagramPage>;
   readonly processActiveCheckbox: Locator;
   readonly processCompletedCheckbox: Locator;
@@ -56,6 +57,11 @@ class OperateProcessesPage {
   readonly collapsedOperationsPanel: Locator;
   readonly expandOperationsButton: Locator;
   readonly inProgressBar: Locator;
+  readonly selectAllRowsCheckbox: Locator;
+  readonly retryButton: Locator;
+  readonly cancelButton: Locator;
+  readonly applyButton: Locator;
+  readonly resultsCount: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -120,7 +126,7 @@ class OperateProcessesPage {
     this.cancelProcessInstanceDialogButton = page
       .getByRole('dialog')
       .getByRole('button', {name: 'Apply'});
-    this.singleCancellationSpinner = page.getByTestId('operation-spinner');
+    this.singleOperationSpinner = page.getByTestId('operation-spinner');
     this.processActiveCheckbox = page
       .locator('label')
       .filter({hasText: 'Active'});
@@ -171,6 +177,13 @@ class OperateProcessesPage {
     this.inProgressBar = this.operationsList.locator(
       '[role="progressbar"][aria-busy="true"]',
     );
+    this.selectAllRowsCheckbox = page.getByRole('columnheader', {
+      name: 'Select all rows',
+    });
+    this.retryButton = page.getByRole('button', {name: 'Retry', exact: true});
+    this.cancelButton = page.getByRole('button', {name: 'Cancel', exact: true});
+    this.applyButton = page.getByRole('button', {name: 'Apply'});
+    this.resultsCount = page.getByText(/\d+ results/);
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -240,6 +253,56 @@ class OperateProcessesPage {
 
   static getProcessVersion(row: Locator): Locator {
     return row.getByTestId('cell-processVersion');
+  }
+
+  getInstanceRow(index: number): Locator {
+    return this.dataList.getByRole('row').nth(index);
+  }
+
+  getCanceledIcon(processInstanceKey: string): Locator {
+    return this.page.getByTestId(`CANCELED-icon-${processInstanceKey}`);
+  }
+
+  getRetryInstanceButton(processInstanceKey: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Retry Instance ${processInstanceKey}`,
+    });
+  }
+
+  getCancelInstanceButton(processInstanceKey: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Cancel Instance ${processInstanceKey}`,
+    });
+  }
+
+  async clickRetryInstanceButton(processInstanceKey: string): Promise<void> {
+    const button = this.getRetryInstanceButton(processInstanceKey);
+    try {
+      await this.page
+        .getByRole('button', {
+          name: `Retry Instance ${processInstanceKey}`,
+        })
+        .click({timeout: 30000});
+    } catch (error) {
+      await button.scrollIntoViewIfNeeded({timeout: 60000});
+      await button.click({timeout: 60000});
+    }
+  }
+
+  async clickCancelInstanceButton(processInstanceKey: string): Promise<void> {
+    const button = this.getCancelInstanceButton(processInstanceKey);
+    await button.scrollIntoViewIfNeeded({timeout: 30000});
+    await button.click({timeout: 30000});
+  }
+
+  getScheduledOperationsIcons(): Locator {
+    return this.page.getByTitle(/has scheduled operations/i);
+  }
+
+  getProcessInstanceLink(processInstanceKey: string): Locator {
+    return this.page.getByRole('link', {
+      name: processInstanceKey,
+    });
   }
 
   static getRowByProcessInstanceKey(page: Page, keyStr: string): Locator {
@@ -402,6 +465,21 @@ class OperateProcessesPage {
     return this.page
       .locator('[data-testid="operations-entry"]')
       .filter({hasText: 'Migrate'})
+      .filter({hasText: `${successCount} operations succeeded`});
+  }
+
+  getRetryOperationEntry(successCount: number): Locator {
+    return this.page
+      .locator('[data-testid="operations-entry"]')
+      .filter({hasText: 'Retry'})
+      .filter({hasText: `${successCount} retries succeeded`})
+      .first();
+  }
+
+  getCancelOperationEntry(successCount: number): Locator {
+    return this.page
+      .locator('[data-testid="operations-entry"]')
+      .filter({hasText: 'Cancel'})
       .filter({hasText: `${successCount} operations succeeded`});
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -10,7 +10,6 @@ import {Page, Locator, expect} from '@playwright/test';
 import {OperateDiagramPage} from './OperateDiagramPage';
 import {sleep} from '../utils/sleep';
 import {checkUpdateOnVersion} from 'utils/zeebeClient';
-import {time} from 'console';
 
 class OperateProcessesPage {
   private page: Page;
@@ -62,6 +61,8 @@ class OperateProcessesPage {
   readonly cancelButton: Locator;
   readonly applyButton: Locator;
   readonly resultsCount: Locator;
+  readonly scheduledOperationsIcons: Locator;
+  processInstanceLinkByKey: (processInstanceKey: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -184,6 +185,13 @@ class OperateProcessesPage {
     this.cancelButton = page.getByRole('button', {name: 'Cancel', exact: true});
     this.applyButton = page.getByRole('button', {name: 'Apply'});
     this.resultsCount = page.getByText(/\d+ results/);
+    this.scheduledOperationsIcons = page.getByTitle(
+      /has scheduled operations/i,
+    );
+    this.processInstanceLinkByKey = (processInstanceKey: string) =>
+      page.getByRole('link', {
+        name: processInstanceKey,
+      });
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -278,11 +286,7 @@ class OperateProcessesPage {
   async clickRetryInstanceButton(processInstanceKey: string): Promise<void> {
     const button = this.getRetryInstanceButton(processInstanceKey);
     try {
-      await this.page
-        .getByRole('button', {
-          name: `Retry Instance ${processInstanceKey}`,
-        })
-        .click({timeout: 30000});
+      await button.click({timeout: 30000});
     } catch (error) {
       await button.scrollIntoViewIfNeeded({timeout: 60000});
       await button.click({timeout: 60000});
@@ -293,16 +297,6 @@ class OperateProcessesPage {
     const button = this.getCancelInstanceButton(processInstanceKey);
     await button.scrollIntoViewIfNeeded({timeout: 30000});
     await button.click({timeout: 30000});
-  }
-
-  getScheduledOperationsIcons(): Locator {
-    return this.page.getByTitle(/has scheduled operations/i);
-  }
-
-  getProcessInstanceLink(processInstanceKey: string): Locator {
-    return this.page.getByRole('link', {
-      name: processInstanceKey,
-    });
   }
 
   static getRowByProcessInstanceKey(page: Page, keyStr: string): Locator {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessA.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessA.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0j0fp4a" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="operationsProcessA" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>SequenceFlow_05ep9w5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>SequenceFlow_05ep9w5</bpmn:incoming>
+      <bpmn:errorEventDefinition errorRef="Error_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_05ep9w5" sourceRef="start" targetRef="end" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="errorEnd" errorCode="end" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="error-end-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_13vjvo9_di" bpmnElement="end">
+        <dc:Bounds x="252" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05ep9w5_di" bpmnElement="SequenceFlow_05ep9w5">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="252" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessB.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/operationsProcessB.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0j0fp4a" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="operationsProcessB" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>SequenceFlow_05ep9w5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>SequenceFlow_05ep9w5</bpmn:incoming>
+      <bpmn:errorEventDefinition errorRef="Error_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_05ep9w5" sourceRef="start" targetRef="end" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="errorEnd" errorCode="end" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="error-end-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_13vjvo9_di" bpmnElement="end">
+        <dc:Bounds x="252" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05ep9w5_di" bpmnElement="SequenceFlow_05ep9w5">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="252" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -96,6 +96,7 @@ test.describe('Operations', () => {
   });
 
   // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
+  // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
   test.skip('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -45,7 +45,7 @@ test.beforeAll(async ({request}) => {
       bpmnProcessId: 'operationsProcessB',
     })),
   };
-
+  await sleep(1000);
   await createDemoOperations(
     request,
     initialData.singleOperationInstance.processInstanceKey,
@@ -66,7 +66,7 @@ test.describe('Operations', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('infinite scrolling', async ({operateOperationPanelPage}) => {
+  test('Infinite scrolling', async ({operateOperationPanelPage}) => {
     await test.step('Expand operations panel and validate initial count', async () => {
       await operateOperationPanelPage.expandOperationIdField();
       await expect(
@@ -95,8 +95,8 @@ test.describe('Operations', () => {
     });
   });
 
-  // Skipped due to bug 42375:  https://github.com/camunda/camunda/issues/42375
-  test.skip('Retry and Cancel single instance', async ({
+  // Skipped due to bug 42375: https://github.com/camunda/camunda/issues/42375
+  test.skip('Retry and cancel single instance', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
@@ -212,9 +212,11 @@ test.describe('Operations', () => {
 
       await operateProcessesPage.expandOperationsPanel();
 
-      await expect(
-        operateProcessesPage.getScheduledOperationsIcons(),
-      ).toHaveCount(instances.length);
+      await expect
+        .poll(async () => {
+          return operateProcessesPage.scheduledOperationsIcons.count();
+        })
+        .toBe(instances.length);
     });
 
     await test.step('Wait for operation to complete', async () => {
@@ -241,7 +243,7 @@ test.describe('Operations', () => {
       await Promise.all(
         instances.map((instance) =>
           expect(
-            operateProcessesPage.getProcessInstanceLink(
+            operateProcessesPage.processInstanceLinkByKey(
               instance.processInstanceKey,
             ),
           ).toBeVisible(),
@@ -263,9 +265,11 @@ test.describe('Operations', () => {
 
       await operateProcessesPage.expandOperationsPanel();
 
-      await expect(
-        operateProcessesPage.getScheduledOperationsIcons(),
-      ).toHaveCount(instances.length);
+      await expect
+        .poll(async () => {
+          return operateProcessesPage.scheduledOperationsIcons.count();
+        })
+        .toBe(instances.length);
 
       const operationEntry = operateProcessesPage.getCancelOperationEntry(
         instances.length,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp, validateURL} from '@pages/UtilitiesPage';
+import {DATE_REGEX} from 'utils/constants';
+import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {createDemoOperations} from 'utils/operations.helper';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+  bpmnProcessId: string;
+};
+
+let initialData: {
+  singleOperationInstance: ProcessInstance;
+  batchOperationInstances: ProcessInstance[];
+};
+
+test.beforeAll(async ({request}) => {
+  await deploy([
+    './resources/operationsProcessA.bpmn',
+    './resources/operationsProcessB.bpmn',
+  ]);
+
+  const singleInstance = await createSingleInstance('operationsProcessA', 1);
+  const batchInstances = await createInstances('operationsProcessB', 1, 10);
+
+  initialData = {
+    singleOperationInstance: {
+      processInstanceKey: singleInstance.processInstanceKey,
+      bpmnProcessId: 'operationsProcessA',
+    },
+    batchOperationInstances: batchInstances.map((instance) => ({
+      processInstanceKey: instance.processInstanceKey,
+      bpmnProcessId: 'operationsProcessB',
+    })),
+  };
+
+  await createDemoOperations(
+    request,
+    initialData.singleOperationInstance.processInstanceKey,
+    50,
+  );
+});
+
+test.describe('Operations', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('infinite scrolling', async ({operateOperationPanelPage}) => {
+    await test.step('Expand operations panel and validate initial count', async () => {
+      await operateOperationPanelPage.expandOperationIdField();
+      await expect(
+        operateOperationPanelPage.getAllOperationEntries(),
+      ).toHaveCount(9);
+    });
+
+    await test.step('Scroll to last operation entry', async () => {
+      const initialCount = await operateOperationPanelPage
+        .getAllOperationEntries()
+        .count();
+
+      await operateOperationPanelPage
+        .getAllOperationEntries()
+        .last()
+        .scrollIntoViewIfNeeded();
+
+      await test.step('Verify more operations loaded', async () => {
+        await expect(async () => {
+          const newCount = await operateOperationPanelPage
+            .getAllOperationEntries()
+            .count();
+          expect(newCount).toBeGreaterThan(initialCount);
+        }).toPass();
+      });
+    });
+  });
+
+  // Skipped due to bug 42375:  https://github.com/camunda/camunda/issues/42375
+  test.skip('Retry and Cancel single instance', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateOperationPanelPage,
+  }) => {
+    const instance = initialData.singleOperationInstance;
+
+    await test.step('Filter by Process Instance Key', async () => {
+      await expect(operateProcessesPage.dataList).toBeVisible();
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instance.processInstanceKey,
+      );
+      await expect(page.getByText('1 result')).toBeVisible();
+    });
+
+    await test.step('Retry single instance using operation button', async () => {
+      await operateProcessesPage.clickRetryInstanceButton(
+        instance.processInstanceKey,
+      );
+
+      await expect(operateProcessesPage.singleOperationSpinner).toBeVisible();
+      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden();
+    });
+
+    await test.step('Cancel single instance using operation button', async () => {
+      await operateProcessesPage.clickCancelInstanceButton(
+        instance.processInstanceKey,
+      );
+
+      await operateProcessesPage.applyButton.click();
+
+      await expect(
+        operateProcessesPage.noMatchingInstancesMessage,
+      ).toBeVisible();
+    });
+
+    await test.step('Validate operation in operations list', async () => {
+      await expect(operateOperationPanelPage.operationList).toBeHidden();
+      await operateOperationPanelPage.expandOperationIdField();
+
+      await expect(operateOperationPanelPage.operationList).toBeVisible();
+
+      const operationEntry = operateProcessesPage.getCancelOperationEntry(1);
+
+      await expect(operationEntry).toBeVisible();
+      await expect(operationEntry.getByText(DATE_REGEX)).toBeVisible();
+
+      const operationId = await operationEntry.getByRole('link').innerText();
+
+      await operateProcessesPage.clickOperationLink(operationEntry);
+      await expect(operateFiltersPanelPage.operationIdFilter).toHaveValue(
+        operationId,
+      );
+      await expect(operateProcessesPage.resultsCount).toBeVisible();
+    });
+
+    await test.step('Validate canceled instance details', async () => {
+      const instanceRow = operateProcessesPage.getInstanceRow(0);
+
+      await expect(
+        operateProcessesPage.getCanceledIcon(instance.processInstanceKey),
+      ).toBeVisible();
+
+      await expect(instanceRow.getByText(instance.bpmnProcessId)).toBeVisible();
+      await expect(
+        instanceRow.getByText(instance.processInstanceKey),
+      ).toBeVisible();
+
+      await operateOperationPanelPage.collapseOperationIdField();
+    });
+  });
+
+  test('Retry and cancel multiple instances', async ({
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateOperationPanelPage,
+    page,
+  }) => {
+    test.slow();
+    const instances = initialData.batchOperationInstances.slice(0, 5);
+
+    await test.step('Filter by Process Instance Keys', async () => {
+      await expect(operateProcessesPage.dataList).toBeVisible();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instances.map((instance) => instance.processInstanceKey).join(','),
+      );
+
+      await expect(operateProcessesPage.dataList.getByRole('row')).toHaveCount(
+        instances.length,
+      );
+    });
+
+    await test.step('Select all instances and retry', async () => {
+      await operateProcessesPage.selectAllRowsCheckbox.click();
+
+      await operateProcessesPage.retryButton.click();
+
+      await expect(operateOperationPanelPage.operationList).toBeHidden();
+
+      await operateProcessesPage.applyButton.click();
+
+      await expect(operateProcessesPage.operationsList).toBeVisible({
+        timeout: 30000,
+      });
+      await sleep(500);
+
+      await operateProcessesPage.expandOperationsPanel();
+
+      await expect(
+        operateProcessesPage.getScheduledOperationsIcons(),
+      ).toHaveCount(instances.length);
+    });
+
+    await test.step('Wait for operation to complete', async () => {
+      const operationEntry = operateProcessesPage.getRetryOperationEntry(
+        instances.length,
+      );
+
+      await expect(operationEntry).toBeVisible({timeout: 120000});
+
+      await operateProcessesPage.clickOperationLink(operationEntry);
+
+      await validateURL(page, /operationId=/);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('5 results')).toBeVisible({
+            timeout: 30000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await Promise.all(
+        instances.map((instance) =>
+          expect(
+            operateProcessesPage.getProcessInstanceLink(
+              instance.processInstanceKey,
+            ),
+          ).toBeVisible(),
+        ),
+      );
+    });
+
+    await test.step('Cancel all instances', async () => {
+      await operateOperationPanelPage.collapseOperationIdField();
+      await operateProcessesPage.selectAllRowsCheckbox.click();
+
+      await operateProcessesPage.cancelButton.click();
+      await operateProcessesPage.applyButton.click();
+
+      await expect(operateProcessesPage.operationsList).toBeVisible({
+        timeout: 30000,
+      });
+      await sleep(500);
+
+      await operateProcessesPage.expandOperationsPanel();
+
+      await expect(
+        operateProcessesPage.getScheduledOperationsIcons(),
+      ).toHaveCount(instances.length);
+
+      const operationEntry = operateProcessesPage.getCancelOperationEntry(
+        instances.length,
+      );
+
+      await expect(operationEntry).toBeVisible({timeout: 120000});
+
+      await Promise.all(
+        instances.map((instance) =>
+          expect(
+            operateProcessesPage.getCanceledIcon(instance.processInstanceKey),
+          ).toBeVisible({timeout: 120000}),
+        ),
+      );
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -495,11 +495,13 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify 3 instances migrated to target version', async () => {
-      await expect(operateProcessesPage.operationSuccessMessage).toBeVisible({
+      const operationEntry = operateProcessesPage.getMigrationOperationEntry(3);
+
+      await expect(operationEntry).toBeVisible({
         timeout: 120000,
       });
 
-      await operateProcessesPage.clickLatestOperationLink();
+      await operateProcessesPage.clickOperationLink(operationEntry);
 
       await validateURL(page, /operationId=/);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -256,10 +256,16 @@ test.describe('Processes', () => {
   test('Cancel process instance', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
-    operateDiagramPage,
     page,
   }) => {
     await test.step('Navigate to process to cancel', async () => {
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instanceToCancel.processInstanceKey,
+      );
+
       await operateFiltersPanelPage.selectProcess(
         'Delete Process Definition API Test',
       );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -24,7 +24,7 @@ export async function createDemoOperations(
   await Promise.all(
     [...new Array(count)].map(async () => {
       const response = await request.post(
-        `http://localhost:8080/api/process-instances/${processInstanceKey}/operation`,
+        `${credentials.baseUrl}/api/process-instances/${processInstanceKey}/operation`,
         {
           ...requestHeaders,
           data: {
@@ -32,6 +32,13 @@ export async function createDemoOperations(
           },
         },
       );
+      if (!response.ok()) {
+        const errorBody = await response.text();
+        console.error(
+          `Failed to create operation: ${response.status()} ${response.statusText()}`,
+        );
+        console.error(`Response body: ${errorBody}`);
+      }
       expect(response.ok()).toBeTruthy();
       return response;
     }),
@@ -41,7 +48,7 @@ export async function createDemoOperations(
     .poll(
       async () => {
         const response = await request.post(
-          `http://localhost:8080/api/batch-operations`,
+          `${credentials.baseUrl}/api/batch-operations`,
           {
             ...requestHeaders,
             data: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, APIRequestContext} from '@playwright/test';
+import {credentials, authHeaders} from './http';
+
+export async function createDemoOperations(
+  request: APIRequestContext,
+  processInstanceKey: string,
+  count: number,
+): Promise<void> {
+  const requestHeaders = {
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(credentials.accessToken),
+    },
+  };
+
+  await Promise.all(
+    [...new Array(count)].map(async () => {
+      const response = await request.post(
+        `http://localhost:8080/api/process-instances/${processInstanceKey}/operation`,
+        {
+          ...requestHeaders,
+          data: {
+            operationType: 'RESOLVE_INCIDENT',
+          },
+        },
+      );
+      expect(response.ok()).toBeTruthy();
+      return response;
+    }),
+  );
+
+  await expect
+    .poll(
+      async () => {
+        const response = await request.post(
+          `http://localhost:8080/api/batch-operations`,
+          {
+            ...requestHeaders,
+            data: {
+              pageSize: count,
+            },
+          },
+        );
+        const operations = await response.json();
+        return operations.length;
+      },
+      {timeout: 30000},
+    )
+    .toBeGreaterThanOrEqual(count);
+}


### PR DESCRIPTION
## Description
Migrated `operations.spec.ts` from the old Operate e2e-playwright suite to the new c8-orchestration-cluster-e2e-test-suite following POM patterns and test suite conventions.

## Key Changes

### Test Migration
- **`tests/operate/operations.spec.ts`** - Migrated 3 test cases (infinite scrolling, retry/cancel single and batch operations)

- **Simplified infinite scrolling test** to handle dynamic loading behavior:
  - Records initial count (9 operations)
  - Scrolls to last item to trigger loading
  - Verifies count increases (rather than expecting exact counts)



### New Utility (`utils/operations.helper.ts`)
- Created `createDemoOperations()` helper to generate test operations via API
- Reuses shared authentication utilities from `http.ts`
- Includes error logging for failed operations


### Bug Fix
- **`tests/operate/processInstanceMigration.spec.ts`** - Fixed incorrect operation selection by using `getMigrationOperationEntry()` instead of `clickLatestOperationLink()` to prevent clicking wrong operation type



🧪 [Test Run](https://github.com/camunda/camunda/actions/runs/20100508672)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
relates to https://github.com/camunda/camunda/issues/34095