### PR TITLE
[Backport stable/8.6] fix: never invalidate written records

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -478,8 +478,6 @@ public final class ProcessingStateMachine {
           currentRecord,
           metadata,
           e);
-      pendingResponses.clear();
-      pendingWrites.clear();
     }
     return false;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -380,6 +380,9 @@ public final class ProcessingStateMachine {
       processedCommandsCount++;
       processingMetrics.commandsProcessed();
     }
+    // We are done with processing, no new writes or responses will be added.
+    pendingWrites = Collections.unmodifiableList(pendingWrites);
+    pendingResponses = Collections.unmodifiableCollection(pendingResponses);
   }
 
   /**


### PR DESCRIPTION
# Description
Backport of #42485 to `stable/8.6`.

relates to 