### PR TITLE
feat: add rootProcessInstanceKey to ES/OS datamodel

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -47,6 +47,7 @@ public class AuditLogTemplate extends AbstractTemplateDescriptor
   public static final String TENANT_ID = "tenantId";
   public static final String TIMESTAMP = "timestamp";
   public static final String USER_TASK_KEY = "userTaskKey";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public static final EntityJoinRelationFactory<AuditLogJoinRelationshipType>
       JOIN_RELATION_FACTORY =

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/CorrelatedMessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/CorrelatedMessageSubscriptionTemplate.java
@@ -32,6 +32,7 @@ public class CorrelatedMessageSubscriptionTemplate extends AbstractTemplateDescr
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String SUBSCRIPTION_KEY = "subscriptionKey";
   public static final String TENANT_ID = "tenantId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public CorrelatedMessageSubscriptionTemplate(
       final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/DecisionInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/DecisionInstanceTemplate.java
@@ -43,6 +43,7 @@ public class DecisionInstanceTemplate extends AbstractTemplateDescriptor
   public static final String RESULT = "result";
   public static final String EVALUATED_INPUTS = "evaluatedInputs";
   public static final String EVALUATED_OUTPUTS = "evaluatedOutputs";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public DecisionInstanceTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/FlowNodeInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/FlowNodeInstanceTemplate.java
@@ -36,6 +36,7 @@ public class FlowNodeInstanceTemplate extends AbstractTemplateDescriptor
   public static final String LEVEL = "level";
   public static final String INCIDENT = "incident"; // true/false
   public static final String SCOPE_KEY = "scopeKey";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public FlowNodeInstanceTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/IncidentTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/IncidentTemplate.java
@@ -33,6 +33,7 @@ public class IncidentTemplate extends AbstractTemplateDescriptor
   public static final String STATE = "state";
   public static final String CREATION_TIME = "creationTime";
   public static final String TREE_PATH = "treePath";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public IncidentTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobTemplate.java
@@ -23,6 +23,7 @@ public class JobTemplate extends AbstractTemplateDescriptor
   public static final String FLOW_NODE_INSTANCE_ID = "flowNodeInstanceId";
   // String - human-readable name
   public static final String FLOW_NODE_ID = "flowNodeId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
   public static final String TENANT_ID = "tenantId";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -104,6 +104,8 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
    */
   @Deprecated public static final String POSITION_JOB = "positionJob";
 
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+
   public MessageSubscriptionTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/OperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/OperationTemplate.java
@@ -41,6 +41,7 @@ public class OperationTemplate extends AbstractTemplateDescriptor
   public static final String BATCH_OPERATION_ID_AGGREGATION = "batchOperationIdAggregation";
   public static final String COMPLETED_DATE = "completedDate";
   public static final String ITEM_KEY = "itemKey";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public OperationTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/PostImporterQueueTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/PostImporterQueueTemplate.java
@@ -25,6 +25,7 @@ public class PostImporterQueueTemplate extends AbstractTemplateDescriptor
   public static final String CREATION_TIME = "creationTime";
   public static final String INTENT = "intent";
   public static final String PARTITION_ID = "partitionId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public PostImporterQueueTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/SequenceFlowTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/SequenceFlowTemplate.java
@@ -25,6 +25,7 @@ public class SequenceFlowTemplate extends AbstractTemplateDescriptor
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String ACTIVITY_ID = "activityId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public SequenceFlowTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/SnapshotTaskVariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/SnapshotTaskVariableTemplate.java
@@ -28,6 +28,7 @@ public class SnapshotTaskVariableTemplate extends AbstractTemplateDescriptor
   public static final String FULL_VALUE = "fullValue";
   public static final String IS_PREVIEW = "isPreview";
   public static final String TENANT_ID = "tenantId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public SnapshotTaskVariableTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/TaskTemplate.java
