### PR TITLE
ci: enable error handling in daily QA workflow

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -13,6 +13,12 @@ on:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
 
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
 env:
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Set default shell to bash for workflow runs so that we get the usual error handling.
This should catch errors as seen here: https://github.com/camunda/camunda/actions/runs/20118921270/job/57734653176#step:3:35 so that we can see the workflow failing instead of silently doing nothing.