### PR TITLE
test: stop double-deleting indices in task list tests

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -82,8 +82,7 @@ public class ElasticsearchTestExtension
   public void beforeEach(final ExtensionContext extensionContext) {
     indexPrefix = tasklistProperties.getElasticsearch().getIndexPrefix();
     if (indexPrefix == null || indexPrefix.isBlank()) {
-      indexPrefix =
-          Optional.ofNullable(indexPrefixHolder.createNewIndexPrefix()).orElse(indexPrefix);
+      indexPrefix = indexPrefixHolder.createNewIndexPrefix();
       tasklistProperties.getElasticsearch().setIndexPrefix(indexPrefix);
       searchEngineConfiguration.connect().setIndexPrefix(indexPrefix);
     }
@@ -100,8 +99,8 @@ public class ElasticsearchTestExtension
   @Override
   public void afterEach(final ExtensionContext extensionContext) {
     if (!failed) {
-      final String indexPrefix = tasklistProperties.getElasticsearch().getIndexPrefix();
-      TestUtil.removeAllIndices(esClient, indexPrefix);
+      indexPrefixHolder.cleanupIndicesIfNeeded(
+          prefix -> TestUtil.removeAllIndices(esClient, prefix));
     }
     tasklistProperties
         .getElasticsearch()

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -88,8 +88,8 @@ public class OpenSearchTestExtension
   @Override
   public void afterEach(final ExtensionContext extensionContext) {
     if (!failed) {
-      final String indexPrefix = tasklistProperties.getOpenSearch().getIndexPrefix();
-      TestUtil.removeAllIndices(osClient, indexPrefix);
+      indexPrefixHolder.cleanupIndicesIfNeeded(
+          prefix -> TestUtil.removeAllIndices(osClient, prefix));
     }
     tasklistProperties
         .getOpenSearch()

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -17,6 +17,7 @@ import io.camunda.tasklist.qa.util.TasklistIndexPrefixHolder;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -135,6 +136,10 @@ public abstract class TasklistZeebeExtension
 
   public void setPrefix(final String prefix) {
     this.prefix = prefix;
+  }
+
+  public void cleanupIndicesIfNeeded(final Consumer<String> indexCleanup) {
+    indexPrefixHolder.cleanupIndicesIfNeeded(indexCleanup);
   }
 
   public TestStandaloneBroker getZeebeBroker() {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -37,7 +37,7 @@ public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension 
   public void afterEach(final ExtensionContext extensionContext) {
     super.afterEach(extensionContext);
     if (!failed) {
-      TestUtil.removeAllIndices(esClient, getPrefix());
+      cleanupIndicesIfNeeded(prefix -> TestUtil.removeAllIndices(esClient, prefix));
     }
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -34,7 +34,7 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
   public void afterEach(final ExtensionContext extensionContext) {
     super.afterEach(extensionContext);
     if (!failed) {
-      TestUtil.removeAllIndices(osClient, getPrefix());
+      cleanupIndicesIfNeeded(prefix -> TestUtil.removeAllIndices(osClient, prefix));
     }
   }
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexPrefixHolder.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexPrefixHolder.java
@@ -7,19 +7,29 @@
  */
 package io.camunda.tasklist.qa.util;
 
+import java.util.function.Consumer;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TasklistIndexPrefixHolder {
 
   private String indexPrefix;
+  private volatile boolean needsCleanUp;
 
   public String createNewIndexPrefix() {
     indexPrefix = TestUtil.createRandomString(10);
+    needsCleanUp = true;
     return indexPrefix;
   }
 
   public String getIndexPrefix() {
     return indexPrefix;
+  }
+
+  public void cleanupIndicesIfNeeded(final Consumer<String> indexCleanup) {
+    if (needsCleanUp && indexPrefix != null) {
+      indexCleanup.accept(indexPrefix);
+      needsCleanUp = false;
+    }
   }
 }


### PR DESCRIPTION
Using a little state to track if we've already deleted them or not as we have multiple places where we attempt to do so and it's a little unclear whether all places are used in all tests or not.

This removes some errors in the tests logs, as the 2nd attempt fails.  This is because the index templates have already been removed and the endpoint for finding those returns a 404, but with a different format (`{"index_templates":[]}`).

As this also avoids performing extra ES/OS calls it should slightly speed the tests up (though probably not by much in practice).

Example logging including stacktrace prior to this fix:
```
2025-12-15 10:32:23.892  INFO 43757 --- [           main] i.c.t.q.u.TestUtil                       : Removing indices
2025-12-15 10:32:25.081  INFO 43757 --- [           main] i.c.t.q.u.TestUtil                       : Removing indices
2025-12-15 10:32:25.123 ERROR 43757 --- [           main] i.c.t.q.u.TestUtil                       : Unable to parse response body

org.elasticsearch.ElasticsearchStatusException: Unable to parse response body
	at org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:2464) ~[elasticsearch-rest-high-level-client-7.17.29.jar:8.16.6]
	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:2184) ~[elasticsearch-rest-high-level-client-7.17.29.jar:8.16.6]
	at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:2154) ~[elasticsearch-rest-high-level-client-7.17.29.jar:8.16.6]
	at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:2118) ~[elasticsearch-rest-high-level-client-7.17.29.jar:8.16.6]
	at org.elasticsearch.client.IndicesClient.getIndexTemplate(IndicesClient.java:2078) ~[elasticsearch-rest-high-level-client-7.17.29.jar:8.16.6]
	at io.camunda.tasklist.qa.util.TestUtil.removeAllIndices(TestUtil.java:74) ~[classes/:?]
	at io.camunda.tasklist.util.ElasticsearchTestExtension.afterEach(ElasticsearchTestExtension.java:104) ~[test-classes/:?]
	at org.junit.jupiter.engine.descriptor.CallbackSupport.lambda$invokeAfterCallbacks$1(CallbackSupport.java:49) ~[junit-jupiter-engine-5.13.4.jar:5.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.jupiter.engine.descriptor.CallbackSupport.lambda$invokeAfterCallbacks$2(CallbackSupport.java:49) ~[junit-jupiter-engine-5.13.4.jar:5.13.4]
	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:263) ~[junit-platform-commons-1.13.4.jar:1.13.4]
	at org.junit.jupiter.engine.descriptor.CallbackSupport.invokeAfterCallbacks(CallbackSupport.java:48) ~[junit-jupiter-engine-5.13.4.jar:5.13.4]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeAfterEachCallbacks(TestMethodTestDescriptor.java:262) ~[junit-jupiter-engine-5.13.4.jar:5.13.4]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:165) ~[junit-jupiter-engine-5.13.4.jar:5.13.4]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70) ~[junit-jupiter-engine-5.13.4.jar:5.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:157) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:145) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:144) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:101) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:161) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:145) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:144) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:101) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:161) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:145) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:144) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:101) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54) ~[junit-platform-engine-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:230) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:91) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:66) ~[junit-platform-launcher-1.13.4.jar:1.13.4]
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:66) ~[junit5-rt.jar:?]
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38) ~[junit-rt.jar:?]
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11) ~[idea_rt.jar:?]
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35) ~[junit-rt.jar:?]
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237) [junit-rt.jar:?]
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58) [junit-rt.jar:?]
	Suppressed: org.elasticsearch.common.ParsingException: Failed to parse object: expecting field with name [error] but found [index_templates]
		at org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName(XContentParserUtils.java:43)
		at org.elasticsearch.ElasticsearchException.failureFromXContent(ElasticsearchException.java:616)
```