@@ -64,6 +64,7 @@ public class TaskTemplate extends AbstractTemplateDescriptor
   public static final String FLOW_NODE_INSTANCE_ID = "flowNodeInstanceId";
   public static final String PROCESS_INSTANCE_ID = "processInstanceId";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public static final String JOIN_FIELD_NAME = "join";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/VariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/VariableTemplate.java
@@ -29,6 +29,7 @@ public class VariableTemplate extends AbstractTemplateDescriptor
   public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public VariableTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
@@ -33,6 +33,10 @@ public class CorrelatedMessageSubscriptionEntity
   @BeforeVersion880 private String subscriptionType;
   @BeforeVersion880 private String tenantId;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
+
   @Override
   public String getId() {
     return id;
@@ -176,6 +180,16 @@ public class CorrelatedMessageSubscriptionEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public CorrelatedMessageSubscriptionEntity setRootProcessInstanceKey(
+      final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -219,7 +233,8 @@ public class CorrelatedMessageSubscriptionEntity
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(processInstanceKey, that.processInstanceKey)
         && Objects.equals(subscriptionType, that.subscriptionType)
-        && Objects.equals(tenantId, that.tenantId);
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 
   @Override
@@ -261,6 +276,8 @@ public class CorrelatedMessageSubscriptionEntity
         + ", tenantId='"
         + tenantId
         + '\''
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + '}';
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
@@ -36,6 +36,10 @@ public class JobEntity
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private OffsetDateTime lastUpdateTime;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
+
   @BeforeVersion880 private String tenantId;
   @BeforeVersion880 private String type;
   @BeforeVersion880 private String worker;
@@ -277,6 +281,15 @@ public class JobEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public JobEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   public Boolean isDenied() {
     return denied;
   }
@@ -323,7 +336,8 @@ public class JobEntity
         denied,
         deniedReason,
         creationTime,
-        lastUpdateTime);
+        lastUpdateTime,
+        rootProcessInstanceKey);
   }
 
   @Override
@@ -360,7 +374,8 @@ public class JobEntity
         && Objects.equals(denied, jobEntity.denied)
         && Objects.equals(deniedReason, jobEntity.deniedReason)
         && Objects.equals(creationTime, jobEntity.creationTime)
-        && Objects.equals(lastUpdateTime, jobEntity.lastUpdateTime);
+        && Objects.equals(lastUpdateTime, jobEntity.lastUpdateTime)
+        && Objects.equals(rootProcessInstanceKey, jobEntity.rootProcessInstanceKey);
   }
 
   @Override
@@ -422,6 +437,8 @@ public class JobEntity
         + creationTime
         + ", lastUpdateTime="
         + lastUpdateTime
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + "} "
         + super.toString();
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SequenceFlowEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SequenceFlowEntity.java
@@ -25,6 +25,10 @@ public class SequenceFlowEntity implements ExporterEntity<SequenceFlowEntity>, T
   @BeforeVersion880 private String activityId;
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
+
   @Override
   public String getId() {
     return id;
@@ -82,10 +86,25 @@ public class SequenceFlowEntity implements ExporterEntity<SequenceFlowEntity>, T
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public SequenceFlowEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
-        id, processInstanceKey, processDefinitionKey, bpmnProcessId, activityId, tenantId);
+        id,
+        processInstanceKey,
+        processDefinitionKey,
+        bpmnProcessId,
+        activityId,
+        tenantId,
+        rootProcessInstanceKey);
   }
 
   @Override
@@ -102,6 +121,7 @@ public class SequenceFlowEntity implements ExporterEntity<SequenceFlowEntity>, T
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(activityId, that.activityId)
-        && Objects.equals(tenantId, that.tenantId);
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  * semantic version the field was introduced.
  *
  * <p>In addition, all fields with this annotation must have a non-null default value. This is to
- * maintain backwards compatability. However, if the nullable field is set to true then it is
+ * maintain backwards compatability. However, if the requireDefault field is set to false then it is
  * acceptable for the field to have a null default.
  *
  * <p>Example usage:
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *    {@literal @SinceVersion("8.8.0")}
  *     private String newField = "bar" // This will pass
  *
