### PR TITLE
Fix flakey ProcessExternalControllerIT form related tests

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
@@ -11,12 +11,8 @@ import static io.camunda.tasklist.util.TestCheck.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
-import io.camunda.tasklist.exceptions.NotFoundException;
-import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
-import io.camunda.tasklist.store.ProcessStore;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
-import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
 import java.util.List;
@@ -38,57 +34,6 @@ import org.springframework.context.annotation.Configuration;
 public class ElasticsearchChecks {
 
   @Autowired private ElasticsearchHelper elasticsearchHelper;
-
-  @Autowired private ProcessStore processStore;
-
-  /** Checks whether the process of given args[0] processId (Long) is deployed. */
-  @Bean(name = PROCESS_IS_DEPLOYED_CHECK)
-  public TestCheck getProcessIsDeployedCheck() {
-    return new TestCheck() {
-      @Override
-      public String getName() {
-        return PROCESS_IS_DEPLOYED_CHECK;
-      }
-
-      @Override
-      public boolean test(final Object[] objects) {
-        assertThat(objects).hasSize(1);
-        assertThat(objects[0]).isInstanceOf(String.class);
-        final String processId = (String) objects[0];
-        try {
-          final ProcessEntity process = processStore.getProcess(processId);
-          return process != null;
-        } catch (final TasklistRuntimeException ex) {
-          return false;
-        }
-      }
-    };
-  }
-
-  @Bean(name = PROCESS_IS_DELETED_CHECK)
-  public TestCheck getProcessIsDeletedCheck() {
-    return new TestCheck() {
-      @Override
-      public String getName() {
-        return PROCESS_IS_DELETED_CHECK;
-      }
-
-      @Override
-      public boolean test(final Object[] objects) {
-        assertThat(objects).hasSize(1);
-        assertThat(objects[0]).isInstanceOf(String.class);
-        final String processId = (String) objects[0];
-        try {
-          processStore.getProcess(processId);
-          return false;
-        } catch (final NotFoundException nfe) {
-          return true;
-        } catch (final TasklistRuntimeException ex) {
-          return false;
-        }
-      }
-    };
-  }
 
   /** Checks whether the task for given args[0] taskId (String) exists and is in state CREATED. */
   @Bean(name = TASK_IS_CREATED_CHECK)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
@@ -11,12 +11,8 @@ import static io.camunda.tasklist.util.TestCheck.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
-import io.camunda.tasklist.exceptions.NotFoundException;
-import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
-import io.camunda.tasklist.store.ProcessStore;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
-import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
 import java.util.List;
@@ -38,58 +34,6 @@ import org.springframework.context.annotation.Configuration;
 public class OpenSearchChecks {
 
   @Autowired private OpenSearchHelper openSearchHelper;
-
-  @Autowired private ProcessStore processStore;
-
-  /** Checks whether the process of given args[0] processId (Long) is deployed. */
-  @Bean(name = PROCESS_IS_DEPLOYED_CHECK)
-  public TestCheck getProcessIsDeployedOsCheck() {
-    return new TestCheck() {
-      @Override
-      public String getName() {
-        return PROCESS_IS_DEPLOYED_CHECK;
-      }
-
-      @Override
-      public boolean test(final Object[] objects) {
-        assertThat(objects).hasSize(1);
-        assertThat(objects[0]).isInstanceOf(String.class);
-        final String processId = (String) objects[0];
-        try {
-          final ProcessEntity process = processStore.getProcess(processId);
-          return process != null;
-        } catch (final TasklistRuntimeException ex) {
-          return false;
-        }
-      }
-    };
-  }
-
-  @Bean(name = PROCESS_IS_DELETED_CHECK)
-  public TestCheck getProcessIsDeletedCheck() {
-
-    return new TestCheck() {
-      @Override
-      public String getName() {
-        return PROCESS_IS_DELETED_CHECK;
-      }
-
-      @Override
-      public boolean test(final Object[] objects) {
-        assertThat(objects).hasSize(1);
-        assertThat(objects[0]).isInstanceOf(String.class);
-        final String processId = (String) objects[0];
-        try {
-          processStore.getProcess(processId);
-          return false;
-        } catch (final NotFoundException nfe) {
-          return true;
-        } catch (final TasklistRuntimeException ex) {
-          return false;
-        }
-      }
-    };
-  }
 
   /** Checks whether the task for given args[0] taskId (String) exists and is in state CREATED. */
   @Bean(name = TASK_IS_CREATED_CHECK)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -85,6 +85,10 @@ public class TasklistTester {
   private TestCheck processIsDeletedCheck;
 
   @Autowired
+  @Qualifier(FORM_EXISTS_CHECK)
+  private TestCheck formExistsCheck;
+
+  @Autowired
   @Qualifier(TASK_IS_CREATED_BY_FLOW_NODE_BPMN_ID_CHECK)
   private TestCheck taskIsCreatedCheck;
 
@@ -352,6 +356,15 @@ public class TasklistTester {
       final String tenantId, final String bpmnProcessId, final String payload) {
     processInstanceId =
         ZeebeTestUtil.startProcessInstance(tenantId, camundaClient, bpmnProcessId, payload);
+    return this;
+  }
+
+  public TasklistTester formExists(final String formId) {
+    return formExists(formId, null);
+  }
+
+  public TasklistTester formExists(final String formId, final Long versionId) {
+    databaseTestExtension.waitFor(formExistsCheck, processDefinitionKey, formId, versionId);
     return this;
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestCheck.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestCheck.java
@@ -15,6 +15,8 @@ public interface TestCheck extends Predicate<Object[]> {
   String PROCESS_IS_DEPLOYED_CHECK = "processIsDeployedCheck";
   String PROCESS_IS_DELETED_CHECK = "processIsDeletedCheck";
 
+  String FORM_EXISTS_CHECK = "formExistsCheck";
+
   String TASK_IS_CREATED_CHECK = "taskIsCreatedCheck";
   String TASK_IS_ASSIGNED_CHECK = "taskIsAssignedCheck";
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestChecks.java
@@ -28,7 +28,7 @@ public class TestChecks {
 
   @Autowired private FormStore formStore;
 
-  /** Checks whether the process of given args[0] processId (Long) is deployed. */
+  /** Checks whether the process of given args[0] processId (numeric string) is deployed. */
   @Bean(name = PROCESS_IS_DEPLOYED_CHECK)
   public TestCheck getProcessIsDeployedCheck() {
     return new TestCheck() {
@@ -52,6 +52,7 @@ public class TestChecks {
     };
   }
 
+  /** Checks whether the process of given args[0] processId (numeric string) is deleted. */
   @Bean(name = PROCESS_IS_DELETED_CHECK)
   public TestCheck getProcessIsDeletedCheck() {
     return new TestCheck() {
@@ -77,6 +78,10 @@ public class TestChecks {
     };
   }
 
+  /**
+   * Checks whether the form of given args[0] processDefinitionId and args[1] formId exists for a
+   * given args[2] versionId (Long - which may be null if we do not want a specific version).
+   */
   @Bean(name = FORM_EXISTS_CHECK)
   public TestCheck getFormExistsCheck() {
     return new TestCheck() {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestChecks.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.util;
+
+import static io.camunda.tasklist.util.TestCheck.FORM_EXISTS_CHECK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.tasklist.exceptions.NotFoundException;
+import io.camunda.tasklist.store.FormStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestChecks {
+  @Autowired private FormStore formStore;
+
+  @Bean(name = FORM_EXISTS_CHECK)
+  public TestCheck getFormExistsCheck() {
+    return new TestCheck() {
+      @Override
+      public String getName() {
+        return FORM_EXISTS_CHECK;
+      }
+
+      @Override
+      public boolean test(final Object[] objects) {
+        assertThat(objects).hasSize(3);
+        assertThat(objects[0]).isInstanceOf(String.class);
+        assertThat(objects[1]).isInstanceOf(String.class);
+        if (objects[2] != null) {
+          assertThat(objects[2]).isInstanceOf(Long.class);
+        }
+        final String processDefinitionId = (String) objects[0];
+        final String formId = (String) objects[1];
+        final Long versionId = (Long) objects[2];
+        try {
+          return formStore.getForm(formId, processDefinitionId, versionId) != null;
+        } catch (final NotFoundException ex) {
+          return false;
+        }
+      }
+    };
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestChecks.java
@@ -8,17 +8,74 @@
 package io.camunda.tasklist.util;
 
 import static io.camunda.tasklist.util.TestCheck.FORM_EXISTS_CHECK;
+import static io.camunda.tasklist.util.TestCheck.PROCESS_IS_DELETED_CHECK;
+import static io.camunda.tasklist.util.TestCheck.PROCESS_IS_DEPLOYED_CHECK;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.tasklist.exceptions.NotFoundException;
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.store.FormStore;
+import io.camunda.tasklist.store.ProcessStore;
+import io.camunda.webapps.schema.entities.ProcessEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class TestChecks {
+
+  @Autowired private ProcessStore processStore;
+
   @Autowired private FormStore formStore;
+
+  /** Checks whether the process of given args[0] processId (Long) is deployed. */
+  @Bean(name = PROCESS_IS_DEPLOYED_CHECK)
+  public TestCheck getProcessIsDeployedCheck() {
+    return new TestCheck() {
+      @Override
+      public String getName() {
+        return PROCESS_IS_DEPLOYED_CHECK;
+      }
+
+      @Override
+      public boolean test(final Object[] objects) {
+        assertThat(objects).hasSize(1);
+        assertThat(objects[0]).isInstanceOf(String.class);
+        final String processId = (String) objects[0];
+        try {
+          final ProcessEntity process = processStore.getProcess(processId);
+          return process != null;
+        } catch (final TasklistRuntimeException ex) {
+          return false;
+        }
+      }
+    };
+  }
+
+  @Bean(name = PROCESS_IS_DELETED_CHECK)
+  public TestCheck getProcessIsDeletedCheck() {
+    return new TestCheck() {
+      @Override
+      public String getName() {
+        return PROCESS_IS_DELETED_CHECK;
+      }
+
+      @Override
+      public boolean test(final Object[] objects) {
+        assertThat(objects).hasSize(1);
+        assertThat(objects[0]).isInstanceOf(String.class);
+        final String processId = (String) objects[0];
+        try {
+          processStore.getProcess(processId);
+          return false;
+        } catch (final NotFoundException nfe) {
+          return true;
+        } catch (final TasklistRuntimeException ex) {
+          return false;
+        }
+      }
+    };
+  }
 
   @Bean(name = FORM_EXISTS_CHECK)
   public TestCheck getFormExistsCheck() {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/external/ProcessExternalControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/external/ProcessExternalControllerIT.java
@@ -60,7 +60,13 @@ public class ProcessExternalControllerIT extends TasklistZeebeIntegrationTest {
     final String bpmnProcessId = "startedByForm";
     final String formId = "testForm";
 
-    tester.having().deployProcess("startedByFormProcess.bpmn").waitUntil().processIsDeployed();
+    tester
+        .having()
+        .deployProcess("startedByFormProcess.bpmn")
+        .waitUntil()
+        .processIsDeployed()
+        .waitUntil()
+        .formExists(formId);
 
     // when
     final var result =
@@ -92,7 +98,13 @@ public class ProcessExternalControllerIT extends TasklistZeebeIntegrationTest {
         .send()
         .join();
 
-    tester.having().deployProcess("startedByLinkedForm.bpmn").waitUntil().processIsDeployed();
+    tester
+        .having()
+        .deployProcess("startedByLinkedForm.bpmn")
+        .waitUntil()
+        .processIsDeployed()
+        .waitUntil()
+        .formExists(formId);
 
     // when
     final var result =
@@ -128,7 +140,13 @@ public class ProcessExternalControllerIT extends TasklistZeebeIntegrationTest {
         .send()
         .join();
 
-    tester.having().deployProcess("startedByLinkedForm.bpmn").waitUntil().processIsDeployed();
+    tester
+        .having()
+        .deployProcess("startedByLinkedForm.bpmn")
+        .waitUntil()
+        .processIsDeployed()
+        .waitUntil()
+        .formExists("Form_0mik7px", 2L);
 
     // when
     final var result =


### PR DESCRIPTION
I'd noticed these tests fail a fair bit:

```
io.camunda.tasklist.webapp.api.rest.v1.controllers.external.ProcessExternalControllerIT.getLinkedFormByProcessIdWithUpdatedForm
io.camunda.tasklist.webapp.api.rest.v1.controllers.external.ProcessExternalControllerIT.getLinkedFormByProcessIdV1
io.camunda.tasklist.webapp.api.rest.v1.controllers.external.ProcessExternalControllerIT.getEmbeddedFormByProcessId
```

it doesn't block merging, but it's quite annoying to have to check when they fail.

This just adds some extra stuff so we wait until the relevant forms are visible in OS/ES before proceeding with making the relevant API/endpoint calls.