### PR TITLE
feat: Add Option to Select Secondary Storage for Load Tests

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -48,6 +48,11 @@ on:
         type: boolean
         required: false
         default: false
+      secondary-storage:
+        description: 'Specify which secondary storage to use'
+        type: string
+        default: 'elasticsearch'
+        required: false
   workflow_call:
     inputs:
       ref:
@@ -98,6 +103,11 @@ on:
         type: boolean
         required: false
         default: false
+      secondary-storage:
+        description: 'Specify which secondary storage to use'
+        type: string
+        default: 'elasticsearch'
+        required: false
 
 env:
   HELM_CHART: camunda-platform-8.9
@@ -109,8 +119,36 @@ defaults:
     shell: bash
 
 jobs:
+  determine-secondary-storage:
+    name: Determine the secondary-storage option
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: { }
+    outputs:
+      enable-secondary-storage-flag: ${{ steps.validate-secondary-storage.outputs.enable-secondary-storage-flag }}
+    steps:
+      - name: Validate secondary-storage input
+        id: validate-secondary-storage
+        run: |
+          SECONDARY_STORAGE="${{ inputs.secondary-storage }}"
+          case "$SECONDARY_STORAGE" in
+            elasticsearch)
+              echo "enable-secondary-storage-flag=--set elasticsearch.enabled=true --set global.elasticsearch.enabled=true" >> "$GITHUB_OUTPUT"
+              echo "✓ Secondary storage set to: elasticsearch"
+              ;;
+            opensearch)
+              echo "enable-secondary-storage-flag=--set elasticsearch.enabled=false --set global.elasticsearch.enabled=false --set opensearch.enabled=true --set global.opensearch.enabled=true" >> "$GITHUB_OUTPUT"
+              echo "✓ Secondary storage set to: opensearch"
+              ;;
+            *)
+              echo "::error::Invalid secondary-storage value: '$SECONDARY_STORAGE'. Must be 'elasticsearch' or 'opensearch'"
+              exit 1
+              ;;
+          esac
+
   calculate-image-tag:
     name: Calculate Image Tag
+    needs: determine-secondary-storage
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: { }
@@ -250,6 +288,7 @@ jobs:
     name: Deploy cluster under test
     needs:
       - calculate-image-tag
+      - determine-secondary-storage
       - build-camunda-image
       - build-load-test-images
     # To have the possibility to re-deploy the tests without rebuilding the images,
@@ -267,7 +306,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'camunda/camunda-platform-helm'
-          ref: 'main'
+          ref: 'yf-40612-setup-opensearch-benchmark' # TEMPORARY: pin to a specific commit until Helm charts are versioned
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
@@ -316,6 +355,7 @@ jobs:
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/load-tests/setup/default/values-stable.yaml', github.ref) || '' }}
+          ${{ needs.determine-secondary-storage.outputs.enable-secondary-storage-flag }}
       - name: Summarize deployment
         if: success()
         run: |

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -81,7 +81,7 @@ The setup for all of our load tests is equal for better comparability, and consi
 
 We always ran load tests with a three-node cluster, configured with three partitions and a replication factor of three. Depending on the version of Camunda/Zeebe, we might only deploy Zeebe Brokers and the Zeebe (standalone) gateway (with two replicas) only (pre 8.8) or (with 8.8+) the single Camunda application (with an embedded gateway).
 