- *    {@literal @SinceVersion(value = "8.8.0", requireDefault = true)}
+ *    {@literal @SinceVersion(value = "8.8.0", requireDefault = false)}
  *     private String newField; // This will pass
  *   }
  * </code></pre>

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/VariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/VariableEntity.java
@@ -35,6 +35,10 @@ public class VariableEntity
 
   @BeforeVersion880 private Long position;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
+
   @JsonIgnore private Object[] sortValues;
 
   @Override
@@ -168,6 +172,15 @@ public class VariableEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public VariableEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     int result =
@@ -184,7 +197,8 @@ public class VariableEntity
             processDefinitionKey,
             bpmnProcessId,
             tenantId,
-            position);
+            position,
+            rootProcessInstanceKey);
     result = 31 * result + Arrays.hashCode(sortValues);
     return result;
   }
@@ -211,7 +225,8 @@ public class VariableEntity
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(position, that.position)
-        && Arrays.equals(sortValues, that.sortValues);
+        && Arrays.equals(sortValues, that.sortValues)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 
   @Override
@@ -236,6 +251,8 @@ public class VariableEntity
         + '\''
         + ", position="
         + position
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + "} "
         + super.toString();
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
@@ -120,6 +120,9 @@ public class AuditLogEntity extends AbstractExporterEntity<AuditLogEntity> {
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long resourceKey;
 
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
+
   public String getEntityKey() {
     return entityKey;
   }
@@ -387,5 +390,14 @@ public class AuditLogEntity extends AbstractExporterEntity<AuditLogEntity> {
 
   public void setDecisionEvaluationKey(final Long decisionEvaluationKey) {
     this.decisionEvaluationKey = decisionEvaluationKey;
+  }
+
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public AuditLogEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -54,6 +55,10 @@ public class DecisionInstanceEntity
   @BeforeVersion880 private List<DecisionInstanceInputEntity> evaluatedInputs = new ArrayList<>();
   @BeforeVersion880 private List<DecisionInstanceOutputEntity> evaluatedOutputs = new ArrayList<>();
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   @JsonIgnore private Object[] sortValues;
 
@@ -335,6 +340,15 @@ public class DecisionInstanceEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public DecisionInstanceEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     int result1 =
@@ -366,7 +380,8 @@ public class DecisionInstanceEntity
             result,
             evaluatedInputs,
             evaluatedOutputs,
-            tenantId);
+            tenantId,
+            rootProcessInstanceKey);
     result1 = 31 * result1 + Arrays.hashCode(sortValues);
     return result1;
   }
@@ -408,6 +423,7 @@ public class DecisionInstanceEntity
         && Objects.equals(evaluatedInputs, that.evaluatedInputs)
         && Objects.equals(evaluatedOutputs, that.evaluatedOutputs)
         && Objects.equals(tenantId, that.tenantId)
-        && Arrays.equals(sortValues, that.sortValues);
+        && Arrays.equals(sortValues, that.sortValues)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/flownode/FlowNodeInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/flownode/FlowNodeInstanceEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -45,6 +46,10 @@ public class FlowNodeInstanceEntity
   @BeforeVersion880 private boolean incident;
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
   @BeforeVersion880 private Long scopeKey;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   @JsonIgnore private Object[] sortValues;
 
@@ -235,6 +240,15 @@ public class FlowNodeInstanceEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public FlowNodeInstanceEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     int result =
@@ -257,7 +271,8 @@ public class FlowNodeInstanceEntity
             position,
             incident,
             tenantId,
-            scopeKey);
+            scopeKey,
+            rootProcessInstanceKey);
     result = 31 * result + Arrays.hashCode(sortValues);
     return result;
   }
@@ -290,6 +305,7 @@ public class FlowNodeInstanceEntity
         && Objects.equals(position, that.position)
         && Objects.equals(tenantId, that.tenantId)
         && Arrays.equals(sortValues, that.sortValues)
