### PR TITLE
Use pinned user task listeners when processing lifecycle events

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
@@ -63,4 +63,28 @@ public enum ZeebeTaskListenerEventType {
   updating,
   completing,
   canceling;
+
+  @SuppressWarnings("deprecation")
+  public ZeebeTaskListenerEventType resolve() {
+    // convert deprecated event types to their non-deprecated counterparts
+    switch (this) {
+      case create:
+      case creating:
+        return ZeebeTaskListenerEventType.creating;
+      case assignment:
+      case assigning:
+        return ZeebeTaskListenerEventType.assigning;
+      case update:
+      case updating:
+        return ZeebeTaskListenerEventType.updating;
+      case complete:
+      case completing:
+        return ZeebeTaskListenerEventType.completing;
+      case cancel:
+      case canceling:
+        return ZeebeTaskListenerEventType.canceling;
+      default:
+        throw new IllegalStateException("Unexpected value: " + this);
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -218,6 +218,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getUserTaskState(),
             processingState.getVariableState(),
             processingState.getAsyncRequestState(),
+            processingState.getGlobalListenersState(),
             clock);
 
     jobBehavior =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -9,14 +9,11 @@ package io.camunda.zeebe.engine.processing.deployment.model;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
-import io.camunda.zeebe.engine.EngineConfiguration;
-import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
 import java.time.InstantSource;
-import java.util.Objects;
 
 public final class BpmnFactory {
 
@@ -24,18 +21,8 @@ public final class BpmnFactory {
     /* utility class */
   }
 
-  public static BpmnTransformer createTransformer(
-      final InstantSource clock, final EngineConfiguration configuration) {
-    final GlobalListenersConfiguration listenerConfig;
-    if (configuration != null) {
-      listenerConfig =
-          Objects.requireNonNullElse(
-              configuration.getGlobalListeners(), GlobalListenersConfiguration.empty());
-    } else {
-      listenerConfig = GlobalListenersConfiguration.empty();
-    }
-    return new BpmnTransformer(
-        createExpressionLanguage(new ZeebeFeelEngineClock(clock)), listenerConfig);
+  public static BpmnTransformer createTransformer(final InstantSource clock) {
+    return new BpmnTransformer(createExpressionLanguage(new ZeebeFeelEngineClock(clock)));
   }
 
   public static BpmnValidator createValidator(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableUserTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableUserTask.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,23 +28,11 @@ public final class ExecutableUserTask extends ExecutableJobWorkerTask {
     this.userTaskProperties = userTaskProperties;
   }
 
-  public List<TaskListener> getTaskListeners(final ZeebeTaskListenerEventType eventType) {
-    return taskListeners.stream().filter(tl -> tl.getEventType() == eventType).toList();
-  }
-
   public List<TaskListener> getTaskListeners() {
     return taskListeners;
   }
 
   public void setTaskListeners(final List<TaskListener> taskListeners) {
     this.taskListeners = taskListeners;
-  }
-
-  public boolean hasTaskListeners(final ZeebeTaskListenerEventType eventType) {
-    return !getTaskListeners(eventType).isEmpty();
-  }
-
-  public boolean hasTaskListeners() {
-    return !getTaskListeners().isEmpty();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.deployment.model.transformation;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
-import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.AdHocSubProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.BoundaryEventTransformer;
@@ -73,9 +72,7 @@ public final class BpmnTransformer {
 
   private final ExpressionLanguage expressionLanguage;
 
-  public BpmnTransformer(
-      final ExpressionLanguage expressionLanguage,
-      final GlobalListenersConfiguration globalListenersConfiguration) {
+  public BpmnTransformer(final ExpressionLanguage expressionLanguage) {
     this.expressionLanguage = expressionLanguage;
 
     step1Visitor = new TransformationVisitor();
@@ -101,8 +98,7 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new ScriptTaskTransformer());
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
-    step2Visitor.registerHandler(
-        new UserTaskTransformer(expressionLanguage, globalListenersConfiguration));
+    step2Visitor.registerHandler(new UserTaskTransformer(expressionLanguage));
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.impl.StaticExpression;
-import io.camunda.zeebe.engine.GlobalListenerConfiguration;
-import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
@@ -32,12 +30,10 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTask;
 import io.camunda.zeebe.protocol.Protocol;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
@@ -46,13 +42,9 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
   private final ExpressionLanguage expressionLanguage;
-  private final GlobalListenersConfiguration globalListenersConfiguration;
 
-  public UserTaskTransformer(
-      final ExpressionLanguage expressionLanguage,
-      final GlobalListenersConfiguration globalListenersConfiguration) {
+  public UserTaskTransformer(final ExpressionLanguage expressionLanguage) {
     this.expressionLanguage = expressionLanguage;
-    this.globalListenersConfiguration = globalListenersConfiguration;
   }
 
   @Override
@@ -306,40 +298,13 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
       final FlowNode element,
       final ExecutableUserTask userTask,
       final UserTaskProperties userTaskProperties) {
-
-    final var taskListeners = new ArrayList<TaskListener>();
-
-    // Add global listeners to be executed before local ones
-    final var globalListenersConfiguration =
-        Optional.ofNullable(this.globalListenersConfiguration)
-            .map(GlobalListenersConfiguration::userTask);
-    globalListenersConfiguration.ifPresent(
-        listeners ->
-            listeners.stream()
-                .filter(Predicate.not(GlobalListenerConfiguration::afterNonGlobal))
-                .map(l -> toTaskListenerModel(l, userTaskProperties))
-                .forEach(taskListeners::addAll));
-
-    // Add listeners defined directly on the model
     Optional.ofNullable(element.getSingleExtensionElement(ZeebeTaskListeners.class))
         .map(
             listeners ->
                 listeners.getTaskListeners().stream()
                     .map(listener -> toTaskListenerModel(listener, userTaskProperties))
                     .toList())
-        .ifPresent(taskListeners::addAll);
-
-    // Add global listeners to be executed after local ones
-    globalListenersConfiguration.ifPresent(
-        listeners ->
-            listeners.stream()
-                .filter(GlobalListenerConfiguration::afterNonGlobal)
-                .map(l -> toTaskListenerModel(l, userTaskProperties))
-                .forEach(taskListeners::addAll));
-
-    if (!taskListeners.isEmpty()) {
-      userTask.setTaskListeners(taskListeners);
-    }
+        .ifPresent(userTask::setTaskListeners);
   }
 
   private TaskListener toTaskListenerModel(
@@ -365,40 +330,6 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         zeebeTaskListener.getType(),
         zeebeTaskListener.getRetries(),
         userTaskProperties);
-  }
-
-  /** Convert global user task listener configuration to task listener model(s). */
-  private List<TaskListener> toTaskListenerModel(
-      final GlobalListenerConfiguration globalTaskListener,
-      final UserTaskProperties userTaskProperties) {
-
-    final var jobType = globalTaskListener.type();
-    final var jobRetries = globalTaskListener.retries();
-
-    // Extract the list of supported listener event typese
-    var eventTypes =
-        globalTaskListener.eventTypes().contains(GlobalListenerConfiguration.ALL_EVENT_TYPES)
-            ? List.of(ZeebeTaskListenerEventType.values())
-            : globalTaskListener.eventTypes().stream()
-                .map(ZeebeTaskListenerEventType::valueOf)
-                .toList();
-    // Remove duplicates (considering deprecated event types as equivalent to their non-deprecated
-    // counterparts)
-    eventTypes =
-        eventTypes.stream()
-            .map(UserTaskTransformer::resolveTaskListenerEventType)
-            .distinct()
-            .toList();
-
-    // Create a task listener model for each supported event type
-    final List<TaskListener> taskListeners = new ArrayList<>();
-    eventTypes.forEach(
-        eventType -> {
-          final TaskListener listener =
-              toTaskListenerModel(eventType, jobType, jobRetries, userTaskProperties);
-          taskListeners.add(listener);
-        });
-    return taskListeners;
   }
 
   @SuppressWarnings("deprecation")

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -313,7 +313,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
       final String jobRetries,
       final UserTaskProperties userTaskProperties) {
     final TaskListener listener = new TaskListener();
-    listener.setEventType(resolveTaskListenerEventType(eventType));
+    listener.setEventType(eventType.resolve());
 
     final JobWorkerProperties jobProperties = new JobWorkerProperties();
     jobProperties.wrap(userTaskProperties);
@@ -330,18 +330,5 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         zeebeTaskListener.getType(),
         zeebeTaskListener.getRetries(),
         userTaskProperties);
-  }
-
-  @SuppressWarnings("deprecation")
-  private static ZeebeTaskListenerEventType resolveTaskListenerEventType(
-      final ZeebeTaskListenerEventType eventType) {
-    // convert deprecated event types to their non-deprecated counterparts
-    return switch (eventType) {
-      case create, creating -> ZeebeTaskListenerEventType.creating;
-      case assignment, assigning -> ZeebeTaskListenerEventType.assigning;
-      case update, updating -> ZeebeTaskListenerEventType.updating;
-      case complete, completing -> ZeebeTaskListenerEventType.completing;
-      case cancel, canceling -> ZeebeTaskListenerEventType.canceling;
-    };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -60,7 +60,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final boolean enableStraightThroughProcessingLoopDetector,
       final EngineConfiguration config,
       final InstantSource clock) {
-    bpmnTransformer = BpmnFactory.createTransformer(clock, config);
+    bpmnTransformer = BpmnFactory.createTransformer(clock);
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -67,6 +68,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   private final AsyncRequestState asyncRequestState;
 
   private final BpmnJobBehavior jobBehavior;
+  private final BpmnUserTaskBehavior userTaskBehavior;
 
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -90,6 +92,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     asyncRequestState = state.getAsyncRequestState();
 
     jobBehavior = bpmnBehaviors.jobBehavior();
+    userTaskBehavior = bpmnBehaviors.userTaskBehavior();
 
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
@@ -201,8 +204,14 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var userTaskElement = getUserTaskElement(persistedRecord);
     final var eventType = mapIntentToEventType(intent);
 
-    if (userTaskElement.hasTaskListeners(eventType)) {
-      final var listener = userTaskElement.getTaskListeners(eventType).getFirst();
+    final var firstTaskListener =
+        userTaskBehavior
+            .getTaskListeners(userTaskElement, persistedRecord.getUserTaskKey(), eventType)
+            .stream()
+            .findFirst();
+
+    if (firstTaskListener.isPresent()) {
+      final var listener = firstTaskListener.get();
       final var userTaskElementInstance = getUserTaskElementInstance(persistedRecord);
       final var context = buildContext(userTaskElementInstance);
       jobBehavior.createNewTaskListenerJob(
@@ -226,7 +235,9 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       final ZeebeTaskListenerEventType eventType,
       final ExecutableUserTask userTask,
       final ElementInstance userTaskElementInstance) {
-    final var listeners = userTask.getTaskListeners(eventType);
+    final var listeners =
+        userTaskBehavior.getTaskListeners(
+            userTask, userTaskElementInstance.getUserTaskKey(), eventType);
     final int currentListenerIndex = userTaskElementInstance.getTaskListenerIndex(eventType);
     return listeners.stream().skip(currentListenerIndex).findFirst();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -92,7 +92,10 @@ public class UserTaskCreateProcessor implements UserTaskCommandProcessor {
     final var context = new BpmnElementContextImpl();
     context.init(elementInstance.getKey(), elementInstance.getValue(), elementInstance.getState());
 
-    element.getTaskListeners(ZeebeTaskListenerEventType.assigning).stream()
+    userTaskBehavior
+        .getTaskListeners(
+            element, userTaskRecord.getUserTaskKey(), ZeebeTaskListenerEventType.assigning)
+        .stream()
         .findFirst()
         .ifPresentOrElse(
             listener ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -114,7 +114,7 @@ public final class DbProcessState implements MutableProcessState {
       final TransactionContext transactionContext,
       final EngineConfiguration config,
       final InstantSource clock) {
-    transformer = BpmnFactory.createTransformer(clock, config);
+    transformer = BpmnFactory.createTransformer(clock);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     tenantIdKey = new DbString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ConditionalEventTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ConditionalEventTransformerTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
-import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableConditional;
@@ -21,7 +20,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.ConditionalEventDefinitionBuilder;
 import java.time.InstantSource;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -40,10 +38,7 @@ public class ConditionalEventTransformerTest {
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
           new ZeebeFeelEngineClock(InstantSource.system()));
-  private final GlobalListenersConfiguration globalListenersConfiguration =
-      new GlobalListenersConfiguration(new ArrayList<>());
-  private final BpmnTransformer transformer =
-      new BpmnTransformer(expressionLanguage, globalListenersConfiguration);
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
 
   private BpmnModelInstance processWithConditionalBoundaryEvent(
       final Consumer<ConditionalEventDefinitionBuilder> modifier) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -11,8 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
-import io.camunda.zeebe.engine.GlobalListenerConfiguration;
-import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
@@ -21,17 +19,14 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.builder.TaskListenerBuilder;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import java.time.InstantSource;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,10 +42,7 @@ class UserTaskTransformerTest {
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
           new ZeebeFeelEngineClock(InstantSource.system()));
-  private final GlobalListenersConfiguration globalListenersConfiguration =
-      new GlobalListenersConfiguration(new ArrayList<>());
-  private final BpmnTransformer transformer =
-      new BpmnTransformer(expressionLanguage, globalListenersConfiguration);
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
 
   private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {
     return Bpmn.createExecutableProcess().startEvent().userTask(TASK_ID, userTaskModifier).done();
@@ -285,11 +277,6 @@ class UserTaskTransformerTest {
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
   class ZeebeTaskListenerTests {
 
-    @BeforeEach
-    public void resetGlobalListeners() {
-      globalListenersConfiguration.userTask().clear();
-    }
-
     Stream<Arguments> taskListeners() {
       return Stream.of(
           Arguments.of(
@@ -345,198 +332,6 @@ class UserTaskTransformerTest {
               listener -> {
                 assertThat(listener.getJobWorkerProperties().getTaskHeaders())
                     .isEqualTo(Map.of("key", "value"));
-              });
-    }
-
-    @DisplayName(
-        "Should transform user task with multiple task listeners and preserve listener definition order")
-    @Test
-    void shouldTransformMultipleTaskListenersAndPreserveListenersDefinitionOrderPerEventType() {
-      final var userTask =
-          transformZeebeUserTask(
-              processWithUserTask(
-                  b ->
-                      b.zeebeTaskListener(tl -> tl.creating().type("create_1"))
-                          .zeebeTaskListener(tl -> tl.updating().type("update"))
-                          .zeebeTaskListener(tl -> tl.assigning().type("assignment_2"))
-                          .zeebeTaskListener(tl -> tl.creating().type("create_3"))
-                          .zeebeTaskListener(tl -> tl.canceling().type("cancel"))
-                          .zeebeTaskListener(tl -> tl.assigning().type("assignment_1"))
-                          .zeebeTaskListener(tl -> tl.creating().type("create_2"))
-                          .zeebeUserTask()));
-
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))
-          .extracting(this::type)
-          .containsExactly("create_1", "create_3", "create_2");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assigning))
-          .extracting(this::type)
-          .containsExactly("assignment_2", "assignment_1");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.updating)).hasSize(1);
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling)).hasSize(1);
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing)).isEmpty();
-    }
-
-    @DisplayName(
-        "Should transform user task with deprecated task listener event types and use new style")
-    @Test
-    @SuppressWarnings("deprecation")
-    void shouldTransformDeprecatedTaskListenersAndUseNewStyle() {
-      final var create = ZeebeTaskListenerEventType.create;
-      final var update = ZeebeTaskListenerEventType.update;
-      final var assignment = ZeebeTaskListenerEventType.assignment;
-      final var complete = ZeebeTaskListenerEventType.complete;
-      final var cancel = ZeebeTaskListenerEventType.cancel;
-      final var userTask =
-          transformZeebeUserTask(
-              processWithUserTask(
-                  b ->
-                      b.zeebeTaskListener(tl -> tl.eventType(create).type("create"))
-                          .zeebeTaskListener(tl -> tl.eventType(assignment).type("assignment"))
-                          .zeebeTaskListener(tl -> tl.eventType(update).type("update"))
-                          .zeebeTaskListener(tl -> tl.eventType(complete).type("complete"))
-                          .zeebeTaskListener(tl -> tl.eventType(cancel).type("cancel"))
-                          .zeebeUserTask()));
-
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))
-          .extracting(this::type)
-          .containsExactly("create");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assigning))
-          .extracting(this::type)
-          .containsExactly("assignment");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.updating))
-          .extracting(this::type)
-          .containsExactly("update");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing))
-          .extracting(this::type)
-          .containsExactly("complete");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling))
-          .extracting(this::type)
-          .containsExactly("cancel");
-    }
-
-    @DisplayName(
-        "Should transform user task with globally-defined task listener including locally-defined task headers")
-    @Test
-    void shouldTransformGlobalListenersWithTaskHeaders() {
-      // given
-      globalListenersConfiguration
-          .userTask()
-          .add(new GlobalListenerConfiguration(List.of("creating"), "global", "3", false));
-
-      // when
-      final var userTask =
-          transformZeebeUserTask(
-              processWithUserTask(b -> b.zeebeTaskHeader("key", "value").zeebeUserTask()));
-
-      // then
-      assertThat(userTask.getTaskListeners())
-          .hasSize(1)
-          .first()
-          .satisfies(
-              listener -> {
-                assertThat(listener.getJobWorkerProperties().getTaskHeaders())
-                    .isEqualTo(Map.of("key", "value"));
-              });
-    }
-
-    @DisplayName(
-        "Should transform user task with globally-defined \"generic\" task listener creating a new listener for each event type")
-    @Test
-    void shouldTransformGenericGlobalListenerWithMultipleIndividualListeners() {
-      // given
-      globalListenersConfiguration
-          .userTask()
-          .add(new GlobalListenerConfiguration(List.of("all"), "global", "3", false));
-
-      // when
-      final var userTask =
-          transformZeebeUserTask(processWithUserTask(AbstractUserTaskBuilder::zeebeUserTask));
-
-      // then
-      assertThat(userTask.getTaskListeners()).hasSize(5);
-      assertThat(userTask.getTaskListeners())
-          .extracting(TaskListener::getEventType)
-          .containsExactly(
-              ZeebeTaskListenerEventType.creating,
-              ZeebeTaskListenerEventType.assigning,
-              ZeebeTaskListenerEventType.updating,
-              ZeebeTaskListenerEventType.completing,
-              ZeebeTaskListenerEventType.canceling);
-      assertThat(userTask.getTaskListeners()).extracting(this::type).containsOnly("global");
-    }
-
-    @DisplayName(
-        "Should transform user task with globally and locally defined task listeners and preserve listener definition order, considering configuration flags")
-    @Test
-    void shouldTransformGlobalListenersAndPreserveListenersDefinitionOrderPerEventType() {
-      // given
-      globalListenersConfiguration
-          .userTask()
-          .add(
-              new GlobalListenerConfiguration(
-                  List.of("creating"), "globalCreateBefore", "3", false));
-      globalListenersConfiguration
-          .userTask()
-          .add(new GlobalListenerConfiguration(List.of("all"), "globalGenericBefore", "3", false));
-      globalListenersConfiguration
-          .userTask()
-          .add(
-              new GlobalListenerConfiguration(List.of("creating"), "globalCreateAfter", "3", true));
-      globalListenersConfiguration
-          .userTask()
-          .add(
-              new GlobalListenerConfiguration(List.of("updating"), "globalUpdateAfter", "3", true));
-
-      // when
-      final var userTask =
-          transformZeebeUserTask(
-              processWithUserTask(
-                  b ->
-                      b.zeebeTaskListener(tl -> tl.creating().type("localCreate"))
-                          .zeebeTaskListener(tl -> tl.assigning().type("localAssign"))
-                          .zeebeUserTask()));
-
-      // then
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))
-          .extracting(this::type)
-          .containsExactly(
-              "globalCreateBefore", "globalGenericBefore", "localCreate", "globalCreateAfter");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assigning))
-          .extracting(this::type)
-          .containsExactly("globalGenericBefore", "localAssign");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.updating))
-          .extracting(this::type)
-          .containsExactly("globalGenericBefore", "globalUpdateAfter");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling))
-          .extracting(this::type)
-          .containsExactly("globalGenericBefore");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing))
-          .extracting(this::type)
-          .containsExactly("globalGenericBefore");
-    }
-
-    @DisplayName(
-        "Should transform user task with globally and locally defined task listeners and preserve listener definition order, considering configuration flags")
-    @Test
-    void shouldTransformDeprecatedGlobalListenersWhileAvoidingDuplicates() {
-      // given
-      globalListenersConfiguration
-          .userTask()
-          .add(
-              new GlobalListenerConfiguration(
-                  List.of("creating", "create"), "globalCreateBefore", "3", false));
-
-      // when
-      final var userTask =
-          transformZeebeUserTask(processWithUserTask(AbstractUserTaskBuilder::zeebeUserTask));
-
-      // then
-      assertThat(userTask.getTaskListeners())
-          .hasSize(1)
-          .first()
-          .satisfies(
-              listener -> {
-                assertThat(listener.getEventType()).isEqualTo(ZeebeTaskListenerEventType.creating);
               });
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
@@ -83,7 +83,7 @@ public final class LegacyProcessState {
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
       final InstantSource clock) {
-    transformer = BpmnFactory.createTransformer(clock, null);
+    transformer = BpmnFactory.createTransformer(clock);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     processColumnFamily =


### PR DESCRIPTION
## Description

Since #42172 the global listeners configuration is automatically stored in the state after a cluster restart when it changes.
Since #42123 lifecycle events "pin" the current configuration when they are started, keeping it fixed even if the configuration changes again while the event is being processed.
In this PR, the pinned configuration is used to actually retrieve the list of listeners to be used when processing a user task lifecycle event, avoiding ambiguities and undefined behaviours.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41902
