### PR TITLE
Reverts the removal of the manual setup

### DIFF
--- a/load-tests/setup/.gitignore
+++ b/load-tests/setup/.gitignore
@@ -1,0 +1,3 @@
+
+#!!! DO NOT ADD CREDENTIALS TO THE REPO !!!
+cloudcredentials.yaml

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -1,0 +1,114 @@
+# Manual set up a load test
+
+Welcome to the manual set up of a load test. :wave:
+
+There are two targets to run a load test against:
+
+* [Self-Managed Zeebe Cluster](#load-testing-self-managed-zeebe-cluster)
+* [Camunda Cloud Cluster](#load-testing-camunda-cloud-saas)
+
+All guides are targeted at a Linux system.
+
+## Requirements
+
+Make sure you have the following installed: docker, gcloud, kubectl, kubens and helm
+
+## Load testing Self-Managed Zeebe Cluster
+
+### How to set up a load test namespace
+
+Just run the `newLoadTest.sh` with your preferred new namespace name.
+
+Like:
+
+```
+. ./newLoadTest.sh my-load-test-name
+```
+
+This will source and run the `newLoadTest.sh` script, which means it will
+create a new k8 namespace and switch to it via `kubens`. Furthermore, a new folder
+will be created with the given name. If you used `.` before `./newLoadTest.sh`
+the script will also change your directory after running, so you can directly start
+to configure your load test.
+
+### How to configure a load test
+
+The load test configuration is completely done via the `values.yaml` file.
+If there is a property missing that you want to change please open an issue at https://github.com/camunda/zeebe-benchmark-helm
+
+#### Use different Zeebe Snapshot
+
+If you want to use your own or a different Zeebe snapshot then you could do the following.
+
+**Build the docker image:**
+
+```bash
+# builds the dist
+mvn clean install -T1C -DskipTests -pl dist -am
+# builds the a new zeebe docker image
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD) --target app .
+# pushes the image to our docker registry
+docker push gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD)
+```
+
+Create a `values.yaml` file and set the newly created image.
+
+The changes should look similar to this:
+
+```yaml
+camunda-platform:
+  zeebe:
+    image:
+      repository: gcr.io/zeebe-io/zeebe
+      tag: <TAG>
+      pullPolicy: Always
+```
+
+### How to run a load test
+
+After you have set up your load test namespace and make changes to your configuration.
+You can start your load test just with `make load-test`.
+
+This will deploy the `camunda`, `elastic` and load tests applications (e.g. `starter` and `worker`).
+
+### How to clean up a load test
+
+After you're done with your load test you should remove the remaining namespace.
+In order to do this easily, just run:
+
+```
+./deleteLoadTest.sh my-load-test-name
+```
+
+This will switch to the default namespace, delete the given namespace, and delete the corresponding folder.
+
+## Running on stable/non-spot VMs
+
+You may sometimes want to run load tests on non-spot (or non-preemptible) VMs, for example, if you
+want to test for slow memory leaks.
+
+To do this, simply pass the copied `values-stable.yaml` file as an additional argument to
+Helm. For example:
+
+```shell
+helm install myRelease zeebe-benchmark/zeebe-benchmark -f values-stable.yaml
+```
+
+You can also use the `*-stable` Makefile jobs, namely:
+
+```shell
+# Deploys the Zeebe pods on stable nodes
+make load-test-stable
+# Spits out the rendered templates targeting stable nodes
+make template-stable
+# Updates a load test targeting stable nodes
+make update-stable
+```
+
+The `clean` job works regardless.
+
+## Load testing Camunda Cloud SaaS
+
+_You need a Kubernetes Cluster at your disposal to run the load test itself, which then connects to your Camunda Cloud Cluster._
+
+Follow the guide [here](https://github.com/camunda/zeebe-benchmark-helm/blob/main/charts/zeebe-benchmark/README.md#running-against-saas).

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -1,0 +1,37 @@
+namespace ?= default
+
+.PHONY: all
+all: load-test
+
+.PHONY: load-test
+load-test:
+	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark --skip-crds
+
+# To deploy the Zeebe pods on stable nodes, use this job
+.PHONY: load-test-stable
+load-test-stable:
+	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values-stable.yaml --skip-crds
+
+# Generates templates from the zeebe helm charts, useful to make some more specific changes which are not doable by the values file.
+# To apply the templates use k apply -f zeebe-benchmark/templates/
+.PHONY: template
+template:
+	helm template $(namespace) zeebe-benchmark/zeebe-benchmark --skip-crds --output-dir .
+
+.PHONY: template-stable
+template-stable:
+	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values-stable.yaml --skip-crds --output-dir .
+
+.PHONY: update
+update:
+	helm upgrade --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark --reuse-values
+
+.PHONY: update-stable
+update-stable:
+	helm upgrade --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark --reuse-values -f values-stable.yaml
+
+.PHONY: clean
+clean:
+	-helm --namespace $(namespace) uninstall $(namespace)
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/instance=$(namespace)
+	-kubectl delete -n $(namespace) pvc -l app=elasticsearch-master

--- a/load-tests/setup/default/values-stable.yaml
+++ b/load-tests/setup/default/values-stable.yaml
@@ -1,0 +1,14 @@
+# Additional values file to run Zeebe on stable VMs
+# https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
+orchestration:
+  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  # However, that node does not have the required cpu/memory capacity
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-4-stable
+
+  # Ignore the stable VM node taints
+  tolerations:
+    - key: cloud.google.com/gke-spot
+      operator: Equal
+      effect: NoSchedule
+      value: 'false'

--- a/load-tests/setup/deleteLoadTest.sh
+++ b/load-tests/setup/deleteLoadTest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -exo pipefail
+
+if [ -z $1 ]
+then
+  echo "Please provide an namespace name!"
+  exit 1
+fi
+
+
+### Load test helper script
+### First parameter is used as namespace name
+### Given namespace will be completely deleted.
+
+namespace=${1//\//} # remove trailing slashes
+
+kubens default
+kubectl delete namespace $namespace --wait=false
+rm -r $namespace

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -exo pipefail
+
+# Contains OS specific sed function
+. utils.sh
+
+if [ -z $1 ]
+then
+  echo "Please provide an namespace name!"
+  exit 1
+fi
+
+### Cloud load test helper script
+### First parameter is used as namespace name
+### For a new namespace a new folder will be created
+
+
+namespace=$1
+
+kubectl create namespace $namespace
+cp -rv cloud-default/ $namespace
+cd $namespace
+
+# calls OS specific sed inplace function
+sed_inplace "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Contains OS specific sed function
+. utils.sh
+
+set -exo pipefail
+
+if [ -z $1 ]
+then
+  echo "Please provide an namespace name!"
+  exit 1
+fi
+
+### Load test helper script
+### First parameter is used as namespace name
+### For a new namespace a new folder will be created
+
+
+namespace=$1
+
+kubectl create namespace $namespace
+cp -rv default/ $namespace
+cd $namespace
+
+# calls OS specific sed inplace function
+sed_inplace "s/default/$namespace/g" Makefile
+
+# get latest updates from zeebe repo
+helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm # skips if already exists
+helm repo update

--- a/load-tests/setup/runLoadTests.sh
+++ b/load-tests/setup/runLoadTests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+trap 'echo Terminated $0; exit' INT;
+
+if [ -z $1 ]
+then
+  echo "Please provide at least 1 namespace name! Usage: ./runLoadTests.sh namespace1 namespace2 etc"
+  exit 1
+fi
+
+namespaces=$@
+
+for n in $namespaces; do
+    echo "Start load test for: $n"
+    cd $n
+    kubens $n
+    make clean zeebe starter worker
+    cd -
+    echo ""
+done

--- a/load-tests/setup/stopLoadTests.sh
+++ b/load-tests/setup/stopLoadTests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+trap 'echo Terminated $0; exit' INT;
+
+if [ -z $1 ]
+then
+  echo "Please provide at least 1 namespace name! Usage: ./stopLoadTests.sh namespace1 namespace2 etc"
+  exit 1
+fi
+
+namespaces=$@
+
+for n in $namespaces; do
+    echo "Stop load test for: $n"
+    cd $n
+    kubens $n
+    make clean
+    cd -
+    echo ""
+done

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+GO_OS=${GO_OS:-"linux"}
+
+function detect_os {
+    # Detect the OS name
+    case "$(uname -s)" in
+      Darwin)
+        host_os=darwin
+        ;;
+      Linux)
+        host_os=linux
+        ;;
+      *)
+        echo "Unsupported host OS. Must be Linux or Mac OS X." >&2
+        exit 1
+        ;;
+    esac
+
+   GO_OS="${host_os}"
+}
+
+
+function sed_inplace() {
+  detect_os
+
+  if [ "${GO_OS}" == "darwin" ]; then
+    sed -i '' -e $@ 
+  else
+    sed -i -e $@
+  fi
+
+}


### PR DESCRIPTION
## Description

We have [recently](https://github.com/camunda/camunda/pull/41782/commits) removed the manual set up, as it was broken and we were not sure whether it is worth to fix it.

Turns out, it is worth it. We need this to quickly experiment with OpenSearch setup or RDBMS, Optimize, etc.

Additionally, @yohanfernando detected that the stable values files have been removed as well, which are used on release tests.

We need to bring them back as well. This will not fix the scripts yet, but I plan to work on this next. Step by step. First this will unblock our release load tests.


