### PR TITLE
[Backport stable/8.8] bugfix: do not error on wrong cache index in ProcessCacheUtil#getCallActivityId

### DIFF
--- a/zeebe/exporter-common/pom.xml
+++ b/zeebe/exporter-common/pom.xml
@@ -15,6 +15,10 @@
   <name>Zeebe Exporter Common</name>
 
   <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.exporter.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +40,7 @@ public class ProcessCacheUtilTest {
 
     // when
     final Optional<String> result =
-        assertDoesNotThrow(
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(
             () ->
                 ProcessCacheUtil.getCallActivityId(
                     mockProcessCache, fakeProcessDefinitionKey, outOfBoundsIndex));

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -8,14 +8,48 @@
 package io.camunda.zeebe.exporter.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class ProcessCacheUtilTest {
+
+  @Test
+  void shouldNotRaiseExceptionWhenGetCallActivityIdHasOutOfBoundsIndex() {
+    // given
+    final Long fakeProcessDefinitionKey = 123L;
+    final int outOfBoundsIndex = 10;
+    final ExporterEntityCache<Long, CachedProcessEntity> mockProcessCache =
+        mock(ExporterEntityCache.class);
+    final CachedProcessEntity mockCachedProcessEntity = mock(CachedProcessEntity.class);
+    final Optional<CachedProcessEntity> optionalCachedProcessEntity =
+        Optional.of(mockCachedProcessEntity);
+    final List<String> shortCallElementIds = List.of("callActivity_1", "callActivity_2");
+
+    // with
+    when(mockProcessCache.get(fakeProcessDefinitionKey)).thenReturn(optionalCachedProcessEntity);
+    when(mockCachedProcessEntity.callElementIds()).thenReturn(shortCallElementIds);
+
+    // when
+    final Optional<String> result =
+        assertDoesNotThrow(
+            () ->
+                ProcessCacheUtil.getCallActivityId(
+                    mockProcessCache, fakeProcessDefinitionKey, outOfBoundsIndex));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.isEmpty()).isTrue();
+  }
 
   @Test
   void shouldExtractCallActivityIds() {


### PR DESCRIPTION
# Description
Backport of #42346 to `stable/8.8`.

relates to camunda/camunda#42110 camunda/camunda#42110