### PR TITLE
feat: add resource level authorization for resource type MESSAGE

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -102,6 +102,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             .permissionType(PermissionType.CREATE)
             .tenantId(command.getValue().getTenantId())
             .newResource()
+            .addResourceId(command.getValue().getName())
             .build();
     final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {


### PR DESCRIPTION
To enable a more fine grained authorization for publishing messages.

## Description

<!-- Describe the goal and purpose of this PR. -->
Currently a message can only be published (authorization enabled) when a CREATE MESSAGE authorization with resource id * is created.
To enable a more fine grained authorization the message name could be used as resource id.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->

## Related issues

closes #42473
