### PR TITLE
build: merge back the optimize 8.6.22 release branch

### DIFF
--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22</version>
+    <version>8.6.23-SNAPSHOT</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22-SNAPSHOT</version>
+    <version>8.6.22</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22-SNAPSHOT</version>
+    <version>8.6.22</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22</version>
+    <version>8.6.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22-SNAPSHOT</version>
+    <version>8.6.22</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22</version>
+    <version>8.6.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -14,7 +14,7 @@
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.6.32</zeebe.version>
+    <zeebe.version>8.6.33</zeebe.version>
     <identity.version>8.6.23</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.6.22</version>
+  <version>8.6.23-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -797,7 +797,7 @@
     <developerConnection>
       scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git
     </developerConnection>
-    <tag>8.6.22-optimize</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.6.22-SNAPSHOT</version>
+  <version>8.6.22</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -797,7 +797,7 @@
     <developerConnection>
       scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git
     </developerConnection>
-    <tag>HEAD</tag>
+    <tag>8.6.22-optimize</tag>
   </scm>
 
   <issueManagement>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22</version>
+    <version>8.6.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.6.22-SNAPSHOT</version>
+    <version>8.6.22</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8622To8623PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8622To8623PlanFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.upgrade.plan.factories;
+
+import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
+import io.camunda.optimize.upgrade.plan.UpgradePlan;
+import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Upgrade8622To8623PlanFactory implements UpgradePlanFactory {
+
+  @Override
+  public UpgradePlan createUpgradePlan(final UpgradeExecutionDependencies dependencies) {
+    return UpgradePlanBuilder.createUpgradePlan().fromVersion("8.6.22").toVersion("8.6.23").build();
+  }
+
+  @Override
+  public void logErrorMessage(final String message) {
+    log.error(message);
+  }
+}

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.6.22-SNAPSHOT</version>
+    <version>8.6.22</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.6.22</version>
+    <version>8.6.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.6.22</version>
+        <version>8.6.23-SNAPSHOT</version>
     </parent>
 
     <artifactId>util</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.6.22-SNAPSHOT</version>
+        <version>8.6.22</version>
     </parent>
 
     <artifactId>util</artifactId>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Merge the Optimize release 8.6.22 changes back to the stable/optimize-8.6.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