-An Elasticsearch cluster with three nodes is deployed as well, which is used to validate the performance of the exporters. Exporting and archiving throughput must be able to sustain the load of the cluster.
+A secondary storage cluster (either Elasticsearch or OpenSearch) with three nodes is deployed as well, which is used to validate the performance of the exporters. Exporting and archiving throughput must be able to sustain the load of the cluster. The choice of secondary storage can be specified via the `secondary-storage` parameter when setting up load tests.
 
 Our [load test Helm Chart](https://github.com/camunda/camunda-load-tests-helm) deploys different load test applications. They can be distinguished into workers and starters. The related code can be found in the [Camunda mono repository](https://github.com/camunda/camunda/tree/main/load-tests/load-tester).
 
@@ -218,19 +218,21 @@ An example payload looks like this:
       "name": benchmark_name,
       "ref": zeebe_ref_name,
       "cluster": "zeebe-cluster",
-      "stable-vms": stable_vms
+      "stable-vms": stable_vms,
+      "secondary-storage": "elasticsearch"
     }
 }
 ```
 
 When we look at an example release process instance from the past, we can find the following example values:
 
-|      Variable       |  Example Value  |              Description               |
-|---------------------|-----------------|----------------------------------------|
-| `workflow_ref_name` | `8.7.17`        | The tag to trigger the workflow on     |
-| `zeebe_ref_name`    | `8.7.17`        | The tag to build the Docker image from |
-| `benchmark_name`    | `release-8-7-x` | The name of the load test              |
-| `stable_vms`        | `true`          | Whether to use stable VM types or not  |
+|      Variable       | Example Value   | Description                                                                |
+|---------------------|-----------------|----------------------------------------------------------------------------|
+| `workflow_ref_name` | `8.7.17`        | The tag to trigger the workflow on                                         |
+| `zeebe_ref_name`    | `8.7.17`        | The tag to build the Docker image from                                     |
+| `benchmark_name`    | `release-8-7-x` | The name of the load test                                                  |
+| `stable_vms`        | `true`          | Whether to use stable VM types or not                                      |
+| `secondary-storage` | `elasticsearch` | Which secondary-storage to use (`elasticsearch` or `opensearch`)           |
 
 In our post-release process, we map our `release_version` variable to the `workflow_ref_name` as input to update our existing load test.
 
@@ -297,6 +299,7 @@ It allows high customization:
 * Specification of the branch to test against (default: main) - will build a Docker image based on the specified branch and be used for the cluster under test and load test applications.
 * Specification of the time to live (TTL) for the load test - making sure that the load test is automatically cleaned up after the specified time.
 * Specification of an existing Docker image to use - making it possible to reuse existing images.
+* Specification of the secondary storage type (`elasticsearch` or `opensearch`) - allows choosing which secondary storage system to deploy for exporter validation.
 * Specification of arbitrary Helm arguments - making it possible to customize the load test set up.
 
 ![load-test-gha](assets/load-test-gha.png)

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -140,6 +140,7 @@ orchestration:
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
       camunda.data.secondary-storage.retention.minimum-age: "70m"
       camunda.data.secondary-storage.elasticsearch.history.policy-name: "camunda-retention-policy"
+      camunda.data.secondary-storage.opensearch.history.policy-name: "camunda-retention-policy"
       camunda.database.retention.policyName: "camunda-retention-policy"
       zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
       #Metrics:
@@ -193,6 +194,8 @@ prometheusServiceMonitor:
 ################################################### Elasticsearch cluster configuration
 ########################################################################################
 elasticsearch:
+  enabled: true
+  clusterName: "elasticsearch"
   master:
     fullnameOverride: elastic
     nameOverride: elastic
@@ -216,3 +219,57 @@ elasticsearch:
         memory: 6Gi
   extraConfig:
     logger.org.elasticsearch.deprecation: "OFF"
+
+########################################################################################
+################################################### OpenSearch cluster configuration
+########################################################################################
+opensearch:
+  enabled: false
+  clusterName: "opensearch"
+  nameOverride: "opensearch"
+  master:
+    replicaCount: 3
+    masterOnly: false
+    extraRoles:
+      - data
+      - ingest
+      - coordinating
+      - remote_cluster_client
+    persistence:
+      size: 128Gi
+      storageClass: "ssd"
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 3
+        memory: 3Gi
+      limits:
+        cpu: 3
+        memory: 6Gi
+  # turn off dedicated data nodes for load test setup
+  data:
+    replicaCount: 0
+    persistence:
+      enabled: false
+    networkPolicy:
+      enabled: false
+  # turn off dedicated coordinating nodes for load test setup
+  coordinating:
+    replicaCount: 0
+    persistence:
+      enabled: false
+    networkPolicy:
+      enabled: false
+  # turn off ingest nodes for load test setup
+  ingest:
+    enabled: false
+    networkPolicy:
+      enabled: false
+  # turn off dashboards for load test setup
+  dashboards:
+    enabled: false
+    networkPolicy:
+      enabled: false
+  # disable volume permissions for load test setup
+  volumePermissions:
+    enabled: false


### PR DESCRIPTION

## Description

This depends on a camunda-platform-helm WIP PR that adds OpenSearch as a Helm dependency and updates the configuration values.

It overrides the necessary configuration options to set up OpenSearch containers. From the action, you can select which secondary storage option to use when running the load test. Providing a secondary-storage option is optional; if not specified, Elasticsearch will be used by default. If an invalid value is provided, the workflow will terminate.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
