### PR TITLE
37204-test-incident-search-api

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/MultipleErrorTypesProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/MultipleErrorTypesProcess.bpmn
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="cc7a9e5" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="MultipleErrorTypesProcess" name="MultipleErrorTypesProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1yfjbnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1yfjbnn" sourceRef="StartEvent_1" targetRef="Gateway_0k46wv2" />
+    <bpmn:parallelGateway id="Gateway_0k46wv2">
+      <bpmn:incoming>Flow_1yfjbnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c9ergg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1n6gn9a</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1c9ergg" sourceRef="Gateway_0k46wv2" targetRef="Activity_0pisi7c" />
+    <bpmn:businessRuleTask id="Activity_0pisi7c" name="Failing Business task">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="MeowDM" resultVariable="meow" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c9ergg</bpmn:incoming>
+      <bpmn:outgoing>Flow_1x1rkh5</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:exclusiveGateway id="Gateway_16k55cq">
+      <bpmn:incoming>Flow_1n6gn9a</bpmn:incoming>
+      <bpmn:outgoing>Flow_1duf9ix</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0agyvum</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1n6gn9a" sourceRef="Gateway_0k46wv2" targetRef="Gateway_16k55cq" />
+    <bpmn:sequenceFlow id="Flow_1duf9ix" name="goUp &#60;= 0" sourceRef="Gateway_16k55cq" targetRef="Gateway_0uag01u">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=goUp &lt;= 0</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_0uag01u">
+      <bpmn:incoming>Flow_1duf9ix</bpmn:incoming>
+      <bpmn:incoming>Flow_0agyvum</bpmn:incoming>
+      <bpmn:outgoing>Flow_0o03mrs</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0o03mrs" sourceRef="Gateway_0uag01u" targetRef="Gateway_12bnbea" />
+    <bpmn:parallelGateway id="Gateway_12bnbea">
+      <bpmn:incoming>Flow_0o03mrs</bpmn:incoming>
+      <bpmn:incoming>Flow_1x1rkh5</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qwq7le</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1x1rkh5" sourceRef="Activity_0pisi7c" targetRef="Gateway_12bnbea" />
+    <bpmn:endEvent id="Event_10qf406">
+      <bpmn:incoming>Flow_1qwq7le</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1qwq7le" sourceRef="Gateway_12bnbea" targetRef="Event_10qf406" />
+    <bpmn:sequenceFlow id="Flow_0agyvum" name="goUp &#62; 0" sourceRef="Gateway_16k55cq" targetRef="Gateway_0uag01u">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=goUp &gt; 0</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MultipleErrorTypesProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0iqlaj4_di" bpmnElement="Gateway_0k46wv2">
+        <dc:Bounds x="245" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sr2wc8_di" bpmnElement="Activity_0pisi7c">
+        <dc:Bounds x="360" y="0" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_16k55cq_di" bpmnElement="Gateway_16k55cq" isMarkerVisible="true">
+        <dc:Bounds x="305" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0uag01u_di" bpmnElement="Gateway_0uag01u" isMarkerVisible="true">
+        <dc:Bounds x="475" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0p0stlp_di" bpmnElement="Gateway_12bnbea">
+        <dc:Bounds x="655" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10qf406_di" bpmnElement="Event_10qf406">
+        <dc:Bounds x="762" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1yfjbnn_di" bpmnElement="Flow_1yfjbnn">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="245" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c9ergg_di" bpmnElement="Flow_1c9ergg">
+        <di:waypoint x="270" y="93" />
+        <di:waypoint x="270" y="40" />
+        <di:waypoint x="360" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n6gn9a_di" bpmnElement="Flow_1n6gn9a">
+        <di:waypoint x="270" y="143" />
+        <di:waypoint x="270" y="200" />
+        <di:waypoint x="305" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1duf9ix_di" bpmnElement="Flow_1duf9ix">
+        <di:waypoint x="330" y="175" />
+        <di:waypoint x="330" y="150" />
+        <di:waypoint x="500" y="150" />
+        <di:waypoint x="500" y="175" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="384" y="121" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o03mrs_di" bpmnElement="Flow_0o03mrs">
+        <di:waypoint x="525" y="200" />
+        <di:waypoint x="655" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x1rkh5_di" bpmnElement="Flow_1x1rkh5">
+        <di:waypoint x="460" y="40" />
+        <di:waypoint x="680" y="40" />
+        <di:waypoint x="680" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qwq7le_di" bpmnElement="Flow_1qwq7le">
+        <di:waypoint x="705" y="200" />
+        <di:waypoint x="762" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0agyvum_di" bpmnElement="Flow_0agyvum">
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="250" />
+        <di:waypoint x="500" y="250" />
+        <di:waypoint x="500" y="225" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="381" y="263" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/loanApprovalProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/loanApprovalProcess.bpmn
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="e32b7ec" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="loanApprovalProcess" name="loanApprovalProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:outgoing>Flow_02bqmo8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_02bqmo8" sourceRef="StartEvent" targetRef="DetermineLoanAproval" />
+    <bpmn:businessRuleTask id="DetermineLoanAproval" name="Determine Loan Aproval">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="DecisionLoanApproval" resultVariable="loanAproval" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_02bqmo8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1t2v4y1</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:exclusiveGateway id="Gateway_0sr2lq5" name="Loan Approved?">
+      <bpmn:incoming>Flow_1t2v4y1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0krssuc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00nbdhj</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1t2v4y1" sourceRef="DetermineLoanAproval" targetRef="Gateway_0sr2lq5" />
+    <bpmn:sequenceFlow id="Flow_0krssuc" name="Yes" sourceRef="Gateway_0sr2lq5" targetRef="Activity_0fnyht5">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=loanAproval</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:userTask id="Activity_0fnyht5" name="Send approval">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0krssuc</bpmn:incoming>
+      <bpmn:outgoing>Flow_17ke21z</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_02sshxz">
+      <bpmn:incoming>Flow_00nbdhj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_00nbdhj" name="No" sourceRef="Gateway_0sr2lq5" targetRef="Event_02sshxz">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(loanAproval)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_09fecdr">
+      <bpmn:incoming>Flow_17ke21z</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_17ke21z" sourceRef="Activity_0fnyht5" targetRef="Event_09fecdr" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loanApprovalProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_087dsn4_di" bpmnElement="DetermineLoanAproval">
+        <dc:Bounds x="320" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0sr2lq5_di" bpmnElement="Gateway_0sr2lq5" isMarkerVisible="true">
+        <dc:Bounds x="525" y="93" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="509" y="69" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bjyx6o_di" bpmnElement="Activity_0fnyht5">
+        <dc:Bounds x="680" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02sshxz_di" bpmnElement="Event_02sshxz">
+        <dc:Bounds x="682" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09fecdr_di" bpmnElement="Event_09fecdr">
+        <dc:Bounds x="892" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02bqmo8_di" bpmnElement="Flow_02bqmo8">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="320" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t2v4y1_di" bpmnElement="Flow_1t2v4y1">
+        <di:waypoint x="420" y="118" />
+        <di:waypoint x="525" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0krssuc_di" bpmnElement="Flow_0krssuc">
+        <di:waypoint x="575" y="118" />
+        <di:waypoint x="680" y="118" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="619" y="100" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00nbdhj_di" bpmnElement="Flow_00nbdhj">
+        <di:waypoint x="550" y="143" />
+        <di:waypoint x="550" y="230" />
+        <di:waypoint x="682" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="558" y="184" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17ke21z_di" bpmnElement="Flow_17ke21z">
+        <di:waypoint x="780" y="118" />
+        <di:waypoint x="892" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
@@ -1,0 +1,308 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {cancelProcessInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import {setupIncidentTest, setupMultipleIncidentsTest, setupMultipleTypeIncidentsTest} from '../../../../utils/requestHelpers/incident-requestHelpers';
+
+const INCIDENT_SEARCH_ENDPOINT = '/incidents/search';
+
+test.describe.parallel('Search Incidents API Tests', () => {
+  const processInstanceKeys: string[] = [];
+
+  test.beforeAll(async () => {
+    await deploy([
+        './resources/processWithAnError.bpmn',
+        './resources/loanApprovalProcess.bpmn',
+        './resources/MultipleErrorTypesProcess.bpmn',
+    ]);
+  });
+
+  test.afterAll(async () => {
+    for (const key of processInstanceKeys) {
+      await cancelProcessInstance(key);
+    }
+  });
+
+    test('Search Incidents Success', async ({request}) => {
+        const localState: Record<string, unknown> = {};
+        await setupIncidentTest(localState, request);
+        processInstanceKeys.push(localState['processInstanceKey'] as string);
+
+         await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {},
+            });
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+                {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+                },
+                res,
+            );
+
+            const body = await res.json();
+            expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+            expect(Array.isArray(body.items)).toBe(true);
+            expect(body.items.length).toBeGreaterThan(0);
+        }).toPass(defaultAssertionOptions);
+    });
+
+    test('Search Incidents within multiple process instances Success', async ({request}) => {
+        const localState: Record<string, unknown> = {};
+        await setupMultipleIncidentsTest(localState, request);
+        for (const element of localState['processInstanceKey'] as string[]) {
+            processInstanceKeys.push(element);
+        }
+
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {},
+            });
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+                {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+                },
+                res,
+            );
+
+            const body = await res.json();
+            expect(body.page.totalItems).toBeGreaterThanOrEqual(3);
+            expect(Array.isArray(body.items)).toBe(true);
+            expect(body.items.length).toBeGreaterThan(0);
+        }).toPass(defaultAssertionOptions);
+    });
+
+    test('Search Incidents With Error Type Filter Success', async ({request}) => {
+        const localState: Record<string, unknown> = {};
+        await setupIncidentTest(localState, request);
+        processInstanceKeys.push(localState['processInstanceKey'] as string);
+
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {
+                filter: {
+                    errorType: 'EXTRACT_VALUE_ERROR',
+                },
+                },
+            });
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+                {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+                },
+                res,
+            );
+
+            const body = await res.json();
+            expect(body.page.totalItems).toBeGreaterThanOrEqual(6);
+            expect(body.items.length).toBeGreaterThan(0);
+            body.items.forEach((item: Record<string, unknown>) => {
+                expect(item.errorType).toBe('EXTRACT_VALUE_ERROR');
+            });
+        }).toPass(defaultAssertionOptions);
+
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {
+                filter: {
+                    errorType: 'CALLED_DECISION_ERROR',
+                },
+                },
+            });
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+                {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+                },
+                res,
+            );
+
+            const body = await res.json();
+            expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+            expect(body.items.length).toBeGreaterThan(0);
+            body.items.forEach((item: Record<string, unknown>) => {
+                expect(item.errorType).toBe('CALLED_DECISION_ERROR');
+            });
+        }).toPass(defaultAssertionOptions);
+    });
+
+    test('Search Incidents With Error Type Filter and PIK Success', async ({request}) => {
+        const localState: Record<string, unknown> = {};
+        await setupMultipleTypeIncidentsTest(localState, request);
+        processInstanceKeys.push(localState['processInstanceKey'] as string);
+
+        await test.step('Search for EXTRACT_VALUE_ERROR incidents', async () => {
+            await expect(async () => {
+                const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                    headers: jsonHeaders(),
+                    data: {
+                    filter: {
+                        errorType: 'EXTRACT_VALUE_ERROR',
+                        processInstanceKey: localState['processInstanceKey'] as string,
+                    },
+                    },
+                });
+
+                await assertStatusCode(res, 200);
+                await validateResponse(
+                    {
+                    path: INCIDENT_SEARCH_ENDPOINT,
+                    method: 'POST',
+                    status: '200',
+                    },
+                    res,
+                );
+
+                const body = await res.json();
+                expect(body.page.totalItems).toEqual(1);
+                expect(body.items.length).toBeGreaterThan(0);
+                body.items.forEach((item: Record<string, unknown>) => {
+                    expect(item.errorType).toBe('EXTRACT_VALUE_ERROR');
+                });
+            }).toPass(defaultAssertionOptions);
+        });
+
+        await test.step('Search for CALLED_DECISION_ERROR incidents', async () => {
+            await expect(async () => {
+                const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                    headers: jsonHeaders(),
+                    data: {
+                    filter: {
+                        errorType: 'CALLED_DECISION_ERROR',
+                        processInstanceKey: localState['processInstanceKey'] as string,
+                    },
+                    },
+                });
+
+                await assertStatusCode(res, 200);
+                await validateResponse(
+                    {
+                    path: INCIDENT_SEARCH_ENDPOINT,
+                    method: 'POST',
+                    status: '200',
+                    },
+                    res,
+                );
+
+                const body = await res.json();
+                expect(body.page.totalItems).toEqual(1);
+                expect(body.items.length).toBeGreaterThan(0);
+                body.items.forEach((item: Record<string, unknown>) => {
+                    expect(item.errorType).toBe('CALLED_DECISION_ERROR');
+                });
+            }).toPass(defaultAssertionOptions);
+        });
+    });
+
+    test('Search Incidents Unauthorized', async ({request}) => {
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                data: {},
+            });
+
+            await assertUnauthorizedRequest(res);
+        }).toPass(defaultAssertionOptions);
+    });
+
+    test('Search Incidents Invalid Filter', async ({request}) => {
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {
+                filter: {
+                    meow: 'meowValue',
+                },
+                },
+            });
+
+            await assertBadRequest(
+                res,
+                'Request property [filter.meow] cannot be parsed',
+            );
+        }).toPass(defaultAssertionOptions);
+    });
+
+    test('Search Incidents Empty Result success', async ({request}) => {
+        const localState: Record<string, unknown> = {};
+        await setupIncidentTest(localState, request);
+        processInstanceKeys.push(localState['processInstanceKey'] as string);
+
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {
+                filter: {
+                    errorType: 'JOB_NO_RETRIES',
+                },
+                },
+            });
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+                {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+                },
+                res,
+            );
+
+            const body = await res.json();
+            expect(body.page.totalItems).toEqual(0);
+            expect(body.items.length).toEqual(0);
+        }).toPass(defaultAssertionOptions);
+    });
+
+    test('Search Incident Pagination Limit 1', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          page: {
+            limit: 1,
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(11);
+      expect(body.items.length).toBe(1);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
@@ -17,7 +17,11 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
-import {createTwoIncidentsInOneProcess, createIncidentsInTwoProcesses, createTwoDifferentIncidentsInOneProcess} from '../../../../utils/requestHelpers/incident-requestHelpers';
+import {
+  createTwoIncidentsInOneProcess,
+  createIncidentsInTwoProcesses,
+  createTwoDifferentIncidentsInOneProcess,
+} from '../../../../utils/requestHelpers/incident-requestHelpers';
 
 const INCIDENT_SEARCH_ENDPOINT = '/incidents/search';
 
@@ -26,9 +30,9 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
   test.beforeAll(async () => {
     await deploy([
-        './resources/processWithAnError.bpmn',
-        './resources/loanApprovalProcess.bpmn',
-        './resources/MultipleErrorTypesProcess.bpmn',
+      './resources/processWithAnError.bpmn',
+      './resources/loanApprovalProcess.bpmn',
+      './resources/MultipleErrorTypesProcess.bpmn',
     ]);
   });
 
@@ -38,292 +42,298 @@ test.describe.parallel('Search Incidents API Tests', () => {
     }
   });
 
-    test('Search Incidents Success', async ({request}) => {
-        const localState: Record<string, unknown> = {};
-        await createTwoIncidentsInOneProcess(localState, request);
-        processInstanceKeys.push(localState['processInstanceKey'] as string);
+  test('Search Incidents Success', async ({request}) => {
+    const localState: Record<string, unknown> = {};
+    await createTwoIncidentsInOneProcess(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
 
-         await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {},
-            });
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {},
+      });
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-                {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-                },
-                res,
-            );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: INCIDENT_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-            const body = await res.json();
-            expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-            expect(Array.isArray(body.items)).toBe(true);
-            expect(body.items.length).toBeGreaterThan(0);
-        }).toPass(defaultAssertionOptions);
-    });
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      expect(Array.isArray(body.items)).toBe(true);
+      expect(body.items.length).toBeGreaterThan(0);
+    }).toPass(defaultAssertionOptions);
+  });
 
