### PR TITLE
deps: update kotlin-stdlib to 2.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,6 +118,7 @@
     <version.byte-buddy>1.17.6</version.byte-buddy>
     <version.revapi>0.28.4</version.revapi>
     <version.resilience4j>2.3.0</version.resilience4j>
+    <version.kotlin-stdlib>2.1.0</version.kotlin-stdlib>
     <version.immutables>2.11.4</version.immutables>
     <version.jsr305>3.0.2</version.jsr305>
     <version.classgraph>4.8.184</version.classgraph>
@@ -1212,6 +1213,23 @@
         <groupId>io.github.resilience4j</groupId>
         <artifactId>resilience4j-core</artifactId>
         <version>${version.resilience4j}</version>
+      </dependency>
+
+      <!-- see https://github.com/camunda/camunda/issues/42660 -->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk7</artifactId>
+        <version>${version.kotlin-stdlib}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Since `resilience4j-core` latest version is `2.3.0` and fetches `kotlin-stlib` related of `1.9.25`, it is better to bump up all `kotlin-stlib` related to `2.1.0`.

Also, avoid convergence issues with `identity-sdk` -> `kotlin-stdlib` transitive dependency.

Two sources where this dependency show up:

```
[INFO] +- io.github.resilience4j:resilience4j-core:jar:2.3.0:compile
[INFO] |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.25:compile
[INFO] |     +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:compile
[INFO] |     |  \- org.jetbrains:annotations:jar:26.0.2-1:compile
[INFO] |     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.9.25:compile
```

```
[INFO] |  +- io.camunda:identity-sdk:jar:8.9.0-alpha2:compile
[INFO] |  |  +- com.auth0:auth0:jar:1.45.1:compile
[INFO] |  |  |  +- com.squareup.okhttp3:okhttp:jar:4.11.0:runtime
[INFO] |  |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:compile
```


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42660
