### PR TITLE
[Backport stable/optimize-8.7] deps: override discontinued LZ4 dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,10 +158,17 @@
     <version.node>v20.12.2</version.node>
     <version.yarn>v1.22.21</version.yarn>
 
+<<<<<<< HEAD
     <version.aws-java-sdk>1.12.772</version.aws-java-sdk>
     <version.elasticsearch-test-container>1.20.1</version.elasticsearch-test-container>
     <version.postgres-test-container>1.20.1</version.postgres-test-container>
     <version.elasticsearch7>7.17.24</version.elasticsearch7>
+=======
+    <version.elasticsearch-test-container>2.0.2</version.elasticsearch-test-container>
+    <version.postgres-test-container>2.0.2</version.postgres-test-container>
+    <version.elasticsearch7>7.17.29</version.elasticsearch7>
+    <version.lz4>1.10.1</version.lz4>
+>>>>>>> 249c946f (deps: override discontinued LZ4 dependency)
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
     <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
@@ -1901,7 +1908,23 @@
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>
         <version>${version.elasticsearch7}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
+<<<<<<< HEAD
+=======
+      <!-- override the transitive dependency from elasticsearch-lz4,
+      once org.elasticsearch:elasticsearch minor or major is bumped up lz4-java direct dependency can be removed -->
+      <dependency>
+        <groupId>at.yawk.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${version.lz4}</version>
+      </dependency>
+>>>>>>> 249c946f (deps: override discontinued LZ4 dependency)
       <dependency>
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch-core</artifactId>


### PR DESCRIPTION
# Description
Backport of #42369 to `stable/optimize-8.7`.

relates to #42364