### PR TITLE
test: migrate multiInstanceSelection.spec.ts to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -19,6 +19,8 @@ export class OperateDiagramPage {
   readonly metadataModal: Locator;
   readonly metadataModalCloseButton: Locator;
   readonly monacoScrollableElement: Locator;
+  readonly showIncidentButton: Locator;
+  readonly showMetadataButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -36,6 +38,12 @@ export class OperateDiagramPage {
     this.monacoScrollableElement = this.metadataModal.locator(
       '.monaco-scrollable-element',
     );
+    this.showIncidentButton = this.popover.getByRole('button', {
+      name: /show incident/i,
+    });
+    this.showMetadataButton = this.popover.getByRole('button', {
+      name: 'show more metadata',
+    });
   }
 
   async moveCanvasHorizontally(dx: number) {
@@ -93,10 +101,32 @@ export class OperateDiagramPage {
     return this.diagram.locator(`[data-element-id="${eventId}"]`);
   }
 
-  showMetaData() {
-    return this.popover
-      .getByRole('button', {name: 'show more metadata'})
-      .click();
+  async clickShowMetaData() {
+    await this.showMetadataButton.click();
+  }
+
+  async clickShowIncident() {
+    await this.showIncidentButton.click();
+  }
+
+  getPopoverButton(name: string | RegExp) {
+    return this.popover.getByRole('button', {name});
+  }
+
+  getPopoverText(text: string | RegExp): Locator {
+    return this.popover.getByText(text);
+  }
+
+  getIncidentsOverlay(elementId: string): Locator {
+    return this.diagram.locator(
+      `[data-container-id="${elementId}"] [data-testid="state-overlay-incidents"] span`,
+    );
+  }
+
+  getExecutionCountOverlay(elementId: string): Locator {
+    return this.diagram.locator(
+      `[data-container-id="${elementId}"] [data-testid="state-overlay-completed"][title="Execution Count"] span`,
+    );
   }
 
   getExecutionCount(elementId: string) {
@@ -131,7 +161,7 @@ export class OperateDiagramPage {
     } else {
       await this.clickFlowNode(flowNodeId);
     }
-    await this.showMetaData();
+    await this.clickShowMetaData();
 
     await this.monacoAriaContainer.waitFor({state: 'visible'});
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -56,4 +56,32 @@ export class OperateOperationPanelPage {
       operationEntry,
     ).innerText();
   }
+
+  getMigrationOperationEntry(successCount: number): Locator {
+    return this.page
+      .locator('[data-testid="operations-entry"]')
+      .filter({hasText: 'Migrate'})
+      .filter({hasText: `${successCount} operations succeeded`});
+  }
+
+  getRetryOperationEntry(successCount: number): Locator {
+    return this.page
+      .locator('[data-testid="operations-entry"]')
+      .filter({hasText: 'Retry'})
+      .filter({hasText: `${successCount} retries succeeded`})
+      .first();
+  }
+
+  getCancelOperationEntry(successCount: number): Locator {
+    return this.page
+      .locator('[data-testid="operations-entry"]')
+      .filter({hasText: 'Cancel'})
+      .filter({hasText: `${successCount} operations succeeded`});
+  }
+
+  async clickOperationLink(operationEntry: Locator): Promise<void> {
+    await operationEntry
+      .locator('[data-testid="operation-id"]')
+      .click({timeout: 30000});
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -58,6 +58,7 @@ class OperateProcessInstancePage {
   readonly incidentBannerButton: (count: number) => Locator;
   readonly incidentTypeFilter: Locator;
   readonly executionCountToggle: Locator;
+  readonly executionCountToggleButton: Locator;
   readonly endDateField: Locator;
   readonly incidentsViewHeader: Locator;
 
@@ -143,6 +144,9 @@ class OperateProcessInstancePage {
     this.executionCountToggle = this.instanceHistory.locator(
       '[aria-label="show execution count"], [aria-label="hide execution count"]',
     );
+    this.executionCountToggleButton = this.instanceHistory.locator(
+      'button[aria-label="Execution count"][role="switch"]',
+    );
     this.endDateField = this.instanceHeader.getByTestId('end-date');
     this.incidentsViewHeader = page.getByText(/incidents\s+-\s+/i);
   }
@@ -210,6 +214,14 @@ class OperateProcessInstancePage {
   ) => {
     return this.listenerTypeFilter.getByText(option, {exact: true});
   };
+
+  getExecutionListenerText(exact = false): Locator {
+    return this.page.getByText('Execution listener', {exact});
+  }
+
+  getTaskListenerText(exact = false): Locator {
+    return this.page.getByText('Task listener', {exact});
+  }
 
   async undoModification() {
     await this.page
@@ -413,18 +425,19 @@ class OperateProcessInstancePage {
   }
 
   async toggleExecutionCount(): Promise<void> {
-    const toggleButton = this.instanceHistory.locator(
-      'button[aria-label="Execution count"][role="switch"]',
-    );
-
-    await toggleButton.waitFor({state: 'visible'});
-    const isChecked = await toggleButton.getAttribute('aria-checked');
+    await this.executionCountToggleButton.waitFor({state: 'visible'});
+    const isChecked =
+      await this.executionCountToggleButton.getAttribute('aria-checked');
 
     if (isChecked === 'false') {
-      await toggleButton.click({force: true});
-      await expect(toggleButton).toHaveAttribute('aria-checked', 'true', {
-        timeout: 5000,
-      });
+      await this.executionCountToggleButton.click({force: true});
+      await expect(this.executionCountToggleButton).toHaveAttribute(
+        'aria-checked',
+        'true',
+        {
+          timeout: 5000,
+        },
+      );
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -461,27 +461,6 @@ class OperateProcessesPage {
       .filter({hasText: 'Migrate'})
       .filter({hasText: `${successCount} operations succeeded`});
   }
-
-  getRetryOperationEntry(successCount: number): Locator {
-    return this.page
-      .locator('[data-testid="operations-entry"]')
-      .filter({hasText: 'Retry'})
-      .filter({hasText: `${successCount} retries succeeded`})
-      .first();
-  }
-
-  getCancelOperationEntry(successCount: number): Locator {
-    return this.page
-      .locator('[data-testid="operations-entry"]')
-      .filter({hasText: 'Cancel'})
-      .filter({hasText: `${successCount} operations succeeded`});
-  }
-
-  async clickOperationLink(operationEntry: Locator): Promise<void> {
-    await operationEntry
-      .locator('[data-testid="operation-id"]')
-      .click({timeout: 30000});
-  }
 }
 
 export {OperateProcessesPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/multiInstanceProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/multiInstanceProcess.bpmn
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0dkpwbm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+  <bpmn:process id="multiInstanceProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0wumr00</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0wumr00" sourceRef="StartEvent_1" targetRef="taskA" />
+    <bpmn:serviceTask id="taskB" name="Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="multiInstanceProcessTaskB" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1jeebm1</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=clients" inputElement="client" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="taskA" name="Task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="multiInstanceProcessTaskA" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0wumr00</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1gi2xny</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0j3eksh</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0j3eksh" sourceRef="taskA" targetRef="ExclusiveGateway_0cjcl1k" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_0cjcl1k" name="Continue?">
+      <bpmn:incoming>SequenceFlow_0j3eksh</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1jeebm1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_07u0xkc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1jeebm1" name="yes" sourceRef="ExclusiveGateway_0cjcl1k" targetRef="taskB">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=i&lt;=loopCardinality</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_02f1al1">
+      <bpmn:incoming>SequenceFlow_07u0xkc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_07u0xkc" name="no" sourceRef="ExclusiveGateway_0cjcl1k" targetRef="EndEvent_02f1al1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=i&gt;loopCardinality</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:boundaryEvent id="Event_06lbs4q" cancelActivity="false" attachedToRef="taskB">
+      <bpmn:outgoing>SequenceFlow_1gi2xny</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0qjwf46">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1gi2xny" sourceRef="Event_06lbs4q" targetRef="taskA" />
+  </bpmn:process>
+  <bpmn:error id="Error_06pg7eb" name="taskBFailed" errorCode="taskBFailed" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multiInstanceProcess">
+      <bpmndi:BPMNEdge id="SequenceFlow_07u0xkc_di" bpmnElement="SequenceFlow_07u0xkc">
+        <di:waypoint x="540" y="195" />
+        <di:waypoint x="540" y="350" />
+        <di:waypoint x="692" y="350" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="549" y="270" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gi2xny_di" bpmnElement="SequenceFlow_1gi2xny">
+        <di:waypoint x="730" y="112" />
+        <di:waypoint x="730" y="80" />
+        <di:waypoint x="380" y="80" />
+        <di:waypoint x="380" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jeebm1_di" bpmnElement="SequenceFlow_1jeebm1">
+        <di:waypoint x="565" y="170" />
+        <di:waypoint x="670" y="170" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="609" y="152" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j3eksh_di" bpmnElement="SequenceFlow_0j3eksh">
+        <di:waypoint x="430" y="170" />
+        <di:waypoint x="515" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wumr00_di" bpmnElement="SequenceFlow_0wumr00">
+        <di:waypoint x="178" y="170" />
+        <di:waypoint x="330" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="142" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0cjcl1k_di" bpmnElement="ExclusiveGateway_0cjcl1k" isMarkerVisible="true">
+        <dc:Bounds x="515" y="145" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="514" y="133" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_02f1al1_di" bpmnElement="EndEvent_02f1al1">
+        <dc:Bounds x="692" y="332" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0s6kryf_di" bpmnElement="taskA">
+        <dc:Bounds x="330" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_185s3ko_di" bpmnElement="taskB">
+        <dc:Bounds x="670" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0x66g4j_di" bpmnElement="Event_06lbs4q">
+        <dc:Bounds x="712" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForIncidents} from 'utils/incidentsHelper';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let multiInstanceProcessInstance: ProcessInstance;
+
+test.beforeAll(async ({request}) => {
+  await deploy(['./resources/multiInstanceProcess.bpmn']);
+
+  createWorker('multiInstanceProcessTaskA', false, {}, (job) => {
+    return job.complete({i: Number(job.variables.i) + 1});
+  });
+
+  createWorker('multiInstanceProcessTaskB', true);
+
+  multiInstanceProcessInstance = await createSingleInstance(
+    'multiInstanceProcess',
+    1,
+    {
+      i: 0,
+      loopCardinality: 5,
+      clients: [0, 1, 2, 3, 4],
+    },
+  );
+
+  await waitForIncidents(
+    request,
+    multiInstanceProcessInstance.processInstanceKey,
+    25,
+  );
+});
+
+test.describe('Multi Instance Flow Node Selection', () => {
+  test.beforeEach(
+    async ({page, loginPage, operateHomePage, operateProcessInstancePage}) => {
+      await navigateToApp(page, 'operate');
+      await loginPage.login('demo', 'demo');
+      await expect(operateHomePage.operateBanner).toBeVisible();
+
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: multiInstanceProcessInstance.processInstanceKey,
+      });
+    },
+  );
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('expand multi instance flow nodes in instance history', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Verify that the process instance is selected by default', async () => {
+      await expect(
+        operateProcessInstancePage.getSelectedTreeItemsInHistory(
+          /multiInstanceProcess/,
+        ),
+      ).toHaveAttribute('aria-label', 'multiInstanceProcess');
+    });
+
+    await test.step('Unfold 2x Task B (Multi Instance)', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+    });
+
+    await test.step('Verify 10x Task B visible', async () => {
+      await expect(
+        operateProcessInstancePage.findTreeItemInHistory('Task B'),
+      ).toHaveCount(2 * 5);
+    });
+  });
+
+  test('select flow node in diagram', async ({
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    await test.step('Expand and click on Task B flow node', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+      await operateProcessInstancePage
+        .findTreeItemInHistory(/^task b \(multi instance\)$/i)
+        .first()
+        .click();
+    });
+
+    await test.step('Verify 5 child Task B instances are visible', async () => {
+      await expect(
+        operateProcessInstancePage.findTreeItemInHistory(/^task b$/i),
+      ).toHaveCount(5);
+    });
+
+    await test.step('Enable execution count toggle', async () => {
+      await operateProcessInstancePage.toggleExecutionCount();
+    });
+
+    await test.step('Verify Task B shows 25 incidents overlay', async () => {
+      await expect(operateDiagramPage.getIncidentsOverlay('taskB')).toHaveText(
+        '25',
+      );
+    });
+
+    await test.step('Verify multi-instance timer event shows execution count of 5', async () => {
+      await expect(
+        operateDiagramPage.getExecutionCountOverlay('Event_06lbs4q'),
+      ).toHaveText('5');
+    });
+
+    await test.step('Verify incidents banner shows 25 incidents', async () => {
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+      await expect(operateProcessInstancePage.incidentsBanner).toContainText(
+        '25 Incidents occurred',
+      );
+    });
+
+    await test.step('Click incidents banner to open incidents table', async () => {
+      await operateProcessInstancePage.incidentsBanner.click();
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toContainText(/Incidents\s+-\s+25 results/i);
+    });
+
+    await test.step('Verify incident table shows 25 "No retries left" errors', async () => {
+      await expect(
+        operateProcessInstancePage.getIncidentRow(/Job: No retries left/i),
+      ).toHaveCount(25);
+    });
+  });
+
+  test('select single task', async ({
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    await test.step('Select a single Task B instance', async () => {
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        /^task b \(multi instance\)$/i,
+      );
+      await operateProcessInstancePage
+        .findTreeItemInHistory(/^task b$/i)
+        .first()
+        .click();
+    });
+
+    await test.step('Verify metadata popover shows flow node instance details', async () => {
+      await expect(
+        operateDiagramPage.getPopoverText(/element instance key/i),
+      ).toBeVisible();
+    });
+
+    await test.step('Open incident table and verify one incident is selected', async () => {
+      await operateDiagramPage.clickShowIncident();
+
+      await expect(
+        operateProcessInstancePage.getIncidentRow(/Job: No retries left/i),
+      ).toHaveCount(1);
+      await expect(
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /Job: No retries left/i,
+        ),
+      ).toHaveCount(1);
+
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toContainText(/Incidents\s+-\s+Filtered by "Task B"\s+-\s+1 result/i);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -19,6 +19,9 @@ type ProcessInstance = {
 
 let multiInstanceProcessInstance: ProcessInstance;
 
+const LOOP_CARDINALITY = 5;
+const EXPANSIONS_COUNT = 2;
+
 test.beforeAll(async ({request}) => {
   await deploy(['./resources/multiInstanceProcess.bpmn']);
 
@@ -41,6 +44,7 @@ test.beforeAll(async ({request}) => {
   await waitForIncidents(
     request,
     multiInstanceProcessInstance.processInstanceKey,
+    'taskB',
     25,
   );
 });
@@ -86,7 +90,7 @@ test.describe('Multi Instance Flow Node Selection', () => {
     await test.step('Verify 10x Task B visible', async () => {
       await expect(
         operateProcessInstancePage.findTreeItemInHistory('Task B'),
-      ).toHaveCount(2 * 5);
+      ).toHaveCount(EXPANSIONS_COUNT * LOOP_CARDINALITY);
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -143,14 +143,15 @@ test.describe('Operations', () => {
 
       await expect(operateOperationPanelPage.operationList).toBeVisible();
 
-      const operationEntry = operateProcessesPage.getCancelOperationEntry(1);
+      const operationEntry =
+        operateOperationPanelPage.getCancelOperationEntry(1);
 
       await expect(operationEntry).toBeVisible();
       await expect(operationEntry.getByText(DATE_REGEX)).toBeVisible();
 
       const operationId = await operationEntry.getByRole('link').innerText();
 
-      await operateProcessesPage.clickOperationLink(operationEntry);
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
       await expect(operateFiltersPanelPage.operationIdFilter).toHaveValue(
         operationId,
       );
@@ -221,13 +222,13 @@ test.describe('Operations', () => {
     });
 
     await test.step('Wait for operation to complete', async () => {
-      const operationEntry = operateProcessesPage.getRetryOperationEntry(
+      const operationEntry = operateOperationPanelPage.getRetryOperationEntry(
         instances.length,
       );
 
       await expect(operationEntry).toBeVisible({timeout: 120000});
 
-      await operateProcessesPage.clickOperationLink(operationEntry);
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
 
       await validateURL(page, /operationId=/);
 
@@ -272,7 +273,7 @@ test.describe('Operations', () => {
         })
         .toBe(instances.length);
 
-      const operationEntry = operateProcessesPage.getCancelOperationEntry(
+      const operationEntry = operateOperationPanelPage.getCancelOperationEntry(
         instances.length,
       );
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -110,9 +110,12 @@ test.describe('Process Instance', () => {
         ),
       ).toBeVisible();
 
-      await expect(
-        operateProcessInstancePage.incidentsTableOperationSpinner,
-      ).not.toBeVisible();
+      await expect
+        .poll(
+          async () =>
+            await operateProcessInstancePage.incidentsTableOperationSpinner.isVisible(),
+        )
+        .toBe(false);
 
       await expect(operateProcessInstancePage.incidentsTableRows).toHaveCount(
         1,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -238,11 +238,9 @@ test.describe('Process Instance Listeners', () => {
         .getListenerTypeFilterOption('Execution listeners')
         .click();
       await expect(
-        operateProcessInstancePage.getExecutionListenerText(true),
+        operateProcessInstancePage.executionListenerText,
       ).toBeVisible();
-      await expect(
-        operateProcessInstancePage.getTaskListenerText(true),
-      ).toBeHidden();
+      await expect(operateProcessInstancePage.taskListenerText).toBeHidden();
     });
 
     await test.step('Filter to show only user task listeners', async () => {
@@ -250,11 +248,9 @@ test.describe('Process Instance Listeners', () => {
       await operateProcessInstancePage
         .getListenerTypeFilterOption('User task listeners')
         .click();
+      await expect(operateProcessInstancePage.taskListenerText).toBeVisible();
       await expect(
-        operateProcessInstancePage.getTaskListenerText(true),
-      ).toBeVisible();
-      await expect(
-        operateProcessInstancePage.getExecutionListenerText(true),
+        operateProcessInstancePage.executionListenerText,
       ).toBeHidden();
     });
 
@@ -264,11 +260,9 @@ test.describe('Process Instance Listeners', () => {
         .getListenerTypeFilterOption('All listeners')
         .click();
       await expect(
-        operateProcessInstancePage.getExecutionListenerText(true),
+        operateProcessInstancePage.executionListenerText,
       ).toBeVisible();
-      await expect(
-        operateProcessInstancePage.getTaskListenerText(true),
-      ).toBeVisible();
+      await expect(operateProcessInstancePage.taskListenerText).toBeVisible();
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -238,9 +238,11 @@ test.describe('Process Instance Listeners', () => {
         .getListenerTypeFilterOption('Execution listeners')
         .click();
       await expect(
-        operateProcessInstancePage.executionListenerText,
+        operateProcessInstancePage.getExecutionListenerText(true),
       ).toBeVisible();
-      await expect(operateProcessInstancePage.taskListenerText).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getTaskListenerText(true),
+      ).toBeHidden();
     });
 
     await test.step('Filter to show only user task listeners', async () => {
@@ -248,9 +250,11 @@ test.describe('Process Instance Listeners', () => {
       await operateProcessInstancePage
         .getListenerTypeFilterOption('User task listeners')
         .click();
-      await expect(operateProcessInstancePage.taskListenerText).toBeVisible();
       await expect(
-        operateProcessInstancePage.executionListenerText,
+        operateProcessInstancePage.getTaskListenerText(true),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getExecutionListenerText(true),
       ).toBeHidden();
     });
 
@@ -260,9 +264,11 @@ test.describe('Process Instance Listeners', () => {
         .getListenerTypeFilterOption('All listeners')
         .click();
       await expect(
-        operateProcessInstancePage.executionListenerText,
+        operateProcessInstancePage.getExecutionListenerText(true),
       ).toBeVisible();
-      await expect(operateProcessInstancePage.taskListenerText).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getTaskListenerText(true),
+      ).toBeVisible();
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -87,6 +87,7 @@ test.describe.serial('Process Instance Migration', () => {
     page,
     operateFiltersPanelPage,
     operateProcessesPage,
+    operateOperationPanelPage,
     operateProcessMigrationModePage,
   }) => {
     test.slow();
@@ -275,11 +276,12 @@ test.describe.serial('Process Instance Migration', () => {
     await test.step('Verify 6 instances migrated to target version', async () => {
       await operateProcessesPage.expandOperationsPanel();
 
-      const operationEntry = operateProcessesPage.getMigrationOperationEntry(6);
+      const operationEntry =
+        operateOperationPanelPage.getMigrationOperationEntry(6);
 
       await expect(operationEntry).toBeVisible({timeout: 120000});
 
-      await operateProcessesPage.clickOperationLink(operationEntry);
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
 
       await validateURL(page, /operationId=/);
 
@@ -377,6 +379,7 @@ test.describe.serial('Process Instance Migration', () => {
     page,
     operateFiltersPanelPage,
     operateProcessesPage,
+    operateOperationPanelPage,
     operateProcessMigrationModePage,
   }) => {
     test.slow();
@@ -565,13 +568,14 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify 3 instances migrated to target version', async () => {
-      const operationEntry = operateProcessesPage.getMigrationOperationEntry(3);
+      const operationEntry =
+        operateOperationPanelPage.getMigrationOperationEntry(3);
 
       await expect(operationEntry).toBeVisible({
         timeout: 120000,
       });
 
-      await operateProcessesPage.clickOperationLink(operationEntry);
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
 
       await validateURL(page, /operationId=/);
 
@@ -626,7 +630,7 @@ test.describe.serial('Process Instance Migration', () => {
 
     await test.step('Verify Business rule task incident migration', async () => {
       await operateDiagramPage.clickFlowNode('BusinessRuleTask2');
-      await operateDiagramPage.showMetaData();
+      await operateDiagramPage.clickShowMetaData();
 
       await operateDiagramPage.verifyIncidentInPopover(/invalid.*decision/i);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
@@ -6,16 +6,19 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {expect} from '@playwright/test';
+import {expect, type APIRequestContext} from '@playwright/test';
 import {sleep} from './sleep';
 
 export async function waitForIncidents(
-  request: any,
+  request: APIRequestContext,
   processInstanceKey: string,
+  flowNodeId: string,
   expectedCount: number,
   timeout = 120000,
 ): Promise<void> {
-  const auth = Buffer.from(`demo:demo`).toString('base64');
+  const username = process.env.TEST_USERNAME || 'demo';
+  const password = process.env.TEST_PASSWORD || 'demo';
+  const auth = Buffer.from(`${username}:${password}`).toString('base64');
   const requestHeaders = {
     headers: {
       'Content-Type': 'application/json',
@@ -31,7 +34,7 @@ export async function waitForIncidents(
           data: {
             filter: {
               processInstanceKey,
-              flowNodeId: 'taskB',
+              flowNodeId,
               type: 'SERVICE_TASK',
               incident: true,
             },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {sleep} from './sleep';
+
+export async function waitForIncidents(
+  request: any,
+  processInstanceKey: string,
+  expectedCount: number,
+  timeout = 120000,
+): Promise<void> {
+  const auth = Buffer.from(`demo:demo`).toString('base64');
+  const requestHeaders = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${auth}`,
+    },
+  };
+
+  await expect
+    .poll(
+      async () => {
+        const response = await request.post('v1/flownode-instances/search', {
+          ...requestHeaders,
+          data: {
+            filter: {
+              processInstanceKey,
+              flowNodeId: 'taskB',
+              type: 'SERVICE_TASK',
+              incident: true,
+            },
+          },
+        });
+
+        const flowNodeInstances = await response.json();
+        return flowNodeInstances.total;
+      },
+      {timeout},
+    )
+    .toBe(expectedCount);
+
+  await sleep(2000);
+}


### PR DESCRIPTION
## Description
This PR migrates [multiInstanceSelection.spec.ts](https://github.com/camunda/camunda/blob/main/operate/client/e2e-playwright/tests/multiInstanceSelection.spec.ts) to the Orchestration Cluster E2E test suite with comprehensive tests for multi-instance flow node selection, diagram navigation, and incident handling.

### Key Changes

- **New Tests**: Multi-instance expansion, flow node selection in diagrams, and single task incident filtering
- **New Utility**: `incidentsHelper.ts` for API-based incident polling to improve test reliability
- **Page Object Refactoring**: 
  - Moves operation methods from `OperateProcessesPage` to `OperateOperationPanelPage`
🧪 [Test Run](https://github.com/camunda/camunda/actions/runs/20160229338)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
relates to https://github.com/camunda/camunda/issues/34093