-    test('Search Incidents within multiple process instances Success', async ({request}) => {
-        const localState: Record<string, unknown> = {};
-        await createIncidentsInTwoProcesses(localState, request);
-        for (const element of localState['processInstanceKey'] as string[]) {
-            processInstanceKeys.push(element);
-        }
+  test('Search Incidents within multiple process instances Success', async ({
+    request,
+  }) => {
+    const localState: Record<string, unknown> = {};
+    await createIncidentsInTwoProcesses(localState, request);
+    for (const element of localState['processInstanceKey'] as string[]) {
+      processInstanceKeys.push(element);
+    }
 
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {},
-            });
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {},
+      });
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-                {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-                },
-                res,
-            );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: INCIDENT_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-            const body = await res.json();
-            expect(body.page.totalItems).toBeGreaterThanOrEqual(3);
-            expect(Array.isArray(body.items)).toBe(true);
-            expect(body.items.length).toBeGreaterThan(0);
-        }).toPass(defaultAssertionOptions);
-    });
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(3);
+      expect(Array.isArray(body.items)).toBe(true);
+      expect(body.items.length).toBeGreaterThan(0);
+    }).toPass(defaultAssertionOptions);
+  });
 
-    test('Search Incidents With IncidentKey Filter Success', async ({request}) => {
-        const localState: Record<string, unknown> = {};
-        await createTwoIncidentsInOneProcess(localState, request);
-        processInstanceKeys.push(localState['processInstanceKey'] as string);
-        const incidentKeys = localState['incidentKeys'] as string[];
+  test('Search Incidents With IncidentKey Filter Success', async ({
+    request,
+  }) => {
+    const localState: Record<string, unknown> = {};
+    await createTwoIncidentsInOneProcess(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
+    const incidentKeys = localState['incidentKeys'] as string[];
 
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {
-                filter: {
-                    incidentKey: incidentKeys[0],
-                },
-                },
-            });
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            incidentKey: incidentKeys[0],
+          },
+        },
+      });
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-                {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-                },
-                res,
-            );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: INCIDENT_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-            const body = await res.json();
-            expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-            expect(body.items.length).toBeGreaterThan(0);
-            body.items.forEach((item: Record<string, unknown>) => {
-                expect(item.incidentKey).toEqual(incidentKeys[0]);
-            });
-        }).toPass(defaultAssertionOptions);
-    });
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      expect(body.items.length).toBeGreaterThan(0);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.incidentKey).toEqual(incidentKeys[0]);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
-    test('Search Incidents With Error Type Filter Success', async ({request}) => {
-        const localState: Record<string, unknown> = {};
-        await createTwoIncidentsInOneProcess(localState, request);
-        processInstanceKeys.push(localState['processInstanceKey'] as string);
+  test('Search Incidents With Error Type Filter Success', async ({request}) => {
+    const localState: Record<string, unknown> = {};
+    await createTwoIncidentsInOneProcess(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
 
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {
-                filter: {
-                    errorType: 'EXTRACT_VALUE_ERROR',
-                },
-                },
-            });
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            errorType: 'EXTRACT_VALUE_ERROR',
+          },
+        },
+      });
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-                {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-                },
-                res,
-            );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: INCIDENT_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-            const body = await res.json();
-            expect(body.page.totalItems).toBeGreaterThanOrEqual(6);
-            expect(body.items.length).toBeGreaterThan(0);
-            body.items.forEach((item: Record<string, unknown>) => {
-                expect(item.errorType).toBe('EXTRACT_VALUE_ERROR');
-            });
-        }).toPass(defaultAssertionOptions);
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(6);
+      expect(body.items.length).toBeGreaterThan(0);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.errorType).toBe('EXTRACT_VALUE_ERROR');
+      });
+    }).toPass(defaultAssertionOptions);
 
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {
-                filter: {
-                    errorType: 'CALLED_DECISION_ERROR',
-                },
-                },
-            });
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            errorType: 'CALLED_DECISION_ERROR',
+          },
+        },
+      });
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-                {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-                },
-                res,
-            );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: INCIDENT_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-            const body = await res.json();
-            expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-            expect(body.items.length).toBeGreaterThan(0);
-            body.items.forEach((item: Record<string, unknown>) => {
-                expect(item.errorType).toBe('CALLED_DECISION_ERROR');
-            });
-        }).toPass(defaultAssertionOptions);
-    });
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      expect(body.items.length).toBeGreaterThan(0);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.errorType).toBe('CALLED_DECISION_ERROR');
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
-    test('Search Incidents With Error Type Filter and Process Instance Key Success', async ({request}) => {
-        const localState: Record<string, unknown> = {};
-        await createTwoDifferentIncidentsInOneProcess(localState, request);
-        processInstanceKeys.push(localState['processInstanceKey'] as string);
+  test('Search Incidents With Error Type Filter and Process Instance Key Success', async ({
+    request,
+  }) => {
+    const localState: Record<string, unknown> = {};
+    await createTwoDifferentIncidentsInOneProcess(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
 
-        await test.step('Search for EXTRACT_VALUE_ERROR incidents', async () => {
-            await expect(async () => {
-                const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                    headers: jsonHeaders(),
-                    data: {
-                    filter: {
-                        errorType: 'EXTRACT_VALUE_ERROR',
-                        processInstanceKey: localState['processInstanceKey'] as string,
-                    },
-                    },
-                });
-
-                await assertStatusCode(res, 200);
-                await validateResponse(
-                    {
-                    path: INCIDENT_SEARCH_ENDPOINT,
-                    method: 'POST',
-                    status: '200',
-                    },
-                    res,
-                );
-
-                const body = await res.json();
-                expect(body.page.totalItems).toEqual(1);
-                expect(body.items.length).toBeGreaterThan(0);
-                body.items.forEach((item: Record<string, unknown>) => {
-                    expect(item.errorType).toBe('EXTRACT_VALUE_ERROR');
-                });
-            }).toPass(defaultAssertionOptions);
+    await test.step('Search for EXTRACT_VALUE_ERROR incidents', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              errorType: 'EXTRACT_VALUE_ERROR',
+              processInstanceKey: localState['processInstanceKey'] as string,
+            },
+          },
         });
 
-        await test.step('Search for CALLED_DECISION_ERROR incidents', async () => {
-            await expect(async () => {
-                const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                    headers: jsonHeaders(),
-                    data: {
-                    filter: {
-                        errorType: 'CALLED_DECISION_ERROR',
-                        processInstanceKey: localState['processInstanceKey'] as string,
-                    },
-                    },
-                });
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: INCIDENT_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
 
-                await assertStatusCode(res, 200);
-                await validateResponse(
-                    {
-                    path: INCIDENT_SEARCH_ENDPOINT,
-                    method: 'POST',
-                    status: '200',
-                    },
-                    res,
-                );
-
-                const body = await res.json();
-                expect(body.page.totalItems).toEqual(1);
-                expect(body.items.length).toBeGreaterThan(0);
-                body.items.forEach((item: Record<string, unknown>) => {
-                    expect(item.errorType).toBe('CALLED_DECISION_ERROR');
-                });
-            }).toPass(defaultAssertionOptions);
+        const body = await res.json();
+        expect(body.page.totalItems).toEqual(1);
+        expect(body.items.length).toBeGreaterThan(0);
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.errorType).toBe('EXTRACT_VALUE_ERROR');
         });
