### PR TITLE
[Backport stable/8.7] deps: override discontinued LZ4 dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -160,7 +160,7 @@
     <version.elasticsearch-test-container>2.0.2</version.elasticsearch-test-container>
     <version.postgres-test-container>2.0.2</version.postgres-test-container>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>
-    <version.lz4>1.8.1</version.lz4>
+    <version.lz4>1.10.1</version.lz4>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
@@ -1870,11 +1870,17 @@
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>
         <version>${version.elasticsearch7}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- override the transitive dependency from elasticsearch-lz4,
       once org.elasticsearch:elasticsearch minor or major is bumped up lz4-java direct dependency can be removed -->
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
         <version>${version.lz4}</version>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1877,7 +1877,7 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- override the transitive dependency from elasticsearch-lz4,
+      <!-- override the transitive dependency from org.elasticsearch:elasticsearch,
       once org.elasticsearch:elasticsearch minor or major is bumped up lz4-java direct dependency can be removed -->
       <dependency>
         <groupId>at.yawk.lz4</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1877,8 +1877,9 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- override the transitive dependency from org.elasticsearch:elasticsearch,
-      once org.elasticsearch:elasticsearch minor or major is bumped up lz4-java direct dependency can be removed -->
+      <!-- Override the transitive dependency from org.elasticsearch:elasticsearch,
+      replacing the discontinued org.lz4:lz4-java with the maintained fork at.yawk.lz4:lz4-java.
+      This override will remain necessary unless Elasticsearch itself adopts the maintained fork. -->
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>


### PR DESCRIPTION
# Description
Backport of #42369 to `stable/8.7`.

relates to #42364