### PR TITLE
fix: Fix OpenAPI spec for conditionals

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -54,7 +54,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: 'common-responses.yaml#/components/responses/Forbidden'
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "404":
           description: The process definition was not found for the given processDefinitionKey.
           content:
@@ -94,10 +94,11 @@ components:
 
     EvaluateConditionalResult:
       type: object
+      required:
+        - processInstances
       properties:
         processInstances:
           type: array
-          required: true
           items:
             $ref: '#/components/schemas/ProcessInstanceReference'
           description: List of process instances created. If no root-level conditional start events evaluated to true, the list will be empty.


### PR DESCRIPTION
## Description

Fix issue with OpenAPI spec for conditionals. See [Slack thread](https://camunda.slack.com/archives/C08PLN35WGM/p1765531708791569)

This PR contains another fix regarding the `403` response, which is now updated to align more with the pattern used for `404`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
