### PR TITLE
refactor: reroute load tests to new cluster infra

### DIFF
--- a/.github/scripts/clean-up-load-test-namespaces.sh
+++ b/.github/scripts/clean-up-load-test-namespaces.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deletes Kubernetes namespaces whose "deadline-date" label is on or before the given date.
+# This ensures namespaces are still cleaned up even if the workflow didn't run on their exact deadline day.
+#
+# Usage: clean-up-load-test-namespaces.sh [--execute] [DATE]
+#   --execute: actually delete namespaces (default is dry-run)
+#   DATE:      optional date in YYYY-MM-DD format (defaults to today)
+#
+# Outputs:
+#   NAMESPACES: multiline list of deleted namespaces (written to $GITHUB_OUTPUT if set)
+
+dryRun=true
+if [[ "${1:-}" == "--execute" ]]; then
+  dryRun=false
+  shift
+fi
+
+currentDate=$(date -d "${1:-}" +'%Y-%m-%d' 2>/dev/null || date +'%Y-%m-%d')
+echo "Date used for deletion: $currentDate"
+
+if [[ "$dryRun" == true ]]; then
+  echo "Running in DRY-RUN mode. No namespaces will be deleted. Pass --execute to delete."
+fi
+
+namespacesDeleted=""
+
+for row in $(kubectl get namespace -l deadline-date -o json | jq -r '.items[] | "\(.metadata.name)=\(.metadata.labels["deadline-date"])"');
+do
+  ns="${row%%=*}"
+  deadlineDate="${row#*=}"
+  if [[ "${deadlineDate//-/}" -le "${currentDate//-/}" ]]; then
+    if [[ "$dryRun" == true ]]; then
+      echo "[DRY-RUN] Would delete namespace: $ns (deadline: $deadlineDate)"
+    else
+      kubectl delete namespace "$ns" --wait=false
+    fi
+    namespacesDeleted+=" * $ns (deadline: $deadlineDate)\n"
+  fi
+done
+
+echo -e "Namespaces eligible for deletion:\n$namespacesDeleted"
+
+# Write output for GitHub Actions if running in CI
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo 'NAMESPACES<<EOF'
+    echo "$namespacesDeleted"
+    echo 'EOF'
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -1,4 +1,4 @@
-# description: This workflow deletes eligible load tests when reaching their deadline
+# description: This workflow deletes eligible load tests that reached or passed their deadline
 # type: CI
 # owner: camunda/orchestration-cluster-team
 name: camunda-load-test-clean-up.yml
@@ -8,9 +8,13 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'Date in YYYY-MM-DD format to delete load tests for (defaults to current date)'
+        description: 'Namespaces with deadline-date on or before this date (YYYY-MM-DD) will be deleted. Defaults to current date.'
         type: string
         required: false
+
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 
 defaults:
   run:
@@ -19,8 +23,11 @@ defaults:
     shell: bash
 
 jobs:
-  delete-load-tests-that-reached-deadline:
-    name: Delete load tests that reached deadline
+  # Legacy job: clean up old GKE-based benchmark infrastructure.
+  # Will be removed once migration to the new benchmark infrastructure is complete.
+  # TODO: remove this job after migration is complete, see https://github.com/camunda/team-infrastructure/issues/829
+  delete-load-tests-legacy:
+    name: Delete load tests (legacy infra)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -38,26 +45,63 @@ jobs:
           location: europe-west1-b
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
-        run: |
-          currentDate=$(date -d "${{ inputs.date }}" +'%Y-%m-%d')
-          echo "Date used for deletion: $currentDate"
-          namespacesDeleted=""
-          for ns in $(kubectl get namespace --selector=deadline-date="$currentDate" -o json | jq -r '.items[].metadata.name');
-          do
-            kubectl delete namespace "$ns" --wait=false
-            namespacesDeleted+=" * $ns\n"
-          done
+        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":meow_trash: *Load tests have been cleaned up (legacy):*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.delete-namespaces.outputs.namespaces }}"
+                  }
+                }
+              ]
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-          echo -e "Namespaces deleted:\n$namespacesDeleted"
-          # With multiline strings the output needs to be set differently.
-          #
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
-          #
-          {
-            echo 'NAMESPACES<<EOF'
-            echo "$namespacesDeleted"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+  delete-load-tests:
+    name: Delete load tests (new infra)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+      - name: Delete namespaces eligible for deletion
+        id: delete-namespaces
+        run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -5,6 +5,13 @@
 # called by: camunda-weekly-load-tests.yml, camunda-pr-load-test.yaml
 # type: CI
 # owner: camunda/orchestration-cluster-team
+#
+# Infos from Infra:
+# - Using the infra benchmark prod cluster requires to use Teleport to authenticate.
+# - Camunda images are pushed to registry.camunda.cloud/team-zeebe and pulled from there.
+#   To use them in a namespace, the namespace must be labeled with "registry=harbor"
+#   You must also set the image pull secret to "harbor-registry" in the helm values.
+
 name: Camunda load test
 on:
   workflow_dispatch:
@@ -132,7 +139,12 @@ on:
         default: elasticsearch
 
 env:
+  CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
   HELM_CHART: camunda-platform-8.9
+  # Namespaces MUST start with c8 due to access policy
+  NAMESPACE: c8-${{ inputs.name }}
+  IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
 
 defaults:
   run:
@@ -224,6 +236,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -251,22 +264,10 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -P\!include-optimize
-      - uses: google-github-actions/auth@v3
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GCR
-        uses: docker/login-action@v3
-        with:
-          registry: gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
-          repository: 'gcr.io/zeebe-io/zeebe'
+          repository: '${{ env.IMAGE_REPOSITORY }}/zeebe'
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -295,30 +296,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GAR
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -351,14 +340,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - uses: google-github-actions/auth@v3
+      # Authenticate with Teleport
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v3.0.0
+            version: 17.2.2
+
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+            proxy: camunda.teleport.sh:443
+            token: ${{ env.TELEPORT_JOIN_TOKEN }}
+            kubernetes-cluster: ${{ env.CLUSTER }}
+      
       - name: Create namespace if not exists
         run: |
           cd load-tests/setup
@@ -366,13 +360,13 @@ jobs:
           # the GitHub action by default. We need to correctly configure the git user here to make it work
           git config user.name ${{ github.actor }}
           # Create the namespace for the load test
-          ./newLoadTest.sh ${{ inputs.name }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          ./newLoadTest.sh ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
       - name: Install latest Camunda Platform
         run: |
-          cd load-tests/setup/${{ inputs.name }}
+          cd load-tests/setup/${{ env.NAMESPACE }}
 
           # Build additional load test configuration
-          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}"
+          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set global.image.repository=${{ env.IMAGE_REPOSITORY }} --set global.image.pullSecrets[0].name=harbor-registry"
           # Append load-test-load configuration if not empty
           if [[ -n "${{ needs.calculate-scenario-config.outputs.load-test-load }}" ]]; then
             load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
@@ -381,7 +375,7 @@ jobs:
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
             enable_optimize=${{ inputs.enable-optimize }} \
-            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'gcr.io' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'zeebe-io/zeebe' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
+            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }} --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }} --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
             additional_load_test_configuration="$load_test_config"
       - name: Summarize platform deployment
         if: success()
