### PR TITLE
ci: use unique CI Health name for DB ITs

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -102,6 +102,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          job_name: "database-integration-tests/${{ inputs.database-type }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: "General"
@@ -149,6 +150,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          job_name: "send-slack-notification/${{ inputs.database-type }}"
           build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
## Description

In the regular CI SLO check-in we found results for `integration-tests` that could not be attributed directly to any Matrix or other job, due to lack of details. This comes from the Database Integration Tests all submitting data [under the same job name](https://github.com/camunda/camunda/actions/runs/20129776463/job/57768147156#step:12:185):

<img width="549" height="149" alt="image" src="https://github.com/user-attachments/assets/6c8c3ddb-dd3b-4ca2-83fe-81b15f2d9934" />

This PR ensures the CI Health data is attributed correctly and allows for unique info per job.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) -- opportunistic in case this is on 8.8 as well

## Related issues

None
