### PR TITLE
deps: update alpine base image to 3.23.0

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -18,7 +18,7 @@ docker buildx create --use
 export VERSION="${VERSION}"
 export DATE="$(date +%FT%TZ)"
 export REVISION="${REVISION}"
-export BASE_IMAGE=docker.io/library/alpine:3.22.0
+export BASE_IMAGE=docker.io/library/alpine:3.23.0
 
 # if CI (GHA) export the variables for pushing in a later step
 if [ "${CI}" = "true" ]; then

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -224,7 +224,7 @@ jobs:
           export VERSION="$VERSION"
           export DATE="$date_time_stamp"
           export REVISION="$commit_hash"
-          export BASE_IMAGE=docker.io/library/alpine:3.19.1
+          export BASE_IMAGE=docker.io/library/alpine:3.23.0
           sudo apt update
           sudo apt install -y jq
           sudo apt install -y bash

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -4,8 +4,8 @@ ARG BASE_DIGEST="sha256:027bcb32b9435055b31412a5ad29868a53b2f3b6637d9fed0e3bc6f7
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:
-#ARG BASE_IMAGE="alpine:3.22.2"
-#ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
+#ARG BASE_IMAGE="alpine:3.23.0"
+#ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
 
 # Prepare Operate Distribution
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -4,8 +4,8 @@ ARG BASE_DIGEST="sha256:027bcb32b9435055b31412a5ad29868a53b2f3b6637d9fed0e3bc6f7
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:
-#ARG BASE_IMAGE="alpine:3.22.2"
-#ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
+#ARG BASE_IMAGE="alpine:3.23.0"
+#ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
 
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
 WORKDIR /

--- a/optimize/docker/test/verify.sh
+++ b/optimize/docker/test/verify.sh
@@ -9,7 +9,7 @@
 #   VERSION - required; the semantic version, e.g. 8.6.0 or 8.6.0-alpha1
 #   REVISION - required; the sha1 of the commit used to build the artifact
 #   DATE - required; the ISO 8601 date at which the image was built
-#   BASE_IMAGE - required; Docker base image name (e.g. docker.io/library/alpine:3.20.0)
+#   BASE_IMAGE - required; Docker base image name (e.g. docker.io/library/alpine:3.23.0)
 # Arguments:
 #   1 - Docker image names to be checked (no limit on number of images, each is checked separately)
 # Outputs:
@@ -44,7 +44,7 @@ fi
 echo "[INFO] DATE=${DATE}"
 
 if [ -z "${BASE_IMAGE}" ]; then
-  echo >&2 "No BASE_IMAGE was given; make sure to pass a valid base image name, e.g. docker.io/library/alpine:3.22.0"
+  echo >&2 "No BASE_IMAGE was given; make sure to pass a valid base image name, e.g. docker.io/library/alpine:3.23.0"
   exit 1
 fi
 echo "[INFO] BASE_IMAGE=${BASE_IMAGE}"

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -4,8 +4,8 @@ ARG BASE_DIGEST="sha256:027bcb32b9435055b31412a5ad29868a53b2f3b6637d9fed0e3bc6f7
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:
-#ARG BASE_IMAGE="alpine:3.22.2"
-#ARG BASE_DIGEST="sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412"
+#ARG BASE_IMAGE="alpine:3.23.0"
+#ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
 
 # Prepare Tasklist Distribution
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare


### PR DESCRIPTION
## Description

Bumps alpine base image to `3.23.0` where needed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/42544
