### PR TITLE
feat: Support disjunctive authorization checks in the Engine

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -133,8 +133,7 @@ public final class AuthorizationCheckBehavior {
    */
   public Either<Rejection, Void> isAnyAuthorized(final AuthorizationRequest... requests) {
     if (requests == null || requests.length == 0) {
-      return Either.left(
-          new Rejection(RejectionType.FORBIDDEN, "No authorization requests provided"));
+      throw new IllegalArgumentException("No authorization requests provided");
     }
 
     final List<Rejection> rejections = new ArrayList<>();
@@ -168,14 +167,13 @@ public final class AuthorizationCheckBehavior {
    * success if at least one request is authorized (OR/disjunctive logic).
    *
    * @param requests the authorization requests to check (at least one must pass)
-   * @return Either containing a rejection if ALL requests failed, or Void if any succeeded or if
-   *     triggered by an internal command
+   * @return Either containing a rejection (left) if ALL requests failed, or Void (right) if any
+   *     succeeded or if triggered by an internal command
    */
   public Either<Rejection, Void> isAnyAuthorizedOrInternalCommand(
       final AuthorizationRequest... requests) {
     if (requests == null || requests.length == 0) {
-      return Either.left(
-          new Rejection(RejectionType.FORBIDDEN, "No authorization requests provided"));
+      throw new IllegalArgumentException("No authorization requests provided");
     }
 
     // bypass authorization if any request is from an internal command

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -142,7 +142,6 @@ public final class AuthorizationCheckBehavior {
     for (final var request : requests) {
       final var result = isAuthorized(request);
       if (result.isRight()) {
-        // At least one authorization passed, no need to check further
         return Either.right(null);
       }
       rejections.add(result.getLeft());
@@ -160,10 +159,7 @@ public final class AuthorizationCheckBehavior {
    *     Void} if the user is authorized or if triggered by an internal command
    */
   public Either<Rejection, Void> isAuthorizedOrInternalCommand(final AuthorizationRequest request) {
-    if (request.isTriggeredByInternalCommand()) {
-      return Either.right(null);
-    }
-    return isAuthorized(request);
+    return isAnyAuthorizedOrInternalCommand(request);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -214,7 +214,7 @@ public final class AuthorizationCheckBehavior {
       return Either.right(null);
     }
 
-    return RejectionAggregator.aggregate(aggregatedRejections);
+    return Either.left(RejectionAggregator.aggregate(aggregatedRejections));
   }
 
   // Helper methods

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/aggregator/RejectionAggregator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/aggregator/RejectionAggregator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.aggregator;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.authorization.result.AuthorizationRejection;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Aggregates multiple {@link AuthorizationRejection} instances into a single {@link Rejection}. */
+public final class RejectionAggregator {
+
+  private RejectionAggregator() {
+    // utility class
+  }
+
+  /**
+   * Aggregates a list of authorization rejections into a single rejection. Prioritizes permission
+   * rejections first, then tenant rejections, and finally returns the first rejection if no
+   * specific type is found.
+   *
+   * @param rejections the list of collected authorization rejections
+   * @return an {@link Either} containing a {@link Rejection} or {@link Void}
+   */
+  public static Either<Rejection, Void> aggregate(final List<AuthorizationRejection> rejections) {
+    // return permission rejection first, if it exists
+    final var permissionRejections =
+        rejections.stream()
+            .filter(AuthorizationRejection::isPermission)
+            .map(AuthorizationRejection::rejection)
+            .toList();
+    if (!permissionRejections.isEmpty()) {
+      final var reason =
+          permissionRejections.stream()
+              .map(Rejection::reason)
+              .distinct()
+              .collect(Collectors.joining("; "));
+      return Either.left(new Rejection(RejectionType.FORBIDDEN, reason));
+    }
+
+    // if there are tenant rejections, return them
+    final var tenantRejections =
+        rejections.stream()
+            .filter(AuthorizationRejection::isTenant)
+            .map(AuthorizationRejection::rejection)
+            .toList();
+    if (!tenantRejections.isEmpty()) {
+      final var reason =
+          tenantRejections.stream()
+              .map(Rejection::reason)
+              .distinct()
+              .collect(Collectors.joining("; "));
+      // Use the first rejection type (should be FORBIDDEN or NOT_FOUND)
+      return Either.left(new Rejection(tenantRejections.getFirst().type(), reason));
+    }
+
+    // Fallback: return the first rejection if present
+    if (!rejections.isEmpty()) {
+      return Either.left(rejections.getFirst().rejection());
+    }
+
+    // Should not happen, but fallback to forbidden
+    return Either.left(
+        new Rejection(RejectionType.FORBIDDEN, "Authorization failed for unknown reason"));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -924,19 +925,11 @@ final class AuthorizationCheckBehaviorTest {
   }
 
   @Test
-  void isAnyAuthorizedShouldRejectWhenNoRequestsProvided() {
-    // when
-    final var result = authorizationCheckBehavior.isAnyAuthorized();
-
-    // then
-    EitherAssert.assertThat(result)
-        .isLeft()
-        .left()
-        .satisfies(
-            rejection -> {
-              assertThat(rejection.type()).isEqualTo(RejectionType.FORBIDDEN);
-              assertThat(rejection.reason()).isEqualTo("No authorization requests provided");
-            });
+  void isAnyAuthorizedShouldThrowExceptionWhenNoRequestsProvided() {
+    // when - then
+    assertThatThrownBy(() -> authorizationCheckBehavior.isAnyAuthorized())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No authorization requests provided");
   }
 
   @Test
@@ -1081,6 +1074,14 @@ final class AuthorizationCheckBehaviorTest {
 
     // then
     assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void isAnyAuthorizedOrInternalCommandShouldThrowExceptionWhenNoRequestsProvided() {
+    // when - then
+    assertThatThrownBy(() -> authorizationCheckBehavior.isAnyAuthorizedOrInternalCommand())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No authorization requests provided");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleReco
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
@@ -900,6 +901,186 @@ final class AuthorizationCheckBehaviorTest {
 
     // then
     assertThat(authorized.isRight()).isFalse();
+  }
+
+  @Test
+  void isAuthorizedOrInternalCommandShouldBeAuthorizedForInternalCommand() {
+    // given
+    final var command = mock(TypedRecord.class);
+    when(command.isInternalCommand()).thenReturn(true);
+
+    // when
+    final var request =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.READ_DECISION_INSTANCE)
+            .addResourceId(UUID.randomUUID().toString())
+            .build();
+    final var authorized = authorizationCheckBehavior.isAuthorizedOrInternalCommand(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  void isAnyAuthorizedShouldRejectWhenNoRequestsProvided() {
+    // when
+    final var result = authorizationCheckBehavior.isAnyAuthorized();
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .satisfies(
+            rejection -> {
+              assertThat(rejection.type()).isEqualTo(RejectionType.FORBIDDEN);
+              assertThat(rejection.reason()).isEqualTo("No authorization requests provided");
+            });
+  }
+
+  @Test
+  void isAnyAuthorizedShouldBeAuthorizedByFirstRequest() {
+    // given
+    final var user = createUser();
+    final var resourceType1 = AuthorizationResourceType.PROCESS_DEFINITION;
+    final var permissionType1 = PermissionType.READ_USER_TASK;
+    final var resourceIdScope1 = AuthorizationScope.of(UUID.randomUUID().toString());
+    addPermission(
+        user.getUsername(),
+        AuthorizationOwnerType.USER,
+        resourceType1,
+        permissionType1,
+        resourceIdScope1);
+    final var command = mockCommand(user.getUsername());
+    final var processDefinitionReadUserTaskRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(resourceType1)
+            .permissionType(permissionType1)
+            .addResourceId(resourceIdScope1.getResourceId())
+            .build();
+
+    // no USER_TASK[READ] permission added for user
+    final var userTaskReadRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.USER_TASK)
+            .permissionType(PermissionType.READ)
+            .addResourceId(String.valueOf(random.nextLong()))
+            .build();
+
+    // when
+    final var result =
+        authorizationCheckBehavior.isAnyAuthorized(
+            processDefinitionReadUserTaskRequest, userTaskReadRequest);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+  }
+
+  @Test
+  void isAnyAuthorizedShouldBeAuthorizedBySecondRequest() {
+    // given
+    final var user = createUser();
+    final var command = mockCommand(user.getUsername());
+
+    // no PROCESS_DEFINITION[READ_USER_TASK] permission added for user
+    final var processDefinitionReadUserTaskRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.READ_USER_TASK)
+            .addResourceId(UUID.randomUUID().toString())
+            .build();
+
+    final var resourceType = AuthorizationResourceType.USER_TASK;
+    final var permissionType = PermissionType.READ;
+    final var resourceIdScope = AuthorizationScope.id(String.valueOf(random.nextLong()));
+    addPermission(
+        user.getUsername(),
+        AuthorizationOwnerType.USER,
+        resourceType,
+        permissionType,
+        resourceIdScope);
+
+    final var userTaskReadRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(resourceType)
+            .permissionType(permissionType)
+            .addResourceId(resourceIdScope.getResourceId())
+            .build();
+
+    // when
+    final var result =
+        authorizationCheckBehavior.isAnyAuthorized(
+            processDefinitionReadUserTaskRequest, userTaskReadRequest);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+  }
+
+  @Test
+  void isAnyAuthorizedShouldRejectWhenNoRequestIsAuthorized() {
+    // given
+    final var user = createUser();
+    // no permissions added for user
+
+    final var command = mockCommand(user.getUsername());
+    final var processDefinitionReadUserTaskRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.READ_USER_TASK)
+            .addResourceId(UUID.randomUUID().toString())
+            .build();
+    final var userTaskReadRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.USER_TASK)
+            .permissionType(PermissionType.READ)
+            .addResourceId(String.valueOf(random.nextLong()))
+            .build();
+
+    // when
+    final var result =
+        authorizationCheckBehavior.isAnyAuthorized(
+            processDefinitionReadUserTaskRequest, userTaskReadRequest);
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .satisfies(
+            rejection -> {
+              assertThat(rejection.type()).isEqualTo(RejectionType.FORBIDDEN);
+              assertThat(rejection.reason())
+                  .startsWith(
+                      "Insufficient permissions to perform operation 'READ_USER_TASK' on resource 'PROCESS_DEFINITION'")
+                  .contains(
+                      "; and Insufficient permissions to perform operation 'READ' on resource 'USER_TASK'");
+            });
+  }
+
+  @Test
+  void isAnyAuthorizedOrInternalCommandShouldBeAuthorizedForInternalCommand() {
+    // given
+    final var externalCommandRequest =
+        AuthorizationRequest.builder().command(mock(TypedRecord.class)).build();
+
+    final var internalCommand = mock(TypedRecord.class);
+    when(internalCommand.isInternalCommand()).thenReturn(true);
+    final var internalCommandRequest =
+        AuthorizationRequest.builder().command(internalCommand).build();
+
+    // when
+    final var result =
+        authorizationCheckBehavior.isAnyAuthorizedOrInternalCommand(
+            externalCommandRequest, internalCommandRequest);
+
+    // then
+    assertThat(result.isRight()).isTrue();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/aggregator/RejectionAggregatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/aggregator/RejectionAggregatorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.authorization.result.AuthorizationRejection;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RejectionAggregatorTest {
+
+  @Test
+  void shouldPrioritizePermissionRejectionsOverTenantRejections() {
+    // given
+    final var permissionRejection =
+        new AuthorizationRejection.Permission(
+            new Rejection(RejectionType.FORBIDDEN, "permission denied"));
+    final var tenantRejection =
+        new AuthorizationRejection.Tenant(
+            new Rejection(RejectionType.NOT_FOUND, "tenant not found"));
+
+    // when
+    final var result = RejectionAggregator.aggregate(List.of(tenantRejection, permissionRejection));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.getLeft().reason()).isEqualTo("permission denied");
+  }
+
+  @Test
+  void shouldAggregateMultiplePermissionRejections() {
+    // given
+    final var permissionRejection1 =
+        new AuthorizationRejection.Permission(
+            new Rejection(RejectionType.FORBIDDEN, "permission denied 1"));
+    final var permissionRejection2 =
+        new AuthorizationRejection.Permission(
+            new Rejection(RejectionType.FORBIDDEN, "permission denied 2"));
+
+    // when
+    final var result =
+        RejectionAggregator.aggregate(List.of(permissionRejection1, permissionRejection2));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.getLeft().reason()).isEqualTo("permission denied 1; permission denied 2");
+  }
+
+  @Test
+  void shouldDeduplicateIdenticalPermissionRejectionReasons() {
+    // given
+    final var permissionRejection1 =
+        new AuthorizationRejection.Permission(
+            new Rejection(RejectionType.FORBIDDEN, "permission denied"));
+    final var permissionRejection2 =
+        new AuthorizationRejection.Permission(
+            new Rejection(RejectionType.FORBIDDEN, "permission denied"));
+
+    // when
+    final var result =
+        RejectionAggregator.aggregate(List.of(permissionRejection1, permissionRejection2));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.getLeft().reason()).isEqualTo("permission denied");
+  }
+
+  @Test
+  void shouldReturnTenantRejectionWhenNoPermissionRejections() {
+    // given
+    final var tenantRejection =
+        new AuthorizationRejection.Tenant(
+            new Rejection(RejectionType.NOT_FOUND, "tenant not found"));
+
+    // when
+    final var result = RejectionAggregator.aggregate(List.of(tenantRejection));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(result.getLeft().reason()).isEqualTo("tenant not found");
+  }
+
+  @Test
+  void shouldAggregateMultipleTenantRejections() {
+    // given
+    final var tenantRejection1 =
+        new AuthorizationRejection.Tenant(
+            new Rejection(RejectionType.NOT_FOUND, "tenant A not found"));
+    final var tenantRejection2 =
+        new AuthorizationRejection.Tenant(
+            new Rejection(RejectionType.NOT_FOUND, "tenant B not found"));
+
+    // when
+    final var result = RejectionAggregator.aggregate(List.of(tenantRejection1, tenantRejection2));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(result.getLeft().reason()).isEqualTo("tenant A not found; tenant B not found");
+  }
+
+  @Test
+  void shouldDeduplicateIdenticalTenantRejectionReasons() {
+    // given
+    final var tenantRejection1 =
+        new AuthorizationRejection.Tenant(
+            new Rejection(RejectionType.NOT_FOUND, "tenant not found"));
+    final var tenantRejection2 =
+        new AuthorizationRejection.Tenant(
+            new Rejection(RejectionType.NOT_FOUND, "tenant not found"));
+
+    // when
+    final var result = RejectionAggregator.aggregate(List.of(tenantRejection1, tenantRejection2));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(result.getLeft().reason()).isEqualTo("tenant not found");
+  }
+
+  @Test
+  void shouldReturnFallbackRejectionForEmptyList() {
+    // when
+    final var result = RejectionAggregator.aggregate(List.of());
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.getLeft().reason()).isEqualTo("Authorization failed for unknown reason");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/aggregator/RejectionAggregatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/aggregator/RejectionAggregatorTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.identity.authorization.aggregator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.result.AuthorizationRejection;
@@ -31,9 +32,8 @@ class RejectionAggregatorTest {
     final var result = RejectionAggregator.aggregate(List.of(tenantRejection, permissionRejection));
 
     // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
-    assertThat(result.getLeft().reason()).isEqualTo("permission denied");
+    assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.reason()).isEqualTo("permission denied");
   }
 
   @Test
@@ -51,9 +51,8 @@ class RejectionAggregatorTest {
         RejectionAggregator.aggregate(List.of(permissionRejection1, permissionRejection2));
 
     // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
-    assertThat(result.getLeft().reason()).isEqualTo("permission denied 1; permission denied 2");
+    assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.reason()).isEqualTo("permission denied 1; permission denied 2");
   }
 
   @Test
@@ -71,9 +70,8 @@ class RejectionAggregatorTest {
         RejectionAggregator.aggregate(List.of(permissionRejection1, permissionRejection2));
 
     // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
-    assertThat(result.getLeft().reason()).isEqualTo("permission denied");
+    assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.reason()).isEqualTo("permission denied");
   }
 
   @Test
@@ -87,9 +85,8 @@ class RejectionAggregatorTest {
     final var result = RejectionAggregator.aggregate(List.of(tenantRejection));
 
     // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(result.getLeft().reason()).isEqualTo("tenant not found");
+    assertThat(result.type()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(result.reason()).isEqualTo("tenant not found");
   }
 
   @Test
@@ -106,9 +103,8 @@ class RejectionAggregatorTest {
     final var result = RejectionAggregator.aggregate(List.of(tenantRejection1, tenantRejection2));
 
     // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(result.getLeft().reason()).isEqualTo("tenant A not found; tenant B not found");
+    assertThat(result.type()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(result.reason()).isEqualTo("tenant A not found; tenant B not found");
   }
 
   @Test
@@ -125,20 +121,16 @@ class RejectionAggregatorTest {
     final var result = RejectionAggregator.aggregate(List.of(tenantRejection1, tenantRejection2));
 
     // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(result.getLeft().reason()).isEqualTo("tenant not found");
+    assertThat(result.type()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(result.reason()).isEqualTo("tenant not found");
   }
 
   @Test
-  void shouldReturnFallbackRejectionForEmptyList() {
-    // when
-    final var result = RejectionAggregator.aggregate(List.of());
-
-    // then
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
-    assertThat(result.getLeft().reason()).isEqualTo("Authorization failed for unknown reason");
+  void aggregateShouldThrowExceptionForEmptyList() {
+    // when / then
+    assertThatThrownBy(() -> RejectionAggregator.aggregate(List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot aggregate empty list of authorization rejections");
   }
 
   @Test
@@ -217,12 +209,10 @@ class RejectionAggregatorTest {
   }
 
   @Test
-  void aggregateCompositeShouldReturnFallbackForEmptyList() {
+  void aggregateCompositeShouldThrowExceptionForEmptyList() {
     // when
-    final var result = RejectionAggregator.aggregateComposite(List.of());
-
-    // then
-    assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
-    assertThat(result.reason()).isEqualTo("Authorization failed for unknown reason");
+    assertThatThrownBy(() -> RejectionAggregator.aggregateComposite(List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot aggregate empty list of rejections");
   }
 }


### PR DESCRIPTION
## Description

This PR introduces support for disjunctive (OR) authorization checks in the Zeebe Engine, enabling scenarios where a user needs to be authorized through at least one of multiple possible authorization paths. 

### Changes

1. (Refactoring) Extracted `RejectionAggregator` - extracted rejection aggregation logic from `AuthorizationCheckBehavior` into a dedicated utility class with:
   - `aggregate()` - Combines rejections for single authorization checks (existing logic)
   - `aggregateComposite()` - Combines rejections from multiple authorization paths using `"; and "` separator

2. Added new authorization methods to `AuthorizationCheckBehavior`:
   - `isAnyAuthorized(AuthorizationRequest...)` - Returns success if any request is authorized
   - `isAnyAuthorizedOrInternalCommand(AuthorizationRequest...)` - Same as above but bypasses auth for internal commands

### Example usage

```java
// User can read a user task if they have EITHER: 
// - READ_USER_TASK permission on the process definition, OR
// - READ user task
authorizationCheckBehavior.isAnyAuthorized(
    AuthorizationRequest.builder()
        .command(command)
        .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
        .permissionType(PermissionType.READ_USER_TASK)
        .addResourceId(processDefinitionId)
        .build(),
    AuthorizationRequest.builder()
        .command(command)
        .resourceType(AuthorizationResourceType.USER_TASK)
        .permissionType(PermissionType.READ)
        .resourceProperties(...)
        .build()
);
```

## Related issues

closes #40112