-        && Objects.equals(scopeKey, that.scopeKey);
+        && Objects.equals(scopeKey, that.scopeKey)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -36,6 +37,10 @@ public class IncidentEntity
   @BeforeVersion880 private String treePath;
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
   @BeforeVersion880 private Long position;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   @Deprecated @JsonIgnore private boolean pending = true;
 
@@ -207,6 +212,15 @@ public class IncidentEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public IncidentEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -255,7 +269,8 @@ public class IncidentEntity
         && Objects.equals(bpmnProcessId, incident.bpmnProcessId)
         && Objects.equals(treePath, incident.treePath)
         && Objects.equals(tenantId, incident.tenantId)
-        && Objects.equals(position, incident.position);
+        && Objects.equals(position, incident.position)
+        && Objects.equals(rootProcessInstanceKey, incident.rootProcessInstanceKey);
   }
 
   @Override
@@ -289,6 +304,8 @@ public class IncidentEntity
         + '\''
         + ", pending="
         + pending
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + '}';
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.messagesubscription;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -42,6 +43,10 @@ public class MessageSubscriptionEntity
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @BeforeVersion880 private Long positionProcessMessageSubscription;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   /**
    * @deprecated since 8.9
@@ -186,6 +191,15 @@ public class MessageSubscriptionEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public MessageSubscriptionEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   /**
    * @deprecated since 8.9
    */
@@ -273,7 +287,8 @@ public class MessageSubscriptionEntity
         position,
         positionIncident,
         positionProcessMessageSubscription,
-        positionJob);
+        positionJob,
+        rootProcessInstanceKey);
   }
 
   @Override
@@ -302,6 +317,7 @@ public class MessageSubscriptionEntity
         && Objects.equals(positionIncident, that.positionIncident)
         && Objects.equals(
             positionProcessMessageSubscription, that.positionProcessMessageSubscription)
-        && Objects.equals(positionJob, that.positionJob);
+        && Objects.equals(positionJob, that.positionJob)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.operation;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -47,6 +48,10 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   @BeforeVersion880 private String migrationPlan;
 
   @BeforeVersion880 private OffsetDateTime completedDate;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   public Long getItemKey() {
     return itemKey;
@@ -228,6 +233,15 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public OperationEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   public OperationEntity withGeneratedId() {
     // Operation reference has to be positive and `UUID.randomUUID().getMostSignificantBits()` can
     // generate negative values
@@ -291,7 +305,8 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
         && Objects.equals(zeebeCommandKey, that.zeebeCommandKey)
         && Objects.equals(username, that.username)
         && Objects.equals(modifyInstructions, that.modifyInstructions)
-        && Objects.equals(migrationPlan, that.migrationPlan);
+        && Objects.equals(migrationPlan, that.migrationPlan)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 
   @Override
@@ -344,6 +359,8 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
         + ", migrationPlan='"
         + migrationPlan
         + '\''
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + '}';
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterQueueEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterQueueEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.post;
 
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
@@ -29,6 +30,10 @@ public class PostImporterQueueEntity implements ExporterEntity<PostImporterQueue
   @BeforeVersion880 private Long processInstanceKey;
 
   @BeforeVersion880 private Long position;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   @Override
   public String getId() {
@@ -104,10 +109,27 @@ public class PostImporterQueueEntity implements ExporterEntity<PostImporterQueue
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public PostImporterQueueEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
-        id, key, actionType, intent, creationTime, partitionId, processInstanceKey, position);
+        id,
+        key,
+        actionType,
+        intent,
+        creationTime,
+        partitionId,
+        processInstanceKey,
+        position,
+        rootProcessInstanceKey);
   }
 
   @Override
@@ -126,6 +148,7 @@ public class PostImporterQueueEntity implements ExporterEntity<PostImporterQueue
         && Objects.equals(creationTime, that.creationTime)
         && Objects.equals(partitionId, that.partitionId)
         && Objects.equals(processInstanceKey, that.processInstanceKey)
