### PR TITLE
Add data availability measurement in starter application (load-test)

### DIFF
--- a/load-tests/load-tester/pom.xml
+++ b/load-tests/load-tester/pom.xml
@@ -101,6 +101,11 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 

--- a/load-tests/load-tester/pom.xml
+++ b/load-tests/load-tester/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>config</artifactId>
       <version>${version.config}</version>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
 
     <!-- Shared dependencies with the rest of the project -->
     <dependency>
@@ -125,6 +129,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessInstanceStartMeter implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
+  private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
+  private final CopyOnWriteArrayList<PiCreationResult> listOfStartedInstances;
+  private final ScheduledExecutorService piCheckExecutorService;
+  private final AvailabilityChecker availabilityChecker;
+  private final MeterRegistry registry;
+
+  public ProcessInstanceStartMeter(
+      final MeterRegistry meterRegistry,
+      final ScheduledExecutorService scheduledExecutorService,
+      final AvailabilityChecker availabilityChecker) {
+    registry = meterRegistry;
+    partitionToTimerMap = new ConcurrentHashMap<>();
+    listOfStartedInstances = new CopyOnWriteArrayList<>();
+    piCheckExecutorService = scheduledExecutorService;
+    this.availabilityChecker = availabilityChecker;
+  }
+
+  /** Starts the periodic checking for process instance availability. */
+  public void start() {
+    piCheckExecutorService.scheduleAtFixedRate(
+        () -> {
+          try {
+            checkForProcessInstances();
+          } catch (final Exception e) {
+            LOG.error("Failed to check process instances. Will retry...", e);
+          }
+        },
+        1000,
+        250,
+        TimeUnit.MILLISECONDS);
+  }
+
+  /** Stops the periodic checking for process instance availability. */
+  public void stop() {
+    close();
+  }
+
+  @Override
+  public void close() {
+    piCheckExecutorService.shutdownNow();
+  }
+
+  private void checkForProcessInstances() {
+    if (listOfStartedInstances.isEmpty()) {
+      LOG.debug("No instances awaiting, skip check for process instances.");
+      return;
+    }
+
+    LOG.debug("Current instances awaiting {}", listOfStartedInstances.size());
+    final List<Long> list = listOfStartedInstances.stream().map(k -> k.processInstanceKey).toList();
+    availabilityChecker
+        .findAvailableInstances(list)
+        .whenCompleteAsync(
+            (availableInstances, error) -> {
+              if (error != null) {
+                LOG.error("Error while checking for available process instances", error);
+                return;
+              }
+
+              checkAvailableInstances(availableInstances);
+            },
+            piCheckExecutorService);
+  }
+
+  private void checkAvailableInstances(final List<Long> availableInstances) {
+    LOG.debug("Available process instances items: {} ", availableInstances.size());
+    for (final Long availableInstanceKey : availableInstances) {
+      LOG.debug("Available process instance key: {} ", availableInstanceKey);
+
+      for (final PiCreationResult awaitingPI :
+          Collections.unmodifiableList(listOfStartedInstances)) {
+        if (awaitingPI.processInstanceKey == availableInstanceKey) {
+          recordInstanceAvailable(awaitingPI);
+          break;
+        }
+      }
+    }
+  }
+
+  private void recordInstanceAvailable(final PiCreationResult awaitingPI) {
+    final long durationNanos = System.nanoTime() - awaitingPI.startTimeNanos;
+    LOG.debug(
+        "Process instance {} retrieved in {} ms",
+        awaitingPI.processInstanceKey,
+        TimeUnit.NANOSECONDS.toMillis(durationNanos));
+
+    final int partitionId = Protocol.decodePartitionId(awaitingPI.processInstanceKey);
+    partitionToTimerMap
+        .computeIfAbsent(
+            partitionId,
+            key ->
+                MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
+                    .tag("partition", Integer.toString(key))
+                    .register(registry))
+        .record(durationNanos, TimeUnit.NANOSECONDS);
+    listOfStartedInstances.remove(awaitingPI);
+  }
+
+  public void recordProcessInstanceStart(final long processInstanceKey, final long startTimeNanos) {
+    listOfStartedInstances.add(new PiCreationResult(processInstanceKey, startTimeNanos));
+  }
+
+  private record PiCreationResult(long processInstanceKey, long startTimeNanos) {}
+
+  /**
+   * Interface to check the availability of process instances.
+   *
+   * <p>Used to decouple the availability checking logic from the ProcessInstanceStartMeter.
+   */
+  public interface AvailabilityChecker {
+    /**
+     * Finds the process instances that are available from the given list of process instance keys.
+     *
+     * @param processInstanceKeys the list of process instance keys to check
+     * @return a CompletionStage that, when completed, provides the list of available process
+     *     instance keys
+     */
+    CompletionStage<List<Long>> findAvailableInstances(List<Long> processInstanceKeys);
+  }
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe;
 
+import io.camunda.zeebe.StarterLatencyMetricsDoc.StarterMetricKeyNames;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -108,7 +109,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
             partitionId,
             key ->
                 MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
