### PR TITLE
[Backport stable/8.8] fix: changed springdoc settings to use local storage for csrf

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -101,6 +101,7 @@ management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
-springdoc.swagger-ui.csrf.use-session-storage=true
+springdoc.swagger-ui.csrf.use-session-storage=false
+springdoc.swagger-ui.csrf.use-local-storage=true
 
 camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}


### PR DESCRIPTION
# Description
Backport of #42383 to `stable/8.8`.

relates to #38326