### PR TITLE
feat: virtual threads autoconfiguration

### DIFF
--- a/clients/camunda-spring-boot-starter-virtual-threads/README.md
+++ b/clients/camunda-spring-boot-starter-virtual-threads/README.md
@@ -1,0 +1,64 @@
+# Camunda Spring Boot Starter Virtual Threads
+
+This module provides a Spring Boot auto-configuration extension for the Camunda client that enables virtual threads for job execution.
+
+## Overview
+
+Virtual threads (introduced in Java 21) are lightweight threads that allow for highly concurrent job processing without the overhead of traditional platform threads. This module configures the Camunda client to use:
+
+- **Virtual threads** for job execution (unbounded, created per task)
+- **Single platform thread** for scheduling operations
+
+## Requirements
+
+- Java 21 or higher
+- Spring Boot 3.x
+- `camunda-spring-boot-starter`
+
+## Usage
+
+Add the dependency to your `pom.xml`:
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-spring-boot-starter-virtual-threads</artifactId>
+  <version>${camunda.version}</version>
+</dependency>
+```
+
+The auto-configuration will automatically override the default executor service with one that uses virtual threads. No additional configuration is required.
+
+## How It Works
+
+1. The `VirtualThreadsAutoConfiguration` runs **before** the standard `CamundaAutoConfiguration`
+2. It creates a `CamundaClientExecutorService` bean with:
+   - A virtual thread executor for job handling (named `job-worker-virtual-N`)
+   - A scheduled executor with 1 platform thread for scheduling
+3. Both executors are marked as "owned by Camunda client" and will be properly shut down when the client closes
+4. The `@ConditionalOnMissingBean` annotation in `CamundaAutoConfiguration` ensures the default executor is not created
+
+## Benefits
+
+- **Scalability**: Handle thousands of concurrent jobs without creating thousands of platform threads
+- **Resource efficiency**: Virtual threads have minimal memory overhead compared to platform threads
+- **Drop-in replacement**: Simply add the dependency to enable virtual threads
+- **Optional**: Other modules can continue using Java 8/17 without virtual thread support
+
+## Thread Naming
+
+Virtual threads created for job execution follow the naming pattern: `job-worker-virtual-N` where N is an incrementing counter.
+
+## Example
+
+```java
+@SpringBootApplication
+public class MyApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+}
+```
+
+That's it! Virtual threads are now enabled for your Camunda client job workers.
+

--- a/clients/camunda-spring-boot-starter-virtual-threads/README.md
+++ b/clients/camunda-spring-boot-starter-virtual-threads/README.md
@@ -2,6 +2,8 @@
 
 This module provides a Spring Boot auto-configuration extension for the Camunda client that enables virtual threads for job execution.
 
+It extends the standard `camunda-spring-boot-starter` and must be used in addition to it; it cannot be used as a standalone replacement.
+
 ## Overview
 
 Virtual threads (introduced in Java 21) are lightweight threads that allow for highly concurrent job processing without the overhead of traditional platform threads. This module configures the Camunda client to use:

--- a/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
+++ b/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-starter</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Spring Boot Auto-configuration -->

--- a/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
+++ b/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-library-parent</artifactId>
+    <version>8.9.0-SNAPSHOT</version>
+    <relativePath>../../library-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-spring-boot-starter-virtual-threads</artifactId>
+
+  <name>Camunda Spring Boot Starter Virtual Threads</name>
+  <description>Spring Boot starter extension that configures Camunda client to use virtual threads for job execution</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <version.java>21</version.java>
+    <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
+  </properties>
+
+  <dependencies>
+    <!-- Camunda Spring Boot Starter -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-starter</artifactId>
+    </dependency>
+
+    <!-- Spring Boot Auto-configuration -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <!-- Spring dependencies used directly -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <!-- Optional metrics support -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>21</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dep>org.springframework.boot:spring-boot-starter-test</dep>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
+++ b/clients/camunda-spring-boot-starter-virtual-threads/pom.xml
@@ -64,6 +64,13 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
@@ -83,7 +83,6 @@ public class VirtualThreadsAutoConfiguration {
   }
 
   private ThreadFactory createVirtualThreadFactory() {
-    final AtomicInteger counter = new AtomicInteger(0);
-    return Thread.ofVirtual().name("job-worker-virtual-", counter.getAndIncrement()).factory();
+    return Thread.ofVirtual().name("job-worker-virtual-", 0).factory();
   }
 }

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.virtualthreads;
+
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Autoconfiguration for Camunda client with virtual threads support.
+ *
+ * <p>This configuration provides a {@link CamundaClientExecutorService} that uses Java 21 virtual
+ * threads for job execution and a single platform thread for scheduling. This configuration runs
+ * before {@link CamundaAutoConfiguration} to override the default executor service.
+ *
+ * <p>Virtual threads are lightweight threads that allow for highly concurrent job processing
+ * without the overhead of traditional platform threads.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(CamundaAutoConfiguration.class)
+public class VirtualThreadsAutoConfiguration {
+
+  /**
+   * Creates a {@link CamundaClientExecutorService} that uses virtual threads for job execution with
+   * metrics support when Micrometer is available.
+   *
+   * @param meterRegistry optional meter registry for metrics (can be null)
+   * @return the configured executor service with virtual threads for job handling and a single
+   *     platform thread for scheduling
+   */
+  @Bean
+  @ConditionalOnClass(MeterRegistry.class)
+  public CamundaClientExecutorService camundaClientExecutorService(
+      @Autowired(required = false) final MeterRegistry meterRegistry) {
+    final ThreadFactory virtualThreadFactory = createVirtualThreadFactory();
+    final ExecutorService jobHandlingExecutor =
+        Executors.newThreadPerTaskExecutor(virtualThreadFactory);
+    final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
+
+    return new MeteredCamundaClientExecutorService(
+        scheduledExecutor, true, jobHandlingExecutor, true, meterRegistry);
+  }
+
+  /**
+   * Fallback bean when Micrometer is not on the classpath.
+   *
+   * @return the configured executor service without metrics
+   */
+  @Bean
+  @ConditionalOnMissingClass("io.micrometer.core.instrument.MeterRegistry")
+  public CamundaClientExecutorService camundaClientExecutorServiceWithoutMetrics() {
+    final ThreadFactory virtualThreadFactory = createVirtualThreadFactory();
+    final ExecutorService jobHandlingExecutor =
+        Executors.newThreadPerTaskExecutor(virtualThreadFactory);
+    final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
+
+    return new CamundaClientExecutorService(scheduledExecutor, true, jobHandlingExecutor, true);
+  }
+
+  private ThreadFactory createVirtualThreadFactory() {
+    final AtomicInteger counter = new AtomicInteger(0);
+    return Thread.ofVirtual().name("job-worker-virtual-", counter.getAndIncrement()).factory();
+  }
+}

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
@@ -23,13 +23,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * Autoconfiguration for Camunda client with virtual threads support.
@@ -54,9 +54,9 @@ public class VirtualThreadsAutoConfiguration {
    *     platform thread for scheduling
    */
   @Bean
-  @ConditionalOnClass(MeterRegistry.class)
+  @ConditionalOnClass({MeterRegistry.class, EndpointAutoConfiguration.class})
   public CamundaClientExecutorService camundaClientExecutorService(
-      @Autowired(required = false) final MeterRegistry meterRegistry) {
+      @Lazy final MeterRegistry meterRegistry) {
     final ThreadFactory virtualThreadFactory = createVirtualThreadFactory();
     final ExecutorService jobHandlingExecutor =
         Executors.newThreadPerTaskExecutor(virtualThreadFactory);

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.camunda.client.virtualthreads.VirtualThreadsAutoConfiguration

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationIT.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationIT.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
     classes = {VirtualThreadsAutoConfiguration.class, CamundaAutoConfiguration.class},
-    properties = {"camunda.client.mode=selfManaged", "camunda.client.zeebe.enabled=false"})
+    properties = {"camunda.client.mode=selfManaged", "camunda.client.enabled=false"})
 class VirtualThreadsAutoConfigurationIT {
 
   @Autowired private CamundaClientExecutorService executorService;

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationIT.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.virtualthreads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {VirtualThreadsAutoConfiguration.class, CamundaAutoConfiguration.class},
+    properties = {"camunda.client.mode=selfManaged", "camunda.client.zeebe.enabled=false"})
+class VirtualThreadsAutoConfigurationIT {
+
+  @Autowired private CamundaClientExecutorService executorService;
+
+  @Test
+  void shouldCreateCamundaClientExecutorServiceBean() {
+    assertThat(executorService).isNotNull();
+  }
+
+  @Test
+  void shouldUseVirtualThreadsForJobHandling() throws InterruptedException {
+    final AtomicReference<Thread> capturedThread = new AtomicReference<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    executorService
+        .getJobHandlingExecutor()
+        .execute(
+            () -> {
+              capturedThread.set(Thread.currentThread());
+              latch.countDown();
+            });
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(capturedThread.get()).isNotNull();
+    assertThat(capturedThread.get().isVirtual()).isTrue();
+  }
+
+  @Test
+  void shouldUsePlatformThreadForScheduling() throws InterruptedException {
+    final AtomicReference<Thread> capturedThread = new AtomicReference<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    executorService
+        .getScheduledExecutor()
+        .execute(
+            () -> {
+              capturedThread.set(Thread.currentThread());
+              latch.countDown();
+            });
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(capturedThread.get()).isNotNull();
+    assertThat(capturedThread.get().isVirtual()).isFalse();
+  }
+
+  @Test
+  void shouldHaveOwnedExecutors() {
+    assertThat(executorService.isJobHandlingExecutorOwnedByCamundaClient()).isTrue();
+    assertThat(executorService.isScheduledExecutorOwnedByCamundaClient()).isTrue();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <module>clients/java</module>
     <module>clients/java-deprecated</module>
     <module>clients/camunda-spring-boot-starter</module>
+    <module>clients/camunda-spring-boot-starter-virtual-threads</module>
     <module>clients/spring-boot-starter-camunda-sdk-deprecated</module>
     <module>testing</module>
     <module>document</module>


### PR DESCRIPTION
## Description

Adds an autoconfiguration to replace the executor service used by Camunda client with a virtual thread executor. This is implemented as a separate module built with Java 21 that can be added instead of / in addition to the normal spring boot starter module.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41070
