### PR TITLE
feat: provide Spring authentication classes with instrumented restClient

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -53,6 +53,16 @@
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.15.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-observation</artifactId>
+      <version>1.15.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
@@ -23,6 +23,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
 
 public class OidcTokenEndpointCustomizer
     implements Customizer<OAuth2LoginConfigurer<HttpSecurity>.TokenEndpointConfig> {
@@ -31,19 +32,23 @@ public class OidcTokenEndpointCustomizer
   private final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository;
   private final AssertionJwkProvider assertionJwkProvider;
   private final Map<String, JWK> resolvedJwks;
+  private final RestClient restClient;
 
   public OidcTokenEndpointCustomizer(
       final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository,
-      final AssertionJwkProvider assertionJwkProvider) {
+      final AssertionJwkProvider assertionJwkProvider,
+      final RestClient restClient) {
     this.oidcAuthenticationConfigurationRepository = oidcAuthenticationConfigurationRepository;
     this.assertionJwkProvider = assertionJwkProvider;
     resolvedJwks = new ConcurrentHashMap<>();
+    this.restClient = restClient;
   }
 
   @Override
   public void customize(final OAuth2LoginConfigurer<HttpSecurity>.TokenEndpointConfig config) {
     final RestClientAuthorizationCodeTokenResponseClient tokenResponseClient =
         new RestClientAuthorizationCodeTokenResponseClient();
+    tokenResponseClient.setRestClient(restClient);
     final var resourceParameterConverter = createResourceParameterConverter();
     final var jwtClientAuthenticationParametersConverter =
         createJwtClientAuthenticationParametersConverter();

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -43,6 +43,10 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -64,6 +68,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -84,6 +89,7 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider
 import org.springframework.security.oauth2.client.endpoint.NimbusJwtClientAuthenticationParametersConverter;
 import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
 import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
+import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -93,6 +99,7 @@ import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedCli
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -113,6 +120,7 @@ import org.springframework.security.web.header.writers.CrossOriginOpenerPolicyHe
 import org.springframework.security.web.header.writers.CrossOriginResourcePolicyHeaderWriter.CrossOriginResourcePolicy;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
 import org.springframework.security.web.savedrequest.NullRequestCache;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Configuration
@@ -590,6 +598,11 @@ public class WebSecurityConfig {
     }
 
     @Bean
+    public MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    @Bean
     public TokenClaimsConverter tokenClaimsConverter(
         final SecurityConfiguration securityConfiguration,
         final MembershipService membershipService) {
@@ -733,22 +746,27 @@ public class WebSecurityConfig {
     @Bean
     public OidcTokenEndpointCustomizer oidcTokenEndpointCustomizer(
         final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository,
-        final AssertionJwkProvider assertionJwkProvider) {
+        final AssertionJwkProvider assertionJwkProvider,
+        final MeterRegistry meterRegistry) {
       return new OidcTokenEndpointCustomizer(
-          oidcAuthenticationConfigurationRepository, assertionJwkProvider);
+          oidcAuthenticationConfigurationRepository,
+          assertionJwkProvider,
+          restClient(meterRegistry));
     }
 
     @Bean
     public OAuth2AuthorizedClientManager authorizedClientManager(
         final ClientRegistrationRepository registrations,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
-        final AssertionJwkProvider assertionJwkProvider) {
+        final AssertionJwkProvider assertionJwkProvider,
+        final MeterRegistry meterRegistry) {
 
       final var manager =
           new DefaultOAuth2AuthorizedClientManager(registrations, authorizedClientRepository);
 
       // we build a refresh token flow client manually to add support for private_key_jwt
       final var refreshClient = new RestClientRefreshTokenTokenResponseClient();
+      refreshClient.setRestClient(restClient(meterRegistry));
       final var assertionConverter =
           new NimbusJwtClientAuthenticationParametersConverter<OAuth2RefreshTokenGrantRequest>(
               registration -> assertionJwkProvider.createJwk(registration.getRegistrationId()));
@@ -956,6 +974,28 @@ public class WebSecurityConfig {
           return filter;
         }
       };
+    }
+
+    private RestClient restClient(final MeterRegistry meterRegistry) {
+      // Setup observation for RestClient as per
+      // https://docs.spring.io/spring-framework/reference/integration/observability.html#observability.http-client.restclient
+      final var observationRegistry = ObservationRegistry.create();
+      observationRegistry
+          .observationConfig()
+          .observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+
+      // The message converters are taken from the expected rest client in
+      // AbstractRestClientOAuth2AccessTokenResponseClient
+      return RestClient.builder()
+          .messageConverters(
+              (messageConverters) -> {
+                messageConverters.clear();
+                messageConverters.add(new FormHttpMessageConverter());
+                messageConverters.add(new OAuth2AccessTokenResponseHttpMessageConverter());
+              })
+          .defaultStatusHandler(new OAuth2ErrorResponseErrorHandler())
+          .observationRegistry(observationRegistry)
+          .build();
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR provides the two core sources of external IDP connections (token retrieval and token refresh) with an instrumented RestClient as per https://docs.spring.io/spring-framework/reference/integration/observability.html#observability.http-client.restclient.

The addition of this instrumentation means that our actuator endpoint exposes call data i.e. 
```
# TYPE http_client_requests_active_seconds summary
http_client_requests_active_seconds_count{client_name="localhost",exception="none",method="POST",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda/protocol/openid-connect/token"} 5
```

I have intentionally not instrumented the userinfo fetch as its currently disabled on the 8.8 branch.

## Related issues

closes https://github.com/camunda/camunda/issues/41825
