### PR TITLE
fix: fix naming for conditional evaluation gRPC call messages

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -32,7 +32,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ConditionalEvaluationInstruction;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
@@ -43,7 +42,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalResult;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
@@ -425,8 +425,8 @@ public final class EndpointManager {
   }
 
   public void evaluateConditional(
-      final ConditionalEvaluationInstruction request,
-      final ServerStreamObserver<EvaluateConditionalResult> responseObserver) {
+      final EvaluateConditionalRequest request,
+      final ServerStreamObserver<EvaluateConditionalResponse> responseObserver) {
     sendRequest(
         request,
         RequestMapper::toEvaluateConditionalRequest,

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ConditionalEvaluationInstruction;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
@@ -29,7 +28,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalResult;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
@@ -227,8 +227,8 @@ public class GatewayGrpcService extends GatewayImplBase {
 
   @Override
   public void evaluateConditional(
-      final ConditionalEvaluationInstruction request,
-      final StreamObserver<EvaluateConditionalResult> responseObserver) {
+      final EvaluateConditionalRequest request,
+      final StreamObserver<EvaluateConditionalResponse> responseObserver) {
     endpointManager.evaluateConditional(
         request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -34,12 +34,12 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ConditionalEvaluationInstruction;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeleteResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.MigrateProcessInstanceRequest;
@@ -407,7 +407,7 @@ public final class RequestMapper extends RequestUtil {
   }
 
   public static BrokerEvaluateConditionalRequest toEvaluateConditionalRequest(
-      final ConditionalEvaluationInstruction grpcRequest) {
+      final EvaluateConditionalRequest grpcRequest) {
     final BrokerEvaluateConditionalRequest brokerRequest = new BrokerEvaluateConditionalRequest();
 
     if (grpcRequest.hasProcessDefinitionKey()) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -28,7 +28,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsM
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeleteResourceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalResult;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluatedDecision;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluatedDecisionInput;
@@ -508,10 +508,10 @@ public final class ResponseMapper {
         .build();
   }
 
-  public static EvaluateConditionalResult toEvaluateConditionalResponse(
+  public static EvaluateConditionalResponse toEvaluateConditionalResponse(
       final long key, final ConditionalEvaluationRecord brokerResponse) {
-    final EvaluateConditionalResult.Builder responseBuilder =
-        EvaluateConditionalResult.newBuilder();
+    final EvaluateConditionalResponse.Builder responseBuilder =
+        EvaluateConditionalResponse.newBuilder();
 
     brokerResponse.getStartedProcessInstances().stream()
         .map(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ConditionalEvaluationInstruction;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
@@ -34,6 +33,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsM
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
@@ -312,7 +312,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
   public void evaluateConditionalShouldUseDefaultTenant() {
     // when
     client.evaluateConditional(
-        ConditionalEvaluationInstruction.newBuilder().setVariables("{\"x\": 1}").build());
+        EvaluateConditionalRequest.newBuilder().setVariables("{\"x\": 1}").build());
 
     // then
     assertThatDefaultTenantIdSet();
@@ -322,7 +322,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
   public void evaluateConditionalRequestRejectsNonDefaultTenantIdWhenMultiTenancyDisabled() {
     // given
     final var request =
-        ConditionalEvaluationInstruction.newBuilder()
+        EvaluateConditionalRequest.newBuilder()
             .setTenantId("tenant-a")
             .setVariables("{\"x\": 1}")
             .build();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ConditionalEvaluationInstruction;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
@@ -33,6 +32,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsM
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateConditionalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
@@ -342,7 +342,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
     // when
     final var response =
         client.evaluateConditional(
-            ConditionalEvaluationInstruction.newBuilder()
+            EvaluateConditionalRequest.newBuilder()
                 .setTenantId("tenant-a")
                 .setVariables("{\"x\": 1}")
                 .build());
@@ -355,8 +355,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
   @Test
   public void evaluateConditionalRequestRequiresTenantId() {
     // given
-    final var request =
-        ConditionalEvaluationInstruction.newBuilder().setVariables("{\"x\": 1}").build();
+    final var request = EvaluateConditionalRequest.newBuilder().setVariables("{\"x\": 1}").build();
 
     // when/then
     assertThatRejectsRequestMissingTenantId(

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -867,7 +867,7 @@ message BroadcastSignalResponse {
   string tenantId = 2;
 }
 
-message ConditionalEvaluationInstruction {
+message EvaluateConditionalRequest {
   // Used to evaluate root-level conditional start events for a tenant with the given ID.
   // This will only evaluate root-level conditional start events of process definitions which belong to the tenant.
   string tenantId = 1;
@@ -884,7 +884,7 @@ message ProcessInstanceReference {
   int64 processInstanceKey = 2;
 }
 
-message EvaluateConditionalResult {
+message EvaluateConditionalResponse {
   // List of process instances created. If no root-level conditional start events evaluated to true, the list will be empty.
   repeated ProcessInstanceReference processInstances = 1;
 }
@@ -1226,7 +1226,7 @@ service Gateway {
       - If a processDefinitionKey is not provided, this indicates that the client is not authorized
         to start process instances for at least one of the matched process definitions
    */
-  rpc EvaluateConditional (ConditionalEvaluationInstruction) returns (EvaluateConditionalResult) {
+  rpc EvaluateConditional (EvaluateConditionalRequest) returns (EvaluateConditionalResponse) {
 
   }
 }


### PR DESCRIPTION
## Description

See [comment on a previously merged PR](https://github.com/camunda/camunda/pull/42505#pullrequestreview-3574254364)

BREAKING CHANGE: This PR alters existing protobufs but they were not part of any previous release, they were added only a few days ago.

The new names follow the pattern set by decision evaluation ([EvaluateDecisionRequest](https://github.com/camunda/camunda/blob/491cf266ef28b8d1cea37775288ec48118ce896d/zeebe/gateway-protocol/src/main/proto/gateway.proto#L338) and [EvaluateDecisionResponse](https://github.com/camunda/camunda/blob/491cf266ef28b8d1cea37775288ec48118ce896d/zeebe/gateway-protocol/src/main/proto/gateway.proto#L355) for `rpc EvaluateDecision (EvaluateDecisionRequest) returns (EvaluateDecisionResponse)`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/40954
