### PR TITLE
feat: audit: added decision evaluation handler

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -125,6 +126,9 @@ public record AuditLogInfo(
       case BatchOperationIntent.CANCELED:
       case BatchOperationIntent.CANCEL:
         return AuditLogOperationType.CANCEL;
+      case DecisionEvaluationIntent.EVALUATED:
+      case DecisionEvaluationIntent.FAILED:
+        return AuditLogOperationType.EVALUATE;
       case ProcessInstanceCreationIntent.CREATED:
         return AuditLogOperationType.CREATE;
       case ProcessInstanceModificationIntent.MODIFIED:

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
+import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MIGRATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION;
@@ -17,6 +18,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificatio
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer.TransformerConfig;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import java.util.Set;
@@ -37,6 +39,10 @@ public class AuditLogTransformerConfigs {
               BatchOperationIntent.SUSPEND,
               BatchOperationIntent.CANCEL),
           Set.of(RejectionType.INVALID_STATE));
+
+  public static final TransformerConfig DECISION_EVALUATION_CONFIG =
+      TransformerConfig.with(DECISION_EVALUATION)
+          .withIntents(DecisionEvaluationIntent.EVALUATED, DecisionEvaluationIntent.FAILED);
 
   public static final TransformerConfig PROCESS_INSTANCE_CREATION_CONFIG =
       TransformerConfig.with(PROCESS_INSTANCE_CREATION)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -69,6 +69,7 @@ import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.exporter.handlers.auditlog.AuditLogHandler;
 import io.camunda.exporter.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
+import io.camunda.exporter.handlers.auditlog.DecisionEvaluationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.ProcessInstanceCreationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.ProcessInstanceMigrationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.ProcessInstanceModificationAuditLogTransformer;
@@ -452,6 +453,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       AuditLogHandler.builder(indexName, auditLog)
           .addHandler(new BatchOperationCreationAuditLogTransformer())
           .addHandler(new BatchOperationLifecycleManagementAuditLogTransformer())
+          .addHandler(new DecisionEvaluationAuditLogTransformer())
           .addHandler(new ProcessInstanceCreationAuditLogTransformer())
           .addHandler(new ProcessInstanceMigrationAuditLogTransformer())
           .addHandler(new ProcessInstanceModificationAuditLogTransformer())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/DecisionEvaluationAuditLogTransformer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogOperationResult;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import java.util.List;
