### PR TITLE
test: set port bindings correctly to 5005:5005 for the jvm debugger

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/RemoteDebugger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/RemoteDebugger.java
@@ -41,7 +41,9 @@ public final class RemoteDebugger {
     // when configuring a port binding, we need to expose the port as well; the port binding just
     // decides to which host port the exposed port will bind, but it will not expose the port itself
     container.addExposedPort(port);
-    container.getPortBindings().add(port + ":" + port);
+    final var portBindings = container.getPortBindings();
+    portBindings.add(port + ":" + port);
+    container.setPortBindings(portBindings);
 
     // prepend agent configuration in front of javaOpts to ensure it's enabled but also keep
     // previously defined options


### PR DESCRIPTION
## Description
The list returned by `getPortBindings` is a copy of the bindings, mutating it does not have any effect. 
As a result, the debugger port was exposed to a random port every time, make it tedious to debug the container.

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