@@ -389,7 +383,7 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             ## Camunda platform \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }} -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Summarize load test deployment
@@ -397,10 +391,10 @@ jobs:
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             # Load test
-            The test has been set up successfully. You can observe it [here](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?var-namespace=${{ inputs.name }})
+            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})
             ## Load test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }}-test -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Observe build status

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
         with:
           branch: ${{ github.event.pull_request.head.ref }}
-          max_length: 53
+          max_length: 50  # reduced to account for load-test prefix "c8-"" and potential suffixes for uniqueness
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -217,7 +217,6 @@ An example payload looks like this:
     "inputs": {
       "name": benchmark_name,
       "ref": zeebe_ref_name,
-      "cluster": "zeebe-cluster",
       "stable-vms": stable_vms
     }
 }

--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -80,5 +80,12 @@ elasticsearch:
       limits:
         cpu: 3
         memory: 6Gi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: n2-standard-4
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-4
+        effect: NoSchedule
   extraConfig:
     logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -15,13 +15,14 @@ global:
     enabled: false
   image:
     # Image.repository defines the repository from which to fetch the docker images
-    repository: "gcr.io/zeebe-io"
+    repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
     tag: SNAPSHOT
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets: []
+    pullSecrets:
+      - name: harbor-registry
   # By default, we run without Identity
   identity:
     auth:
@@ -58,6 +59,8 @@ orchestration:
   # This means we will have pods like: camunda-0, camunda-1, camunda-2
   fullnameOverride: camunda
   image:
+    registry: registry.camunda.cloud
+    repository: team-zeebe/zeebe
     tag: "SNAPSHOT"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
@@ -72,14 +75,20 @@ orchestration:
   # Resources of the orchestration cluster
   resources:
     requests:
-      cpu: 3500m
+      cpu: 3400m # max on n2-standard-4 due to other overhead
       memory: 2Gi
     limits:
-      cpu: 3500m
+      cpu: 3400m # max on n2-standard-4 due to other overhead
       memory: 2Gi
 
   nodeSelector:
     cloud.google.com/gke-nodepool: n2-standard-4
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
   ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "64Gi"

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -87,6 +87,7 @@ install-platform: setup-leader-balancer
 		--reset-then-reuse-values \
 		--render-subchart-notes \
 		$(platform_values) \
+		-f values-preemptible.yaml \
 		$(additional_platform_configuration)
 
 # Install/upgrade Camunda Platform on stable VMs
@@ -129,6 +130,7 @@ setup-leader-balancer:
 template:
 	helm template $(namespace) camunda/$(helm_chart) \
 		$(platform_values) \
+		-f values-preemptible.yaml \
 		--output-dir .
 
 .PHONY: template-stable

--- a/load-tests/setup/default/values-preemptible.yaml
+++ b/load-tests/setup/default/values-preemptible.yaml
@@ -1,13 +1,13 @@
-# Additional values file to run Zeebe on stable VMs
+# Additional values file to run Zeebe on preemptible/spot VMs
 # https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
 orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4-stable
+    cloud.google.com/gke-nodepool: n2-standard-4
 
   tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-4-stable
+    value: n2-standard-4
     effect: NoSchedule

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -85,6 +85,9 @@ else
 fi
 kubectl label namespace $namespace deadline-date="${deadline_date}" --overwrite
 
+# Label namespace with registry (required to inject image pull secrets)
+kubectl label namespace "$namespace" registry=harbor --overwrite
+
 # Copy default folder to new namespace folder
 cp -rv default/ $namespace
 


### PR DESCRIPTION
## Description

This PR reconfigures the `camunda-load-test.yml` workflow to use the newly introduced `camunda-benchmark` kubernetes infrastructure introduced by the Infra-Team.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

- https://github.com/camunda/team-infrastructure/issues/829
