### PR TITLE
fix: include missing intent to operation type mappings

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import java.util.Map;
 import java.util.Optional;
@@ -124,6 +126,20 @@ public record AuditLogInfo(
     }
 
     switch (intent) {
+      case BatchOperationIntent.CREATED:
+      case BatchOperationIntent.CREATE:
+        return AuditLogOperationType.CREATE;
+      case BatchOperationIntent.RESUMED:
+      case BatchOperationIntent.RESUME:
+        return AuditLogOperationType.RESUME;
+      case BatchOperationIntent.SUSPENDED:
+      case BatchOperationIntent.SUSPEND:
+        return AuditLogOperationType.SUSPEND;
+      case BatchOperationIntent.CANCELED:
+      case BatchOperationIntent.CANCEL:
+        return AuditLogOperationType.CANCEL;
+      case ProcessInstanceCreationIntent.CREATED:
+        return AuditLogOperationType.CREATE;
       case ProcessInstanceModificationIntent.MODIFIED:
         return AuditLogOperationType.MODIFY;
       // TODO: map additional intents to operations here

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -25,6 +25,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_START_EVENT_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MIGRATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
@@ -353,6 +354,7 @@ public class CamundaExporter implements Exporter {
             DECISION,
             DECISION_REQUIREMENTS,
             PROCESS_INSTANCE,
+            PROCESS_INSTANCE_CREATION,
             PROCESS_INSTANCE_MIGRATION,
             PROCESS_INSTANCE_MODIFICATION,
             ROLE,

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -320,6 +320,7 @@ components:
         - SUSPEND
         - UNASSIGN
         - UPDATE
+        - UNKNOWN
 
     AuditLogActorTypeEnum:
       type: string


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #41147, #41146