+      }).toPass(defaultAssertionOptions);
     });
 
-    test('Search Incidents Unauthorized', async ({request}) => {
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                data: {},
-            });
+    await test.step('Search for CALLED_DECISION_ERROR incidents', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              errorType: 'CALLED_DECISION_ERROR',
+              processInstanceKey: localState['processInstanceKey'] as string,
+            },
+          },
+        });
 
-            await assertUnauthorizedRequest(res);
-        }).toPass(defaultAssertionOptions);
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: INCIDENT_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        expect(body.page.totalItems).toEqual(1);
+        expect(body.items.length).toBeGreaterThan(0);
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.errorType).toBe('CALLED_DECISION_ERROR');
+        });
+      }).toPass(defaultAssertionOptions);
     });
+  });
 
-    test('Search Incidents Invalid Filter', async ({request}) => {
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {
-                filter: {
-                    meow: 'meowValue',
-                },
-                },
-            });
+  test('Search Incidents Unauthorized', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+      });
 
-            await assertBadRequest(
-                res,
-                'Request property [filter.meow] cannot be parsed',
-            );
-        }).toPass(defaultAssertionOptions);
-    });
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
 
-    test('Search Incidents Empty Result success', async ({request}) => {
-        const localState: Record<string, unknown> = {};
-        await createTwoIncidentsInOneProcess(localState, request);
-        processInstanceKeys.push(localState['processInstanceKey'] as string);
+  test('Search Incidents Invalid Filter', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            meow: 'meowValue',
+          },
+        },
+      });
 
