### PR TITLE
Send delete process instance request from gateway to broker

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -23,6 +23,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.T
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.DELETE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_DECISION_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_DECISION_INSTANCE;
@@ -172,6 +173,10 @@ public record Authorization<T>(
 
     public Builder<T> readUsageMetric() {
       return permissionType(READ_USAGE_METRIC);
+    }
+
+    public Builder<T> deleteProcessInstance() {
+      return permissionType(DELETE_PROCESS_INSTANCE);
     }
 
     public Builder<T> batchOperation() {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -379,14 +379,10 @@ public final class ProcessInstanceServices
       final Long processInstanceKey, final Long operationReference) {
 
     // make sure process instance exists before deletion, otherwise return not found
-    final ProcessInstanceEntity processInstance =
+    final var processInstance =
         getByKey(
             processInstanceKey,
-            securityContextProvider.provideSecurityContext(
-                authentication,
-                Authorization.withAuthorization(
-                    PROCESS_DEFINITION_DELETE_PROCESS_INSTANCE_AUTHORIZATION,
-                    ProcessInstanceEntity::processDefinitionId)));
+            securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()));
 
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -102,4 +102,8 @@ public abstract class Authorizations {
 
   public static final Authorization<ClusterVariableEntity> CLUSTER_VARIABLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.clusterVariable().read());
+
+  public static final Authorization<ProcessInstanceEntity>
+      PROCESS_DEFINITION_DELETE_PROCESS_INSTANCE_AUTHORIZATION =
+          Authorization.of(a -> a.processDefinition().deleteProcessInstance());
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.gateway.rest.mapper.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryResponseMapper;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -137,10 +138,15 @@ public class ProcessInstanceController {
   @CamundaPostMapping(path = "/{processInstanceKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteProcessInstance(
       @PathVariable("processInstanceKey") final Long processInstanceKey,
-      @RequestBody(required = false) final DeleteProcessInstanceRequest deleteRequest) {
-    // NOOP: The actual implementation will be added in a later issue.
-    // This endpoint is for deleting completed/terminated process instances.
-    return CompletableFuture.completedFuture(ResponseEntity.noContent().build());
+      @RequestBody(required = false) final DeleteProcessInstanceRequest request) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            processInstanceServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .deleteProcessInstance(
+                    processInstanceKey,
+                    Objects.nonNull(request) ? request.getOperationReference() : null),
+        ResponseMapper::toBatchOperationCreatedWithResultResponse);
   }
 
   @RequiresSecondaryStorage


### PR DESCRIPTION
## Description

Delete process instance from secondary storage using Batch Operation providing a single `processInstanceKey`.
If process instance is not present, then throw a `NOT_FOUND`

### Question ❓
`getByKey` method currently requires `READ_PROCESS_INSTANCE` permission. 
Probably if user has `DELETE_PROCESS_INSTANCE` permission, I expect they also have `READ_PROCESS_INSTANCE`, so that shouldn't be a problem.

Do you think we should change this to `anonymous()` for `getByKey` since it is internal logic?

## Related issues

closes #41885
