### PR TITLE
feat: add PROCESS_INSTANCE_CREATION to CamundaExporter filter

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import java.util.Map;
 import java.util.Optional;
@@ -123,13 +124,12 @@ public record AuditLogInfo(
       return AuditLogOperationType.UNKNOWN;
     }
 
-    switch (intent) {
-      case ProcessInstanceModificationIntent.MODIFIED:
-        return AuditLogOperationType.MODIFY;
+    return switch (intent) {
+      case ProcessInstanceModificationIntent.MODIFIED -> AuditLogOperationType.MODIFY;
+      case ProcessInstanceCreationIntent.CREATED -> AuditLogOperationType.CREATE;
       // TODO: map additional intents to operations here
-      default:
-        return AuditLogOperationType.UNKNOWN;
-    }
+      default -> AuditLogOperationType.UNKNOWN;
+    };
   }
 
   public record AuditLogActor(AuditLogActorType actorType, String actorId) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -25,6 +25,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_START_EVENT_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MIGRATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
@@ -353,6 +354,7 @@ public class CamundaExporter implements Exporter {
             DECISION,
             DECISION_REQUIREMENTS,
             PROCESS_INSTANCE,
+            PROCESS_INSTANCE_CREATION,
             PROCESS_INSTANCE_MIGRATION,
             PROCESS_INSTANCE_MODIFICATION,
             ROLE,


### PR DESCRIPTION
## Description

feat: add PROCESS_INSTANCE_CREATION to CamundaExporter filter

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related

Related to: #42411

