### PR TITLE
feat: Delay RdbmsExporter until schema migration is completed

### DIFF
--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -53,6 +53,10 @@
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import liquibase.integration.spring.MultiTenantSpringLiquibase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the database schema using Liquibase for multi-tenant applications.
+ *
+ * <p>This class extends {@link MultiTenantSpringLiquibase} to leverage its capabilities for
+ * managing database migrations in a multi-tenant environment. It also implements the {@link
+ * RdbmsSchemaManager} interface to provide a method for checking if the schema has been
+ * initialized.
+ */
+public class LiquibaseSchemaManager extends MultiTenantSpringLiquibase
+    implements RdbmsSchemaManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LiquibaseSchemaManager.class);
+
+  private volatile boolean initialized = false;
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    super.afterPropertiesSet();
+    initialized = true;
+    LOG.debug("Liquibase migrations completed.");
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return initialized;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/NoopSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/NoopSchemaManager.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+/**
+ * A no-operation implementation of the {@link RdbmsSchemaManager} interface.
+ *
+ * <p>This class always indicates that the schema is initialized.
+ */
+public class NoopSchemaManager implements RdbmsSchemaManager {
+
+  @Override
+  public boolean isInitialized() {
+    return true;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManager.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+/**
+ * Interface for managing RDBMS database schemas.
+ *
+ * <p>This interface defines methods for checking the initialization status of the database schema.
+ */
+public interface RdbmsSchemaManager {
+
+  boolean isInitialized();
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -55,7 +55,7 @@ class LiquibaseSchemaManagerTest {
    * Test implementation that overrides the parent's afterPropertiesSet to avoid actual Liquibase
    * initialization.
    */
-  private static class TestLiquibaseSchemaManager extends LiquibaseSchemaManager {
+  private static final class TestLiquibaseSchemaManager extends LiquibaseSchemaManager {
     @Override
     public void afterPropertiesSet() throws Exception {
       // Skip the actual Liquibase initialization (super.afterPropertiesSet())

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import org.junit.jupiter.api.Test;
+
+class LiquibaseSchemaManagerTest {
+
+  @Test
+  void shouldHaveInitializedFalseByDefault() {
+    // given
+    final var schemaManager = new LiquibaseSchemaManager();
+
+    // when / then
+    assertThat(schemaManager.isInitialized()).isFalse();
+  }
+
+  @Test
+  void shouldSetInitializedTrueAfterSuccessfulInitialization() throws Exception {
+    // given
+    final var schemaManager = new TestLiquibaseSchemaManager();
+
+    // when
+    schemaManager.afterPropertiesSet();
+
+    // then
+    assertThat(schemaManager.isInitialized()).isTrue();
+  }
+
+  @Test
+  void shouldKeepInitializedFalseWhenInitializationFails() {
+    // given
+    final var schemaManager = spy(new TestLiquibaseSchemaManager());
+    doThrow(new RuntimeException("Initialization failed")).when(schemaManager).performMigration();
+
+    // when / then
+    assertThatThrownBy(() -> schemaManager.afterPropertiesSet())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Initialization failed");
+
+    assertThat(schemaManager.isInitialized()).isFalse();
+  }
+
+  /**
+   * Test implementation that overrides the parent's afterPropertiesSet to avoid actual Liquibase
+   * initialization.
+   */
+  private static class TestLiquibaseSchemaManager extends LiquibaseSchemaManager {
+    @Override
+    public void afterPropertiesSet() throws Exception {
+      // Skip the actual Liquibase initialization (super.afterPropertiesSet())
+      // and just perform our state update
+      performMigration();
+      setInitialized();
+    }
+
+    protected void performMigration() {
+      // No-op for testing, can be overridden in spy
+    }
+
+    protected void setInitialized() {
+      // Access the inherited behavior through a test method
+      try {
+        final var field = LiquibaseSchemaManager.class.getDeclaredField("initialized");
+        field.setAccessible(true);
+        field.set(this, true);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -314,11 +314,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.liquibase</groupId>
-      <artifactId>liquibase-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.exporter.rdbms.RdbmsExporterFactory;
@@ -32,8 +33,10 @@ public class RdbmsExporterConfiguration {
 
   @Bean
   public RdbmsExporterFactory rdbmsExporterFactory(
-      final RdbmsService rdbmsService, final VendorDatabaseProperties vendorDatabaseProperties) {
-    return new RdbmsExporterFactory(rdbmsService, vendorDatabaseProperties);
+      final RdbmsService rdbmsService,
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final RdbmsSchemaManager rdbmsSchemaManager) {
+    return new RdbmsExporterFactory(rdbmsService, vendorDatabaseProperties, rdbmsSchemaManager);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -26,6 +26,7 @@ import static io.camunda.it.rdbms.exporter.RecordFixtures.getRejectedCancelProce
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import io.camunda.db.rdbms.LiquibaseSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
@@ -74,6 +75,8 @@ class RdbmsExporterBatchOperationsIT {
             }
           });
 
+  @Autowired private LiquibaseSchemaManager liquibaseSchemaManager;
+
   @Autowired private RdbmsService rdbmsService;
 
   private RdbmsExporterWrapper exporter;
@@ -84,7 +87,8 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   private void setup(final boolean exportPendingItems) {
-    exporter = new RdbmsExporterWrapper(rdbmsService, vendorDatabaseProperties);
+    exporter =
+        new RdbmsExporterWrapper(rdbmsService, liquibaseSchemaManager, vendorDatabaseProperties);
     exporter.configure(
         new ExporterContext(
             null,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -29,6 +29,7 @@ import static io.camunda.it.rdbms.exporter.RecordFixtures.getUserRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getUserTaskCreatingRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.LiquibaseSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
@@ -116,13 +117,15 @@ class RdbmsExporterIT {
             }
           });
 
+  @Autowired private LiquibaseSchemaManager liquibaseSchemaManager;
   @Autowired private RdbmsService rdbmsService;
 
   private RdbmsExporterWrapper exporter;
 
   @BeforeEach
   void setUp() {
-    exporter = new RdbmsExporterWrapper(rdbmsService, vendorDatabaseProperties);
+    exporter =
+        new RdbmsExporterWrapper(rdbmsService, liquibaseSchemaManager, vendorDatabaseProperties);
     exporter.configure(
         new ExporterContext(
             null,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.rdbms;
 
+import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.zeebe.broker.exporter.repo.ExporterFactory;
@@ -17,11 +18,15 @@ public class RdbmsExporterFactory implements ExporterFactory {
 
   private final RdbmsService rdbmsService;
   private final VendorDatabaseProperties vendorDatabaseProperties;
+  private final RdbmsSchemaManager rdbmsSchemaManager;
 
   public RdbmsExporterFactory(
-      final RdbmsService rdbmsService, final VendorDatabaseProperties vendorDatabaseProperties) {
+      final RdbmsService rdbmsService,
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final RdbmsSchemaManager rdbmsSchemaManager) {
     this.rdbmsService = rdbmsService;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
+    this.rdbmsSchemaManager = rdbmsSchemaManager;
   }
 
   @Override
@@ -31,7 +36,7 @@ public class RdbmsExporterFactory implements ExporterFactory {
 
   @Override
   public Exporter newInstance() throws ExporterInstantiationException {
-    return new RdbmsExporterWrapper(rdbmsService, vendorDatabaseProperties);
+    return new RdbmsExporterWrapper(rdbmsService, rdbmsSchemaManager, vendorDatabaseProperties);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.rdbms;
 
+import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.RdbmsWriter;
@@ -70,6 +71,7 @@ public class RdbmsExporterWrapper implements Exporter {
   public static final String NAMESPACE = "camunda.rdbms.exporter.cache";
 
   private final RdbmsService rdbmsService;
+  private final RdbmsSchemaManager rdbmsSchemaManager;
   private final VendorDatabaseProperties vendorDatabaseProperties;
 
   private RdbmsExporter exporter;
@@ -79,9 +81,12 @@ public class RdbmsExporterWrapper implements Exporter {
   private ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
 
   public RdbmsExporterWrapper(
-      final RdbmsService rdbmsService, final VendorDatabaseProperties vendorDatabaseProperties) {
-    this.vendorDatabaseProperties = vendorDatabaseProperties;
+      final RdbmsService rdbmsService,
+      final RdbmsSchemaManager rdbmsSchemaManager,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
     this.rdbmsService = rdbmsService;
+    this.rdbmsSchemaManager = rdbmsSchemaManager;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
   }
 
   @Override
@@ -122,7 +127,7 @@ public class RdbmsExporterWrapper implements Exporter {
     createHandlers(partitionId, rdbmsWriter, builder);
     createBatchOperationHandlers(rdbmsWriter, builder);
 
-    exporter = builder.build();
+    exporter = builder.rdbmsSchemaManager(rdbmsSchemaManager).build();
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
+import io.camunda.db.rdbms.LiquibaseSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.RdbmsWriter;
@@ -35,7 +36,9 @@ class RdbmsExporterWrapperTest {
 
     final RdbmsExporterWrapper exporterWrapper =
         new RdbmsExporterWrapper(
-            Mockito.mock(RdbmsService.class), Mockito.mock(VendorDatabaseProperties.class));
+            Mockito.mock(RdbmsService.class),
+            Mockito.mock(LiquibaseSchemaManager.class),
+            Mockito.mock(VendorDatabaseProperties.class));
 
     // when
     assertThatThrownBy(() -> exporterWrapper.configure(context))
@@ -56,7 +59,10 @@ class RdbmsExporterWrapperTest {
     Mockito.when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriter);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsService, Mockito.mock(VendorDatabaseProperties.class));
+        new RdbmsExporterWrapper(
+            rdbmsService,
+            Mockito.mock(LiquibaseSchemaManager.class),
+            Mockito.mock(VendorDatabaseProperties.class));
 
     // when
     exporterWrapper.configure(context);


### PR DESCRIPTION
## Description

* Introduces RdbmsSchemaManager to take care of SchemaMigration, that allows to check the migration status
* Abort opening the RdbmsExporter when schema migration is not completed

## Related issues

closes #42405
