### PR TITLE
feat: create a map from resource id to permission types

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessGroupDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessGroupDto.java
@@ -17,6 +17,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Schema(
     name = "Process group object",
@@ -38,13 +39,16 @@ public class ProcessGroupDto {
       final PermissionsService permissionsService) {
     final List<ProcessGroupDto> groups = new ArrayList<>();
 
-    final List<String> resourceIds =
-        processesGrouped.keySet().stream().map(ProcessKey::getBpmnProcessId).toList();
+    final Set<String> resourceIds =
+        processesGrouped.keySet().stream()
+            .map(ProcessKey::getBpmnProcessId)
+            .collect(Collectors.toSet());
 
     final Map<String, Set<String>> permissionsByResourceId =
         permissionsService.getProcessDefinitionPermissionsByResourceId(resourceIds);
 
-    processesGrouped.values().stream()
+    processesGrouped
+        .values()
         .forEach(
             group -> {
               final ProcessGroupDto groupDto = new ProcessGroupDto();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessGroupDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessGroupDto.java
@@ -14,7 +14,6 @@ import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,11 +34,6 @@ public class ProcessGroupDto {
   private List<ProcessDto> processes;
 
   public static List<ProcessGroupDto> createFrom(
-      final Map<ProcessStore.ProcessKey, List<ProcessEntity>> processesGrouped) {
-    return createFrom(processesGrouped, null);
-  }
-
-  public static List<ProcessGroupDto> createFrom(
       final Map<ProcessStore.ProcessKey, List<ProcessEntity>> processesGrouped,
       final PermissionsService permissionsService) {
     final List<ProcessGroupDto> groups = new ArrayList<>();
@@ -54,15 +48,11 @@ public class ProcessGroupDto {
         .forEach(
             group -> {
               final ProcessGroupDto groupDto = new ProcessGroupDto();
-              final ProcessEntity process0 = group.get(0);
-              final var permissions =
-                  new HashSet<>(
-                      permissionsByResourceId.getOrDefault(process0.getBpmnProcessId(), Set.of()));
-              permissions.addAll(permissionsByResourceId.getOrDefault("*", Set.of()));
+              final ProcessEntity process0 = group.getFirst();
               groupDto.setBpmnProcessId(process0.getBpmnProcessId());
               groupDto.setTenantId(process0.getTenantId());
               groupDto.setName(process0.getName());
-              groupDto.setPermissions(permissions);
+              groupDto.setPermissions(permissionsByResourceId.get(process0.getBpmnProcessId()));
               groupDto.setProcesses(DtoCreator.create(group, ProcessDto.class));
               groups.add(groupDto);
             });

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/ListViewProcessInstanceDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/ListViewProcessInstanceDto.java
@@ -151,10 +151,10 @@ public class ListViewProcessInstanceDto {
       return new ArrayList<>();
     }
 
-    final List<String> resourceIds =
+    final Set<String> resourceIds =
         processInstanceEntities.stream()
             .map(ProcessInstanceForListViewEntity::getBpmnProcessId)
-            .toList();
+            .collect(Collectors.toSet());
 
     final Map<String, Set<String>> permissionsByResourceId =
         permissionsService.getProcessDefinitionPermissionsByResourceId(resourceIds);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -52,6 +52,12 @@ public class PermissionsService {
     return getResourcePermissions(bpmnProcessId, AuthorizationResourceType.PROCESS_DEFINITION);
   }
 
+  /**
+   * Get permissions for multiple process definitions.
+   *
+   * @param bpmnProcessIds bpmnProcessIds
+   * @return permissions the user has for the given bpmnProcessId
+   */
   public Map<String, Set<String>> getProcessDefinitionPermissionsByResourceId(
       final Set<String> bpmnProcessIds) {
     return getResourcePermissionsByResourceIds(
@@ -66,6 +72,18 @@ public class PermissionsService {
    */
   public Set<String> getDecisionDefinitionPermissions(final String decisionId) {
     return getResourcePermissions(decisionId, AuthorizationResourceType.DECISION_DEFINITION);
+  }
+
+  /**
+   * Get permissions for multiple decision definitions.
+   *
+   * @param decisionIds decisionIds
+   * @return permissions the user has for the given decisionId
+   */
+  public Map<String, Set<String>> getDecisionDefinitionPermissionsByResourceId(
+      final Set<String> decisionIds) {
+    return getResourcePermissionsByResourceIds(
+        decisionIds, AuthorizationResourceType.DECISION_DEFINITION);
   }
 
   /**

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -55,7 +55,7 @@ public class PermissionsService {
 
   public Map<String, Set<String>> getProcessDefinitionPermissionsByResourceId(
       final List<String> bpmnProcessIds) {
-    return getResourcePermissionsByResourceId(
+    return getResourcePermissionsByResourceIds(
         bpmnProcessIds, AuthorizationResourceType.PROCESS_DEFINITION);
   }
 
@@ -87,10 +87,17 @@ public class PermissionsService {
     return permissions;
   }
 
-  public Map<String, Set<String>> getResourcePermissionsByResourceId(
+  /**
+   * Returns the permissions for each of the given resource ids.
+   *
+   * @param resourceKeys resourceKeys
+   * @param resourceType resourceType
+   * @return permissions the user has for the given resource
+   */
+  public Map<String, Set<String>> getResourcePermissionsByResourceIds(
       final List<String> resourceKeys, final AuthorizationResourceType resourceType) {
     final Map<String, Set<PermissionType>> permissionTypeSet =
-        authorizationChecker.collectPermissionTypes2(
+        authorizationChecker.collectPermissionTypesByResourceIds(
             resourceKeys, resourceType, getAuthentication());
     return permissionTypeSet.entrySet().stream()
         .collect(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -54,7 +53,7 @@ public class PermissionsService {
   }
 
   public Map<String, Set<String>> getProcessDefinitionPermissionsByResourceId(
-      final List<String> bpmnProcessIds) {
+      final Set<String> bpmnProcessIds) {
     return getResourcePermissionsByResourceIds(
         bpmnProcessIds, AuthorizationResourceType.PROCESS_DEFINITION);
   }
@@ -95,7 +94,7 @@ public class PermissionsService {
    * @return permissions the user has for the given resource
    */
   public Map<String, Set<String>> getResourcePermissionsByResourceIds(
-      final List<String> resourceKeys, final AuthorizationResourceType resourceType) {
+      final Set<String> resourceKeys, final AuthorizationResourceType resourceType) {
     final Map<String, Set<PermissionType>> permissionTypeSet =
         authorizationChecker.collectPermissionTypesByResourceIds(
             resourceKeys, resourceType, getAuthentication());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -19,7 +19,11 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PermissionsService {
 
@@ -49,6 +53,12 @@ public class PermissionsService {
     return getResourcePermissions(bpmnProcessId, AuthorizationResourceType.PROCESS_DEFINITION);
   }
 
+  public Map<String, Set<String>> getProcessDefinitionPermissionsByResourceId(
+      final List<String> bpmnProcessIds) {
+    return getResourcePermissionsByResourceId(
+        bpmnProcessIds, AuthorizationResourceType.PROCESS_DEFINITION);
+  }
+
   /**
    * getDecisionDefinitionPermissions
    *
@@ -75,6 +85,18 @@ public class PermissionsService {
     permissionTypeSet.forEach(p -> permissions.add(p.name()));
 
     return permissions;
+  }
+
+  public Map<String, Set<String>> getResourcePermissionsByResourceId(
+      final List<String> resourceKeys, final AuthorizationResourceType resourceType) {
+    final Map<String, Set<PermissionType>> permissionTypeSet =
+        authorizationChecker.collectPermissionTypes2(
+            resourceKeys, resourceType, getAuthentication());
+    return permissionTypeSet.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Entry::getKey,
+                p -> p.getValue().stream().map(PermissionType::name).collect(Collectors.toSet())));
   }
 
   /**

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -155,7 +156,7 @@ public class AuthorizationChecker {
    * @return the permission types found
    */
   public Map<String, Set<PermissionType>> collectPermissionTypesByResourceIds(
-      final Set<String> resourceIds,
+      final Collection<String> resourceIds,
       final AuthorizationResourceType resourceType,
       final CamundaAuthentication authentication) {
     final var resourceKeys = new ArrayList<>(resourceIds);
@@ -187,7 +188,7 @@ public class AuthorizationChecker {
   }
 
   private Map<String, Set<PermissionType>> collectPermissionTypesByResourceId(
-      final List<AuthorizationEntity> authorizationEntities, final Set<String> resourceIds) {
+      final List<AuthorizationEntity> authorizationEntities, final Collection<String> resourceIds) {
 
     // group permissions by resource ID
     final var permissionTypesByResourceId =

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -155,7 +155,7 @@ public class AuthorizationChecker {
    * @return the permission types found
    */
   public Map<String, Set<PermissionType>> collectPermissionTypesByResourceIds(
-      final List<String> resourceIds,
+      final Set<String> resourceIds,
       final AuthorizationResourceType resourceType,
       final CamundaAuthentication authentication) {
     final var resourceKeys = new ArrayList<>(resourceIds);
@@ -187,7 +187,7 @@ public class AuthorizationChecker {
   }
 
   private Map<String, Set<PermissionType>> collectPermissionTypesByResourceId(
-      final List<AuthorizationEntity> authorizationEntities, final List<String> resourceIds) {
+      final List<AuthorizationEntity> authorizationEntities, final Set<String> resourceIds) {
 
     // group permissions by resource ID
     final var permissionTypesByResourceId =


### PR DESCRIPTION
## Description

Fetch permissions in one call for Operate V1 APIs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/42395
