### PR TITLE
refactor: replace selectedRunningInstanceCount in TopPanel

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -55,6 +55,8 @@ const ModificationDropdown: React.FC<Props> = observer(
       selectedElementId,
       selectedElementInstanceKey,
       isFetchingElement,
+      isSelectedInstanceMultiInstanceBody,
+      resolvedElementInstance,
       clearSelection,
     } = useProcessInstanceElementSelection();
     const {data: businessObjects} = useBusinessObjects();
@@ -67,11 +69,13 @@ const ModificationDropdown: React.FC<Props> = observer(
     const {data: totalRunningInstancesByFlowNode} =
       useTotalRunningInstancesByFlowNode();
 
-    const availableModifications = useAvailableModifications(
-      selectedElementRunningInstanceCount ?? 0,
-      selectedElementId ?? undefined,
-      selectedElementInstanceKey ?? undefined,
-    );
+    const availableModifications = useAvailableModifications({
+      runningElementInstanceCount: selectedElementRunningInstanceCount ?? 0,
+      elementId: selectedElementId ?? undefined,
+      elementInstanceKey: selectedElementInstanceKey ?? undefined,
+      isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
+      isElementInstanceResolved: resolvedElementInstance !== null,
+    });
     const canBeModified = useCanBeModified(selectedElementId ?? undefined);
     const {data: processInstance} = useProcessInstance();
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -60,7 +60,7 @@ const ModificationDropdown: React.FC<Props> = observer(
       clearSelection,
     } = useProcessInstanceElementSelection();
     const {data: businessObjects} = useBusinessObjects();
-    const {data: selectedElementRunningInstanceCount} =
+    const {data: selectedElementRunningInstancesCount} =
       useTotalRunningInstancesForFlowNode(selectedElementId ?? undefined);
     const {data: totalRunningInstancesVisible} =
       useTotalRunningInstancesVisibleForFlowNode(
@@ -70,7 +70,7 @@ const ModificationDropdown: React.FC<Props> = observer(
       useTotalRunningInstancesByFlowNode();
 
     const availableModifications = useAvailableModifications({
-      runningElementInstanceCount: selectedElementRunningInstanceCount ?? 0,
+      runningElementInstanceCount: selectedElementRunningInstancesCount ?? 0,
       elementId: selectedElementId ?? undefined,
       elementInstanceKey: selectedElementInstanceKey ?? undefined,
       isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
@@ -121,9 +121,9 @@ const ModificationDropdown: React.FC<Props> = observer(
 
               return (
                 <>
-                  {(selectedElementRunningInstanceCount ?? 0) > 0 && (
+                  {(selectedElementRunningInstancesCount ?? 0) > 0 && (
                     <SelectedInstanceCount>
-                      {`Selected running instances: ${selectedElementRunningInstanceCount ?? 0}`}
+                      {`Selected running instances: ${selectedElementRunningInstancesCount ?? 0}`}
                     </SelectedInstanceCount>
                   )}
                   <Stack gap={2}>
@@ -225,7 +225,7 @@ const ModificationDropdown: React.FC<Props> = observer(
 
                             cancelAllTokens(
                               selectedElementId,
-                              selectedElementRunningInstanceCount ?? 0,
+                              selectedElementRunningInstancesCount ?? 0,
                               totalRunningInstancesVisible ?? 0,
                               businessObjects,
                             );

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
@@ -11,7 +11,9 @@ import {Stack} from '@carbon/react';
 import {flip, offset} from '@floating-ui/react-dom';
 import {Add, ArrowRight, Error} from '@carbon/react/icons';
 import isNil from 'lodash/isNil';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {modificationsStore} from 'modules/stores/modifications';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {tracking} from 'modules/tracking';
 import {generateUniqueID} from 'modules/utils/generateUniqueID';
 import {Popover} from 'modules/components/Popover';
@@ -22,6 +24,10 @@ import {
   Button,
   InlineLoading,
 } from './styled';
+import {
+  clearSelection,
+  getSelectedRunningInstanceCount,
+} from 'modules/utils/flowNodeSelection';
 import {
   useTotalRunningInstancesByFlowNode,
   useTotalRunningInstancesForFlowNode,
@@ -41,8 +47,11 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {getFlowNodeName} from 'modules/utils/flowNodes';
 import {getParentElement} from 'modules/bpmn-js/utils/getParentElement';
+import {
+  useIsRootNodeSelected,
+  useRootNode,
+} from 'modules/hooks/flowNodeSelection';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
 type Props = {
   selectedFlowNodeRef?: SVGSVGElement;
@@ -51,28 +60,27 @@ type Props = {
 
 const ModificationDropdown: React.FC<Props> = observer(
   ({selectedFlowNodeRef, diagramCanvasRef}) => {
-    const {
-      selectedElementId,
-      selectedElementInstanceKey,
-      isFetchingElement,
-      clearSelection,
-    } = useProcessInstanceElementSelection();
+    const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
+    const flowNodeInstanceId =
+      flowNodeSelectionStore.state.selection?.flowNodeInstanceId ??
+      flowNodeMetaDataStore.state.metaData?.flowNodeInstanceId;
     const {data: businessObjects} = useBusinessObjects();
-    const {data: selectedElementRunningInstanceCount} =
-      useTotalRunningInstancesForFlowNode(selectedElementId ?? undefined);
+    const {data: totalRunningInstances} =
+      useTotalRunningInstancesForFlowNode(flowNodeId);
     const {data: totalRunningInstancesVisible} =
-      useTotalRunningInstancesVisibleForFlowNode(
-        selectedElementId ?? undefined,
-      );
+      useTotalRunningInstancesVisibleForFlowNode(flowNodeId);
     const {data: totalRunningInstancesByFlowNode} =
       useTotalRunningInstancesByFlowNode();
-
+    const isRootNodeSelected = useIsRootNodeSelected();
+    const selectedRunningInstanceCount = getSelectedRunningInstanceCount({
+      totalRunningInstancesForFlowNode: totalRunningInstances || 0,
+      isRootNodeSelected,
+    });
     const availableModifications = useAvailableModifications(
-      selectedElementRunningInstanceCount ?? 0,
-      selectedElementId ?? undefined,
-      selectedElementInstanceKey ?? undefined,
+      selectedRunningInstanceCount,
     );
-    const canBeModified = useCanBeModified(selectedElementId ?? undefined);
+    const canBeModified = useCanBeModified();
+    const rootNode = useRootNode();
     const {data: processInstance} = useProcessInstance();
 
     const processDefinitionKey = useProcessDefinitionKeyContext();
@@ -81,7 +89,7 @@ const ModificationDropdown: React.FC<Props> = observer(
     });
 
     if (
-      selectedElementId === null ||
+      flowNodeId === undefined ||
       modificationsStore.state.status === 'moving-token'
     ) {
       return null;
@@ -104,7 +112,7 @@ const ModificationDropdown: React.FC<Props> = observer(
           <Title>Flow Node Modifications</Title>
           <Stack gap={4}>
             {(() => {
-              if (isFetchingElement) {
+              if (flowNodeMetaDataStore.state.status === 'fetching') {
                 return <InlineLoading data-testid="dropdown-spinner" />;
               }
               if (!canBeModified) {
@@ -117,9 +125,9 @@ const ModificationDropdown: React.FC<Props> = observer(
 
               return (
                 <>
-                  {(selectedElementRunningInstanceCount ?? 0) > 0 && (
+                  {selectedRunningInstanceCount > 0 && (
                     <SelectedInstanceCount>
-                      {`Selected running instances: ${selectedElementRunningInstanceCount ?? 0}`}
+                      Selected running instances: {selectedRunningInstanceCount}
                     </SelectedInstanceCount>
                   )}
                   <Stack gap={2}>
@@ -134,7 +142,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                           onClick={() => {
                             const parentElement = getParentElement(
                               processDefinitionData?.businessObjects?.[
-                                selectedElementId
+                                flowNodeId
                               ],
                             );
                             if (
@@ -143,9 +151,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                                 totalRunningInstancesByFlowNode,
                               )
                             ) {
-                              modificationsStore.startAddingToken(
-                                selectedElementId,
-                              );
+                              modificationsStore.startAddingToken(flowNodeId);
                             } else {
                               tracking.track({
                                 eventName: 'add-token',
@@ -157,23 +163,24 @@ const ModificationDropdown: React.FC<Props> = observer(
                                   operation: 'ADD_TOKEN',
                                   scopeId: generateUniqueID(),
                                   flowNode: {
-                                    id: selectedElementId,
+                                    id: flowNodeId,
                                     name: getFlowNodeName({
                                       businessObjects,
-                                      flowNodeId: selectedElementId,
+                                      flowNodeId,
                                     }),
                                   },
                                   affectedTokenCount: 1,
                                   visibleAffectedTokenCount: 1,
                                   parentScopeIds: generateParentScopeIds(
                                     businessObjects,
-                                    selectedElementId,
+                                    flowNodeId,
                                     processInstance?.processDefinitionId,
                                   ),
                                 },
                               });
                             }
-                            clearSelection();
+
+                            clearSelection(rootNode);
                           }}
                         >
                           Add
@@ -181,7 +188,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                       )}
 
                     {availableModifications.includes('cancel-instance') &&
-                      !isNil(selectedElementInstanceKey) &&
+                      !isNil(flowNodeInstanceId) &&
                       businessObjects && (
                         <Button
                           kind="ghost"
@@ -195,11 +202,11 @@ const ModificationDropdown: React.FC<Props> = observer(
                             });
 
                             modificationsStore.cancelToken(
-                              selectedElementId,
-                              selectedElementInstanceKey,
+                              flowNodeId,
+                              flowNodeInstanceId,
                               businessObjects,
                             );
-                            clearSelection();
+                            clearSelection(rootNode);
                           }}
                         >
                           Cancel instance
@@ -220,12 +227,12 @@ const ModificationDropdown: React.FC<Props> = observer(
                             });
 
                             cancelAllTokens(
-                              selectedElementId,
-                              selectedElementRunningInstanceCount ?? 0,
+                              flowNodeId,
+                              totalRunningInstances ?? 0,
                               totalRunningInstancesVisible ?? 0,
                               businessObjects,
                             );
-                            clearSelection();
+                            clearSelection(rootNode);
                           }}
                         >
                           Cancel all
@@ -233,7 +240,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                       )}
 
                     {availableModifications.includes('move-instance') &&
-                      !isNil(selectedElementInstanceKey) && (
+                      !isNil(flowNodeInstanceId) && (
                         <Button
                           kind="ghost"
                           title="Move selected instance in this flow node to another target"
@@ -242,10 +249,10 @@ const ModificationDropdown: React.FC<Props> = observer(
                           renderIcon={ArrowRight}
                           onClick={() => {
                             modificationsStore.startMovingToken(
-                              selectedElementId,
-                              selectedElementInstanceKey,
+                              flowNodeId,
+                              flowNodeInstanceId,
                             );
-                            clearSelection();
+                            clearSelection(rootNode);
                           }}
                         >
                           Move instance
@@ -258,10 +265,8 @@ const ModificationDropdown: React.FC<Props> = observer(
                         size="sm"
                         renderIcon={ArrowRight}
                         onClick={() => {
-                          modificationsStore.startMovingToken(
-                            selectedElementId,
-                          );
-                          clearSelection();
+                          modificationsStore.startMovingToken(flowNodeId);
+                          clearSelection(rootNode);
                         }}
                       >
                         Move all

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
@@ -76,10 +76,18 @@ const ModificationDropdown: React.FC<Props> = observer(
       totalRunningInstancesForFlowNode: totalRunningInstances || 0,
       isRootNodeSelected,
     });
-    const availableModifications = useAvailableModifications(
-      selectedRunningInstanceCount,
-    );
-    const canBeModified = useCanBeModified();
+    const availableModifications = useAvailableModifications({
+      runningElementInstanceCount: selectedRunningInstanceCount,
+      elementId: flowNodeId,
+      elementInstanceKey:
+        flowNodeSelectionStore.state.selection?.flowNodeInstanceId,
+      isMultiInstanceBody:
+        flowNodeSelectionStore.state.selection?.isMultiInstance,
+      isElementInstanceResolved: !isNil(
+        flowNodeSelectionStore.selectedFlowNodeInstanceId,
+      ),
+    });
+    const canBeModified = useCanBeModified(flowNodeId);
     const rootNode = useRootNode();
     const {data: processInstance} = useProcessInstance();
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mocks.tsx
@@ -13,7 +13,7 @@ import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails
 import {createInstance} from 'modules/testUtils';
 import {createRef, useEffect} from 'react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import {ModificationDropdown} from '..';
+import {ModificationDropdown} from '../indexV1';
 import {modificationsStore} from 'modules/stores/modifications';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {Paths} from 'modules/Routes';

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -32,6 +32,7 @@ import {Diagram} from 'modules/components/Diagram';
 import {MetadataPopover} from './MetadataPopover';
 import {ModificationBadgeOverlay} from './ModificationBadgeOverlay';
 import {ModificationInfoBanner} from './ModificationInfoBanner';
+import {ModificationDropdown as ModificationDropdownV1} from './ModificationDropdown/indexV1';
 import {ModificationDropdown} from './ModificationDropdown';
 import {StateOverlay} from 'modules/components/StateOverlay';
 import {executionCountToggleStore} from 'modules/stores/executionCountToggle';
@@ -424,7 +425,11 @@ const TopPanel: React.FC = observer(() => {
                 }
                 selectedFlowNodeOverlay={
                   isModificationModeEnabled ? (
+                    IS_ELEMENT_SELECTION_V2 ? (
                     <ModificationDropdown />
+                    ) : (
+                      <ModificationDropdownV1 />
+                    )
                   ) : (
                     !isIncidentBarOpen && <MetadataPopover />
                   )

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -136,13 +136,16 @@ const TopPanel: React.FC = observer(() => {
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const rootNode = useRootNode();
   const {isExecutionCountVisible} = executionCountToggleStore.state;
-  const {clearSelection, selectElement} = useProcessInstanceElementSelection();
+  const {clearSelection, selectElement, resolvedElementInstance} =
+    useProcessInstanceElementSelection();
 
   const isRootNodeSelected = useIsRootNodeSelected();
   const selectedRunningInstanceCount = getSelectedRunningInstanceCount({
     totalRunningInstancesForFlowNode: totalRunningInstances ?? 0,
     isRootNodeSelected,
   });
+  const isSelectedElementInstanceRunning =
+    resolvedElementInstance?.state === 'ACTIVE';
 
   const {
     data: processDefinitionData,
@@ -350,9 +353,13 @@ const TopPanel: React.FC = observer(() => {
           />
         )}
       {modificationsStore.isModificationModeEnabled &&
-        selectedRunningInstanceCount > 1 && (
-          <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
-        )}
+        (IS_ELEMENT_SELECTION_V2
+          ? isSelectedElementInstanceRunning && (
+              <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
+            )
+          : selectedRunningInstanceCount > 1 && (
+              <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
+            ))}
       {modificationsStore.state.status === 'adding-token' &&
         businessObjects && (
           <ModificationInfoBanner
@@ -426,7 +433,7 @@ const TopPanel: React.FC = observer(() => {
                 selectedFlowNodeOverlay={
                   isModificationModeEnabled ? (
                     IS_ELEMENT_SELECTION_V2 ? (
-                    <ModificationDropdown />
+                      <ModificationDropdown />
                     ) : (
                       <ModificationDropdownV1 />
                     )
@@ -442,7 +449,11 @@ const TopPanel: React.FC = observer(() => {
                     : undefined
                 }
                 hasOuterBorderOnSelection={
-                  !isModificationModeEnabled || selectedRunningInstanceCount > 1
+                  IS_ELEMENT_SELECTION_V2
+                    ? !isModificationModeEnabled ||
+                      isSelectedElementInstanceRunning
+                    : !isModificationModeEnabled ||
+                      selectedRunningInstanceCount > 1
                 }
               >
                 {stateOverlays.map((overlay) => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -134,9 +134,14 @@ const TopPanel: React.FC = observer(() => {
     useProcessSequenceFlows(processInstanceId);
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const rootNode = useRootNode();
-  const isRootNodeSelected = useIsRootNodeSelected();
   const {isExecutionCountVisible} = executionCountToggleStore.state;
   const {clearSelection, selectElement} = useProcessInstanceElementSelection();
+
+  const isRootNodeSelected = useIsRootNodeSelected();
+  const selectedRunningInstanceCount = getSelectedRunningInstanceCount({
+    totalRunningInstancesForFlowNode: totalRunningInstances ?? 0,
+    isRootNodeSelected,
+  });
 
   const {
     data: processDefinitionData,
@@ -344,10 +349,7 @@ const TopPanel: React.FC = observer(() => {
           />
         )}
       {modificationsStore.isModificationModeEnabled &&
-        getSelectedRunningInstanceCount({
-          totalRunningInstancesForFlowNode: totalRunningInstances ?? 0,
-          isRootNodeSelected,
-        }) > 1 && (
+        selectedRunningInstanceCount > 1 && (
           <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
         )}
       {modificationsStore.state.status === 'adding-token' &&
@@ -429,6 +431,14 @@ const TopPanel: React.FC = observer(() => {
                 }
                 highlightedSequenceFlows={highlightedSequenceFlows}
                 highlightedFlowNodeIds={highlightedSequenceFlowIds}
+                nonSelectableNodeTooltipText={
+                  isModificationModeEnabled
+                    ? 'Modification is not supported for this flow node.'
+                    : undefined
+                }
+                hasOuterBorderOnSelection={
+                  !isModificationModeEnabled || selectedRunningInstanceCount > 1
+                }
               >
                 {stateOverlays.map((overlay) => {
                   const payload = overlay.payload as {

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -14,18 +14,10 @@ import {
 } from 'modules/bpmn-js/BpmnJS';
 import DiagramControls from './DiagramControls';
 import {Diagram as StyledDiagram, DiagramCanvas} from './styled';
-import {modificationsStore} from 'modules/stores/modifications';
 import {observer} from 'mobx-react';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {useTotalRunningInstancesForFlowNode} from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
-import {
-  clearSelection,
-  getSelectedRunningInstanceCount,
-} from 'modules/utils/flowNodeSelection';
-import {
-  useIsRootNodeSelected,
-  useRootNode,
-} from 'modules/hooks/flowNodeSelection';
+import {clearSelection} from 'modules/utils/flowNodeSelection';
+import {useRootNode} from 'modules/hooks/flowNodeSelection';
 
 type SelectedFlowNodeOverlayProps = {
   selectedFlowNodeRef: SVGElement;
@@ -45,6 +37,8 @@ type Props = {
     | false;
   highlightedSequenceFlows?: string[];
   highlightedFlowNodeIds?: string[];
+  nonSelectableNodeTooltipText?: string;
+  hasOuterBorderOnSelection?: boolean;
 };
 
 const Diagram: React.FC<Props> = observer(
@@ -59,20 +53,13 @@ const Diagram: React.FC<Props> = observer(
     children,
     highlightedSequenceFlows,
     highlightedFlowNodeIds,
+    nonSelectableNodeTooltipText,
+    hasOuterBorderOnSelection = true,
   }) => {
     const diagramCanvasRef = useRef<HTMLDivElement | null>(null);
     const [isDiagramRendered, setIsDiagramRendered] = useState(false);
     const viewerRef = useRef<BpmnJS | null>(null);
     const [isViewboxChanging, setIsViewboxChanging] = useState(false);
-    const {isModificationModeEnabled} = modificationsStore;
-    const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
-    const {data: totalRunningInstances} =
-      useTotalRunningInstancesForFlowNode(flowNodeId);
-    const isRootNodeSelected = useIsRootNodeSelected();
-    const selectedRunningInstanceCount = getSelectedRunningInstanceCount({
-      totalRunningInstancesForFlowNode: totalRunningInstances ?? 0,
-      isRootNodeSelected,
-    });
     const rootNode = useRootNode();
 
     function getViewer() {
@@ -94,12 +81,9 @@ const Diagram: React.FC<Props> = observer(
             selectedFlowNodeIds,
             overlaysData,
             highlightedSequenceFlows,
-            highlightedFlowNodeIds: highlightedFlowNodeIds,
-            nonSelectableNodeTooltipText: isModificationModeEnabled
-              ? 'Modification is not supported for this flow node.'
-              : undefined,
-            hasOuterBorderOnSelection:
-              !isModificationModeEnabled || selectedRunningInstanceCount > 1,
+            highlightedFlowNodeIds,
+            nonSelectableNodeTooltipText,
+            hasOuterBorderOnSelection,
           });
           setIsDiagramRendered(true);
         }
@@ -112,9 +96,9 @@ const Diagram: React.FC<Props> = observer(
       overlaysData,
       viewer,
       highlightedSequenceFlows,
-      isModificationModeEnabled,
-      selectedRunningInstanceCount,
       highlightedFlowNodeIds,
+      nonSelectableNodeTooltipText,
+      hasOuterBorderOnSelection,
     ]);
 
     useEffect(() => {

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
@@ -68,12 +68,12 @@ const getWrapper = (initialSearchParams?: {[key: string]: string}) => {
 
 describe('useProcessInstanceElementSelection', () => {
   describe('Initial state', () => {
-    it('should return null for selectedElementInstance when no selection', () => {
+    it('should return null for resolvedElementInstance when no selection', () => {
       const {result} = renderHook(() => useProcessInstanceElementSelection(), {
         wrapper: getWrapper(),
       });
 
-      expect(result.current.selectedElementInstance).toBeNull();
+      expect(result.current.resolvedElementInstance).toBeNull();
       expect(result.current.selectedElementId).toBeNull();
       expect(result.current.isFetchingElement).toBe(false);
     });
@@ -225,7 +225,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       await waitFor(() =>
-        expect(result.current.selectedElementInstance).toEqual(
+        expect(result.current.resolvedElementInstance).toEqual(
           mockElementInstance,
         ),
       );
@@ -245,7 +245,7 @@ describe('useProcessInstanceElementSelection', () => {
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
 
-      expect(result.current.selectedElementInstance).toBeNull();
+      expect(result.current.resolvedElementInstance).toBeNull();
     });
 
     it('should return null when search returns no element instances', async () => {
@@ -260,7 +260,7 @@ describe('useProcessInstanceElementSelection', () => {
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
 
-      expect(result.current.selectedElementInstance).toBeNull();
+      expect(result.current.resolvedElementInstance).toBeNull();
     });
 
     it('should handle network error when searching element instances', async () => {
@@ -272,7 +272,7 @@ describe('useProcessInstanceElementSelection', () => {
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
 
-      expect(result.current.selectedElementInstance).toBeNull();
+      expect(result.current.resolvedElementInstance).toBeNull();
     });
   });
 
@@ -358,7 +358,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       await waitFor(() =>
-        expect(result.current.selectedElementInstance).toEqual(
+        expect(result.current.resolvedElementInstance).toEqual(
           mockElementInstance,
         ),
       );
@@ -378,7 +378,7 @@ describe('useProcessInstanceElementSelection', () => {
 
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
 
-      expect(result.current.selectedElementInstance).toBeNull();
+      expect(result.current.resolvedElementInstance).toBeNull();
     });
 
     it('should prefer elementInstanceKey over elementId search', async () => {
@@ -394,7 +394,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       await waitFor(() =>
-        expect(result.current.selectedElementInstance).toEqual(
+        expect(result.current.resolvedElementInstance).toEqual(
           mockElementInstance,
         ),
       );
@@ -432,7 +432,7 @@ describe('useProcessInstanceElementSelection', () => {
       );
     });
 
-    it('should clear selectedElementInstance when clearing selection', async () => {
+    it('should clear resolvedElementInstance when clearing selection', async () => {
       mockFetchElementInstance('2251799813699889').withSuccess(
         mockElementInstance,
       );
@@ -445,7 +445,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       await waitFor(() =>
-        expect(result.current.selectedElementInstance).toEqual(
+        expect(result.current.resolvedElementInstance).toEqual(
           mockElementInstance,
         ),
       );
@@ -455,7 +455,7 @@ describe('useProcessInstanceElementSelection', () => {
       });
 
       await waitFor(() =>
-        expect(result.current.selectedElementInstance).toBeNull(),
+        expect(result.current.resolvedElementInstance).toBeNull(),
       );
     });
   });

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -60,6 +60,7 @@ const useProcessInstanceElementSelection = () => {
   const {processInstanceId: processInstanceKey} =
     useProcessInstancePageParams();
   const elementInstanceKey = searchParams.get(ELEMENT_INSTANCE_KEY);
+
   const elementId = searchParams.get(ELEMENT_ID);
   const isMultiInstanceBody =
     searchParams.get(IS_MULTI_INSTANCE_BODY) === 'true';
@@ -116,7 +117,7 @@ const useProcessInstanceElementSelection = () => {
       enabled: !!elementId && !elementInstanceKey && !!processInstanceKey,
     });
 
-  const selectedElementInstance =
+  const resolvedElementInstance =
     elementInstanceByKey ??
     (searchResult?.page.totalItems === 1 ? searchResult?.items[0] : null);
 
@@ -124,8 +125,18 @@ const useProcessInstanceElementSelection = () => {
     selectElement,
     selectElementInstance,
     clearSelection,
-    selectedElementInstance,
+    /**
+     * The resolved element instance based on the URL search params, is null
+     * if no instance could be resolved or multiple instances exist for the given element id
+     */
+    resolvedElementInstance,
+    /**
+     * The currently selected element id from the URL search params
+     */
     selectedElementId: elementId,
+    /**
+     * The currently selected element instance key from the URL search params
+     */
     selectedElementInstanceKey: elementInstanceKey,
     isSelectedInstanceMultiInstanceBody: isMultiInstanceBody,
     isFetchingElement:

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -126,6 +126,8 @@ const useProcessInstanceElementSelection = () => {
     clearSelection,
     selectedElementInstance,
     selectedElementId: elementId,
+    selectedElementInstanceKey: elementInstanceKey,
+    isSelectedInstanceMultiInstanceBody: isMultiInstanceBody,
     isFetchingElement:
       isFetchingElementInstanceByKey || isFetchingElementInstancesSearch,
   };


### PR DESCRIPTION
## Description

- refactor: move modification related code out of generic Diagram
  - cleanup Diagram component and remove the depedency to modificationsStore from it
- refactor use useProcessInstanceElementSelection in ModificationDropdown
  - this removes the depdency to flowNodeSelectionStore and flowNodeMetaDataStore from ModificationDropdown
- refactor: remove flowNodeSelectionStore dependency from modifications hooks
- replace `selectedRunningInstanceCount` by `useTotalRunningInstancesForFlowNode` in TopPanel

Note: there are still dependencies to isSelectedInstanceRunning in the variable panel. I will remove them in a followup PR to keep this PR's size reasonable.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #41819
