### PR TITLE
Add expression evaluate to the camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -3110,7 +3110,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   IncidentProcessInstanceStatisticsRequest newIncidentProcessInstanceStatisticsRequest();
 
   /**
-   * Command to evaluate a FEEL expression.
+   * Command to evaluate an expression.
    *
    * <pre>
    * camundaClient

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -58,6 +58,7 @@ import io.camunda.client.api.command.DeployProcessCommandStep1;
 import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.command.EvaluateConditionalCommandStep1;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableDeletionCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
@@ -3107,4 +3108,19 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the incident statistics request
    */
   IncidentProcessInstanceStatisticsRequest newIncidentProcessInstanceStatisticsRequest();
+
+  /**
+   * Command to evaluate a FEEL expression.
+   *
+   * <pre>
+   * camundaClient
+   *  .newEvaluateExpressionCommand()
+   *  .expression("=x + y")
+   *  .tenantId("tenant_123")
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the command
+   */
+  EvaluateExpressionCommandStep1 newEvaluateExpressionCommand();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+
+/** Command to evaluate a FEEL expression. */
+public interface EvaluateExpressionCommandStep1 {
+
+  /**
+   * Sets the FEEL expression to evaluate.
+   *
+   * @param expression the FEEL expression to evaluate (e.g., "=x + y")
+   * @return the builder for this command
+   */
+  EvaluateExpressionCommandStep2 expression(String expression);
+
+  interface EvaluateExpressionCommandStep2
+      extends CommandWithTenantStep<EvaluateExpressionCommandStep2>,
+          FinalCommandStep<EvaluateExpressionResponse> {
+
+    /**
+     * Sets the tenant ID for multi-tenant environments.
+     *
+     * @param tenantId the tenant ID
+     * @return the builder for this command
+     */
+    @Override
+    EvaluateExpressionCommandStep2 tenantId(String tenantId);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
@@ -17,28 +17,18 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 
-/** Command to evaluate a FEEL expression. */
+/** Command to evaluate an expression. */
 public interface EvaluateExpressionCommandStep1 {
 
   /**
-   * Sets the FEEL expression to evaluate.
+   * Sets the expression to evaluate.
    *
-   * @param expression the FEEL expression to evaluate (e.g., "=x + y")
+   * @param expression the expression to evaluate (e.g., "=x + y")
    * @return the builder for this command
    */
   EvaluateExpressionCommandStep2 expression(String expression);
 
   interface EvaluateExpressionCommandStep2
       extends CommandWithTenantStep<EvaluateExpressionCommandStep2>,
-          FinalCommandStep<EvaluateExpressionResponse> {
-
-    /**
-     * Sets the tenant ID for multi-tenant environments.
-     *
-     * @param tenantId the tenant ID
-     * @return the builder for this command
-     */
-    @Override
-    EvaluateExpressionCommandStep2 tenantId(String tenantId);
-  }
+          FinalCommandStep<EvaluateExpressionResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluateExpressionResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluateExpressionResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import java.util.List;
+
+/** Response for the expression evaluation command. */
+public interface EvaluateExpressionResponse {
+
+  /**
+   * Returns the evaluated expression.
+   *
+   * @return the expression that was evaluated
+   */
+  String getExpression();
+
+  /**
+   * Returns the result of the expression evaluation.
+   *
+   * @return the result value. Type depends on the result type (String, Boolean, Number, or Object)
+   */
+  Object getResult();
+
+  /**
+   * Returns the list of warnings generated during expression evaluation.
+   *
+   * @return the list of warnings, or an empty list if none
+   */
+  List<String> getWarnings();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -66,6 +66,7 @@ import io.camunda.client.api.command.DeployProcessCommandStep1;
 import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.command.EvaluateConditionalCommandStep1;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableDeletionCommandStep1;
@@ -226,6 +227,7 @@ import io.camunda.client.impl.command.DeployProcessCommandImpl;
 import io.camunda.client.impl.command.DeployResourceCommandImpl;
 import io.camunda.client.impl.command.EvaluateConditionalCommandImpl;
 import io.camunda.client.impl.command.EvaluateDecisionCommandImpl;
+import io.camunda.client.impl.command.EvaluateExpressionCommandImpl;
 import io.camunda.client.impl.command.GloballyScopedCreateClusterVariableImpl;
 import io.camunda.client.impl.command.GloballyScopedDeleteClusterVariableImpl;
 import io.camunda.client.impl.command.JobUpdateRetriesCommandImpl;
@@ -1548,6 +1550,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public IncidentProcessInstanceStatisticsRequest newIncidentProcessInstanceStatisticsRequest() {
     return new IncidentProcessInstanceStatisticsRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public EvaluateExpressionCommandStep1 newEvaluateExpressionCommand() {
+    return new EvaluateExpressionCommandImpl(httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1554,7 +1554,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public EvaluateExpressionCommandStep1 newEvaluateExpressionCommand() {
-    return new EvaluateExpressionCommandImpl(httpClient, jsonMapper);
+    return new EvaluateExpressionCommandImpl(config, httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.EvaluateExpressionResponseImpl;
+import io.camunda.client.protocol.rest.ExpressionEvaluationRequest;
+import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class EvaluateExpressionCommandImpl
+    implements EvaluateExpressionCommandStep1, EvaluateExpressionCommandStep2 {
+
+  private final ExpressionEvaluationRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public EvaluateExpressionCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new ExpressionEvaluationRequest();
+  }
+
+  @Override
+  public EvaluateExpressionCommandStep2 expression(final String expression) {
+    ArgumentUtil.ensureNotNull("expression", expression);
+    request.setExpression(expression);
+    return this;
+  }
+
+  @Override
+  public EvaluateExpressionCommandStep2 tenantId(final String tenantId) {
+    request.setTenantId(tenantId);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<EvaluateExpressionResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<EvaluateExpressionResponse> send() {
+    final HttpCamundaFuture<EvaluateExpressionResponse> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/expression/evaluation",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        ExpressionEvaluationResult.class,
+        EvaluateExpressionResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
@@ -15,8 +15,10 @@
  */
 package io.camunda.client.impl.command;
 
+import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
@@ -38,11 +40,35 @@ public class EvaluateExpressionCommandImpl
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
+  public EvaluateExpressionCommandImpl(
+      final CamundaClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new ExpressionEvaluationRequest();
+    tenantId(config.getDefaultTenantId());
+  }
+
+  /**
+   * A constructor that provides an instance with the <code><default></code> tenantId set.
+   *
+   * <p>From version 8.8.0, the java client supports multi-tenancy for this command, which requires
+   * the <code>tenantId</code> property to be defined. This constructor is only intended for
+   * backwards compatibility in tests.
+   *
+   * @deprecated since 8.8.0, use {@link
+   *     EvaluateExpressionCommandImpl#EvaluateExpressionCommandImpl(CamundaClientConfiguration,
+   *     HttpClient, JsonMapper)}
+   */
+  @Deprecated
   public EvaluateExpressionCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     request = new ExpressionEvaluationRequest();
+    request.setTenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateExpressionResponseImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
+import java.util.Collections;
+import java.util.List;
+
+public class EvaluateExpressionResponseImpl implements EvaluateExpressionResponse {
+
+  private final String expression;
+  private final Object result;
+  private final List<String> warnings;
+
+  public EvaluateExpressionResponseImpl(final ExpressionEvaluationResult response) {
+    expression = response.getExpression();
+    result = response.getResult();
+    warnings = response.getWarnings() != null ? response.getWarnings() : Collections.emptyList();
+  }
+
+  @Override
+  public String getExpression() {
+    return expression;
+  }
+
+  @Override
+  public Object getResult() {
+    return result;
+  }
+
+  @Override
+  public List<String> getWarnings() {
+    return warnings;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -48,7 +48,7 @@ public final class EvaluateExpressionTest extends ClientRestTest {
         .hasMethod(RequestMethod.POST)
         .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
         .extractingBody(ExpressionEvaluationRequest.class)
-        .isEqualTo(new ExpressionEvaluationRequest().expression(expression));
+        .isEqualTo(new ExpressionEvaluationRequest().expression(expression).tenantId("<default>"));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.expression;
+
+import static io.camunda.client.util.assertions.LoggedRequestAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.protocol.rest.ExpressionEvaluationRequest;
+import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public final class EvaluateExpressionTest extends ClientRestTest {
+
+  @Test
+  void shouldEvaluateExpression() {
+    // given
+    final String expression = "=x + y";
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client.newEvaluateExpressionCommand().expression(expression).send().join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(new ExpressionEvaluationRequest().expression(expression));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithTenantId() {
+    // given
+    final String expression = "=x + y";
+    final String tenantId = "tenant_123";
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client.newEvaluateExpressionCommand().expression(expression).tenantId(tenantId).send().join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(new ExpressionEvaluationRequest().expression(expression).tenantId(tenantId));
+  }
+
+  @Test
+  void shouldRaiseIllegalArgumentExceptionWhenExpressionIsNull() {
+    // when / then
+    assertThatThrownBy(() -> client.newEvaluateExpressionCommand().expression(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("expression must not be null");
+  }
+
+  @Test
+  void shouldReceiveExpressionEvaluationResult() {
+    // given
+    final String expression = "=x + y";
+    final Object resultValue = 30;
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult()
+            .expression(expression)
+            .result(resultValue)
+            .warnings(Collections.emptyList()));
+
+    // when
+    final EvaluateExpressionResponse response =
+        client.newEvaluateExpressionCommand().expression(expression).send().join();
+
+    // then
+    assertThat(response.getExpression()).isEqualTo(expression);
+    assertThat(response.getResult()).isEqualTo(resultValue);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldReceiveExpressionEvaluationResultWithWarnings() {
+    // given
+    final String expression = "=x + y";
+    final Object resultValue = 30;
+    final List<String> warnings = Arrays.asList("Warning 1", "Warning 2");
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult()
+            .expression(expression)
+            .result(resultValue)
+            .warnings(warnings));
+
+    // when
+    final EvaluateExpressionResponse response =
+        client.newEvaluateExpressionCommand().expression(expression).send().join();
+
+    // then
+    assertThat(response.getExpression()).isEqualTo(expression);
+    assertThat(response.getResult()).isEqualTo(resultValue);
+    assertThat(response.getWarnings()).containsExactly("Warning 1", "Warning 2");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -44,6 +44,7 @@ public class RestGatewayPaths {
       REST_API_PATH + "/decision-requirements/%s";
   private static final String URL_DEPLOYMENTS = REST_API_PATH + "/deployments";
   private static final String URL_ELEMENT_INSTANCE = REST_API_PATH + "/element-instances/%s";
+  private static final String URL_EXPRESSION_EVALUATION = REST_API_PATH + "/expression/evaluation";
   private static final String URL_GROUP = REST_API_PATH + "/groups/%s";
   private static final String URL_GROUPS = REST_API_PATH + "/groups";
   private static final String URL_INCIDENT = REST_API_PATH + "/incidents/%s";
@@ -197,6 +198,10 @@ public class RestGatewayPaths {
 
   public static String getEvaluateDecisionUrl() {
     return URL_DECISION_EVALUATION;
+  }
+
+  public static String getExpressionEvaluationUrl() {
+    return URL_EXPRESSION_EVALUATION;
   }
 
   /**

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -35,6 +35,7 @@ import io.camunda.client.protocol.rest.DeploymentResult;
 import io.camunda.client.protocol.rest.ElementInstanceResult;
 import io.camunda.client.protocol.rest.EvaluateConditionalResult;
 import io.camunda.client.protocol.rest.EvaluateDecisionResult;
+import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
 import io.camunda.client.protocol.rest.FormResult;
 import io.camunda.client.protocol.rest.GroupCreateResult;
 import io.camunda.client.protocol.rest.GroupResult;
@@ -118,6 +119,10 @@ public class RestGatewayService {
 
   public void onEvaluateDecisionRequest(final EvaluateDecisionResult response) {
     registerPost(RestGatewayPaths.getEvaluateDecisionUrl(), response);
+  }
+
+  public void onExpressionEvaluationRequest(final ExpressionEvaluationResult response) {
+    registerPost(RestGatewayPaths.getExpressionEvaluationUrl(), response);
   }
 
   public void onDeploymentsRequest(final DeploymentResult response) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.EVALUATE;
+import static io.camunda.client.api.search.enums.ResourceType.EXPRESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class ExpressionAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final String AUTHORIZED_USER = "authorizedUser";
+  private static final String UNAUTHORIZED_USER = "unauthorizedUser";
+
+  @UserDefinition
+  private static final TestUser AUTHORIZED_USER_DEF =
+      new TestUser(
+          AUTHORIZED_USER,
+          "password",
+          List.of(new Permissions(EXPRESSION, EVALUATE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser UNAUTHORIZED_USER_DEF =
+      new TestUser(UNAUTHORIZED_USER, "password", List.of());
+
+  @Test
+  void shouldEvaluateExpressionWithEvaluatePermission(
+      @Authenticated(AUTHORIZED_USER) final CamundaClient userClient) {
+    // when
+    final var response =
+        userClient.newEvaluateExpressionCommand().expression("=1 + 2").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldRejectEvaluateExpressionWithoutEvaluatePermission(
+      @Authenticated(UNAUTHORIZED_USER) final CamundaClient userClient) {
+    // when / then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () -> userClient.newEvaluateExpressionCommand().expression("=1 + 2").send().join())
+        .withMessageContaining("403");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -1,0 +1,677 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ExpressionEvaluationIT {
+
+  private static CamundaClient camundaClient;
+
+  // ============ BASIC EXPRESSION TESTS (NO VARIABLES) ============
+
+  @Test
+  void shouldEvaluateSimpleIntegerExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=1 + 2").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getExpression()).isEqualTo("=1 + 2");
+    assertThat(response.getResult()).isEqualTo(3);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateSimpleDoubleExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=1.5 + 2.6").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(4.1);
+  }
+
+  @Test
+  void shouldEvaluateSimpleStringExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=\"Hello\" + \" \" + \"World\"")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("Hello World");
+  }
+
+  @Test
+  void shouldEvaluateBooleanExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=true and false").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(false);
+  }
+
+  @Test
+  void shouldEvaluateBooleanExpressionTrue() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=true or false").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(true);
+  }
+
+  @Test
+  void shouldEvaluateComparisonExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=5 > 3").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(true);
+  }
+
+  @Test
+  void shouldEvaluateListExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=[1, 2, 3]").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(List.of(1, 2, 3));
+  }
+
+  @Test
+  void shouldEvaluateContextExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("={name: \"John\", age: 30}")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(Map.of("name", "John", "age", 30));
+  }
+
+  @Test
+  void shouldEvaluateIfExpression() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=if 10 > 5 then \"greater\" else \"smaller\"")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("greater");
+  }
+
+  @Test
+  void shouldEvaluateMathFunctions() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("=abs(-5)").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldEvaluateStringFunctions() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=upper case(\"hello\")")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("HELLO");
+  }
+
+  @Test
+  void shouldRejectInvalidExpression() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newEvaluateExpressionCommand()
+                    .expression("={{invalid_syntax}")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("400");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithWarnings() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=invalid_function()")
+            .send()
+            .join();
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getWarnings())
+        .contains("No function found with name 'invalid_function' and 0 parameters");
+  }
+
+  // ============ GLOBAL SCOPED CLUSTER VARIABLE TESTS ============
+
+  @Test
+  void shouldEvaluateExpressionWithGlobalClusterVariableInteger() {
+    // given
+    final String variableName = "globalIntVar_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, 42)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName + " + 8")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithGlobalClusterVariableDouble() {
+    // given
+    final String variableName = "globalDoubleVar_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, 3.14)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName + " * 2")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(6.28);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithGlobalClusterVariableString() {
+    // given
+    final String variableName = "globalStringVar_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "Hello")
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName + " + \" World\"")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("Hello World");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithGlobalClusterVariableObject() {
+    // given
+    final String variableName = "globalObjectVar_" + UUID.randomUUID().toString().replace("-", "");
+    final Map<String, Object> objectValue = Map.of("name", "John", "age", 30);
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, objectValue)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName + ".name")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("John");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithGlobalClusterVariableNestedObject() {
+    // given
+    final String variableName = "globalNestedVar_" + UUID.randomUUID().toString().replace("-", "");
+    final Map<String, Object> nestedObject =
+        Map.of("person", Map.of("name", "Jane", "address", Map.of("city", "Berlin")));
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, nestedObject)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName + ".person.address.city")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("Berlin");
+  }
+
+  // ============ TENANT SCOPED CLUSTER VARIABLE TESTS ============
+
+  @Test
+  void shouldEvaluateExpressionWithTenantClusterVariableInteger() {
+    // given
+    final String variableName = "tenantIntVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantId = "<default>";
+    camundaClient
+        .newTenantScopedClusterVariableCreateRequest(tenantId)
+        .create(variableName, 100)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName + " - 50")
+            .tenantId(tenantId)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithTenantClusterVariableString() {
+    // given
+    final String variableName = "tenantStringVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantId = "<default>";
+    camundaClient
+        .newTenantScopedClusterVariableCreateRequest(tenantId)
+        .create(variableName, "Tenant")
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName + " + \" Value\"")
+            .tenantId(tenantId)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("Tenant Value");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithTenantClusterVariableObject() {
+    // given
+    final String variableName = "tenantObjectVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantId = "<default>";
+    final Map<String, Object> objectValue = Map.of("product", "Widget", "price", 19.99);
+    camundaClient
+        .newTenantScopedClusterVariableCreateRequest(tenantId)
+        .create(variableName, objectValue)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName + ".product")
+            .tenantId(tenantId)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("Widget");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithTenantClusterVariableNestedObject() {
+    // given
+    final String variableName = "tenantNestedVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantId = "<default>";
+    final Map<String, Object> nestedObject =
+        Map.of("config", Map.of("settings", Map.of("enabled", true, "maxRetries", 3)));
+    camundaClient
+        .newTenantScopedClusterVariableCreateRequest(tenantId)
+        .create(variableName, nestedObject)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName + ".config.settings.maxRetries")
+            .tenantId(tenantId)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(3);
+  }
+
+  // ============ ENV (MERGED CONTEXT) TESTS ============
+
+  @Test
+  void shouldEvaluateExpressionWithEnvVariableFromGlobalScope() {
+    // given - create a global variable
+    final String variableName = "envGlobalVar_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    // when - access via env (merged context)
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("GlobalValue");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithEnvVariableFromTenantScope() {
+    // given - create a tenant variable
+    final String variableName = "envTenantVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantId = "<default>";
+    camundaClient
+        .newTenantScopedClusterVariableCreateRequest(tenantId)
+        .create(variableName, "TenantValue")
+        .send()
+        .join();
+
+    // when - access via env (merged context) with tenant
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(tenantId)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("TenantValue");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithEnvVariableTenantOverridesGlobal() {
+    // given - create both global and tenant variable with same name
+    final String variableName = "envOverrideVar_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantId = "<default>";
+
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    camundaClient
+        .newTenantScopedClusterVariableCreateRequest(tenantId)
+        .create(variableName, "TenantValue")
+        .send()
+        .join();
+
+    // when - access via env (merged context) with tenant - should get tenant value
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(tenantId)
+            .send()
+            .join();
+
+    // then - tenant value should override global value
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("TenantValue");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithEnvNestedVariable() {
+    // given
+    final String variableName = "envNestedVar_" + UUID.randomUUID().toString().replace("-", "");
+    final Map<String, Object> nestedObject =
+        Map.of("database", Map.of("host", "localhost", "port", 5432));
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, nestedObject)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName + ".database.host")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("localhost");
+  }
+
+  // ============ COMPLEX EXPRESSION TESTS WITH CLUSTER VARIABLES ============
+
+  @Test
+  void shouldEvaluateComplexExpressionWithMultipleGlobalVariables() {
+    // given
+    final String priceVar = "price_" + UUID.randomUUID().toString().replace("-", "");
+    final String quantityVar = "quantity_" + UUID.randomUUID().toString().replace("-", "");
+    final String discountVar = "discount_" + UUID.randomUUID().toString().replace("-", "");
+
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(priceVar, 100)
+        .send()
+        .join();
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(quantityVar, 5)
+        .send()
+        .join();
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(discountVar, 0.1)
+        .send()
+        .join();
+
+    // when - calculate total with discount
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=camunda.vars.cluster."
+                    + priceVar
+                    + " * camunda.vars.cluster."
+                    + quantityVar
+                    + " * (1 - camunda.vars.cluster."
+                    + discountVar
+                    + ")")
+            .send()
+            .join();
+
+    // then - 100 * 5 * 0.9 = 450
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(450);
+  }
+
+  @Test
+  void shouldEvaluateConditionalExpressionWithClusterVariable() {
+    // given
+    final String thresholdVar = "threshold_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(thresholdVar, 50)
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=if 75 > camunda.vars.cluster." + thresholdVar + " then \"above\" else \"below\"")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("above");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithClusterVariableInList() {
+    // given
+    final String listVar = "items_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(listVar, List.of(1, 2, 3, 4, 5))
+        .send()
+        .join();
+
+    // when - sum of list
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=sum(camunda.vars.cluster." + listVar + ")")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(15);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithClusterVariableStringConcatenation() {
+    // given
+    final String firstNameVar = "firstName_" + UUID.randomUUID().toString().replace("-", "");
+    final String lastNameVar = "lastName_" + UUID.randomUUID().toString().replace("-", "");
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(firstNameVar, "John")
+        .send()
+        .join();
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(lastNameVar, "Doe")
+        .send()
+        .join();
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=camunda.vars.cluster."
+                    + firstNameVar
+                    + " + \" \" + camunda.vars.cluster."
+                    + lastNameVar)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("John Doe");
+  }
+
+  // ============ ERROR HANDLING TESTS ============
+
+  @Test
+  void shouldRejectExpressionWithNonExistentClusterVariable() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newEvaluateExpressionCommand()
+                    .expression("=camunda.vars.cluster.nonExistentVar_" + UUID.randomUUID())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class);
+  }
+
+  @Test
+  void shouldRejectNullExpression() {
+    // when / then
+    assertThatThrownBy(
+            () -> camundaClient.newEvaluateExpressionCommand().expression(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("expression must not be null");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -24,6 +24,97 @@ public class ExpressionEvaluationIT {
 
   private static CamundaClient camundaClient;
 
+  // ============ STATIC EXPRESSION TESTS (LITERALS) ============
+
+  @Test
+  void shouldEvaluateStaticStringLiteral() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("Hello World").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getExpression()).isEqualTo("Hello World");
+    assertThat(response.getResult()).isEqualTo("Hello World");
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateStaticIntegerLiteral() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("42").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(42);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateStaticDoubleLiteral() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("3.14").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(3.14);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateStaticBooleanTrueLiteral() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("true").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(true);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateStaticBooleanFalseLiteral() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("false").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(false);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateStaticNullLiteral() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient.newEvaluateExpressionCommand().expression("null").send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isNull();
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateStaticNestedStructure() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("{person: {name: \"Bob\", scores: [10, 20, 30]}}")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("{person: {name: \"Bob\", scores: [10, 20, 30]}}");
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
   // ============ BASIC EXPRESSION TESTS (NO VARIABLES) ============
 
   @Test
@@ -649,6 +740,81 @@ public class ExpressionEvaluationIT {
     // then
     assertThat(response).isNotNull();
     assertThat(response.getResult()).isEqualTo("John Doe");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithNestedFunctionCalls() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=upper case(substring(\"hello world\", 1, 5))")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo("HELLO");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithForLoop() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=for i in [1, 2, 3] return i * 2")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(List.of(2, 4, 6));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithSomeQuantifier() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=some x in [1, 2, 3] satisfies x > 2")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(true);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithEveryQuantifier() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=every x in [1, 2, 3] satisfies x > 0")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(true);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithFilterList() {
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=[1, 2, 3, 4, 5][item > 2]")
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(List.of(3, 4, 5));
   }
 
   // ============ ERROR HANDLING TESTS ============

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationMultiTenantsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationMultiTenantsIT.java
@@ -1,0 +1,755 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.createTenant;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.configuration.InitializationConfiguration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class ExpressionEvaluationMultiTenantsIT {
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication TEST_INSTANCE =
+      new TestCamundaApplication().withBasicAuth().withMultiTenancyEnabled();
+
+  private static final String TENANT_ID_1 = "tenant1";
+  private static final String TENANT_ID_2 = "tenant2";
+  private static final String USERNAME_1 = "user1";
+  private static final String USERNAME_2 = "user2";
+
+  private static CamundaClient adminClient;
+
+  @UserDefinition
+  private static final TestUser USER_1 = new TestUser(USERNAME_1, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_2 = new TestUser(USERNAME_2, "password", List.of());
+
+  @BeforeAll
+  public static void beforeAll(@Authenticated final CamundaClient client) {
+    adminClient = client;
+
+    // Create tenants and assign users
+    createTenant(
+        adminClient,
+        TENANT_ID_1,
+        TENANT_ID_1,
+        InitializationConfiguration.DEFAULT_USER_USERNAME,
+        USERNAME_1);
+
+    createTenant(
+        adminClient,
+        TENANT_ID_2,
+        TENANT_ID_2,
+        InitializationConfiguration.DEFAULT_USER_USERNAME,
+        USERNAME_2);
+  }
+
+  // ============ VARIABLE SCOPING TESTS ============
+
+  @Test
+  void shouldEnforceClusterScopeAlwaysReturnsGlobalVariable() {
+    // given - create both global and tenant variable with same name
+    final String variableName = "scopedVar_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "Tenant1Value")
+        .send()
+        .join();
+
+    // when - access via .cluster from tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - .cluster ALWAYS returns global value, ignoring tenant scope
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo("GlobalValue");
+
+    // when - access via .cluster from tenant2 (no tenant variable)
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - .cluster ALWAYS returns global value
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo("GlobalValue");
+  }
+
+  @Test
+  void shouldEnforceTenantScopeAlwaysReturnsTenantSpecificVariable() {
+    // given - create both global and tenant variable with same name
+    final String variableName = "tenantOnly_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "Tenant1Value")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_2)
+        .create(variableName, "Tenant2Value")
+        .send()
+        .join();
+
+    // when - access via .tenant from tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - .tenant ONLY returns tenant-scoped value, never global
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo("Tenant1Value");
+
+    // when - access via .tenant from tenant2
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - .tenant ONLY returns tenant-scoped value for tenant2
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo("Tenant2Value");
+  }
+
+  @Test
+  void shouldEnforceEnvScopePrioritizesTenantOverGlobal() {
+    // given - create global variable
+    final String variableName = "envPriority_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    // when - access via .env from tenant1 (no tenant override yet)
+    final EvaluateExpressionResponse responseBeforeOverride =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - .env returns global value when no tenant variable exists
+    assertThat(responseBeforeOverride).isNotNull();
+    assertThat(responseBeforeOverride.getResult()).isEqualTo("GlobalValue");
+
+    // given - now create tenant-scoped override
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "Tenant1Override")
+        .send()
+        .join();
+
+    // when - access via .env from tenant1 (with tenant override)
+    final EvaluateExpressionResponse responseAfterOverride =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - .env now returns tenant value (tenant takes priority over global)
+    assertThat(responseAfterOverride).isNotNull();
+    assertThat(responseAfterOverride.getResult()).isEqualTo("Tenant1Override");
+
+    // when - access via .env from tenant2 (no tenant override for tenant2)
+    final EvaluateExpressionResponse responseTenant2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - .env falls back to global value for tenant2
+    assertThat(responseTenant2).isNotNull();
+    assertThat(responseTenant2.getResult()).isEqualTo("GlobalValue");
+  }
+
+  @Test
+  void shouldDemonstrateAllThreeScopesWithSameVariableName() {
+    // given - create same variable name in global and two tenant scopes
+    final String variableName = "multiScope_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GLOBAL")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "TENANT1")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_2)
+        .create(variableName, "TENANT2")
+        .send()
+        .join();
+
+    // when - evaluate all three scopes from tenant1 context
+    final EvaluateExpressionResponse clusterResponse =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    final EvaluateExpressionResponse tenantResponse =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    final EvaluateExpressionResponse envResponse =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - each scope returns its specific value
+    assertThat(clusterResponse.getResult())
+        .as(".cluster always returns global")
+        .isEqualTo("GLOBAL");
+    assertThat(tenantResponse.getResult())
+        .as(".tenant always returns tenant-specific")
+        .isEqualTo("TENANT1");
+    assertThat(envResponse.getResult())
+        .as(".env prioritizes tenant over global")
+        .isEqualTo("TENANT1");
+
+    // when - evaluate all three scopes from tenant2 context
+    final EvaluateExpressionResponse clusterResponse2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    final EvaluateExpressionResponse tenantResponse2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    final EvaluateExpressionResponse envResponse2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - tenant2 gets different tenant-specific values
+    assertThat(clusterResponse2.getResult())
+        .as(".cluster always returns global (same for all tenants)")
+        .isEqualTo("GLOBAL");
+    assertThat(tenantResponse2.getResult())
+        .as(".tenant returns tenant2-specific value")
+        .isEqualTo("TENANT2");
+    assertThat(envResponse2.getResult())
+        .as(".env prioritizes tenant2 value over global")
+        .isEqualTo("TENANT2");
+  }
+
+  @Test
+  void shouldShowEnvFallbackWhenOnlyGlobalExists() {
+    // given - create only global variable (no tenant overrides)
+    final String variableName = "globalOnly_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    // when - access via .env from tenant1 (no tenant variable)
+    final EvaluateExpressionResponse envResponse1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - .env falls back to global when no tenant variable exists
+    assertThat(envResponse1).isNotNull();
+    assertThat(envResponse1.getResult()).isEqualTo("GlobalValue");
+
+    // when - access via .cluster from tenant1
+    final EvaluateExpressionResponse clusterResponse1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - .cluster returns global (as always)
+    assertThat(clusterResponse1).isNotNull();
+    assertThat(clusterResponse1.getResult()).isEqualTo("GlobalValue");
+
+    // when - try to access via .tenant from tenant1
+    // then - this should fail because .tenant ONLY looks at tenant scope
+    final EvaluateExpressionResponse tenantResponse1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    assertThat(tenantResponse1).isNotNull();
+    assertThat(tenantResponse1.getResult()).isNull();
+  }
+
+  @Test
+  void shouldShowTenantScopeDoesNotFallbackToGlobal() {
+    // given - create only global variable
+    final String variableName = "tenantNoFallback_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    // when/then - .tenant does NOT fall back to global
+    final EvaluateExpressionResponse firstResponse =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    assertThat(firstResponse).isNotNull();
+    assertThat(firstResponse.getResult()).isNull();
+
+    // given - now create tenant-scoped variable
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "Tenant1Value")
+        .send()
+        .join();
+
+    // when - access via .tenant again
+    final EvaluateExpressionResponse secondResponse =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - now it works and returns tenant value
+    assertThat(secondResponse).isNotNull();
+    assertThat(secondResponse.getResult()).isEqualTo("Tenant1Value");
+  }
+
+  // ============ TENANT ISOLATION TESTS ============
+
+  @Test
+  void shouldIsolateTenantClusterVariablesBetweenTenants() {
+    // given - create variables in different tenants with same name
+    final String variableName = "isolatedVar_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "Tenant1Value")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_2)
+        .create(variableName, "Tenant2Value")
+        .send()
+        .join();
+
+    // when - evaluate for tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - should get tenant1 value
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo("Tenant1Value");
+
+    // when - evaluate for tenant2
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.tenant." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - should get tenant2 value
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo("Tenant2Value");
+  }
+
+  @Test
+  void shouldAccessGlobalVariableFromAnyTenant() {
+    // given - create global variable
+    final String variableName = "globalVar_" + UUID.randomUUID().toString().replace("-", "");
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    // when - access from tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - should access global variable
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo("GlobalValue");
+
+    // when - access from tenant2
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.cluster." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - should access same global variable
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo("GlobalValue");
+  }
+
+  @Test
+  void shouldPrioritizeTenantVariableOverGlobalInEnvContext() {
+    // given - create both global and tenant variable with same name
+    final String variableName = "priorityVar_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, "GlobalValue")
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(variableName, "Tenant1Override")
+        .send()
+        .join();
+
+    // when - access via env from tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - tenant value should override global
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo("Tenant1Override");
+
+    // when - access via env from tenant2 (no tenant override)
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=camunda.vars.env." + variableName)
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - should get global value
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo("GlobalValue");
+  }
+
+  // ============ COMPLEX MULTI-TENANT SCENARIOS ============
+
+  @Test
+  void shouldEvaluateComplexExpressionWithMixedGlobalAndTenantVariables() {
+    // given - create global and tenant-specific variables
+    final String globalTaxRate = "taxRate_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantDiscount = "discount_" + UUID.randomUUID().toString().replace("-", "");
+    final String price = "price_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(globalTaxRate, 0.2) // 20% tax
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(tenantDiscount, 0.1) // 10% discount
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(price, 100.0)
+        .send()
+        .join();
+
+    // when - calculate final price: (price - discount) * (1 + tax)
+    final EvaluateExpressionResponse response =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=(camunda.vars.tenant."
+                    + price
+                    + " * (1 - camunda.vars.tenant."
+                    + tenantDiscount
+                    + ")) * (1 + camunda.vars.cluster."
+                    + globalTaxRate
+                    + ")")
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - (100 * 0.9) * 1.2 = 108
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(108);
+  }
+
+  @Test
+  void shouldEvaluateConditionalExpressionBasedOnTenantConfiguration() {
+    // given - different threshold for each tenant
+    final String threshold = "threshold_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(threshold, 100)
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_2)
+        .create(threshold, 200)
+        .send()
+        .join();
+
+    // when - evaluate same expression for tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=if 150 > camunda.vars.tenant." + threshold + " then \"high\" else \"low\"")
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - 150 > 100 = high
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo("high");
+
+    // when - evaluate same expression for tenant2
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=if 150 > camunda.vars.tenant." + threshold + " then \"high\" else \"low\"")
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - 150 > 200 = low
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo("low");
+  }
+
+  @Test
+  void shouldHandleTenantSpecificObjectsAndGlobalReferences() {
+    // given - global reference data and tenant-specific configuration
+    final String globalCurrencies = "currencies_" + UUID.randomUUID().toString().replace("-", "");
+    final String tenantConfig = "config_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(globalCurrencies, Map.of("EUR", 0.90))
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(globalCurrencies, Map.of("EUR", 0.85))
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(tenantConfig, Map.of("currency", "EUR", "amount", 100))
+        .send()
+        .join();
+
+    // when - calculate amount in USD using tenant currency preference
+    final EvaluateExpressionResponse response =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "=camunda.vars.tenant."
+                    + tenantConfig
+                    + ".amount / camunda.vars.env."
+                    + globalCurrencies
+                    + ".EUR")
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - 100 / 0.85 ≈ 117.647
+    assertThat(response).isNotNull();
+    assertThat((Double) response.getResult())
+        .isCloseTo(117.647, org.assertj.core.data.Offset.offset(0.01));
+  }
+
+  @Test
+  void shouldEvaluateTenantSpecificListOperations() {
+    // given - tenant-specific lists
+    final String allowedRegions = "regions_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(allowedRegions, List.of("US", "EU", "APAC"))
+        .send()
+        .join();
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_2)
+        .create(allowedRegions, List.of("US", "EU"))
+        .send()
+        .join();
+
+    // when - check if region is in allowed list for tenant1
+    final EvaluateExpressionResponse response1 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=list contains(camunda.vars.tenant." + allowedRegions + ", \"APAC\")")
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then - APAC is in tenant1's list
+    assertThat(response1).isNotNull();
+    assertThat(response1.getResult()).isEqualTo(true);
+
+    // when - check if region is in allowed list for tenant2
+    final EvaluateExpressionResponse response2 =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression("=list contains(camunda.vars.tenant." + allowedRegions + ", \"APAC\")")
+            .tenantId(TENANT_ID_2)
+            .send()
+            .join();
+
+    // then - APAC is not in tenant2's list
+    assertThat(response2).isNotNull();
+    assertThat(response2.getResult()).isEqualTo(false);
+  }
+
+  @Test
+  void shouldCombineStaticValuesWithTenantVariablesInComplexExpression() {
+    // given - tenant-specific configuration
+    final String multiplier = "multiplier_" + UUID.randomUUID().toString().replace("-", "");
+
+    adminClient
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID_1)
+        .create(multiplier, 2.5)
+        .send()
+        .join();
+
+    // when - combine static value with tenant variable
+    final EvaluateExpressionResponse response =
+        adminClient
+            .newEvaluateExpressionCommand()
+            .expression(
+                "={\"baseValue\": 10, \"multiplied\": 10 * camunda.vars.tenant."
+                    + multiplier
+                    + ", \"label\": \"Tenant "
+                    + TENANT_ID_1
+                    + "\"}")
+            .tenantId(TENANT_ID_1)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult())
+        .isEqualTo(Map.of("baseValue", 10, "multiplied", 25, "label", "Tenant " + TENANT_ID_1));
+  }
+}

--- a/testing/camunda-process-test-coverage-frontend/package-lock.json
+++ b/testing/camunda-process-test-coverage-frontend/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3581,7 +3580,6 @@
       "integrity": "sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tapable": "^1",
@@ -3636,7 +3634,6 @@
       "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "4.33.0",
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -3708,7 +3705,6 @@
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -4067,7 +4063,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4163,7 +4158,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5625,7 +5619,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -7770,7 +7763,6 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
       "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",
@@ -8553,7 +8545,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -8717,7 +8708,6 @@
       "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
@@ -8735,7 +8725,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8803,7 +8792,6 @@
       "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       },
@@ -8826,7 +8814,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8857,7 +8844,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8891,7 +8877,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8946,7 +8931,6 @@
       "integrity": "sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^3.10.1"
       },
@@ -12604,7 +12588,6 @@
       "integrity": "sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^26.6.0",
         "import-local": "^3.0.2",
@@ -13016,7 +12999,6 @@
       "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.0",
         "chalk": "^4.0.0",
@@ -17451,7 +17433,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -17740,7 +17721,6 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18622,7 +18602,6 @@
       "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/node": "*",
@@ -19968,7 +19947,6 @@
       "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "eventsource": "^2.0.2",
@@ -22673,7 +22651,6 @@
       "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",
@@ -22757,7 +22734,6 @@
       "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",

--- a/testing/camunda-process-test-coverage-frontend/package-lock.json
+++ b/testing/camunda-process-test-coverage-frontend/package-lock.json
@@ -67,6 +67,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",

--- a/testing/camunda-process-test-coverage-frontend/package-lock.json
+++ b/testing/camunda-process-test-coverage-frontend/package-lock.json
@@ -3581,6 +3581,7 @@
       "integrity": "sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tapable": "^1",
@@ -3635,6 +3636,7 @@
       "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "4.33.0",
         "@typescript-eslint/scope-manager": "4.33.0",
@@ -3706,6 +3708,7 @@
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -4064,6 +4067,7 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4159,6 +4163,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5620,6 +5625,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -7764,6 +7770,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
       "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",
@@ -8546,6 +8553,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -8709,6 +8717,7 @@
       "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
@@ -8726,6 +8735,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8793,6 +8803,7 @@
       "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       },
@@ -8815,6 +8826,7 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8845,6 +8857,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8878,6 +8891,7 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8932,6 +8946,7 @@
       "integrity": "sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^3.10.1"
       },
@@ -12589,6 +12604,7 @@
       "integrity": "sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^26.6.0",
         "import-local": "^3.0.2",
@@ -13000,6 +13016,7 @@
       "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.0",
         "chalk": "^4.0.0",
@@ -17434,6 +17451,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -17722,6 +17740,7 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18603,6 +18622,7 @@
       "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/node": "*",
@@ -19948,6 +19968,7 @@
       "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "eventsource": "^2.0.2",
@@ -22652,6 +22673,7 @@
       "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",
@@ -22735,6 +22757,7 @@
       "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",


### PR DESCRIPTION
This pull request introduces support for evaluating expressions through the Java client, including a new command, response types, implementation, and comprehensive tests. The main focus is to allow users to evaluate expressions (such as `=x + y`) via the client API, with support for multi-tenancy and proper authorization checks.

The most important changes are:

**New Expression Evaluation Command:**

* Added the `EvaluateExpressionCommandStep1` interface to define the builder pattern for evaluating expressions, including methods to set the expression and tenant ID (`EvaluateExpressionCommandStep1.java`).
* Introduced the `newEvaluateExpressionCommand()` method to the `CamundaClient` interface and implemented it in `CamundaClientImpl` to instantiate the new command (`CamundaClient.java`, `CamundaClientImpl.java`). [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR3111-R3125) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R1555-R1559)

**Implementation and Response Handling:**

* Implemented the command logic in `EvaluateExpressionCommandImpl`, handling HTTP requests, tenant IDs, and response mapping (`EvaluateExpressionCommandImpl.java`).
* Added the `EvaluateExpressionResponse` interface and its implementation to encapsulate the evaluated expression, result, and warnings (`EvaluateExpressionResponse.java`, `EvaluateExpressionResponseImpl.java`). [[1]](diffhunk://#diff-61acef9ebdd1cca735c20eb3fe921a01793cf7cd71559a35c7e55bc8085e15bcR1-R43) [[2]](diffhunk://#diff-039de71ec2606bf90db8ca5cbe1ec86f143325fdce7bb034bbba121129d99565R1-R49)

**Testing and Test Utilities:**

* Added comprehensive unit tests for expression evaluation, including scenarios for tenant IDs, null expressions, and warnings (`EvaluateExpressionTest.java`).
* Updated test utilities to support expression evaluation endpoints and mock responses (`RestGatewayPaths.java`, `RestGatewayService.java`). [[1]](diffhunk://#diff-d7b83c8272c1ffd291792fb70d194f9b783371586a2c728318417fa632edb896R47) [[2]](diffhunk://#diff-d7b83c8272c1ffd291792fb70d194f9b783371586a2c728318417fa632edb896R203-R206) [[3]](diffhunk://#diff-3628147ab45f432fe6f659b44aa4058e9991f76d911a90546e8cb473e93b2a73R38) [[4]](diffhunk://#diff-3628147ab45f432fe6f659b44aa4058e9991f76d911a90546e8cb473e93b2a73R124-R127)

**Authorization Integration Tests:**

* Introduced an integration test to verify that expression evaluation is properly authorized, ensuring only users with the correct permissions can evaluate expressions (`ExpressionAuthorizationIT.java`).