### PR TITLE
ci: make release not latest

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -357,7 +357,7 @@ jobs:
 
           echo "Docker build completed. Running verification..."
           echo "Verifying with VERSION=${VERSION}, REVISION=${REVISION}, DATE=${DATE}, BASE_IMAGE=${BASE_IMAGE}"
-          
+
           # Verify using the most reliable tag (DockerHub)
           ./optimize/docker/test/verify.sh "${DOCKER_IMAGE_DOCKER_HUB}:${RELEASE_VERSION}"
 
@@ -389,11 +389,10 @@ jobs:
         uses: octokit/request-action@v2.4.0
         with:
           route: POST /repos/camunda/camunda/releases
-          draft: false
+          make_latest: false
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
           generate_release_notes: true
-          make_latest: \"false\"
 
       - name: Docker log dump
         if: always()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR updates the release workflow to prevent module releases from being automatically marked as “latest” by explicitly setting `make_latest`: false, ensuring only the monorepo release is tagged as latest. The `draft` property is set to false by default.

In YAML, values are already quoted automatically when needed, so escaping the quotes (\"false\") causes the literal value \"false\" to be sent to the API, not "false" or false. This does not match the expected enum (true | false | legacy), so GitHub ignores it and applies the default.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
