### PR TITLE
feat: fix tests flakiness for cluster variables

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -54,9 +54,7 @@ public class ClusterVariableIT {
                 randomizedVariable.name(),
                 randomizedVariable.tenantId(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
-                    // FIXME: change resource type to CLUSTER_VARIABLE once available
-                    //  (see https://github.com/camunda/camunda/issues/39054)
-                    AuthorizationResourceType.UNSPECIFIED, randomizedVariable.name()));
+                    AuthorizationResourceType.CLUSTER_VARIABLE, randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertVariableDbModelEqualToEntity(randomizedVariable, instance);


### PR DESCRIPTION
This pull request improves the reliability and correctness of cluster variable authorization and tenancy acceptance tests. The main enhancements include adding proper cleanup after variable creation to prevent test data leakage, introducing utility methods to wait for variable deletion and baseline data availability, and updating resource type usage for authorization checks.

**Test reliability and cleanup improvements:**

* Added `finally` blocks to ensure cluster variables created during tests are deleted afterwards, preventing leftover test data in both global and tenant-scoped variable tests (`ClusterVariableAuthorizationIT.java`, `ClusterVariableTenancyIT.java`). [[1]](diffhunk://#diff-735588a647f74989e254e88be0cb65ec53b3abb0c35ff03b5d0edc61cbdf486dR232-R257) [[2]](diffhunk://#diff-735588a647f74989e254e88be0cb65ec53b3abb0c35ff03b5d0edc61cbdf486dR316-R341) [[3]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R235-R243)
* Added calls to `waitForClusterVariableToBeDeleted` after variable deletion operations to ensure the variable is fully removed before assertions, improving test stability (`ClusterVariableAuthorizationIT.java`, `ClusterVariableTenancyIT.java`). [[1]](diffhunk://#diff-735588a647f74989e254e88be0cb65ec53b3abb0c35ff03b5d0edc61cbdf486dR416) [[2]](diffhunk://#diff-735588a647f74989e254e88be0cb65ec53b3abb0c35ff03b5d0edc61cbdf486dR500) [[3]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R267)

**Utility methods for test synchronization:**

* Introduced `waitForClusterVariableToBeDeleted` and related methods to actively wait for variable deletion, reducing flakiness in tests that depend on eventual consistency (`ClusterVariableAuthorizationIT.java`, `ClusterVariableTenancyIT.java`). [[1]](diffhunk://#diff-735588a647f74989e254e88be0cb65ec53b3abb0c35ff03b5d0edc61cbdf486dR578-R600) [[2]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R463-R499)
* Added utility methods to wait for baseline cluster variables to be available before running assertions, ensuring that tests start with the expected data state (`ClusterVariableTenancyIT.java`). [[1]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R99-R101) [[2]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R120-R122) [[3]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R414-R416) [[4]](diffhunk://#diff-28b9bf978c044cdcf69f7cfe6f157b89dab5b0b7545bbc7a2390a8ddc1611cf6R463-R499)

**Authorization resource type update:**

* Updated the resource type used in authorization checks from `UNSPECIFIED` to `CLUSTER_VARIABLE`, aligning tests with the correct resource type and improving their accuracy (`ClusterVariableIT.java`).