### PR TITLE
fix: never invalidate written records

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -500,8 +500,6 @@ public final class ProcessingStateMachine {
           currentRecord,
           metadata,
           e);
-      pendingResponses.clear();
-      pendingWrites.clear();
     }
     return false;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -395,6 +395,9 @@ public final class ProcessingStateMachine {
       processedCommandsCount++;
       processingMetrics.commandsProcessed();
     }
+    // We are done with processing, no new writes or responses will be added.
+    pendingWrites = Collections.unmodifiableList(pendingWrites);
+    pendingResponses = Collections.unmodifiableCollection(pendingResponses);
   }
 
   /**


### PR DESCRIPTION
This fixes a potential bug where `pendingWrites` were already handed off to the sequencer for writing but not yet serialized and written to disk, but `tryExitOutOfErrorLoop` encounters an unexpected error and tries to clear the `pendingWrites`. This could lead to an empty log entry being written because the `SequencedBatch` already passed the non-empty check in the sequencer but then doesn't have anything to serialize in the raft layer.
This could lead to corrupted log entries of size 0 which can't be handled properly.

We can avoid the clear of `pendingWrites` and `pendingResponses` because they will be reinitialized on the next processing attempt, for example in `errorHandlingInTransaction`.

This doesn't come with tests because it's not fully clear what would need to happen to trigger an unexpected error in `tryExitOutOfErrorLoop`.

Closes https://github.com/camunda/camunda/issues/43015