### PR TITLE
feat: add camunda.security properties to the unified config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -25,6 +25,7 @@ public class Camunda {
   @NestedConfigurationProperty private Api api = new Api();
   @NestedConfigurationProperty private Processing processing = new Processing();
   @NestedConfigurationProperty private Monitoring monitoring = new Monitoring();
+  @NestedConfigurationProperty private Security security = new Security();
 
   public Cluster getCluster() {
     return cluster;
@@ -72,5 +73,13 @@ public class Camunda {
 
   public void setMonitoring(final Monitoring monitoring) {
     this.monitoring = monitoring;
+  }
+
+  public Security getSecurity() {
+    return security;
+  }
+
+  public void setSecurity(final Security security) {
+    this.security = security;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -53,7 +53,8 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** Template priority for index templates. */
   private Integer templatePriority;
 
-  @NestedConfigurationProperty private Security security = new Security(databaseName());
+  @NestedConfigurationProperty
+  private SecondaryStorageSecurity security = new SecondaryStorageSecurity(databaseName());
 
   /** Sets the interceptor plugins */
   private List<InterceptorPlugin> interceptorPlugins = new ArrayList<>();
@@ -197,11 +198,11 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.bulk = bulk;
   }
 
-  public Security getSecurity() {
+  public SecondaryStorageSecurity getSecurity() {
     return security;
   }
 
-  public void setSecurity(final Security security) {
+  public void setSecurity(final SecondaryStorageSecurity security) {
     this.security = security;
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/KeyStore.java
+++ b/configuration/src/main/java/io/camunda/configuration/KeyStore.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class KeyStore implements Cloneable {
-  private static final String PREFIX = "camunda.api.grpc.ssl.key-store";
   private static final Map<String, String> LEGACY_GATEWAY_KEY_STORE_PROPERTIES =
       Map.of(
           "filePath", "zeebe.gateway.security.keyStore.filePath",
@@ -22,7 +21,16 @@ public class KeyStore implements Cloneable {
       Map.of(
           "filePath", "zeebe.broker.gateway.security.keyStore.filePath",
           "password", "zeebe.broker.gateway.security.keyStore.password");
+  private static final Map<String, String> LEGACY_BROKER_NETWORK_SECURITY_KEY_STORE_PROPERTIES =
+      Map.of(
+          "filePath", "zeebe.broker.network.security.keyStore.filePath",
+          "password", "zeebe.broker.network.security.keyStore.password");
+  private static final Map<String, String> LEGACY_GATEWAY_CLUSTER_SECURITY_KEY_STORE_PROPERTIES =
+      Map.of(
+          "filePath", "zeebe.gateway.cluster.security.keyStore.filePath",
+          "password", "zeebe.gateway.cluster.security.keyStore.password");
 
+  private String prefix = "camunda.api.grpc.ssl.key-store";
   private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_KEY_STORE_PROPERTIES;
 
   /** The path for keystore file */
@@ -33,7 +41,7 @@ public class KeyStore implements Cloneable {
 
   public File getFilePath() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + ".file-path",
+        prefix + ".file-path",
         filePath,
         File.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -46,7 +54,7 @@ public class KeyStore implements Cloneable {
 
   public String getPassword() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        PREFIX + ".password",
+        prefix + ".password",
         password,
         String.class,
         BackwardsCompatibilityMode.SUPPORTED,
@@ -68,13 +76,30 @@ public class KeyStore implements Cloneable {
 
   public KeyStore withBrokerKeyStoreProperties() {
     final var copy = (KeyStore) clone();
+    copy.prefix = "camunda.api.grpc.ssl.key-store";
     copy.legacyPropertiesMap = LEGACY_BROKER_KEY_STORE_PROPERTIES;
+
     return copy;
   }
 
   public KeyStore withGatewayKeyStoreProperties() {
     final var copy = (KeyStore) clone();
+    copy.prefix = "camunda.api.grpc.ssl.key-store";
     copy.legacyPropertiesMap = LEGACY_GATEWAY_KEY_STORE_PROPERTIES;
+    return copy;
+  }
+
+  public KeyStore withBrokerTlsClusterKeyStoreProperties() {
+    final var copy = (KeyStore) clone();
+    copy.prefix = "camunda.security.transport-layer-security.cluster.key-store";
+    copy.legacyPropertiesMap = LEGACY_BROKER_NETWORK_SECURITY_KEY_STORE_PROPERTIES;
+    return copy;
+  }
+
+  public KeyStore withGatewayTlsClusterKeyStoreProperties() {
+    final var copy = (KeyStore) clone();
+    copy.prefix = "camunda.security.transport-layer-security.cluster.key-store";
+    copy.legacyPropertiesMap = LEGACY_GATEWAY_CLUSTER_SECURITY_KEY_STORE_PROPERTIES;
     return copy;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageSecurity.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageSecurity.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class SecondaryStorageSecurity {
+
+  private final String databaseName;
+
+  /** Enable security */
+  private boolean enabled = false;
+
+  /** Path to certificate used by Elasticsearch or Opensearch */
+  private String certificatePath;
+
+  /** Should the hostname be validated */
+  private boolean verifyHostname = true;
+
+  /** Certificate was self-signed */
+  private boolean selfSigned = false;
+
+  public SecondaryStorageSecurity(final String databaseName) {
+    this.databaseName = databaseName.toLowerCase();
+  }
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyEnabledProperties());
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getCertificatePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".certificate-path",
+        certificatePath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyCertificatePathProperties());
+  }
+
+  public void setCertificatePath(final String certificatePath) {
+    this.certificatePath = certificatePath;
+  }
+
+  public boolean isVerifyHostname() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".verify-hostname",
+        verifyHostname,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyVerifyHostnameProperties());
+  }
+
+  public void setVerifyHostname(final boolean verifyHostname) {
+    this.verifyHostname = verifyHostname;
+  }
+
+  public boolean isSelfSigned() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".self-signed",
+        selfSigned,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacySelfSignedProperties());
+  }
+
+  public void setSelfSigned(final boolean selfSigned) {
+    this.selfSigned = selfSigned;
+  }
+
+  private String prefix() {
+    return "camunda.data.secondary-storage." + databaseName + ".security";
+  }
+
+  private Set<String> legacyEnabledProperties() {
+    return Set.of(
+        "camunda.database.security.enabled",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.enabled");
+  }
+
+  private Set<String> legacyCertificatePathProperties() {
+    return Set.of(
+        "camunda.database.security.certificatePath",
+        "camunda.tasklist." + databaseName + ".ssl.certificatePath",
+        "camunda.operate." + databaseName + ".ssl.certificatePath",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.certificatePath");
+  }
+
+  private Set<String> legacyVerifyHostnameProperties() {
+    return Set.of(
+        "camunda.database.security.verifyHostname",
+        "camunda.tasklist." + databaseName + ".ssl.verifyHostname",
+        "camunda.operate." + databaseName + ".ssl.verifyHostname",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.verifyHostname");
+  }
+
+  private Set<String> legacySelfSignedProperties() {
+    return Set.of(
+        "camunda.database.security.selfSigned",
+        "camunda.tasklist." + databaseName + ".ssl.selfSigned",
+        "camunda.operate." + databaseName + ".ssl.selfSigned",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.selfSigned");
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Tls.java
+++ b/configuration/src/main/java/io/camunda/configuration/Tls.java
@@ -9,16 +9,16 @@ package io.camunda.configuration;
 
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-public class Security {
+public class Tls {
 
-  /** TLS configuration. */
-  @NestedConfigurationProperty private Tls transportLayerSecurity = new Tls();
+  /** TLS configuration for the cluster. */
+  @NestedConfigurationProperty private TlsCluster cluster = new TlsCluster();
 
-  public Tls getTransportLayerSecurity() {
-    return transportLayerSecurity;
+  public TlsCluster getCluster() {
+    return cluster;
   }
 
-  public void setTransportLayerSecurity(final Tls transportLayerSecurity) {
-    this.transportLayerSecurity = transportLayerSecurity;
+  public void setCluster(final TlsCluster cluster) {
+    this.cluster = cluster;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/TlsCluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/TlsCluster.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class TlsCluster implements Cloneable {
+  private static final String PREFIX = "camunda.security.transport-layer-security.cluster";
+
+  private static final Map<String, String> LEGACY_BROKER_NETWORK_SECURITY_PROPERTIES =
+      Map.of(
+          "enabled",
+          "zeebe.broker.network.security.enabled",
+          "certificateChainPath",
+          "zeebe.broker.network.security.certificateChainPath",
+          "certificatePrivateKeyPath",
+          "zeebe.broker.network.security.privateKeyPath");
+
+  private static final Map<String, String> LEGACY_GATEWAY_CLUSTER_SECURITY_PROPERTIES =
+      Map.of(
+          "enabled",
+          "zeebe.gateway.cluster.security.enabled",
+          "certificateChainPath",
+          "zeebe.gateway.cluster.security.certificateChainPath",
+          "certificatePrivateKeyPath",
+          "zeebe.gateway.cluster.security.privateKeyPath");
+
+  private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_NETWORK_SECURITY_PROPERTIES;
+
+  /** Enables TLS authentication between this gateway and other nodes in the cluster */
+  private boolean enabled = false;
+
+  /** Sets the path to the certificate chain file */
+  private File certificateChainPath;
+
+  /** Sets the path to the private key file location */
+  private File certificatePrivateKeyPath;
+
+  /**
+   * Configures the keystore file containing both the certificate chain and the private key.
+   * Currently only supports PKCS12 format.
+   */
+  @NestedConfigurationProperty private KeyStore keyStore = new KeyStore();
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("enabled")));
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public File getCertificateChainPath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".certificate-chain-path",
+        certificateChainPath,
+        File.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("certificateChainPath")));
+  }
+
+  public void setCertificateChainPath(final File certificateChainPath) {
+    this.certificateChainPath = certificateChainPath;
+  }
+
+  public File getCertificatePrivateKeyPath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".certificate-private-key-path",
+        certificatePrivateKeyPath,
+        File.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("certificatePrivateKeyPath")));
+  }
+
+  public void setCertificatePrivateKeyPath(final File certificatePrivateKeyPath) {
+    this.certificatePrivateKeyPath = certificatePrivateKeyPath;
+  }
+
+  public KeyStore getKeyStore() {
+    return keyStore;
+  }
+
+  public void setKeyStore(final KeyStore keyStore) {
+    this.keyStore = keyStore;
+  }
+
+  @Override
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
+  }
+
+  public TlsCluster withBrokerTlsClusterProperties() {
+    final var copy = (TlsCluster) clone();
+    copy.legacyPropertiesMap = LEGACY_BROKER_NETWORK_SECURITY_PROPERTIES;
+    return copy;
+  }
+
+  public TlsCluster withGatewayTlsClusterProperties() {
+    final var copy = (TlsCluster) clone();
+    copy.legacyPropertiesMap = LEGACY_GATEWAY_CLUSTER_SECURITY_PROPERTIES;
+    return copy;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -69,8 +69,32 @@ public class GatewayBasedPropertiesOverride {
     populateFromGrpc(override);
     populateFromLongPolling(override);
     populateFromRestFilters(override);
+    populateFromSecurity(override);
 
     return override;
+  }
+
+  private void populateFromSecurity(final GatewayBasedProperties override) {
+    final var tlsCluster =
+        unifiedConfiguration
+            .getCamunda()
+            .getSecurity()
+            .getTransportLayerSecurity()
+            .getCluster()
+            .withGatewayTlsClusterProperties();
+
+    final SecurityCfg clusterSecurity = override.getCluster().getSecurity();
+    clusterSecurity.setEnabled(tlsCluster.isEnabled());
+    clusterSecurity.setCertificateChainPath(tlsCluster.getCertificateChainPath());
+    clusterSecurity.setPrivateKeyPath(tlsCluster.getCertificatePrivateKeyPath());
+    clusterSecurity
+        .getKeyStore()
+        .setFilePath(
+            tlsCluster.getKeyStore().withGatewayTlsClusterKeyStoreProperties().getFilePath());
+    clusterSecurity
+        .getKeyStore()
+        .setPassword(
+            tlsCluster.getKeyStore().withGatewayTlsClusterKeyStoreProperties().getPassword());
   }
 
   private void populateFromGrpc(final GatewayBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -11,7 +11,7 @@ import io.camunda.configuration.DocumentBasedSecondaryStorageBackup;
 import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.Security;
+import io.camunda.configuration.SecondaryStorageSecurity;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.BackupProperties;
@@ -139,7 +139,7 @@ public class OperatePropertiesOverride {
   }
 
   private void populateFromSecurity(
-      final Security security,
+      final SecondaryStorageSecurity security,
       final Supplier<SslProperties> getSsl,
       final Consumer<SslProperties> setSsl) {
     final SslProperties sslProps = Objects.requireNonNullElseGet(getSsl.get(), SslProperties::new);

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -12,7 +12,7 @@ import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.SecondaryStorageDatabase;
-import io.camunda.configuration.Security;
+import io.camunda.configuration.SecondaryStorageSecurity;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
@@ -113,7 +113,7 @@ public class SearchEngineConnectPropertiesOverride {
   }
 
   private void populateFromSecurity(final SearchEngineConnectProperties override) {
-    final Security security = resolveSecurity(override);
+    final SecondaryStorageSecurity security = resolveSecurity(override);
     if (security == null) {
       return;
     }
@@ -124,7 +124,7 @@ public class SearchEngineConnectPropertiesOverride {
     override.getSecurity().setSelfSigned(security.isSelfSigned());
   }
 
-  private Security resolveSecurity(final SearchEngineConnectProperties override) {
+  private SecondaryStorageSecurity resolveSecurity(final SearchEngineConnectProperties override) {
     final SecondaryStorage secondaryStorage =
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -12,7 +12,7 @@ import io.camunda.configuration.DocumentBasedSecondaryStorageBackup;
 import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.Security;
+import io.camunda.configuration.SecondaryStorageSecurity;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.tasklist.property.SslProperties;
@@ -134,7 +134,7 @@ public class TasklistPropertiesOverride {
   }
 
   private void populateFromSecurity(
-      final Security security,
+      final SecondaryStorageSecurity security,
       final Supplier<SslProperties> getSsl,
       final Consumer<SslProperties> setSsl) {
     final SslProperties sslProps = Objects.requireNonNullElseGet(getSsl.get(), SslProperties::new);

--- a/configuration/src/test/java/io/camunda/configuration/TlsClusterBrokerTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/TlsClusterBrokerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.KeyStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
+import java.io.File;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  BrokerBasedPropertiesOverride.class
+})
+public class TlsClusterBrokerTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.transport-layer-security.cluster.enabled=true",
+        "camunda.security.transport-layer-security.cluster.certificate-chain-path=certificateChainPath",
+        "camunda.security.transport-layer-security.cluster.certificate-private-key-path=certificatePrivateKeyPath",
+        "camunda.security.transport-layer-security.cluster.key-store.file-path=keyStoreFilePath",
+        "camunda.security.transport-layer-security.cluster.key-store.password=keyStorePassword",
+      })
+  @ActiveProfiles({"broker"})
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaBrokerProperties() {
+      assertThat(brokerBasedProperties.getNetwork().getSecurity())
+          .returns(true, SecurityCfg::isEnabled)
+          .returns(new File("certificateChainPath"), SecurityCfg::getCertificateChainPath)
+          .returns(new File("certificatePrivateKeyPath"), SecurityCfg::getPrivateKeyPath);
+
+      assertThat(brokerBasedProperties.getNetwork().getSecurity().getKeyStore())
+          .returns(new File("keyStoreFilePath"), KeyStoreCfg::getFilePath)
+          .returns("keyStorePassword", KeyStoreCfg::getPassword);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.security.transport-layer-security.cluster.enabled=true",
+        "camunda.security.transport-layer-security.cluster.certificate-chain-path=certificateChainPath",
+        "camunda.security.transport-layer-security.cluster.certificate-private-key-path=certificatePrivateKeyPath",
+        "camunda.security.transport-layer-security.cluster.key-store.file-path=keyStoreFilePath",
+        "camunda.security.transport-layer-security.cluster.key-store.password=keyStorePassword",
+        // legacy
+        "zeebe.broker.network.security.enabled=false",
+        "zeebe.broker.network.security.certificateChainPath=certificateChainPathLegacy",
+        "zeebe.broker.network.security.privateKeyPath=certificatePrivateKeyPathLegacy",
+        "zeebe.broker.network.security.keyStore.filePath=certificateKeyStoreFilePathLegacy",
+        "zeebe.broker.network.security.keyStore.password=certificateKeyStorePasswordLegacy",
+      })
+  @ActiveProfiles({"broker"})
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaBrokerProperties() {
+      assertThat(brokerBasedProperties.getNetwork().getSecurity())
+          .returns(true, SecurityCfg::isEnabled)
+          .returns(new File("certificateChainPath"), SecurityCfg::getCertificateChainPath)
+          .returns(new File("certificatePrivateKeyPath"), SecurityCfg::getPrivateKeyPath);
+
+      assertThat(brokerBasedProperties.getNetwork().getSecurity().getKeyStore())
+          .returns(new File("keyStoreFilePath"), KeyStoreCfg::getFilePath)
+          .returns("keyStorePassword", KeyStoreCfg::getPassword);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // legacy
+        "zeebe.broker.network.security.enabled=false",
+        "zeebe.broker.network.security.certificateChainPath=certificateChainPathLegacy",
+        "zeebe.broker.network.security.privateKeyPath=certificatePrivateKeyPathLegacy",
+        "zeebe.broker.network.security.keyStore.filePath=certificateKeyStoreFilePathLegacy",
+        "zeebe.broker.network.security.keyStore.password=certificateKeyStorePasswordLegacy",
+      })
+  @ActiveProfiles({"broker"})
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaBrokerProperties() {
+      assertThat(brokerBasedProperties.getNetwork().getSecurity())
+          .returns(false, SecurityCfg::isEnabled)
+          .returns(new File("certificateChainPathLegacy"), SecurityCfg::getCertificateChainPath)
+          .returns(new File("certificatePrivateKeyPathLegacy"), SecurityCfg::getPrivateKeyPath);
+
+      assertThat(brokerBasedProperties.getNetwork().getSecurity().getKeyStore())
+          .returns(new File("keyStoreFilePathLegacy"), KeyStoreCfg::getFilePath)
+          .returns("keyStorePasswordLegacy", KeyStoreCfg::getPassword);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/TlsClusterGatewayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/TlsClusterGatewayTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beans.GatewayBasedProperties;
+import java.io.File;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  GatewayBasedPropertiesOverride.class,
+})
+public class TlsClusterGatewayTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.transport-layer-security.cluster.enabled=true",
+        "camunda.security.transport-layer-security.cluster.certificate-chain-path=certificateChainPath",
+        "camunda.security.transport-layer-security.cluster.certificate-private-key-path=certificatePrivateKeyPath",
+        "camunda.security.transport-layer-security.cluster.key-store.file-path=keyStoreFilePath",
+        "camunda.security.transport-layer-security.cluster.key-store.password=keyStorePassword",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayBasedProperties gatewayBasedProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayBasedProperties gatewayBasedProperties) {
+      this.gatewayBasedProperties = gatewayBasedProperties;
+    }
+
+    @Test
+    void testCamundaGatewayProperties() {
+      assertThat(gatewayBasedProperties.getCluster().getSecurity())
+          .returns(true, io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::isEnabled)
+          .returns(
+              new File("certificateChainPath"),
+              io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::getCertificateChainPath)
+          .returns(
+              new File("certificatePrivateKeyPath"),
+              io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::getPrivateKeyPath);
+
+      assertThat(gatewayBasedProperties.getCluster().getSecurity().getKeyStore())
+          .returns(
+              new File("keyStoreFilePath"),
+              io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg::getFilePath)
+          .returns(
+              "keyStorePassword",
+              io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg::getPassword);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.security.transport-layer-security.cluster.enabled=true",
+        "camunda.security.transport-layer-security.cluster.certificate-chain-path=certificateChainPath",
+        "camunda.security.transport-layer-security.cluster.certificate-private-key-path=certificatePrivateKeyPath",
+        "camunda.security.transport-layer-security.cluster.key-store.file-path=keyStoreFilePath",
+        "camunda.security.transport-layer-security.cluster.key-store.password=keyStorePassword",
+        // legacy
+        "zeebe.gateway.cluster.security.enabled=false",
+        "zeebe.gateway.cluster.security.certificateChainPath=certificateChainPathLegacy",
+        "zeebe.gateway.cluster.security.privateKeyPath=certificatePrivateKeyPathLegacy",
+        "zeebe.gateway.cluster.security.keyStore.filePath=certificateKeyStoreFilePathLegacy",
+        "zeebe.gateway.cluster.security.keyStore.password=certificateKeyStorePasswordLegacy",
+      })
+  class WithNewAndLegacySet {
+    final GatewayBasedProperties gatewayBasedProperties;
+
+    WithNewAndLegacySet(@Autowired final GatewayBasedProperties gatewayBasedProperties) {
+      this.gatewayBasedProperties = gatewayBasedProperties;
+    }
+
+    @Test
+    void testCamundaGatewayProperties() {
+      assertThat(gatewayBasedProperties.getCluster().getSecurity())
+          .returns(true, io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::isEnabled)
+          .returns(
+              new File("certificateChainPath"),
+              io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::getCertificateChainPath)
+          .returns(
+              new File("certificatePrivateKeyPath"),
+              io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::getPrivateKeyPath);
+
+      assertThat(gatewayBasedProperties.getCluster().getSecurity().getKeyStore())
+          .returns(
+              new File("keyStoreFilePath"),
+              io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg::getFilePath)
+          .returns(
+              "keyStorePassword",
+              io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg::getPassword);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // legacy
+        "zeebe.gateway.cluster.security.enabled=false",
+        "zeebe.gateway.cluster.security.certificateChainPath=certificateChainPathLegacy",
+        "zeebe.gateway.cluster.security.privateKeyPath=certificatePrivateKeyPathLegacy",
+        "zeebe.gateway.cluster.security.keyStore.filePath=certificateKeyStoreFilePathLegacy",
+        "zeebe.gateway.cluster.security.keyStore.password=certificateKeyStorePasswordLegacy",
+      })
+  class WithOnlyLegacySet {
+    final GatewayBasedProperties gatewayBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final GatewayBasedProperties gatewayBasedProperties) {
+      this.gatewayBasedProperties = gatewayBasedProperties;
+    }
+
+    @Test
+    void testCamundaGatewayProperties() {
+      assertThat(gatewayBasedProperties.getCluster().getSecurity())
+          .returns(true, io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::isEnabled)
+          .returns(
+              new File("certificateChainPathLegacy"),
+              io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::getCertificateChainPath)
+          .returns(
+              new File("certificatePrivateKeyPathLegacy"),
+              io.camunda.zeebe.gateway.impl.configuration.SecurityCfg::getPrivateKeyPath);
+
+      assertThat(gatewayBasedProperties.getCluster().getSecurity().getKeyStore())
+          .returns(
+              new File("keyStoreFilePathLegacy"),
+              io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg::getFilePath)
+          .returns(
+              "keyStorePasswordLegacy",
+              io.camunda.zeebe.gateway.impl.configuration.KeyStoreCfg::getPassword);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -69,9 +69,13 @@ final class SecuredClusteredMessagingIT {
       new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
           .withNetwork(NETWORK)
           .withNetworkAliases("zeebe")
-          .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
-          .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", "/tmp/certificate.pem")
-          .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", "/tmp/key.pem")
+          .withEnv("CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_ENABLED", "true")
+          .withEnv(
+              "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATECHAINPATH",
+              "/tmp/certificate.pem")
+          .withEnv(
+              "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATEPRIVATEKEYPATH",
+              "/tmp/key.pem")
           .withCopyToContainer(
               MountableFile.forHostPath(CERTIFICATE.certificate().toPath(), 0777),
               "/tmp/certificate.pem")
@@ -107,9 +111,13 @@ final class SecuredClusteredMessagingIT {
           .withEnv("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", "zeebe:26502")
           .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", "operate")
           .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", "operate")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED", "true")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH", "/tmp/certificate.pem")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH", "/tmp/key.pem")
+          .withEnv("CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_ENABLED", "true")
+          .withEnv(
+              "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATECHAINPATH",
+              "/tmp/certificate.pem")
+          .withEnv(
+              "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATEPRIVATEKEYPATH",
+              "/tmp/key.pem")
           .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", zeebe.getInternalGatewayAddress())
           .withCopyToContainer(
               MountableFile.forHostPath(CERTIFICATE.certificate().toPath(), 0777),
@@ -148,9 +156,13 @@ final class SecuredClusteredMessagingIT {
           .withEnv("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", "zeebe:26502")
           .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", "tasklist")
           .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", "tasklist")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED", "true")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH", "/tmp/certificate.pem")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH", "/tmp/key.pem")
+          .withEnv("CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_ENABLED", "true")
+          .withEnv(
+              "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATECHAINPATH",
+              "/tmp/certificate.pem")
+          .withEnv(
+              "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATEPRIVATEKEYPATH",
+              "/tmp/key.pem")
           .withCopyToContainer(
               MountableFile.forHostPath(CERTIFICATE.certificate().toPath(), 0777),
               "/tmp/certificate.pem")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/SecureClusteredMessagingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/SecureClusteredMessagingIT.java
@@ -146,38 +146,45 @@ final class SecureClusteredMessagingIT {
   }
 
   private static void configureCertChainGateway(final TestStandaloneGateway gateway) {
-    // set security via properties because it is not yet supported in unified config
-    gateway.withProperty("zeebe.gateway.cluster.security.enabled", true);
-    gateway.withProperty(
-        "zeebe.gateway.cluster.security.certificateChainPath", CERTIFICATE.certificate());
-    gateway.withProperty("zeebe.gateway.cluster.security.privateKeyPath", CERTIFICATE.privateKey());
+    gateway.withUnifiedConfig(
+        cfg -> {
+          final var tlsCluster = cfg.getSecurity().getTransportLayerSecurity().getCluster();
+          tlsCluster.setEnabled(true);
+          tlsCluster.setCertificateChainPath(CERTIFICATE.certificate());
+          tlsCluster.setCertificatePrivateKeyPath(CERTIFICATE.privateKey());
+        });
   }
 
   private static void configureCertChainBroker(final TestStandaloneBroker broker) {
-    // set security via properties because it is not yet supported in unified config
-    broker.withProperty("zeebe.broker.network.security.enabled", true);
-    broker.withProperty(
-        "zeebe.broker.network.security.certificateChainPath", CERTIFICATE.certificate());
-    broker.withProperty("zeebe.broker.network.security.privateKeyPath", CERTIFICATE.privateKey());
+    broker.withUnifiedConfig(
+        cfg -> {
+          final var tlsCluster = cfg.getSecurity().getTransportLayerSecurity().getCluster();
+          tlsCluster.setEnabled(true);
+          tlsCluster.setCertificateChainPath(CERTIFICATE.certificate());
+          tlsCluster.setCertificatePrivateKeyPath(CERTIFICATE.privateKey());
+        });
   }
 
   private static void configureKeyStoreGateway(
-      // set security via properties because it is not yet supported in unified config
-      final TestStandaloneGateway gateway,
-      final File pkcs12) {
-    gateway.withProperty("zeebe.gateway.cluster.security.enabled", true);
-    gateway.withProperty(
-        "zeebe.gateway.cluster.security.keyStore.filePath", pkcs12.getAbsolutePath());
-    gateway.withProperty("zeebe.gateway.cluster.security.keyStore.password", "password");
+      final TestStandaloneGateway gateway, final File pkcs12) {
+    gateway.withUnifiedConfig(
+        cfg -> {
+          final var tlsCluster = cfg.getSecurity().getTransportLayerSecurity().getCluster();
+          tlsCluster.setEnabled(true);
+          tlsCluster.getKeyStore().setFilePath(pkcs12.getAbsoluteFile());
+          tlsCluster.getKeyStore().setPassword("password");
+        });
   }
 
   private static void configureKeyStoreBroker(
       final TestStandaloneBroker broker, final File pkcs12) {
-    // set security via properties because it is not yet supported in unified config
-    broker.withProperty("zeebe.broker.network.security.enabled", true);
-    broker.withProperty(
-        "zeebe.broker.network.security.keyStore.filePath", pkcs12.getAbsoluteFile());
-    broker.withProperty("zeebe.broker.network.security.keyStore.password", "password");
+    broker.withUnifiedConfig(
+        cfg -> {
+          final var tlsCluster = cfg.getSecurity().getTransportLayerSecurity().getCluster();
+          tlsCluster.setEnabled(true);
+          tlsCluster.getKeyStore().setFilePath(pkcs12.getAbsoluteFile());
+          tlsCluster.getKeyStore().setPassword("password");
+        });
   }
 
   private record TestCase(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/Pkcs1SupportTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/Pkcs1SupportTest.java
@@ -55,12 +55,16 @@ final class Pkcs1SupportTest {
             .withEnv("SERVER_SSL_ENABLED", "true")
             .withEnv("SERVER_SSL_CERTIFICATE", containerCertPath)
             .withEnv("SERVER_SSL_CERTIFICATEPRIVATEKEY", containerKeyPath)
-            .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
-            .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", containerCertPath)
-            .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", containerKeyPath)
-            .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED", "true")
-            .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_CERTIFICATECHAINPATH", containerCertPath)
-            .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH", containerKeyPath)
+            .withEnv("CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_ENABLED", "true")
+            .withEnv(
+                "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATECHAINPATH",
+                containerCertPath)
+            .withEnv(
+                "CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_CERTIFICATEPRIVATEKEYPATH",
+                containerKeyPath)
+            .withEnv("CAMUNDA_API_GRPC_SSL_ENABLED", "true")
+            .withEnv("CAMUNDA_API_GRPC_SSL_CERTIFICATE", containerCertPath)
+            .withEnv("CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY", containerKeyPath)
             .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
             .withoutTopologyCheck(); // avoid the missing TLS config by the client
 


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.security in unified config.

The legacy properties are:
zeebe.broker.network.security.enabled
zeebe.broker.network.security.certificateChainPath
zeebe.broker.network.security.privateKeyPath
zeebe.broker.network.security.keyStore.filePath
zeebe.broker.network.security.keyStore.password
zeebe.gateway.cluster.security.enabled
zeebe.gateway.cluster.security.certificateChainPath
zeebe.gateway.cluster.security.privateKeyPath
zeebe.gateway.cluster.security.keyStore.filePath
zeebe.gateway.cluster.security.keyStore.password

The new properties are:
camunda.security.transport-layer-security.cluster.enabled
camunda.security.transport-layer-security.cluster.certificate-chain-path
camunda.security.transport-layer-security.cluster.certificate-private-key-path
camunda.security.transport-layer-security.cluster.key-store.file-path
camunda.security.transport-layer-security.cluster.key-store.password

Backwards compatibility is not supported for these properties, with the exception that if the legacy properties are set with values that corrrespond to the modern properties, they are accepted.

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code