+import java.util.Optional;
+
+public class DecisionEvaluationAuditLogTransformer
+    implements AuditLogTransformer<DecisionEvaluationRecordValue, AuditLogEntity> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.DECISION_EVALUATION_CONFIG;
+  }
+
+  @Override
+  public void transform(
+      final Record<DecisionEvaluationRecordValue> record, final AuditLogEntity entity) {
+    final var value = record.getValue();
+    entity.setDecisionDefinitionId(value.getDecisionId());
+    entity.setDecisionDefinitionKey(value.getDecisionKey());
+    entity.setDecisionRequirementsId(value.getDecisionRequirementsId());
+    entity.setDecisionRequirementsKey(value.getDecisionRequirementsKey());
+    entity.setDecisionEvaluationKey(
+        Optional.ofNullable(value.getEvaluatedDecisions())
+            .filter(list -> !list.isEmpty())
+            .map(List::getFirst)
+            .map(EvaluatedDecisionValue::getDecisionKey)
+            .orElse(null));
+    entity.setTenantId(value.getTenantId());
+    entity.setTenantScope(AuditLogTenantScope.TENANT);
+    if (record.getIntent() == DecisionEvaluationIntent.FAILED) {
+      entity.setResult(AuditLogOperationResult.FAIL);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -161,6 +161,7 @@ public class DefaultExporterResourceProviderTest {
         Set.of(
             ValueType.BATCH_OPERATION_CREATION,
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            ValueType.DECISION_EVALUATION,
             ValueType.PROCESS_INSTANCE_CREATION,
             ValueType.PROCESS_INSTANCE_MIGRATION,
             ValueType.PROCESS_INSTANCE_MODIFICATION);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/DecisionEvaluationAuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/DecisionEvaluationAuditLogHandlerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogOperationResult;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableEvaluatedDecisionValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DecisionEvaluationAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final DecisionEvaluationAuditLogTransformer transformer =
+      new DecisionEvaluationAuditLogTransformer();
+
+  @Test
+  void shouldTransformDecisionEvaluationRecord() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withDecisionRequirementsId("drg-1")
+            .withDecisionRequirementsKey(789L)
+            .withTenantId("tenant-1")
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionDefinitionId()).isEqualTo("decision-1");
+    assertThat(entity.getDecisionDefinitionKey()).isEqualTo(456L);
+    assertThat(entity.getDecisionRequirementsId()).isEqualTo("drg-1");
+    assertThat(entity.getDecisionRequirementsKey()).isEqualTo(789L);
+    assertThat(entity.getTenantId()).isEqualTo("tenant-1");
+    assertThat(entity.getTenantScope()).isEqualTo(AuditLogTenantScope.TENANT);
+  }
+
+  @Test
+  void shouldHandleNullEvaluatedDecisions() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionEvaluationKey()).isNull();
+  }
+
+  @Test
+  void shouldHandleEmptyEvaluatedDecisions() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(Collections.emptyList())
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionEvaluationKey()).isNull();
+  }
+
+  @Test
+  void shouldExtractDecisionEvaluationKeyFromSingleEvaluatedDecision() {
+    // given
+    final ImmutableEvaluatedDecisionValue evaluatedDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(999L)
+            .build();
+
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(List.of(evaluatedDecision))
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionEvaluationKey()).isEqualTo(999L);
+  }
+
+  @Test
+  void shouldExtractDecisionEvaluationKeyFromFirstOfMultipleEvaluatedDecisions() {
+    // given
+    final ImmutableEvaluatedDecisionValue firstDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(111L)
+            .build();
+
+    final ImmutableEvaluatedDecisionValue secondDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(222L)
+            .build();
+
+    final ImmutableEvaluatedDecisionValue thirdDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(333L)
+            .build();
+
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(List.of(firstDecision, secondDecision, thirdDecision))
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionEvaluationKey()).isEqualTo(111L);
+  }
+
+  @Test
+  void shouldSetResultToFailWhenIntentIsFailed() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.FAILED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getResult()).isEqualTo(AuditLogOperationResult.FAIL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -41,6 +41,7 @@ import io.camunda.exporter.rdbms.handlers.VariableExportHandler;
 import io.camunda.exporter.rdbms.handlers.auditlog.AuditLogExportHandler;
 import io.camunda.exporter.rdbms.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
+import io.camunda.exporter.rdbms.handlers.auditlog.DecisionEvaluationAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.ProcessInstanceCreationAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.ProcessInstanceMigrationAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.ProcessInstanceModificationAuditLogTransformer;
@@ -277,6 +278,7 @@ public class RdbmsExporterWrapper implements Exporter {
     Set.of(
             new BatchOperationCreationAuditLogTransformer(),
             new BatchOperationLifecycleManagementAuditLogTransformer(),
+            new DecisionEvaluationAuditLogTransformer(),
             new ProcessInstanceCreationAuditLogTransformer(),
             new ProcessInstanceMigrationAuditLogTransformer(),
             new ProcessInstanceModificationAuditLogTransformer())

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/DecisionEvaluationAuditLogTransformer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel.Builder;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
+import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import java.util.List;
+import java.util.Optional;
+
+public class DecisionEvaluationAuditLogTransformer
+    implements AuditLogTransformer<DecisionEvaluationRecordValue, Builder> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.DECISION_EVALUATION_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<DecisionEvaluationRecordValue> record, final Builder entity) {
+    final var value = record.getValue();
+    entity.decisionDefinitionId(value.getDecisionId());
+    entity.decisionDefinitionKey(value.getDecisionKey());
+    entity.decisionRequirementsId(value.getDecisionRequirementsId());
+    entity.decisionRequirementsKey(value.getDecisionRequirementsKey());
+    entity.decisionEvaluationKey(
+        Optional.ofNullable(value.getEvaluatedDecisions())
+            .filter(list -> !list.isEmpty())
+            .map(List::getFirst)
+            .map(EvaluatedDecisionValue::getDecisionKey)
+            .orElse(null));
+    entity.tenantId(value.getTenantId());
+    entity.tenantScope(AuditLogTenantScope.TENANT);
+    if (record.getIntent() == DecisionEvaluationIntent.FAILED) {
+      entity.result(AuditLogOperationResult.FAIL);
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -77,6 +77,7 @@ class RdbmsExporterWrapperTest {
         Set.of(
             ValueType.BATCH_OPERATION_CREATION,
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            ValueType.DECISION_EVALUATION,
             ValueType.PROCESS_INSTANCE_CREATION,
             ValueType.PROCESS_INSTANCE_MIGRATION,
             ValueType.PROCESS_INSTANCE_MODIFICATION);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/DecisionEvaluationAuditLogHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/DecisionEvaluationAuditLogHandlerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
+import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableEvaluatedDecisionValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DecisionEvaluationAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final DecisionEvaluationAuditLogTransformer transformer =
+      new DecisionEvaluationAuditLogTransformer();
+
+  @Test
+  void shouldTransformDecisionEvaluationRecord() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withDecisionRequirementsId("drg-1")
+            .withDecisionRequirementsKey(789L)
+            .withTenantId("tenant-1")
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.decisionDefinitionId()).isEqualTo("decision-1");
+    assertThat(entity.decisionDefinitionKey()).isEqualTo(456L);
+    assertThat(entity.decisionRequirementsId()).isEqualTo("drg-1");
+    assertThat(entity.decisionRequirementsKey()).isEqualTo(789L);
+    assertThat(entity.tenantId()).isEqualTo("tenant-1");
+    assertThat(entity.tenantScope()).isEqualTo(AuditLogTenantScope.TENANT);
+  }
+
+  @Test
+  void shouldHandleNullEvaluatedDecisions() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.decisionEvaluationKey()).isNull();
+  }
+
+  @Test
+  void shouldHandleEmptyEvaluatedDecisions() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(Collections.emptyList())
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.decisionEvaluationKey()).isNull();
+  }
+
+  @Test
+  void shouldExtractDecisionEvaluationKeyFromSingleEvaluatedDecision() {
+    // given
+    final ImmutableEvaluatedDecisionValue evaluatedDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(999L)
+            .build();
+
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(List.of(evaluatedDecision))
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.decisionEvaluationKey()).isEqualTo(999L);
+  }
+
+  @Test
+  void shouldExtractDecisionEvaluationKeyFromFirstOfMultipleEvaluatedDecisions() {
+    // given
+    final ImmutableEvaluatedDecisionValue firstDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(111L)
+            .build();
+
+    final ImmutableEvaluatedDecisionValue secondDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(222L)
+            .build();
+
+    final ImmutableEvaluatedDecisionValue thirdDecision =
+        ImmutableEvaluatedDecisionValue.builder()
+            .from(factory.generateObject(EvaluatedDecisionValue.class))
+            .withDecisionKey(333L)
+            .build();
+
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .withEvaluatedDecisions(List.of(firstDecision, secondDecision, thirdDecision))
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.EVALUATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.decisionEvaluationKey()).isEqualTo(111L);
+  }
+
+  @Test
+  void shouldSetResultToFailWhenIntentIsFailed() {
+    // given
+    final DecisionEvaluationRecordValue recordValue =
+        ImmutableDecisionEvaluationRecordValue.builder()
+            .from(factory.generateObject(DecisionEvaluationRecordValue.class))
+            .withDecisionId("decision-1")
+            .withDecisionKey(456L)
+            .build();
+
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_EVALUATION,
+            r -> r.withIntent(DecisionEvaluationIntent.FAILED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.result()).isEqualTo(AuditLogOperationResult.FAIL);
+  }
+}


### PR DESCRIPTION
## Description

feat: audit: added decision evaluation handler

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41152