-        await expect(async () => {
-            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-                headers: jsonHeaders(),
-                data: {
-                filter: {
-                    processInstanceKey: '225179981', // non-existing
-                },
-                },
-            });
+      await assertBadRequest(
+        res,
+        'Request property [filter.meow] cannot be parsed',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-                {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-                },
-                res,
-            );
+  test('Search Incidents Empty Result success', async ({request}) => {
+    const localState: Record<string, unknown> = {};
+    await createTwoIncidentsInOneProcess(localState, request);
+    processInstanceKeys.push(localState['processInstanceKey'] as string);
 
-            const body = await res.json();
-            expect(body.page.totalItems).toEqual(0);
-            expect(body.items.length).toEqual(0);
-        }).toPass(defaultAssertionOptions);
-    });
+    await expect(async () => {
+      const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: '225179981', // non-existing
+          },
+        },
+      });
 
-    test('Search Incident Pagination Limit 1', async ({request}) => {
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: INCIDENT_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(0);
+      expect(body.items.length).toEqual(0);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Incident Pagination Limit 1', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
-import {setupIncidentTest, setupMultipleIncidentsTest, setupMultipleTypeIncidentsTest} from '../../../../utils/requestHelpers/incident-requestHelpers';
+import {createTwoIncidentsInOneProcess, createIncidentsInTwoProcesses, createTwoDifferentIncidentsInOneProcess} from '../../../../utils/requestHelpers/incident-requestHelpers';
 
 const INCIDENT_SEARCH_ENDPOINT = '/incidents/search';
 
@@ -40,7 +40,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     test('Search Incidents Success', async ({request}) => {
         const localState: Record<string, unknown> = {};
-        await setupIncidentTest(localState, request);
+        await createTwoIncidentsInOneProcess(localState, request);
         processInstanceKeys.push(localState['processInstanceKey'] as string);
 
          await expect(async () => {
@@ -68,7 +68,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     test('Search Incidents within multiple process instances Success', async ({request}) => {
         const localState: Record<string, unknown> = {};
-        await setupMultipleIncidentsTest(localState, request);
+        await createIncidentsInTwoProcesses(localState, request);
         for (const element of localState['processInstanceKey'] as string[]) {
             processInstanceKeys.push(element);
         }
@@ -98,7 +98,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     test('Search Incidents With IncidentKey Filter Success', async ({request}) => {
         const localState: Record<string, unknown> = {};
-        await setupIncidentTest(localState, request);
+        await createTwoIncidentsInOneProcess(localState, request);
         processInstanceKeys.push(localState['processInstanceKey'] as string);
         const incidentKeys = localState['incidentKeys'] as string[];
 
@@ -133,7 +133,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     test('Search Incidents With Error Type Filter Success', async ({request}) => {
         const localState: Record<string, unknown> = {};
-        await setupIncidentTest(localState, request);
+        await createTwoIncidentsInOneProcess(localState, request);
         processInstanceKeys.push(localState['processInstanceKey'] as string);
 
         await expect(async () => {
@@ -193,9 +193,9 @@ test.describe.parallel('Search Incidents API Tests', () => {
         }).toPass(defaultAssertionOptions);
     });
 
-    test('Search Incidents With Error Type Filter and PIK Success', async ({request}) => {
+    test('Search Incidents With Error Type Filter and Process Instance Key Success', async ({request}) => {
         const localState: Record<string, unknown> = {};
-        await setupMultipleTypeIncidentsTest(localState, request);
+        await createTwoDifferentIncidentsInOneProcess(localState, request);
         processInstanceKeys.push(localState['processInstanceKey'] as string);
 
         await test.step('Search for EXTRACT_VALUE_ERROR incidents', async () => {
@@ -294,7 +294,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
 
     test('Search Incidents Empty Result success', async ({request}) => {
         const localState: Record<string, unknown> = {};
-        await setupIncidentTest(localState, request);
+        await createTwoIncidentsInOneProcess(localState, request);
         processInstanceKeys.push(localState['processInstanceKey'] as string);
 
         await expect(async () => {
@@ -302,7 +302,7 @@ test.describe.parallel('Search Incidents API Tests', () => {
                 headers: jsonHeaders(),
                 data: {
                 filter: {
-                    errorType: 'JOB_NO_RETRIES',
+                    processInstanceKey: '225179981', // non-existing
                 },
                 },
             });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/incident-search-api.spec.ts
@@ -96,6 +96,41 @@ test.describe.parallel('Search Incidents API Tests', () => {
         }).toPass(defaultAssertionOptions);
     });
 
+    test('Search Incidents With IncidentKey Filter Success', async ({request}) => {
+        const localState: Record<string, unknown> = {};
+        await setupIncidentTest(localState, request);
+        processInstanceKeys.push(localState['processInstanceKey'] as string);
+        const incidentKeys = localState['incidentKeys'] as string[];
+
+        await expect(async () => {
+            const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+                headers: jsonHeaders(),
+                data: {
+                filter: {
+                    incidentKey: incidentKeys[0],
+                },
+                },
+            });
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+                {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+                },
+                res,
+            );
+
+            const body = await res.json();
+            expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+            expect(body.items.length).toBeGreaterThan(0);
+            body.items.forEach((item: Record<string, unknown>) => {
+                expect(item.incidentKey).toEqual(incidentKeys[0]);
+            });
+        }).toPass(defaultAssertionOptions);
+    });
+
     test('Search Incidents With Error Type Filter Success', async ({request}) => {
         const localState: Record<string, unknown> = {};
         await setupIncidentTest(localState, request);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {APIRequestContext} from 'playwright-core';
+import {expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {defaultAssertionOptions} from '../constants';
+import {validateResponse} from '../../json-body-assertions';
+import {createInstances, createSingleInstance} from '../zeebeClient';
+
+const INCIDENT_SEARCH_ENDPOINT = '/incidents/search';
+
+export async function searchIncidentByPIK(
+    request: APIRequestContext,
+    {processInstanceKey}:{processInstanceKey: string}
+) {
+    const localState: Record<string, unknown> = {};
+
+    await expect(async () => {
+        const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+            headers: jsonHeaders(),
+            data: {
+                page: {
+                    from: 0,
+                    limit: 10,
+                },
+                filter: {
+                    processInstanceKey,
+                },
+            },
+        });
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+            {
+                path: INCIDENT_SEARCH_ENDPOINT,
+                method: 'POST',
+                status: '200',
+            },
+            res,
+        );
+        const json = await res.json();
+        expect(json.items.length).toBeGreaterThan(0);
+        localState['incidents'] = json.items;
+    }).toPass(defaultAssertionOptions);
+    
+    return localState['incidents'] as {
+        incidentKey: string,
+        errorMessage: string,
+        processDefinitionId: string,
+        processDefinitionKey: string,
+        processInstanceKey: string,
+        elementInstanceKey: string,
+        elementId: string,
+        creationTime: string,
+        tenantId: string,
+        jobKey?: string,
+    }[];
+}
+
+/**
+ * Create Instance of one process with two incidents of the same type
+ * @param localState 
+ * @param request 
+ */
+export async function setupIncidentTest (
+  localState: Record<string, unknown>,
+  request: APIRequestContext,
+) {
+    await test.step('Create process instance with an incident', async () => {
+        const instances = await createInstances('processWithAnError', 1, 1);
+        localState['processInstanceKey'] = instances[0].processInstanceKey;
+    });
+
+    await test.step('Search incident to get incidentKey', async () => {
+        const incidents = await searchIncidentByPIK(request, {
+          processInstanceKey: localState['processInstanceKey'] as string,
+        });
+        localState['incidentKeys'] = incidents.map(incident => incident.incidentKey);
+      });
+}
+
+/**
+ * Create two process instances with incidents of different type
+ */
+export async function setupMultipleIncidentsTest(
+  localState: Record<string, unknown>,
+  request: APIRequestContext,
+) {
+    await test.step('Create process instances with incidents', async () => {
+        const instances = [];
+        const processWithAnErrorInstance = await createSingleInstance('processWithAnError', 1,);
+        instances.push(processWithAnErrorInstance.processInstanceKey);
+
+        const loanApprovalProcessInstance = await createSingleInstance('loanApprovalProcess', 1,);
+        instances.push(loanApprovalProcessInstance.processInstanceKey);
+        localState['processInstanceKey'] = instances;
+    });
+
+    await test.step('Search incident to get incidentKey', async () => {
+        const allKeys: Array<number | string> = [];
+        for (const key of localState['processInstanceKey'] as string[]) {
+            const incidents = await searchIncidentByPIK(request, { processInstanceKey: key });
+            allKeys.push(...(incidents ?? []).map(i => i.incidentKey));
+        }
+
+        localState['incidentKeys'] = allKeys;
+      });
+}
+
+/**
+ * Create one process instance with two incidents of different type
+ */
+export async function setupMultipleTypeIncidentsTest(
+  localState: Record<string, unknown>,
+  request: APIRequestContext,
+) {
+    await test.step('Create process instance with two different incidents', async () => {
+        const instance = await createSingleInstance('MultipleErrorTypesProcess', 1,);
+        localState['processInstanceKey'] = instance.processInstanceKey;
+    });
+
+    await test.step('Search incident to get incidentKey', async () => {
+        const incidents = await searchIncidentByPIK(request, {
+          processInstanceKey: localState['processInstanceKey'] as string,
+        });
+        localState['incidentKeys'] = incidents.map(incident => incident.incidentKey);
+      });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
@@ -65,10 +65,8 @@ export async function searchIncidentByPIK(
 
 /**
  * Create Instance of one process with two incidents of the same type
- * @param localState 
- * @param request 
  */
-export async function setupIncidentTest (
+export async function createTwoIncidentsInOneProcess (
   localState: Record<string, unknown>,
   request: APIRequestContext,
 ) {
@@ -88,7 +86,7 @@ export async function setupIncidentTest (
 /**
  * Create two process instances with incidents of different type
  */
-export async function setupMultipleIncidentsTest(
+export async function createIncidentsInTwoProcesses(
   localState: Record<string, unknown>,
   request: APIRequestContext,
 ) {
@@ -116,7 +114,7 @@ export async function setupMultipleIncidentsTest(
 /**
  * Create one process instance with two incidents of different type
  */
-export async function setupMultipleTypeIncidentsTest(
+export async function createTwoDifferentIncidentsInOneProcess(
   localState: Record<string, unknown>,
   request: APIRequestContext,
 ) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
@@ -16,71 +16,73 @@ import {createInstances, createSingleInstance} from '../zeebeClient';
 const INCIDENT_SEARCH_ENDPOINT = '/incidents/search';
 
 export async function searchIncidentByPIK(
-    request: APIRequestContext,
-    {processInstanceKey}:{processInstanceKey: string}
+  request: APIRequestContext,
+  {processInstanceKey}: {processInstanceKey: string},
 ) {
-    const localState: Record<string, unknown> = {};
+  const localState: Record<string, unknown> = {};
 
-    await expect(async () => {
-        const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
-            headers: jsonHeaders(),
-            data: {
-                page: {
-                    from: 0,
-                    limit: 10,
-                },
-                filter: {
-                    processInstanceKey,
-                },
-            },
-        });
+  await expect(async () => {
+    const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+      headers: jsonHeaders(),
+      data: {
+        page: {
+          from: 0,
+          limit: 10,
+        },
+        filter: {
+          processInstanceKey,
+        },
+      },
+    });
 
-        await assertStatusCode(res, 200);
-        await validateResponse(
-            {
-                path: INCIDENT_SEARCH_ENDPOINT,
-                method: 'POST',
-                status: '200',
-            },
-            res,
-        );
-        const json = await res.json();
-        expect(json.items.length).toBeGreaterThan(0);
-        localState['incidents'] = json.items;
-    }).toPass(defaultAssertionOptions);
-    
-    return localState['incidents'] as {
-        incidentKey: string,
-        errorMessage: string,
-        processDefinitionId: string,
-        processDefinitionKey: string,
-        processInstanceKey: string,
-        elementInstanceKey: string,
-        elementId: string,
-        creationTime: string,
-        tenantId: string,
-        jobKey?: string,
-    }[];
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: INCIDENT_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const json = await res.json();
+    expect(json.items.length).toBeGreaterThan(0);
+    localState['incidents'] = json.items;
+  }).toPass(defaultAssertionOptions);
+
+  return localState['incidents'] as {
+    incidentKey: string;
+    errorMessage: string;
+    processDefinitionId: string;
+    processDefinitionKey: string;
+    processInstanceKey: string;
+    elementInstanceKey: string;
+    elementId: string;
+    creationTime: string;
+    tenantId: string;
+    jobKey?: string;
+  }[];
 }
 
 /**
  * Create Instance of one process with two incidents of the same type
  */
-export async function createTwoIncidentsInOneProcess (
+export async function createTwoIncidentsInOneProcess(
   localState: Record<string, unknown>,
   request: APIRequestContext,
 ) {
-    await test.step('Create process instance with an incident', async () => {
-        const instances = await createInstances('processWithAnError', 1, 1);
-        localState['processInstanceKey'] = instances[0].processInstanceKey;
-    });
+  await test.step('Create process instance with an incident', async () => {
+    const instances = await createInstances('processWithAnError', 1, 1);
+    localState['processInstanceKey'] = instances[0].processInstanceKey;
+  });
 
-    await test.step('Search incident to get incidentKey', async () => {
-        const incidents = await searchIncidentByPIK(request, {
-          processInstanceKey: localState['processInstanceKey'] as string,
-        });
-        localState['incidentKeys'] = incidents.map(incident => incident.incidentKey);
-      });
+  await test.step('Search incident to get incidentKey', async () => {
+    const incidents = await searchIncidentByPIK(request, {
+      processInstanceKey: localState['processInstanceKey'] as string,
+    });
+    localState['incidentKeys'] = incidents.map(
+      (incident) => incident.incidentKey,
+    );
+  });
 }
 
 /**
@@ -90,25 +92,33 @@ export async function createIncidentsInTwoProcesses(
   localState: Record<string, unknown>,
   request: APIRequestContext,
 ) {
-    await test.step('Create process instances with incidents', async () => {
-        const instances = [];
-        const processWithAnErrorInstance = await createSingleInstance('processWithAnError', 1,);
-        instances.push(processWithAnErrorInstance.processInstanceKey);
+  await test.step('Create process instances with incidents', async () => {
+    const instances = [];
+    const processWithAnErrorInstance = await createSingleInstance(
+      'processWithAnError',
+      1,
+    );
+    instances.push(processWithAnErrorInstance.processInstanceKey);
 
-        const loanApprovalProcessInstance = await createSingleInstance('loanApprovalProcess', 1,);
-        instances.push(loanApprovalProcessInstance.processInstanceKey);
-        localState['processInstanceKey'] = instances;
-    });
+    const loanApprovalProcessInstance = await createSingleInstance(
+      'loanApprovalProcess',
+      1,
+    );
+    instances.push(loanApprovalProcessInstance.processInstanceKey);
+    localState['processInstanceKey'] = instances;
+  });
 
-    await test.step('Search incident to get incidentKey', async () => {
-        const allKeys: Array<number | string> = [];
-        for (const key of localState['processInstanceKey'] as string[]) {
-            const incidents = await searchIncidentByPIK(request, { processInstanceKey: key });
-            allKeys.push(...(incidents ?? []).map(i => i.incidentKey));
-        }
-
-        localState['incidentKeys'] = allKeys;
+  await test.step('Search incident to get incidentKey', async () => {
+    const allKeys: Array<number | string> = [];
+    for (const key of localState['processInstanceKey'] as string[]) {
+      const incidents = await searchIncidentByPIK(request, {
+        processInstanceKey: key,
       });
+      allKeys.push(...(incidents ?? []).map((i) => i.incidentKey));
+    }
+
+    localState['incidentKeys'] = allKeys;
+  });
 }
 
 /**
@@ -118,15 +128,17 @@ export async function createTwoDifferentIncidentsInOneProcess(
   localState: Record<string, unknown>,
   request: APIRequestContext,
 ) {
-    await test.step('Create process instance with two different incidents', async () => {
-        const instance = await createSingleInstance('MultipleErrorTypesProcess', 1,);
-        localState['processInstanceKey'] = instance.processInstanceKey;
-    });
+  await test.step('Create process instance with two different incidents', async () => {
+    const instance = await createSingleInstance('MultipleErrorTypesProcess', 1);
+    localState['processInstanceKey'] = instance.processInstanceKey;
+  });
 
-    await test.step('Search incident to get incidentKey', async () => {
-        const incidents = await searchIncidentByPIK(request, {
-          processInstanceKey: localState['processInstanceKey'] as string,
-        });
-        localState['incidentKeys'] = incidents.map(incident => incident.incidentKey);
-      });
+  await test.step('Search incident to get incidentKey', async () => {
+    const incidents = await searchIncidentByPIK(request, {
+      processInstanceKey: localState['processInstanceKey'] as string,
+    });
+    localState['incidentKeys'] = incidents.map(
+      (incident) => incident.incidentKey,
+    );
+  });
 }


### PR DESCRIPTION
## Description

This PR covers happy path of [incident-search-api](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-incidents/):

- Search Incidents Success
- Search Incidents within multiple process instances Success
- Search Incidents With Error Type Filter Success
- Search Incidents With Error Type Filter and PIK Success
- Search Incidents Empty Result success
- Search Incidents With IncidentKey Filter Success
- Search Incident Pagination Limit 1

And unhappy path
- Search Incidents Unauthorized
- Search Incidents Invalid Filter

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
related #37204

## On demand workflow
[was successfull](https://github.com/camunda/camunda/actions/runs/20161547727)