### PR TITLE
Fix: SQL subquery alias for RDBMS compatibility

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -25,6 +25,8 @@ import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceVersionStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionMessageSubscriptionStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.RoleDbReader;
@@ -78,6 +80,10 @@ public class RdbmsService {
   private final ProcessDefinitionMessageSubscriptionStatisticsDbReader
       processDefinitionMessageSubscriptionStatisticsDbReader;
   private final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader;
+  private final ProcessDefinitionInstanceStatisticsDbReader
+      processDefinitionInstanceStatisticsDbReader;
+  private final ProcessDefinitionInstanceVersionStatisticsDbReader
+      processDefinitionInstanceVersionStatisticsDbReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -111,7 +117,10 @@ public class RdbmsService {
       final MessageSubscriptionDbReader messageSubscriptionReader,
       final ProcessDefinitionMessageSubscriptionStatisticsDbReader
           processDefinitionMessageSubscriptionStatisticsDbReader,
-      final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader) {
+      final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader,
+      final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsDbReader,
+      final ProcessDefinitionInstanceVersionStatisticsDbReader
+          processDefinitionInstanceVersionStatisticsDbReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.auditLogReader = auditLogReader;
     this.authorizationReader = authorizationReader;
@@ -144,6 +153,9 @@ public class RdbmsService {
     this.processDefinitionMessageSubscriptionStatisticsDbReader =
         processDefinitionMessageSubscriptionStatisticsDbReader;
     this.correlatedMessageSubscriptionReader = correlatedMessageSubscriptionReader;
+    this.processDefinitionInstanceStatisticsDbReader = processDefinitionInstanceStatisticsDbReader;
+    this.processDefinitionInstanceVersionStatisticsDbReader =
+        processDefinitionInstanceVersionStatisticsDbReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -269,6 +281,16 @@ public class RdbmsService {
 
   public RdbmsWriter createWriter(final long partitionId) { // todo fix in all itests afterwards?
     return createWriter(new RdbmsWriterConfig.Builder().partitionId((int) partitionId).build());
+  }
+
+  public ProcessDefinitionInstanceStatisticsDbReader
+      getProcessDefinitionInstanceStatisticsReader() {
+    return processDefinitionInstanceStatisticsDbReader;
+  }
+
+  public ProcessDefinitionInstanceVersionStatisticsDbReader
+      getProcessDefinitionInstanceVersionStatisticsReader() {
+    return processDefinitionInstanceVersionStatisticsDbReader;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceStatisticsDbReader.java
@@ -35,6 +35,11 @@ public class ProcessDefinitionInstanceStatisticsDbReader
     this.processDefinitionMapper = processDefinitionMapper;
   }
 
+  public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> aggregate(
+      final ProcessDefinitionInstanceStatisticsQuery query) {
+    return aggregate(query, ResourceAccessChecks.disabled());
+  }
+
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> aggregate(
       final ProcessDefinitionInstanceStatisticsQuery query,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceVersionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceVersionStatisticsDbReader.java
@@ -35,6 +35,11 @@ public class ProcessDefinitionInstanceVersionStatisticsDbReader
     this.processDefinitionMapper = processDefinitionMapper;
   }
 
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity> aggregate(
+      final ProcessDefinitionInstanceVersionStatisticsQuery query) {
+    return aggregate(query, ResourceAccessChecks.disabled());
+  }
+
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity> aggregate(
       final ProcessDefinitionInstanceVersionStatisticsQuery query,

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -351,7 +351,7 @@
       FROM ${prefix}PROCESS_INSTANCE pi
     <include refid="processInstanceStatisticsWhere"/>
     <include refid="processInstanceStatisticsGroupBy"/>
-    )
+    ) t
   </select>
 
   <select id="processInstanceStatistics" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionInstanceStatisticsDbQuery"

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -77,8 +77,6 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
-import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
-import io.camunda.search.clients.reader.ProcessDefinitionInstanceVersionStatisticsReader;
 import io.camunda.search.clients.reader.ProcessDefinitionMessageSubscriptionStatisticsReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
@@ -269,7 +267,7 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader(
+  public ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsReader(
       final ProcessDefinitionMapper processDefinitionMapper) {
     return new ProcessDefinitionInstanceStatisticsDbReader(processDefinitionMapper);
   }
@@ -282,7 +280,7 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public ProcessDefinitionInstanceVersionStatisticsReader
+  public ProcessDefinitionInstanceVersionStatisticsDbReader
       processDefinitionInstanceVersionStatisticsReader(
           final ProcessDefinitionMapper processDefinitionMapper) {
     return new ProcessDefinitionInstanceVersionStatisticsDbReader(processDefinitionMapper);
@@ -387,7 +385,10 @@ public class RdbmsConfiguration {
       final MessageSubscriptionDbReader messageSubscriptionReader,
       final ProcessDefinitionMessageSubscriptionStatisticsDbReader
           processDefinitionMessageSubscriptionStatisticsReader,
-      final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader) {
+      final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader,
+      final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsReader,
+      final ProcessDefinitionInstanceVersionStatisticsDbReader
+          processDefinitionInstanceVersionStatisticsReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         auditLogReader,
@@ -419,7 +420,9 @@ public class RdbmsConfiguration {
         usageMetricTUDbReader,
         messageSubscriptionReader,
         processDefinitionMessageSubscriptionStatisticsReader,
-        correlatedMessageSubscriptionReader);
+        correlatedMessageSubscriptionReader,
+        processDefinitionInstanceStatisticsReader,
+        processDefinitionInstanceVersionStatisticsReader);
   }
 
   @Bean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR fixes an invalid SQL subquery by adding a required alias, ensuring compatibility with MySQL and other RDBMS databases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