-                    .tag("partition", Integer.toString(key))
+                    .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(key))
                     .register(registry))
         .record(durationNanos, TimeUnit.NANOSECONDS);
     startedInstances.remove(awaitingPI.processInstanceKey);

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -11,30 +11,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -57,9 +53,7 @@ public class Starter extends App {
   private final StarterCfg starterCfg;
   private Timer responseLatencyTimer;
   private ScheduledExecutorService executorService;
-  private ScheduledExecutorService piCheckExecutorService;
-  private ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
-  private CopyOnWriteArrayList<PiCreationResult> results;
+  private ProcessInstanceStartMeter processInstanceStartMeter;
 
   Starter(final AppCfg config) {
     super(config);
@@ -68,47 +62,36 @@ public class Starter extends App {
 
   @Override
   public void run() {
-    partitionToTimerMap = new ConcurrentHashMap<>();
     responseLatencyTimer =
         MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.RESPONSE_LATENCY).register(registry);
-    results = new CopyOnWriteArrayList<>();
-    partitionToTimerMap.put(
-        1,
-        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
-            .tag("partition", "1")
-            .register(registry));
-    partitionToTimerMap.put(
-        2,
-        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
-            .tag("partition", "2")
-            .register(registry));
-    partitionToTimerMap.put(
-        3,
-        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
-            .tag("partition", "3")
-            .register(registry));
+
     final CamundaClient client = createCamundaClient();
+    processInstanceStartMeter =
+        new ProcessInstanceStartMeter(
+            registry,
+            Executors.newScheduledThreadPool(1),
+            (listOfStartedInstances) -> {
+              final CamundaFuture<SearchResponse<ProcessInstance>> send =
+                  client
+                      .newProcessInstanceSearchRequest()
+                      .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
+                      .sort(ProcessInstanceSort::startDate)
+                      .send();
+
+              return send.thenApply(
+                  processInstanceSearchResponse ->
+                      processInstanceSearchResponse.items().stream()
+                          .map(ProcessInstance::getProcessInstanceKey)
+                          .toList());
+            });
+    processInstanceStartMeter.start();
 
     // init - check for topology and deploy process
     printTopology(client);
     deployProcess(client, starterCfg);
 
     // setup to start instances on given rate
-    piCheckExecutorService = Executors.newScheduledThreadPool(20);
     final CountDownLatch countDownLatch = new CountDownLatch(1);
-
-    piCheckExecutorService.scheduleAtFixedRate(
-        () -> {
-          try {
-            queryProcessInstances(client);
-          } catch (final Exception e) {
-            LOG.error("Failed to query process instances. Will retry...", e);
-          }
-        },
-        1000,
-        250,
-        TimeUnit.MILLISECONDS);
-
     executorService = Executors.newScheduledThreadPool(starterCfg.getThreads());
     final ScheduledFuture<?> scheduledTask =
         scheduleProcessInstanceCreation(executorService, countDownLatch, client);
@@ -119,7 +102,7 @@ public class Starter extends App {
                 () -> {
                   if (!executorService.isShutdown()) {
                     executorService.shutdown();
-                    piCheckExecutorService.shutdown();
+                    processInstanceStartMeter.close();
                     try {
                       executorService.awaitTermination(60, TimeUnit.SECONDS);
                     } catch (final InterruptedException e) {
@@ -139,80 +122,7 @@ public class Starter extends App {
 
     scheduledTask.cancel(true);
     executorService.shutdown();
-    piCheckExecutorService.shutdown();
-  }
-
-  private void queryProcessInstances(final CamundaClient client) {
-    LOG.warn("Started {} process instances so far", results.size());
-    // request results for started instances
-
-    final PiCreationResult first = results.getFirst();
-    LOG.info("First result {} ", results.getFirst());
-    final long startTimeNanos = first.startTimeNanos;
-    LOG.info("StartTimeNanos {} ", startTimeNanos);
-    final long millis = TimeUnit.NANOSECONDS.toMillis(startTimeNanos);
-    LOG.info("millis {} ", millis);
-    final long startTimeEpochMillis = first.startTimeEpochMillis;
-    LOG.info("EpochMillis {} ", startTimeEpochMillis);
-    final Instant temporal = Instant.ofEpochMilli(startTimeEpochMillis);
-    LOG.info("Instant {} ", temporal);
-    final OffsetDateTime from = OffsetDateTime.from(temporal.atZone(ZoneId.of("UTC")));
-    LOG.info("OffsetDateTime {} ", from);
-    final List<Long> list = results.stream().map(k -> k.processInstanceKey).toList();
-
-    client
-        .newProcessInstanceSearchRequest()
-        .filter((f) -> f.processInstanceKey(key -> key.in(list)))
-        .sort(ProcessInstanceSort::startDate)
-        .send()
-        .whenCompleteAsync(
-            (resp, error) -> {
-              if (error != null) {
-                LOG.error("Error while requesting process instances", error);
-                return;
-              }
-
-              LOG.warn("Response items: {} ", resp.items().size());
-              resp.items()
-                  .forEach(
-                      pi -> {
-                        LOG.info(
-                            "PI {} - {} start {}",
-                            pi,
-                            pi.getProcessInstanceKey(),
-                            pi.getStartDate());
-                        for (final PiCreationResult waitingPI :
-                            Collections.unmodifiableList(results)) {
-
-                          // TODO do more efficient search
-                          final long processInstanceKey = waitingPI.processInstanceKey;
-                          if (processInstanceKey == pi.getProcessInstanceKey()) {
-                            final long durationNanos = System.nanoTime() - waitingPI.startTimeNanos;
-                            final long durationMillisNanos =
-                                System.currentTimeMillis() - waitingPI.startTimeNanos;
-                            LOG.warn(
-                                "Process instance {} retrieved in {} ms; {} ms (from epoch)",
-                                processInstanceKey,
-                                TimeUnit.NANOSECONDS.toMillis(durationNanos),
-                                durationMillisNanos);
-
-                            final int partitionId = Protocol.decodePartitionId(processInstanceKey);
-                            partitionToTimerMap
-                                .get(partitionId)
-                                .record(durationNanos, TimeUnit.NANOSECONDS);
-                            results.remove(waitingPI);
-                            break;
-                          }
-                          //                          else {
-                          //                            LOG.info(
-                          //                                "PI {} not match {}",
-                          //                                pi.getProcessInstanceKey(),
-                          //                                waitingPI.processInstanceKey);
-                          //                          }
-                        }
-                      });
-            },
-            piCheckExecutorService);
+    processInstanceStartMeter.close();
   }
 
   private ScheduledFuture<?> scheduleProcessInstanceCreation(
@@ -289,55 +199,9 @@ public class Starter extends App {
         .thenApply(
             (response) -> {
               final long processInstanceKey = response.getProcessInstanceKey();
-              final long duration = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
-              final long epochMilli = System.currentTimeMillis() - duration;
-              results.add(new PiCreationResult(processInstanceKey, startTime, epochMilli));
-              //              LOG.warn(
-              //              LOG.warn(
-              //                  "Process instance {} started at around {} (delay {} ms) try to get
-              // from API",
-              //                  processInstanceKey,
-              //                  Instant.ofEpochMilli(epochMilli),
-              //                  duration);
-              //              checkForProcessInstanceExistence(client, startTime,
-              // processInstanceKey);
+              processInstanceStartMeter.recordProcessInstanceStart(processInstanceKey, startTime);
               return response;
             });
-  }
-
-  private void checkForProcessInstanceExistence(
-      final CamundaClient client, final long startTime, final long processInstanceKey) {
-
-    final long duration = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
-    LOG.warn(
-        "Process instance {} started at around {} (delay {} ms) try to get from API",
-        processInstanceKey,
-        Instant.ofEpochMilli(System.currentTimeMillis() - duration),
-        duration);
-    client
-        .newProcessInstanceGetRequest(processInstanceKey)
-        .send()
-        .whenCompleteAsync(
-            (resp, err) -> {
-              if (err != null) {
-                // on error, we need to retry
-                piCheckExecutorService.schedule(
-                    () -> checkForProcessInstanceExistence(client, startTime, processInstanceKey),
-                    100,
-                    TimeUnit.MILLISECONDS);
-                LOG.trace("Failed to get process instance {}", processInstanceKey, err);
-              } else {
-                final long durationNanos = System.nanoTime() - startTime;
-                LOG.warn(
-                    "Process instance {} retrieved in {} ms",
-                    processInstanceKey,
-                    durationNanos / 1_000_000);
-
-                final int partitionId = Protocol.decodePartitionId(processInstanceKey);
-                partitionToTimerMap.get(partitionId).record(durationNanos, TimeUnit.NANOSECONDS);
-              }
-            },
-            piCheckExecutorService);
   }
 
   private CompletionStage<?> startInstanceWithAwaitingResult(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -12,19 +12,29 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
+import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -45,6 +55,11 @@ public class Starter extends App {
       new TypeReference<>() {};
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final StarterCfg starterCfg;
+  private Timer responseLatencyTimer;
+  private ScheduledExecutorService executorService;
+  private ScheduledExecutorService piCheckExecutorService;
+  private ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
+  private CopyOnWriteArrayList<PiCreationResult> results;
 
   Starter(final AppCfg config) {
     super(config);
@@ -53,6 +68,25 @@ public class Starter extends App {
 
   @Override
   public void run() {
+    partitionToTimerMap = new ConcurrentHashMap<>();
+    responseLatencyTimer =
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.RESPONSE_LATENCY).register(registry);
+    results = new CopyOnWriteArrayList<>();
+    partitionToTimerMap.put(
+        1,
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
+            .tag("partition", "1")
+            .register(registry));
+    partitionToTimerMap.put(
+        2,
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
+            .tag("partition", "2")
+            .register(registry));
+    partitionToTimerMap.put(
+        3,
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
+            .tag("partition", "3")
+            .register(registry));
     final CamundaClient client = createCamundaClient();
 
     // init - check for topology and deploy process
@@ -60,9 +94,22 @@ public class Starter extends App {
     deployProcess(client, starterCfg);
 
     // setup to start instances on given rate
+    piCheckExecutorService = Executors.newScheduledThreadPool(20);
     final CountDownLatch countDownLatch = new CountDownLatch(1);
-    final ScheduledExecutorService executorService =
-        Executors.newScheduledThreadPool(starterCfg.getThreads());
+
+    piCheckExecutorService.scheduleAtFixedRate(
+        () -> {
+          try {
+            queryProcessInstances(client);
+          } catch (final Exception e) {
+            LOG.error("Failed to query process instances. Will retry...", e);
+          }
+        },
+        1000,
+        250,
+        TimeUnit.MILLISECONDS);
+
+    executorService = Executors.newScheduledThreadPool(starterCfg.getThreads());
     final ScheduledFuture<?> scheduledTask =
         scheduleProcessInstanceCreation(executorService, countDownLatch, client);
 
@@ -72,6 +119,7 @@ public class Starter extends App {
                 () -> {
                   if (!executorService.isShutdown()) {
                     executorService.shutdown();
+                    piCheckExecutorService.shutdown();
                     try {
                       executorService.awaitTermination(60, TimeUnit.SECONDS);
                     } catch (final InterruptedException e) {
@@ -91,6 +139,80 @@ public class Starter extends App {
 
     scheduledTask.cancel(true);
     executorService.shutdown();
+    piCheckExecutorService.shutdown();
+  }
+
+  private void queryProcessInstances(final CamundaClient client) {
+    LOG.warn("Started {} process instances so far", results.size());
+    // request results for started instances
+
+    final PiCreationResult first = results.getFirst();
+    LOG.info("First result {} ", results.getFirst());
+    final long startTimeNanos = first.startTimeNanos;
+    LOG.info("StartTimeNanos {} ", startTimeNanos);
+    final long millis = TimeUnit.NANOSECONDS.toMillis(startTimeNanos);
+    LOG.info("millis {} ", millis);
+    final long startTimeEpochMillis = first.startTimeEpochMillis;
+    LOG.info("EpochMillis {} ", startTimeEpochMillis);
+    final Instant temporal = Instant.ofEpochMilli(startTimeEpochMillis);
+    LOG.info("Instant {} ", temporal);
+    final OffsetDateTime from = OffsetDateTime.from(temporal.atZone(ZoneId.of("UTC")));
+    LOG.info("OffsetDateTime {} ", from);
+    final List<Long> list = results.stream().map(k -> k.processInstanceKey).toList();
+
+    client
+        .newProcessInstanceSearchRequest()
+        .filter((f) -> f.processInstanceKey(key -> key.in(list)))
+        .sort(ProcessInstanceSort::startDate)
+        .send()
+        .whenCompleteAsync(
+            (resp, error) -> {
+              if (error != null) {
+                LOG.error("Error while requesting process instances", error);
+                return;
+              }
+
+              LOG.warn("Response items: {} ", resp.items().size());
+              resp.items()
+                  .forEach(
+                      pi -> {
+                        LOG.info(
+                            "PI {} - {} start {}",
+                            pi,
+                            pi.getProcessInstanceKey(),
+                            pi.getStartDate());
+                        for (final PiCreationResult waitingPI :
+                            Collections.unmodifiableList(results)) {
+
+                          // TODO do more efficient search
+                          final long processInstanceKey = waitingPI.processInstanceKey;
+                          if (processInstanceKey == pi.getProcessInstanceKey()) {
+                            final long durationNanos = System.nanoTime() - waitingPI.startTimeNanos;
+                            final long durationMillisNanos =
+                                System.currentTimeMillis() - waitingPI.startTimeNanos;
+                            LOG.warn(
+                                "Process instance {} retrieved in {} ms; {} ms (from epoch)",
+                                processInstanceKey,
+                                TimeUnit.NANOSECONDS.toMillis(durationNanos),
+                                durationMillisNanos);
+
+                            final int partitionId = Protocol.decodePartitionId(processInstanceKey);
+                            partitionToTimerMap
+                                .get(partitionId)
+                                .record(durationNanos, TimeUnit.NANOSECONDS);
+                            results.remove(waitingPI);
+                            break;
+                          }
+                          //                          else {
+                          //                            LOG.info(
+                          //                                "PI {} not match {}",
+                          //                                pi.getProcessInstanceKey(),
+                          //                                waitingPI.processInstanceKey);
+                          //                          }
+                        }
+                      });
+            },
+            piCheckExecutorService);
   }
 
   private ScheduledFuture<?> scheduleProcessInstanceCreation(
@@ -120,6 +242,7 @@ public class Starter extends App {
             final var vars = new HashMap<>(baseVariables);
             vars.put(starterCfg.getBusinessKey(), businessKey.incrementAndGet());
 
+            final var startTime = System.nanoTime();
             final CompletionStage<?> requestFuture;
             if (starterCfg.isStartViaMessage()) {
               requestFuture = startInstanceByMessagePublishing(client, vars);
@@ -127,10 +250,12 @@ public class Starter extends App {
               requestFuture =
                   startInstanceWithAwaitingResult(client, starterCfg.getProcessId(), vars);
             } else {
-              requestFuture = startInstance(client, starterCfg.getProcessId(), vars);
+              requestFuture = startInstance(client, startTime, starterCfg.getProcessId(), vars);
             }
-            requestFuture.exceptionally(
-                (error) -> {
+            requestFuture.whenComplete(
+                (noop, error) -> {
+                  final long durationNanos = System.nanoTime() - startTime;
+                  responseLatencyTimer.record(durationNanos, TimeUnit.NANOSECONDS);
                   if (error instanceof final StatusRuntimeException statusRuntimeException) {
                     if (statusRuntimeException.getStatus().getCode() != Code.RESOURCE_EXHAUSTED) {
                       // we don't want to flood the log
@@ -140,7 +265,6 @@ public class Starter extends App {
                           error);
                     }
                   }
-                  return null;
                 });
           } catch (final Exception e) {
             THROTTLED_LOGGER.error("Error on creating new process instance", e);
@@ -151,14 +275,69 @@ public class Starter extends App {
         TimeUnit.NANOSECONDS);
   }
 
-  private static CompletionStage<?> startInstance(
-      final CamundaClient client, final String processId, final HashMap<String, Object> variables) {
+  private CompletionStage<?> startInstance(
+      final CamundaClient client,
+      final long startTime,
+      final String processId,
+      final HashMap<String, Object> variables) {
     return client
         .newCreateInstanceCommand()
         .bpmnProcessId(processId)
         .latestVersion()
         .variables(variables)
-        .send();
+        .send()
+        .thenApply(
+            (response) -> {
+              final long processInstanceKey = response.getProcessInstanceKey();
+              final long duration = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+              final long epochMilli = System.currentTimeMillis() - duration;
+              results.add(new PiCreationResult(processInstanceKey, startTime, epochMilli));
+              //              LOG.warn(
+              //              LOG.warn(
+              //                  "Process instance {} started at around {} (delay {} ms) try to get
+              // from API",
+              //                  processInstanceKey,
+              //                  Instant.ofEpochMilli(epochMilli),
+              //                  duration);
+              //              checkForProcessInstanceExistence(client, startTime,
+              // processInstanceKey);
+              return response;
+            });
+  }
+
+  private void checkForProcessInstanceExistence(
+      final CamundaClient client, final long startTime, final long processInstanceKey) {
+
+    final long duration = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+    LOG.warn(
+        "Process instance {} started at around {} (delay {} ms) try to get from API",
+        processInstanceKey,
+        Instant.ofEpochMilli(System.currentTimeMillis() - duration),
+        duration);
+    client
+        .newProcessInstanceGetRequest(processInstanceKey)
+        .send()
+        .whenCompleteAsync(
+            (resp, err) -> {
+              if (err != null) {
+                // on error, we need to retry
+                piCheckExecutorService.schedule(
+                    () -> checkForProcessInstanceExistence(client, startTime, processInstanceKey),
+                    100,
+                    TimeUnit.MILLISECONDS);
+                LOG.trace("Failed to get process instance {}", processInstanceKey, err);
+              } else {
+                final long durationNanos = System.nanoTime() - startTime;
+                LOG.warn(
+                    "Process instance {} retrieved in {} ms",
+                    processInstanceKey,
+                    durationNanos / 1_000_000);
+
+                final int partitionId = Protocol.decodePartitionId(processInstanceKey);
+                partitionToTimerMap.get(partitionId).record(durationNanos, TimeUnit.NANOSECONDS);
+              }
+            },
+            piCheckExecutorService);
   }
 
   private CompletionStage<?> startInstanceWithAwaitingResult(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 import java.time.Duration;
 
@@ -17,6 +18,8 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
    * instance creation to the time the instance can be queried.
    */
   DATA_AVAILABILITY_LATENCY {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.PARTITION};
+
     private static final Duration[] BUCKETS = {
       Duration.ofMillis(500),
       Duration.ofSeconds(1),
@@ -29,6 +32,11 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
       Duration.ofSeconds(60),
       Duration.ofSeconds(90),
     };
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
 
     @Override
     public String getDescription() {
@@ -90,4 +98,15 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
       return BUCKETS;
     }
   };
+
+  public enum StarterMetricKeyNames implements KeyName {
+
+    /** The ID of the partition associated to the metric */
+    PARTITION {
+      @Override
+      public String asString() {
+        return "partition";
+      }
+    },
+  }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * The data availability latency when starting process instances. It measures the time from
+   * instance creation to the time the instance can be queried.
+   */
+  DATA_AVAILABILITY_LATENCY {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45),
+      Duration.ofSeconds(60),
+      Duration.ofSeconds(90),
+    };
+
+    @Override
+    public String getDescription() {
+      return "The data availability latency when starting process instances. It measures the time from instance creation to the time the instance can be queried.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.data.availability.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
+   * The response latency when starting process instances. It measures the time from sending the
+   * request to receiving the response.
+   */
+  RESPONSE_LATENCY {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(10),
+      Duration.ofMillis(25),
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The response latency when starting process instances. It measures the time from sending the request to receiving the response.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.response.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  };
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.config;
 
+import java.time.Duration;
+
 public class AppCfg {
 
   private String brokerUrl;
@@ -16,6 +18,8 @@ public class AppCfg {
   private StarterCfg starter;
   private WorkerCfg worker;
   private AuthCfg auth;
+  private boolean monitorDataAvailability = true;
+  private Duration monitorDataAvailabilityInterval = Duration.ofMillis(250);
 
   public String getBrokerUrl() {
     return brokerUrl;
@@ -71,5 +75,21 @@ public class AppCfg {
 
   public void setAuth(final AuthCfg auth) {
     this.auth = auth;
+  }
+
+  public boolean isMonitorDataAvailability() {
+    return monitorDataAvailability;
+  }
+
+  public void setMonitorDataAvailability(final boolean monitorDataAvailability) {
+    this.monitorDataAvailability = monitorDataAvailability;
+  }
+
+  public Duration getMonitorDataAvailabilityInterval() {
+    return monitorDataAvailabilityInterval;
+  }
+
+  public void setMonitorDataAvailabilityInterval(final Duration monitorDataAvailabilityInterval) {
+    this.monitorDataAvailabilityInterval = monitorDataAvailabilityInterval;
   }
 }

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -7,6 +7,8 @@ app {
   tls = ${?TLS}
   preferRest = false
   monitoringPort = 9600
+  monitorDataAvailability = true
+  monitorDataAvailabilityInterval = 250ms
 
   auth {
     type = "NONE" # NONE, BASIC

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -25,6 +25,8 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8080");
     assertThat(appCfg.isPreferRest()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+    assertThat(appCfg.isMonitorDataAvailability()).isTrue();
+    assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);
 
     // authentication
     final var authCfg = appCfg.getAuth();
@@ -78,6 +80,8 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8081");
     assertThat(appCfg.isPreferRest()).isTrue();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+    assertThat(appCfg.isMonitorDataAvailability()).isFalse();
+    assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(50);
 
     // authentication
     final var authCfg = appCfg.getAuth();

--- a/load-tests/load-tester/src/test/resources/different-application.conf
+++ b/load-tests/load-tester/src/test/resources/different-application.conf
@@ -5,6 +5,8 @@ app {
   tls = false
   monitoringPort = 9600
   preferRest = true
+  monitorDataAvailability = false
+  monitorDataAvailabilityInterval = 50ms
 
   auth {
     type = "BASIC" # NONE, BASIC

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -109,7 +109,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "enable": true,
+        "enable": false,
         "expr": "zeebe_flow_control_write_rate_maximum{namespace=~\"$namespace\", pod=~\"$pod\"} > zeebe_flow_control_write_rate_limit{namespace=~\"$namespace\", pod=~\"$pod\"}",
         "hide": false,
         "iconColor": "orange",
@@ -121,7 +121,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 26,
   "links": [],
   "panels": [
     {
@@ -230,7 +229,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -329,7 +328,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -364,6 +363,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -424,11 +424,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -513,7 +514,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -546,6 +547,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -606,11 +608,12 @@
               "width": 250
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -654,6 +657,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -714,11 +718,12 @@
               "width": 250
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -754,6 +759,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -801,7 +807,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 12
+            "y": 1015
           },
           "id": 62,
           "options": {
@@ -812,11 +818,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -877,7 +884,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 12
+            "y": 1015
           },
           "id": 232,
           "options": {
@@ -898,7 +905,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -933,6 +940,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -981,7 +989,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 12
+            "y": 1015
           },
           "id": 74,
           "options": {
@@ -992,11 +1000,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1054,7 +1063,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 14
+            "y": 1017
           },
           "id": 118,
           "maxDataPoints": 100,
@@ -1075,7 +1084,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1133,7 +1142,7 @@
             "h": 2,
             "w": 5,
             "x": 8,
-            "y": 842
+            "y": 1019
           },
           "id": 117,
           "maxDataPoints": 100,
@@ -1154,7 +1163,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1212,7 +1221,7 @@
             "h": 2,
             "w": 4,
             "x": 13,
-            "y": 842
+            "y": 1019
           },
           "id": 655,
           "maxDataPoints": 100,
@@ -1233,7 +1242,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1268,6 +1277,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -1317,7 +1327,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 844
+            "y": 1021
           },
           "id": 39,
           "options": {
@@ -1328,11 +1338,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1363,6 +1374,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1411,7 +1423,7 @@
             "h": 6,
             "w": 5,
             "x": 8,
-            "y": 844
+            "y": 1021
           },
           "id": 190,
           "options": {
@@ -1435,11 +1447,12 @@
             "text": {},
             "textMode": "auto",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1501,7 +1514,7 @@
             "h": 6,
             "w": 4,
             "x": 13,
-            "y": 844
+            "y": 1021
           },
           "id": 612,
           "options": {
@@ -1519,7 +1532,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1555,6 +1568,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -1645,7 +1659,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 844
+            "y": 1021
           },
           "id": 33,
           "options": {
@@ -1656,11 +1670,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -1763,7 +1778,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 898
+            "y": 1027
           },
           "id": 622,
           "maxPerRow": 3,
@@ -1886,7 +1901,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 2
+            "y": 1913
           },
           "id": 272,
           "options": {
@@ -1942,7 +1957,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 1920
           },
           "id": 418,
           "options": {
@@ -2060,7 +2075,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 1920
           },
           "id": 421,
           "options": {
@@ -2159,7 +2174,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 843
+            "y": 2754
           },
           "id": 192,
           "options": {
@@ -2272,7 +2287,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 843
+            "y": 2754
           },
           "id": 602,
           "options": {
@@ -2394,7 +2409,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 899
+            "y": 2810
           },
           "id": 194,
           "options": {
@@ -2526,7 +2541,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 899
+            "y": 2810
           },
           "id": 199,
           "options": {
@@ -2665,7 +2680,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 899
+            "y": 2810
           },
           "id": 196,
           "options": {
@@ -2804,7 +2819,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 899
+            "y": 2810
           },
           "id": 200,
           "options": {
@@ -2943,7 +2958,7 @@
             "h": 8,
             "w": 5,
             "x": 12,
-            "y": 903
+            "y": 2814
           },
           "id": 198,
           "options": {
@@ -3082,7 +3097,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 903
+            "y": 2814
           },
           "id": 268,
           "options": {
@@ -3186,7 +3201,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 905
+            "y": 2816
           },
           "id": 189,
           "options": {
@@ -3320,7 +3335,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 905
+            "y": 2816
           },
           "id": 201,
           "options": {
@@ -3443,7 +3458,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 911
+            "y": 2822
           },
           "id": 604,
           "interval": "1s",
@@ -3572,7 +3587,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 911
+            "y": 2822
           },
           "id": 605,
           "interval": "1s",
@@ -3692,7 +3707,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 917
+            "y": 2828
           },
           "id": 543,
           "options": {
@@ -3786,7 +3801,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 923
+            "y": 2834
           },
           "id": 561,
           "options": {
@@ -3884,7 +3899,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 923
+            "y": 2834
           },
           "id": 594,
           "options": {
@@ -3989,7 +4004,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 1914
           },
           "id": 12,
           "options": {
@@ -4089,7 +4104,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 1914
           },
           "id": 13,
           "options": {
@@ -4194,7 +4209,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 8
+            "y": 1919
           },
           "id": 2,
           "options": {
@@ -4301,7 +4316,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 1919
           },
           "id": 3,
           "options": {
@@ -4408,7 +4423,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 14
+            "y": 1925
           },
           "id": 4,
           "options": {
@@ -4506,7 +4521,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 14
+            "y": 1925
           },
           "id": 266,
           "options": {
@@ -4605,7 +4620,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 14
+            "y": 1925
           },
           "id": 267,
           "options": {
@@ -4704,7 +4719,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 846
+            "y": 2757
           },
           "id": 290,
           "options": {
@@ -4800,7 +4815,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 846
+            "y": 2757
           },
           "id": 291,
           "options": {
@@ -4896,7 +4911,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 846
+            "y": 2757
           },
           "id": 288,
           "options": {
@@ -4992,7 +5007,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 846
+            "y": 2757
           },
           "id": 289,
           "options": {
@@ -5102,7 +5117,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 918
+            "y": 2829
           },
           "id": 102,
           "options": {
@@ -5158,7 +5173,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 918
+            "y": 2829
           },
           "id": 112,
           "options": {
@@ -5296,7 +5311,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 926
+            "y": 2837
           },
           "id": 105,
           "options": {
@@ -5351,7 +5366,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 926
+            "y": 2837
           },
           "id": 106,
           "options": {
@@ -5473,7 +5488,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 961
+            "y": 2872
           },
           "id": 182,
           "options": {
@@ -5626,7 +5641,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 1916
           },
           "id": 261,
           "options": {
@@ -5800,7 +5815,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 1916
           },
           "id": 659,
           "options": {
@@ -5921,7 +5936,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 1925
           },
           "id": 98,
           "options": {
@@ -6064,7 +6079,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 1925
           },
           "id": 35,
           "options": {
@@ -6169,7 +6184,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 848
+            "y": 2759
           },
           "id": 579,
           "options": {
@@ -6260,7 +6275,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 848
+            "y": 2759
           },
           "id": 580,
           "options": {
@@ -6355,7 +6370,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 904
+            "y": 2815
           },
           "id": 285,
           "options": {
@@ -6464,7 +6479,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 904
+            "y": 2815
           },
           "id": 286,
           "options": {
@@ -6588,7 +6603,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 6
+            "y": 1917
           },
           "id": 614,
           "options": {
@@ -6690,7 +6705,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 1926
           },
           "id": 64,
           "options": {
@@ -6793,7 +6808,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 1926
           },
           "id": 294,
           "options": {
@@ -6943,7 +6958,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 989
+            "y": 2900
           },
           "id": 260,
           "options": {
@@ -7035,7 +7050,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 994
+            "y": 2905
           },
           "id": 379,
           "options": {
@@ -7130,7 +7145,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 994
+            "y": 2905
           },
           "id": 381,
           "options": {
@@ -7251,7 +7266,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1002
+            "y": 2913
           },
           "id": 37,
           "options": {
@@ -7359,7 +7374,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1002
+            "y": 2913
           },
           "id": 40,
           "options": {
@@ -7457,7 +7472,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1010
+            "y": 2921
           },
           "id": 122,
           "options": {
@@ -7556,7 +7571,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1010
+            "y": 2921
           },
           "id": 124,
           "options": {
@@ -7654,7 +7669,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1018
+            "y": 2929
           },
           "id": 126,
           "options": {
@@ -7752,7 +7767,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1018
+            "y": 2929
           },
           "id": 127,
           "options": {
@@ -7824,7 +7839,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1027
+            "y": 2938
           },
           "id": 339,
           "options": {
@@ -7922,7 +7937,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1027
+            "y": 2938
           },
           "id": 341,
           "options": {
@@ -8059,7 +8074,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 1035
+            "y": 2946
           },
           "id": 343,
           "options": {
@@ -8183,7 +8198,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 1035
+            "y": 2946
           },
           "id": 345,
           "options": {
@@ -8305,7 +8320,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1045
+            "y": 2956
           },
           "id": 347,
           "options": {
@@ -8400,7 +8415,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1045
+            "y": 2956
           },
           "id": 349,
           "options": {
@@ -8495,7 +8510,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1053
+            "y": 2964
           },
           "id": 353,
           "options": {
@@ -8591,7 +8606,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1053
+            "y": 2964
           },
           "id": 351,
           "options": {
@@ -8640,6 +8655,211 @@
         {
           "datasource": {
             "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 692,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "#F2495C",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "s"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "adhocFilters": [],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum by (le) (rate(starter_data_availability_latency_seconds_bucket{ namespace=\"ck-try-queue-benchmark\"}[$__rate_interval]))",
+              "format": "heatmap",
+              "fromExploreMetrics": true,
+              "interval": "",
+              "refId": "starter_data_availability_latency_seconds_bucket-heatmap"
+            }
+          ],
+          "title": "Data availability latency",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 693,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "adhocFilters": [],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(0.99,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{ namespace=\"ck-try-queue-benchmark\"}[$__rate_interval])))",
+              "fromExploreMetrics": true,
+              "interval": "",
+              "legendFormat": "99th Percentile",
+              "refId": "starter_data_availability_latency_seconds_bucket-p99-histogram_quantile"
+            },
+            {
+              "adhocFilters": [],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(0.9,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{ namespace=\"ck-try-queue-benchmark\"}[$__rate_interval])))",
+              "fromExploreMetrics": true,
+              "interval": "",
+              "legendFormat": "90th Percentile",
+              "refId": "starter_data_availability_latency_seconds_bucket-p90-histogram_quantile"
+            },
+            {
+              "adhocFilters": [],
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(0.5,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{ namespace=\"ck-try-queue-benchmark\"}[$__rate_interval])))",
+              "fromExploreMetrics": true,
+              "interval": "",
+              "legendFormat": "50th Percentile",
+              "refId": "starter_data_availability_latency_seconds_bucket-p50-histogram_quantile"
+            }
+          ],
+          "title": "Data availability latency percentiles",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it.",
@@ -8662,7 +8882,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 17
           },
           "id": 132,
           "options": {
@@ -8703,7 +8923,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -8756,6 +8976,7 @@
                 "axisLabel": "seconds",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -8803,7 +9024,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 17
           },
           "id": 222,
           "options": {
@@ -8814,11 +9035,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -8900,7 +9122,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 843
+            "y": 25
           },
           "id": 133,
           "options": {
@@ -8941,7 +9163,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9000,7 +9222,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 843
+            "y": 25
           },
           "id": 135,
           "options": {
@@ -9041,7 +9263,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9099,7 +9321,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 899
+            "y": 33
           },
           "id": 28,
           "options": {
@@ -9140,7 +9362,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9178,6 +9400,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -9223,7 +9446,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 906
+            "y": 40
           },
           "id": 593,
           "options": {
@@ -9234,11 +9457,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9312,7 +9536,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 916
+            "y": 50
           },
           "id": 233,
           "options": {
@@ -9353,7 +9577,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9397,7 +9621,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 916
+            "y": 50
           },
           "id": 269,
           "options": {
@@ -9438,7 +9662,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9454,6 +9678,178 @@
             }
           ],
           "title": "Batch Event Replay Duration",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Time taken to evaluate a feel expression",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 57
+          },
+          "id": 690,
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_feel_expression_evaluation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Feel expression eval duration",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Time taken to prase a feel expression",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 57
+          },
+          "id": 691,
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "12.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_feel_expression_parsing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Feel expression parsing duration",
           "type": "heatmap"
         },
         {
@@ -9481,7 +9877,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 923
+            "y": 64
           },
           "id": 420,
           "options": {
@@ -9519,7 +9915,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9563,7 +9959,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 923
+            "y": 64
           },
           "id": 419,
           "options": {
@@ -9601,7 +9997,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9637,6 +10033,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -9683,7 +10080,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 930
+            "y": 71
           },
           "id": 310,
           "options": {
@@ -9694,11 +10091,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9765,6 +10163,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -9811,7 +10210,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 930
+            "y": 71
           },
           "id": 311,
           "options": {
@@ -9822,11 +10221,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9899,7 +10299,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 937
+            "y": 78
           },
           "id": 235,
           "options": {
@@ -9940,7 +10340,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -9982,7 +10382,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 937
+            "y": 78
           },
           "id": 234,
           "options": {
@@ -10023,7 +10423,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.0.2",
           "targets": [
             {
               "datasource": {
@@ -10119,7 +10519,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2145
+            "y": 4056
           },
           "id": 26,
           "options": {
@@ -10215,7 +10615,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2145
+            "y": 4056
           },
           "id": 27,
           "options": {
@@ -10282,7 +10682,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 2152
+            "y": 4063
           },
           "id": 22,
           "options": {
@@ -10376,7 +10776,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 2152
+            "y": 4063
           },
           "id": 23,
           "options": {
@@ -10470,7 +10870,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 2152
+            "y": 4063
           },
           "id": 24,
           "options": {
@@ -10579,7 +10979,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2146
+            "y": 4057
           },
           "id": 164,
           "options": {
@@ -10735,7 +11135,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2154
+            "y": 4065
           },
           "id": 166,
           "options": {
@@ -10853,7 +11253,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2154
+            "y": 4065
           },
           "id": 168,
           "options": {
@@ -11003,7 +11403,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2147
+            "y": 4058
           },
           "id": 278,
           "options": {
@@ -11142,7 +11542,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2147
+            "y": 4058
           },
           "id": 283,
           "options": {
@@ -11238,7 +11638,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 2154
+            "y": 4065
           },
           "id": 373,
           "options": {
@@ -11335,7 +11735,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2162
+            "y": 4073
           },
           "id": 363,
           "options": {
@@ -11432,7 +11832,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2162
+            "y": 4073
           },
           "id": 406,
           "options": {
@@ -11529,7 +11929,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2169
+            "y": 4080
           },
           "id": 79,
           "options": {
@@ -11626,7 +12026,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2169
+            "y": 4080
           },
           "id": 114,
           "options": {
@@ -11680,7 +12080,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2176
+            "y": 4087
           },
           "id": 86,
           "options": {
@@ -11801,7 +12201,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2176
+            "y": 4087
           },
           "id": 305,
           "options": {
@@ -11866,7 +12266,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2183
+            "y": 4094
           },
           "id": 70,
           "options": {
@@ -12010,7 +12410,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2183
+            "y": 4094
           },
           "id": 72,
           "options": {
@@ -12109,7 +12509,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2191
+            "y": 4102
           },
           "id": 432,
           "interval": "1s",
@@ -12251,7 +12651,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2191
+            "y": 4102
           },
           "id": 95,
           "interval": "1s",
@@ -12370,7 +12770,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 2199
+            "y": 4110
           },
           "id": 205,
           "options": {
@@ -12497,7 +12897,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 2264
+            "y": 4175
           },
           "id": 209,
           "options": {
@@ -12572,7 +12972,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 2319
+            "y": 4230
           },
           "id": 396,
           "options": {
@@ -12637,7 +13037,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 2329
+            "y": 4240
           },
           "id": 215,
           "options": {
@@ -12712,7 +13112,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 407
+            "y": 2318
           },
           "id": 78,
           "options": {
@@ -12757,7 +13157,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
@@ -12834,7 +13235,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 918
+            "y": 2829
           },
           "id": 180,
           "options": {
@@ -12930,7 +13331,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 926
+            "y": 2837
           },
           "id": 368,
           "options": {
@@ -13027,7 +13428,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 926
+            "y": 2837
           },
           "id": 411,
           "options": {
@@ -13123,7 +13524,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 933
+            "y": 2844
           },
           "id": 300,
           "options": {
@@ -13194,7 +13595,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 933
+            "y": 2844
           },
           "id": 89,
           "options": {
@@ -13278,7 +13679,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 940
+            "y": 2851
           },
           "id": 401,
           "options": {
@@ -13401,7 +13802,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 940
+            "y": 2851
           },
           "id": 416,
           "options": {
@@ -13494,7 +13895,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 947
+            "y": 2858
           },
           "id": 386,
           "options": {
@@ -13577,7 +13978,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 947
+            "y": 2858
           },
           "id": 81,
           "options": {
@@ -13662,7 +14063,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 953
+            "y": 2864
           },
           "id": 426,
           "options": {
@@ -13784,7 +14185,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 953
+            "y": 2864
           },
           "id": 427,
           "options": {
@@ -13891,7 +14292,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 960
+            "y": 2871
           },
           "id": 304,
           "options": {
@@ -13963,7 +14364,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 960
+            "y": 2871
           },
           "id": 391,
           "options": {
@@ -14008,7 +14409,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_last_flushed_index_update_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
@@ -14046,7 +14448,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 966
+            "y": 2877
           },
           "id": 687,
           "options": {
@@ -14091,7 +14493,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
@@ -14128,7 +14531,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 966
+            "y": 2877
           },
           "id": 559,
           "options": {
@@ -14173,7 +14576,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(atomix_journal_seek_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_journal_seek_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
@@ -14247,7 +14651,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 966
+            "y": 2877
           },
           "id": 560,
           "options": {
@@ -14356,7 +14760,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 919
+            "y": 2830
           },
           "id": 356,
           "options": {
@@ -14376,7 +14780,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_sequencer_queue_size{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (pod, partition)",
@@ -14416,7 +14821,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 925
+            "y": 2836
           },
           "id": 357,
           "options": {
@@ -14460,7 +14865,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(zeebe_sequencer_batch_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
@@ -14500,7 +14906,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 925
+            "y": 2836
           },
           "id": 358,
           "options": {
@@ -14545,7 +14951,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(zeebe_sequencer_batch_length_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
@@ -14622,7 +15029,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 933
+            "y": 2844
           },
           "id": 586,
           "options": {
@@ -14641,7 +15048,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\"}[$__rate_interval])) by (valueType, intent)",
@@ -14718,7 +15126,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 933
+            "y": 2844
           },
           "id": 589,
           "options": {
@@ -14737,7 +15145,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\"}[$__rate_interval])) by (valueType, intent)",
@@ -14814,7 +15223,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 933
+            "y": 2844
           },
           "id": 590,
           "options": {
@@ -14833,7 +15242,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\"}[$__rate_interval])) by (valueType, intent)",
@@ -14910,7 +15320,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 942
+            "y": 2853
           },
           "id": 606,
           "options": {
@@ -15009,7 +15419,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 942
+            "y": 2853
           },
           "id": 607,
           "options": {
@@ -15118,7 +15528,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 950
+            "y": 2861
           },
           "id": 608,
           "options": {
@@ -15210,7 +15620,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 950
+            "y": 2861
           },
           "id": 609,
           "options": {
@@ -15306,7 +15716,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 958
+            "y": 2869
           },
           "id": 610,
           "options": {
@@ -15416,7 +15826,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 958
+            "y": 2869
           },
           "id": 611,
           "options": {
@@ -15478,7 +15888,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 966
+            "y": 2877
           },
           "id": 588,
           "options": {
@@ -15504,7 +15914,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\"}[$__rate_interval])) by (recordType, valueType, intent)",
@@ -15548,7 +15959,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 966
+            "y": 2877
           },
           "id": 591,
           "options": {
@@ -15574,7 +15985,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\"}[$__rate_interval])) by (valueType, intent)",
@@ -15619,7 +16031,7 @@
             "h": 9,
             "w": 5,
             "x": 12,
-            "y": 966
+            "y": 2877
           },
           "id": 592,
           "options": {
@@ -15645,7 +16057,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\"}[$__rate_interval])) by (valueType, intent)",
@@ -15696,7 +16109,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 966
+            "y": 2877
           },
           "id": 613,
           "options": {
@@ -15813,7 +16226,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 922
+            "y": 2833
           },
           "id": 154,
           "options": {
@@ -15910,7 +16323,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 922
+            "y": 2833
           },
           "id": 144,
           "options": {
@@ -16006,7 +16419,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 928
+            "y": 2839
           },
           "id": 142,
           "options": {
@@ -16103,7 +16516,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 934
+            "y": 2845
           },
           "id": 151,
           "options": {
@@ -16200,7 +16613,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 934
+            "y": 2845
           },
           "id": 152,
           "options": {
@@ -16297,7 +16710,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 940
+            "y": 2851
           },
           "id": 150,
           "options": {
@@ -16394,7 +16807,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 946
+            "y": 2857
           },
           "id": 147,
           "options": {
@@ -16491,7 +16904,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 946
+            "y": 2857
           },
           "id": 149,
           "options": {
@@ -16587,7 +17000,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 953
+            "y": 2864
           },
           "id": 148,
           "options": {
@@ -16683,7 +17096,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 959
+            "y": 2870
           },
           "id": 155,
           "options": {
@@ -16779,7 +17192,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 959
+            "y": 2870
           },
           "id": 156,
           "options": {
@@ -16873,7 +17286,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 967
+            "y": 2878
           },
           "id": 158,
           "options": {
@@ -16970,7 +17383,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 967
+            "y": 2878
           },
           "id": 157,
           "options": {
@@ -17066,7 +17479,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 967
+            "y": 2878
           },
           "id": 146,
           "options": {
@@ -17162,7 +17575,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 973
+            "y": 2884
           },
           "id": 159,
           "options": {
@@ -17258,7 +17671,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 973
+            "y": 2884
           },
           "id": 160,
           "options": {
@@ -17355,7 +17768,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 973
+            "y": 2884
           },
           "id": 153,
           "options": {
@@ -17454,7 +17867,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 980
+            "y": 2891
           },
           "id": 603,
           "options": {
@@ -17534,7 +17947,7 @@
             "h": 8,
             "w": 4,
             "x": 0,
-            "y": 16
+            "y": 1927
           },
           "id": 675,
           "options": {
@@ -17598,7 +18011,7 @@
             "h": 8,
             "w": 10,
             "x": 4,
-            "y": 16
+            "y": 1927
           },
           "id": 676,
           "options": {
@@ -17671,7 +18084,7 @@
             "h": 8,
             "w": 10,
             "x": 14,
-            "y": 16
+            "y": 1927
           },
           "id": 677,
           "options": {
@@ -17783,7 +18196,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 754
+            "y": 2665
           },
           "id": 667,
           "options": {
@@ -17883,7 +18296,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 754
+            "y": 2665
           },
           "id": 683,
           "options": {
@@ -17940,7 +18353,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 762
+            "y": 2673
           },
           "id": 670,
           "options": {
@@ -18025,7 +18438,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 762
+            "y": 2673
           },
           "id": 673,
           "options": {
@@ -18105,7 +18518,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 770
+            "y": 2681
           },
           "id": 669,
           "maxDataPoints": 494,
@@ -18233,7 +18646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 770
+            "y": 2681
           },
           "id": 674,
           "options": {
@@ -18296,7 +18709,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 778
+            "y": 2689
           },
           "id": 678,
           "options": {
@@ -18380,7 +18793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 778
+            "y": 2689
           },
           "id": 668,
           "options": {
@@ -18466,7 +18879,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 786
+            "y": 2697
           },
           "id": 672,
           "options": {
@@ -18586,7 +18999,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 786
+            "y": 2697
           },
           "id": 665,
           "options": {
@@ -18661,7 +19074,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 1101
+            "y": 3012
           },
           "id": 20,
           "options": {
@@ -18706,7 +19119,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(zeebe_elasticsearch_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
@@ -18784,7 +19198,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 1101
+            "y": 3012
           },
           "id": 255,
           "options": {
@@ -18803,7 +19217,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "rate(zeebe_elasticsearch_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_elasticsearch_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
@@ -18839,7 +19254,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 1111
+            "y": 3022
           },
           "id": 21,
           "options": {
@@ -18884,7 +19299,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum(increase(zeebe_elasticsearch_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
@@ -18961,7 +19377,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 1111
+            "y": 3022
           },
           "id": 185,
           "options": {
@@ -18980,7 +19396,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "zeebe_elasticsearch_exporter_bulk_memory_size{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}",
               "format": "time_series",
@@ -19062,7 +19479,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 1121
+            "y": 3032
           },
           "id": 52,
           "options": {
@@ -19086,7 +19503,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*elastic.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*elastic.*\"})",
@@ -19136,7 +19554,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 18
+            "y": 1929
           },
           "id": 616,
           "options": {
@@ -19181,7 +19599,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(zeebe_camunda_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
@@ -19230,7 +19649,7 @@
             "h": 9,
             "w": 3,
             "x": 10,
-            "y": 18
+            "y": 1929
           },
           "id": 617,
           "options": {
@@ -19252,7 +19671,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
               "exemplar": true,
@@ -19335,7 +19755,7 @@
             "h": 9,
             "w": 11,
             "x": 13,
-            "y": 18
+            "y": 1929
           },
           "id": 621,
           "options": {
@@ -19355,7 +19775,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -19393,7 +19814,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 1963
           },
           "id": 618,
           "options": {
@@ -19438,7 +19859,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(zeebe_camunda_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
@@ -19518,7 +19940,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 1968
           },
           "id": 628,
           "options": {
@@ -19571,7 +19993,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$DS_PROMETHEUS"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the rate of evictions of the process cache",
           "fieldConfig": {
@@ -19633,7 +20055,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 1968
           },
           "id": 623,
           "options": {
@@ -19670,7 +20092,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$DS_PROMETHEUS"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The time the cache spent computing or retrieving the new value",
           "fieldConfig": {
@@ -19692,7 +20114,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 1975
           },
           "id": 626,
           "options": {
@@ -19754,7 +20176,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$DS_PROMETHEUS"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -19836,7 +20258,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 1975
           },
           "id": 627,
           "options": {
@@ -19856,7 +20278,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition)",
@@ -19950,7 +20373,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 70
+            "y": 1981
           },
           "id": 643,
           "options": {
@@ -20026,7 +20449,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 79
+            "y": 1990
           },
           "id": 647,
           "options": {
@@ -20110,7 +20533,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 87
+            "y": 1998
           },
           "id": 646,
           "options": {
@@ -20209,7 +20632,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 87
+            "y": 1998
           },
           "id": 645,
           "options": {
@@ -20292,7 +20715,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 87
+            "y": 1998
           },
           "id": 658,
           "options": {
@@ -20388,7 +20811,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 19
+            "y": 1930
           },
           "id": 630,
           "options": {
@@ -20433,7 +20856,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(zeebe_rdbms_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
@@ -20474,7 +20898,7 @@
             "h": 9,
             "w": 11,
             "x": 10,
-            "y": 19
+            "y": 1930
           },
           "id": 636,
           "options": {
@@ -20528,7 +20952,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -20569,7 +20994,7 @@
             "h": 9,
             "w": 3,
             "x": 21,
-            "y": 19
+            "y": 1930
           },
           "id": 634,
           "options": {
@@ -20591,7 +21016,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "$DS_PROMETHEUS"
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
@@ -20647,7 +21073,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 28
+            "y": 1939
           },
           "id": 633,
           "options": {
@@ -20733,7 +21159,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 28
+            "y": 1939
           },
           "id": 688,
           "options": {
@@ -20881,7 +21307,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 36
+            "y": 1947
           },
           "id": 684,
           "options": {
@@ -21074,7 +21500,7 @@
             "h": 8,
             "w": 8,
             "x": 10,
-            "y": 36
+            "y": 1947
           },
           "id": 685,
           "options": {
@@ -21161,7 +21587,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 36
+            "y": 1947
           },
           "id": 686,
           "options": {
@@ -21287,7 +21713,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 1955
           },
           "id": 689,
           "options": {
@@ -21315,7 +21741,11 @@
               "legendFormat": "__auto",
               "range": true,
               "refId": "Execution Queue Memory Size",
-              "useBackend": false
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              }
             }
           ],
           "title": "RDBMS Execution Queue Memory Size",
@@ -21369,7 +21799,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 1544
+            "y": 3455
           },
           "id": 170,
           "maxPerRow": 6,
@@ -21453,7 +21883,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1556
+            "y": 3467
           },
           "id": 174,
           "options": {
@@ -21529,7 +21959,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1556
+            "y": 3467
           },
           "id": 265,
           "options": {
@@ -21609,7 +22039,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2153
+            "y": 4064
           },
           "id": 329,
           "options": {
@@ -21675,7 +22105,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2153
+            "y": 4064
           },
           "id": 319,
           "options": {
@@ -21735,7 +22165,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2161
+            "y": 4072
           },
           "id": 323,
           "maxDataPoints": 25,
@@ -21826,7 +22256,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2161
+            "y": 4072
           },
           "id": 325,
           "options": {
@@ -21924,7 +22354,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2169
+            "y": 4080
           },
           "id": 313,
           "options": {
@@ -21983,7 +22413,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2169
+            "y": 4080
           },
           "id": 321,
           "options": {
@@ -22079,7 +22509,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2177
+            "y": 4088
           },
           "id": 335,
           "options": {
@@ -22137,7 +22567,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2177
+            "y": 4088
           },
           "id": 317,
           "options": {
@@ -22199,7 +22629,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2185
+            "y": 4096
           },
           "id": 327,
           "options": {
@@ -22274,7 +22704,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1106
+            "y": 3017
           },
           "id": 538,
           "options": {
@@ -22359,7 +22789,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1106
+            "y": 3017
           },
           "id": 540,
           "options": {
@@ -22484,7 +22914,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1114
+            "y": 3025
           },
           "id": 444,
           "options": {
@@ -22594,7 +23024,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1114
+            "y": 3025
           },
           "id": 446,
           "options": {
@@ -22703,7 +23133,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1122
+            "y": 3033
           },
           "id": 440,
           "options": {
@@ -22798,7 +23228,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1122
+            "y": 3033
           },
           "id": 442,
           "options": {
@@ -22869,7 +23299,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1107
+            "y": 3018
           },
           "id": 547,
           "options": {
@@ -22992,7 +23422,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1107
+            "y": 3018
           },
           "id": 549,
           "options": {
@@ -23104,7 +23534,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 1108
+            "y": 3019
           },
           "id": 562,
           "options": {
@@ -23203,7 +23633,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 1108
+            "y": 3019
           },
           "id": 563,
           "options": {
@@ -23302,7 +23732,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 1108
+            "y": 3019
           },
           "id": 564,
           "options": {
@@ -23423,7 +23853,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 1109
+            "y": 3020
           },
           "id": 566,
           "options": {
@@ -23521,7 +23951,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 1109
+            "y": 3020
           },
           "id": 567,
           "options": {
@@ -23619,7 +24049,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 1109
+            "y": 3020
           },
           "id": 568,
           "options": {
@@ -23749,7 +24179,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1110
+            "y": 3021
           },
           "id": 573,
           "options": {
@@ -23875,7 +24305,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1110
+            "y": 3021
           },
           "id": 574,
           "options": {
@@ -23989,7 +24419,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1118
+            "y": 3029
           },
           "id": 600,
           "options": {
@@ -24092,7 +24522,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1118
+            "y": 3029
           },
           "id": 601,
           "options": {
@@ -24188,7 +24618,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1126
+            "y": 3037
           },
           "id": 575,
           "options": {
@@ -24297,7 +24727,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1569
+            "y": 3480
           },
           "id": 570,
           "options": {
@@ -24403,7 +24833,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1569
+            "y": 3480
           },
           "id": 577,
           "options": {
@@ -24508,7 +24938,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1577
+            "y": 3488
           },
           "id": 578,
           "options": {
@@ -24604,7 +25034,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1577
+            "y": 3488
           },
           "id": 571,
           "options": {
@@ -24710,7 +25140,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 2176
+            "y": 4087
           },
           "id": 582,
           "options": {
@@ -24801,7 +25231,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 2176
+            "y": 4087
           },
           "id": 583,
           "options": {
@@ -24893,7 +25323,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 2176
+            "y": 4087
           },
           "id": 584,
           "options": {
@@ -24998,7 +25428,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1113
+            "y": 3024
           },
           "id": 596,
           "options": {
@@ -25095,7 +25525,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1113
+            "y": 3024
           },
           "id": 597,
           "options": {
@@ -25157,7 +25587,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1121
+            "y": 3032
           },
           "id": 598,
           "options": {
@@ -25282,7 +25712,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1121
+            "y": 3032
           },
           "id": 599,
           "options": {
@@ -25404,7 +25834,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 903
+            "y": 2814
           },
           "id": 680,
           "options": {
@@ -25502,7 +25932,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 903
+            "y": 2814
           },
           "id": 666,
           "options": {
@@ -25559,7 +25989,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 911
+            "y": 2822
           },
           "id": 681,
           "options": {
@@ -25657,7 +26087,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 911
+            "y": 2822
           },
           "id": 682,
           "options": {
@@ -25811,7 +26241,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1114
+            "y": 3025
           },
           "id": 664,
           "maxPerRow": 6,
@@ -25858,7 +26288,6 @@
       "type": "row"
     }
   ],
-  "preload": false,
   "refresh": "",
   "schemaVersion": 41,
   "tags": [],
@@ -26001,5 +26430,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "zeebe-dashboard",
-  "version": 45
+  "version": 46,
 }


### PR DESCRIPTION
## Description

This PR adds data availability measurement (metrics) to the starter (load test) application.

<img width="1892" height="341" alt="data-availability" src="https://github.com/user-attachments/assets/ba35fe9a-38dd-4783-900e-8117c38fd87c" />

It shows that our instance data is available on average under 2 seconds and with p99 ~5s

How we measure:

* We create an instance async - we take the time (nanos)
* On response (async), we collect the corresponding key
* We collect the key and start time (ns) as a record and put it into a list
* We have a regular job running every 250 ms (separate pool)
* We query/search the process instance API - filter by the keys we know (part of the list)
* If they exist, we get the corresponding PIs back, with that, we can remove our PIs from the list, take the endTime, calculate the duration,a nd register the corresponding time as a metric

**Benefits**:

* We don't do requests for all started instances (first approach https://github.com/camunda/camunda/pull/42082), and do not have a big queue of jobs in the executor and high load on the system as before
    * With this approach, we have ~ 4 requests per second (vs 2000 req/s), meaning a quite low impact
* This allows us to have the same resources (no need for 3 CPUs or higher memory)
* We do not filter by startTime (first approach), as the results were unreliable and often gave the same results, due to sorting, etc. We were not able to properly find our instances
* With the instances directly passing as a filter, we have a great way to directly find the instances we care about

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related https://github.com/camunda/camunda/issues/38890
first approach https://github.com/camunda/camunda/pull/42082 was closed
