### PR TITLE
chore: update camunda helm directory to version 8.9 and add new paraneters for keycloak integration

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -20,8 +20,11 @@ jobs:
     secrets: inherit
     with:
       identifier: camunda-helm-int
-      camunda-helm-dir: camunda-platform-8.8
+      camunda-helm-dir: camunda-platform-8.9
       test-enabled: true
+      scenario: keycloak-original
+      shortname: keyco
+      e2e-enabled: true
       caller-git-ref: main
       extra-values: |
         zeebe:


### PR DESCRIPTION
This PR enables e2e testing when deploying helm. Tests being run in the e2e suite are the smoke tests.

I've also set the deployment scenario to use external elasticserach and external keycloak. This is both faster and requires few k8s resources.

Finally, I've updated the helm directory to 8.9 as this is likely what is needed for the main line of monorepo.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