-        && Objects.equals(position, that.position);
+        && Objects.equals(position, that.position)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/SnapshotTaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/SnapshotTaskVariableEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.usertask;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -29,6 +30,10 @@ public class SnapshotTaskVariableEntity
   @BeforeVersion880 private String fullValue;
   @BeforeVersion880 private boolean isPreview;
   @BeforeVersion880 private Long processInstanceKey;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
 
   public SnapshotTaskVariableEntity() {}
 
@@ -127,9 +132,19 @@ public class SnapshotTaskVariableEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public SnapshotTaskVariableEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(id, tenantId, taskId, name, value, fullValue, isPreview);
+    return Objects.hash(
+        id, tenantId, taskId, name, value, fullValue, isPreview, rootProcessInstanceKey);
   }
 
   @Override
@@ -147,6 +162,7 @@ public class SnapshotTaskVariableEntity
         && Objects.equals(taskId, that.taskId)
         && Objects.equals(name, that.name)
         && Objects.equals(value, that.value)
-        && Objects.equals(fullValue, that.fullValue);
+        && Objects.equals(fullValue, that.fullValue)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -140,6 +141,11 @@ public class TaskEntity
   @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskImplementation implementation;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long rootProcessInstanceKey;
 
   public TaskEntity() {}
 
@@ -441,6 +447,15 @@ public class TaskEntity
 
   public TaskEntity setImplementation(final TaskImplementation implementation) {
     this.implementation = implementation;
+    return this;
+  }
+
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public TaskEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-audit-log.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-audit-log.json
@@ -95,6 +95,9 @@
       },
       "userTaskKey": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-correlated-message-subscription.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-correlated-message-subscription.json
@@ -47,6 +47,9 @@
       },
       "tenantId": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-decision-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-decision-instance.json
@@ -118,6 +118,9 @@
             "type": "integer"
           }
         }
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -90,6 +90,9 @@
       "positionJob": {
         "type": "long",
         "index": false
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-flownode-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-flownode-instance.json
@@ -60,6 +60,9 @@
 			},
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-incident.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-incident.json
@@ -70,6 +70,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -87,6 +87,9 @@
       },
       "tags": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-operation.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-operation.json
@@ -67,6 +67,9 @@
       },
       "itemKey": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-post-importer-queue.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-post-importer-queue.json
@@ -26,6 +26,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-sequence-flow.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-sequence-flow.json
@@ -25,6 +25,9 @@
 			},
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-variable.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-variable.json
@@ -42,6 +42,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/tasklist-task-variable.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/tasklist-task-variable.json
@@ -33,6 +33,9 @@
 			},
       "processInstanceKey": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
 	}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/tasklist-task.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/tasklist-task.json
@@ -126,6 +126,9 @@
       },
       "changedAttributes": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-audit-log.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-audit-log.json
@@ -95,6 +95,9 @@
       },
       "userTaskKey": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-correlated-message-subscription.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-correlated-message-subscription.json
@@ -47,6 +47,9 @@
       },
       "tenantId": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-decision-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-decision-instance.json
@@ -118,6 +118,9 @@
             "type": "integer"
           }
         }
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
@@ -90,6 +90,9 @@
       "positionJob": {
         "type": "long",
         "index": false
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-flownode-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-flownode-instance.json
@@ -60,6 +60,9 @@
 			},
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-incident.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-incident.json
@@ -75,6 +75,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -87,6 +87,9 @@
       },
       "tags": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-operation.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-operation.json
@@ -67,6 +67,9 @@
       },
       "itemKey": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-post-importer-queue.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-post-importer-queue.json
@@ -26,6 +26,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-sequence-flow.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-sequence-flow.json
@@ -25,6 +25,9 @@
 			},
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-variable.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-variable.json
@@ -42,6 +42,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task-variable.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task-variable.json
@@ -33,6 +33,9 @@
       },
       "processInstanceKey": {
         "type": "long"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
@@ -125,6 +125,9 @@
       },
       "changedAttributes": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request introduces the new field `rootProcessInstanceKey` across the process instance dependent entity and template classes, and in their index mappings. The field is intended to be populated by the exporter starting from 8.9.0.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41658
