### PR TITLE
Remove documents updated check when updating incidentPosition

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -156,9 +156,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
                   documentsUpdated,
                   batch.highestPosition());
 
-              if (documentsUpdated > 0) {
-                metadata.setLastIncidentUpdatePosition(batch.highestPosition());
-              }
+              metadata.setLastIncidentUpdatePosition(batch.highestPosition());
 
               return CompletableFuture.completedFuture(documentsUpdated);
             },

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -227,12 +227,6 @@ abstract class IncidentUpdateRepositoryIT {
       indexIncident(incident);
       return incident;
     }
-
-    private void indexIncident(final IncidentEntity incident) throws PersistenceException {
-      final var batchRequest = clientAdapter.createBatchRequest();
-      batchRequest.add(incidentTemplate.getFullQualifiedName(), incident);
-      batchRequest.executeWithRefresh();
-    }
   }
 
   @DisabledIfSystemProperty(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -9,10 +9,15 @@ package io.camunda.exporter.tasks.incident;
 
 import static io.camunda.search.test.utils.SearchDBExtension.INCIDENT_IDX_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
@@ -56,11 +61,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.groups.Tuple;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -69,6 +77,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -120,6 +129,12 @@ abstract class IncidentUpdateRepositoryIT {
             template -> engineClient.createIndexTemplate(template, new IndexConfiguration(), true));
   }
 
+  protected abstract IncidentUpdateRepository createRepository();
+
+  protected abstract <T> Collection<T> search(
+      final String index, final String field, final List<String> terms, final Class<T> documentType)
+      throws IOException;
+
   private IncidentEntity newIncident(final long key) {
     final var incident = new IncidentEntity();
     final var id = String.valueOf(key);
@@ -136,11 +151,11 @@ abstract class IncidentUpdateRepositoryIT {
     return incident;
   }
 
-  protected abstract IncidentUpdateRepository createRepository();
-
-  protected abstract <T> Collection<T> search(
-      final String index, final String field, final List<String> terms, final Class<T> documentType)
-      throws IOException;
+  private void indexIncident(final IncidentEntity incident) throws PersistenceException {
+    final var batchRequest = clientAdapter.createBatchRequest();
+    batchRequest.add(incidentTemplate.getFullQualifiedName(), incident);
+    batchRequest.executeWithRefresh();
+  }
 
   @DisabledIfSystemProperty(
       named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
@@ -382,6 +397,48 @@ abstract class IncidentUpdateRepositoryIT {
       final var batchRequest = clientAdapter.createBatchRequest();
       updates.forEach(e -> batchRequest.add(postImporterQueueTemplate.getFullQualifiedName(), e));
       batchRequest.executeWithRefresh();
+    }
+
+    @Test
+    void shouldUpdateLastIncidentUpdatePositionEvenIfBatchMakesNoUpdates() {
+      // given
+      final var metadata = new ExporterMetadata(new ObjectMapper());
+      final var repository = createRepository();
+      final var executor = Executors.newSingleThreadScheduledExecutor();
+
+      final var incidentNotifier = Mockito.mock(IncidentNotifier.class);
+      when(incidentNotifier.notifyAsync(anyList()))
+          .thenReturn(CompletableFuture.completedFuture(null));
+
+      // this is the expected state of the incident after the pending incident update
+      final var sparseTree = "PI_1/FN_1/FNI_1";
+      final var incident = newIncident(1L).setState(IncidentState.ACTIVE).setTreePath(sparseTree);
+      indexIncident(incident);
+
+      final var incidentUpdatePosition = 1L;
+      setupIncidentUpdates(incidentUpdatePosition, incidentUpdatePosition);
+
+      engineClient.createIndex(listViewTemplate, new IndexConfiguration());
+      engineClient.createIndex(flowNodeInstanceTemplate, new IndexConfiguration());
+
+      Awaitility.await()
+          .until(
+              () ->
+                  engineClient.indexExists(listViewTemplate.getFullQualifiedName())
+                      && engineClient.indexExists(flowNodeInstanceTemplate.getFullQualifiedName()));
+
+      // when
+      final var incidentUpdateTask =
+          new IncidentUpdateTask(
+              metadata, repository, true, 100, executor, incidentNotifier, LOGGER);
+
+      incidentUpdateTask.execute().toCompletableFuture().join();
+
+      // then
+      Awaitility.await()
+          .until(() -> metadata.getLastIncidentUpdatePosition() == incidentUpdatePosition);
+
+      executor.close();
     }
   }
 


### PR DESCRIPTION
## Description

Incidents are not being generate properly due to a requirement that documents must be updated before updating the incident updated position. For more information refer to the issue. 

The check has been removed as it currently does not seem to have a reason and a test written.

## Related issues

closes https://github.com/camunda/camunda/issues/42366
