### PR TITLE
test: migrate modifications.spec.ts to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -22,6 +22,7 @@ class OperateProcessInstancePage {
   readonly statusVariable: Locator;
   readonly instanceHeader: Locator;
   readonly instanceHistory: Locator;
+  readonly rootProcessNode: Locator;
   readonly incidentsTable: Locator;
   readonly incidentsTableOperationSpinner: Locator;
   readonly incidentsTableRows: Locator;
@@ -61,6 +62,14 @@ class OperateProcessInstancePage {
   readonly executionCountToggleButton: Locator;
   readonly endDateField: Locator;
   readonly incidentsViewHeader: Locator;
+  readonly modificationModeText: Locator;
+  readonly lastAddedModificationText: Locator;
+  readonly undoModificationButton: Locator;
+  readonly deleteVariableModificationButton: Locator;
+  readonly cancelButton: Locator;
+  readonly addVariableModificationButton: Locator;
+  readonly modalDialog: Locator;
+  readonly noVariablesText: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -86,6 +95,9 @@ class OperateProcessInstancePage {
     this.variableValueInput = page.getByTestId('edit-variable-value');
     this.instanceHeader = page.getByTestId('instance-header');
     this.instanceHistory = page.getByTestId('instance-history');
+    this.rootProcessNode = this.instanceHistory
+      .locator('[data-testid^="node-details-"]')
+      .first();
     this.incidentsTable = page.getByTestId('data-list');
     this.incidentsTableOperationSpinner =
       this.incidentsTable.getByTestId('operation-spinner');
@@ -149,6 +161,20 @@ class OperateProcessInstancePage {
     );
     this.endDateField = this.instanceHeader.getByTestId('end-date');
     this.incidentsViewHeader = page.getByText(/incidents\s+-\s+/i);
+    this.modificationModeText = page.getByText(
+      'Process Instance Modification Mode',
+    );
+    this.lastAddedModificationText = page.getByText('Last added modification:');
+    this.undoModificationButton = page.getByRole('button', {name: 'undo'});
+    this.deleteVariableModificationButton = page.getByRole('button', {
+      name: /delete variable modification/i,
+    });
+    this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+    this.addVariableModificationButton = page.getByRole('button', {
+      name: /add variable/i,
+    });
+    this.modalDialog = page.getByRole('dialog');
+    this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -209,6 +235,10 @@ class OperateProcessInstancePage {
       .getByTestId('new-variable-value');
   };
 
+  getVariableTestId(variableName: string) {
+    return this.page.getByTestId(`variable-${variableName}`);
+  }
+
   getListenerTypeFilterOption = (
     option: 'Execution listeners' | 'User task listeners' | 'All listeners',
   ) => {
@@ -224,11 +254,101 @@ class OperateProcessInstancePage {
   }
 
   async undoModification() {
-    await this.page
-      .getByRole('button', {
-        name: 'undo',
-      })
-      .click();
+    await this.undoModificationButton.click();
+  }
+
+  async enterModificationMode() {
+    await this.modifyInstanceButton.click();
+  }
+
+  async clickApplyModifications() {
+    await this.applyModificationsButton.click();
+  }
+
+  async clickAddVariable() {
+    await this.addVariableModificationButton.click();
+  }
+
+  async clickDeleteVariableModification() {
+    await this.deleteVariableModificationButton.click();
+  }
+
+  async clickCancel() {
+    await this.cancelButton.click();
+  }
+
+  getEditVariableModificationText(variableName: string) {
+    return this.page.getByText(
+      new RegExp(`edit variable "${variableName}"`, 'i'),
+    );
+  }
+
+  getAddVariableModificationText(variableName: string) {
+    return this.page.getByText(
+      new RegExp(`add new variable "${variableName}"`, 'i'),
+    );
+  }
+
+  getVariableModificationSummaryText(variableName: string, value: string) {
+    return this.page.getByText(`${variableName}: ${value}`);
+  }
+
+  getDialogVariableModificationSummaryText(
+    variableName: string,
+    value: string,
+  ) {
+    return this.modalDialog.getByText(`${variableName}: ${value}`);
+  }
+
+  getDialogDeleteVariableModificationButton(index?: number) {
+    const button = this.modalDialog.getByRole('button', {
+      name: 'Delete variable modification',
+    });
+    return index !== undefined ? button.nth(index) : button;
+  }
+
+  getDialogCancelButton() {
+    return this.modalDialog.getByRole('button', {name: 'Cancel'});
+  }
+
+  async clickDialogDeleteVariableModification(index?: number) {
+    await this.getDialogDeleteVariableModificationButton(index).click();
+  }
+
+  async clickDialogCancel() {
+    await this.getDialogCancelButton().click();
+  }
+
+  async clickFlowNode(flowNodeName: string) {
+    await this.diagram.getByText(flowNodeName).first().click({timeout: 20000});
+  }
+
+  async navigateToRootScope() {
+    await this.rootProcessNode.click();
+  }
+
+  async addNewVariableModificationMode(
+    variableIndex: string,
+    name: string,
+    value: string,
+  ) {
+    await this.addVariableModificationButton.click();
+    await expect(
+      this.page.getByTestId(`variable-${variableIndex}`),
+    ).toBeVisible();
+
+    await this.getNewVariableNameFieldSelector(variableIndex).clear();
+    await this.getNewVariableNameFieldSelector(variableIndex).type(name);
+    await this.page.keyboard.press('Tab');
+
+    await this.getNewVariableValueFieldSelector(variableIndex).type(value);
+    await this.page.keyboard.press('Tab');
+  }
+
+  async editVariableValueModificationMode(variableName: string, value: string) {
+    await this.getEditVariableFieldSelector(variableName).clear();
+    await this.getEditVariableFieldSelector(variableName).type(value);
+    await this.page.keyboard.press('Tab');
   }
 
   async navigateToProcessInstance(id: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
@@ -31,6 +31,15 @@ export async function navigateToApp(
   }
 }
 
+export async function hideModificationHelperModal(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      'sharedState',
+      JSON.stringify({hideModificationHelperModal: true}),
+    );
+  });
+}
+
 export async function validateURL(page: Page, URL: RegExp): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises, playwright/missing-playwright-await
   expect(page).toHaveURL(URL);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_1.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="withoutIncidentsProcess" name="Without Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverFails" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverFails" targetRef="end" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverFails" name="Never fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="withoutIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="602" y="120" />
+        <di:waypoint x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverFails">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -1,0 +1,427 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp, hideModificationHelperModal} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let instanceWithoutAnIncident: ProcessInstance;
+
+test.beforeAll(async () => {
+  await deploy(['./resources/withoutIncidentsProcess_v_1.bpmn']);
+
+  instanceWithoutAnIncident = await createSingleInstance(
+    'withoutIncidentsProcess',
+    1,
+    {
+      test: 123,
+      foo: 'bar',
+    },
+  );
+
+  await sleep(2000);
+});
+
+test.describe('Process Instance Modifications', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await hideModificationHelperModal(page);
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Should apply/remove edit variable modifications', async ({
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Navigate to process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: instanceWithoutAnIncident.processInstanceKey,
+      });
+    });
+
+    await test.step('Verify initial variables are visible', async () => {
+      await expect(
+        operateProcessInstancePage.getVariableTestId('foo'),
+      ).toBeVisible();
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+
+      await expect(
+        operateProcessInstancePage.modificationModeText,
+      ).toBeVisible();
+    });
+
+    await test.step('Edit variable foo to value 1', async () => {
+      await operateProcessInstancePage.editVariableValueModificationMode(
+        'foo',
+        '1',
+      );
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableModificationText('foo'),
+      ).toBeVisible();
+    });
+
+    await test.step('Edit variable test to value 2', async () => {
+      await operateProcessInstancePage.editVariableValueModificationMode(
+        'test',
+        '2',
+      );
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableModificationText('test'),
+      ).toBeVisible();
+    });
+
+    await test.step('Edit variable foo again to value 3', async () => {
+      await operateProcessInstancePage.editVariableValueModificationMode(
+        'foo',
+        '3',
+      );
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableModificationText('foo'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('3');
+    });
+
+    await test.step('Undo last modification and verify value reverted to 1', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('1');
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableModificationText('test'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to different flow node and undo', async () => {
+      await operateProcessInstancePage.clickFlowNode('never fails');
+      await expect(operateProcessInstancePage.noVariablesText).toBeVisible();
+
+      await operateProcessInstancePage.undoModification();
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getEditVariableModificationText('foo'),
+      ).toBeVisible();
+    });
+
+    await test.step('Return to root scope and verify correct values', async () => {
+      await operateProcessInstancePage.navigateToRootScope();
+
+      await expect(
+        operateProcessInstancePage.getVariableTestId('foo'),
+      ).toBeVisible();
+
+      // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
+      // await expect(
+      //   operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      // ).toHaveValue('123');
+      // await expect(
+      //   operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      // ).toHaveValue('1');
+    });
+
+    await test.step('Undo again and verify all modifications removed', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('test'),
+      ).toHaveValue('123');
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('"bar"');
+    });
+
+    await test.step('Edit variable and remove from summary modal', async () => {
+      await operateProcessInstancePage.editVariableValueModificationMode(
+        'foo',
+        '1',
+      );
+      await operateProcessInstancePage.editVariableValueModificationMode(
+        'foo',
+        '2',
+      );
+
+      await operateProcessInstancePage.clickApplyModifications();
+
+      await expect(
+        operateProcessInstancePage.getVariableModificationSummaryText(
+          'foo',
+          '2',
+        ),
+      ).toBeVisible();
+      await operateProcessInstancePage.clickDeleteVariableModification();
+
+      await operateProcessInstancePage.clickCancel();
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getEditVariableFieldSelector('foo'),
+      ).toHaveValue('"bar"');
+    });
+  });
+
+  // Skipped due to bug 42546: https://github.com/camunda/camunda/issues/42546
+  // !Note: assert the code after the bug is fixed as it was discoverd during the test implementation
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip('Should apply/remove add variable modifications', async ({
+    page,
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Navigate to process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: instanceWithoutAnIncident.processInstanceKey,
+      });
+      await sleep(1000);
+    });
+
+    await test.step('Verify initial variables are visible', async () => {
+      await expect(
+        operateProcessInstancePage.getVariableTestId('foo'),
+      ).toBeVisible();
+    });
+
+    await test.step('Enter modification mode', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+
+      await expect(
+        operateProcessInstancePage.modificationModeText,
+      ).toBeVisible();
+    });
+
+    await test.step('Add first new variable test2', async () => {
+      await operateProcessInstancePage.addNewVariableModificationMode(
+        'newVariables[0]',
+        'test2',
+        '1',
+      );
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getAddVariableModificationText('test2'),
+      ).toBeVisible();
+    });
+
+    await test.step('Add second new variable test3', async () => {
+      await operateProcessInstancePage.addNewVariableModificationMode(
+        'newVariables[1]',
+        'test3',
+        '2',
+      );
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getAddVariableModificationText('test3'),
+      ).toBeVisible();
+    });
+
+    await test.step('Edit first added variable name', async () => {
+      await operateProcessInstancePage
+        .getNewVariableNameFieldSelector('newVariables[0]')
+        .clear();
+      await operateProcessInstancePage
+        .getNewVariableNameFieldSelector('newVariables[0]')
+        .type('test2-edited');
+      await page.keyboard.press('Tab');
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getAddVariableModificationText(
+          'test2-edited',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('test2-edited');
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[1]',
+        ),
+      ).toHaveValue('test3');
+    });
+
+    await test.step('Undo last modification and verify name reverted', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('test2');
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getAddVariableModificationText('test3'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to different flow node and undo', async () => {
+      await operateProcessInstancePage.clickFlowNode('never fails');
+      await expect(operateProcessInstancePage.noVariablesText).toBeVisible();
+
+      await operateProcessInstancePage.undoModification();
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getAddVariableModificationText('test2'),
+      ).toBeVisible();
+    });
+
+    await test.step('Return to root scope and verify first variable', async () => {
+      await operateProcessInstancePage.navigateToRootScope();
+
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[1]'),
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getNewVariableNameFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('test2');
+      await expect(
+        operateProcessInstancePage.getNewVariableValueFieldSelector(
+          'newVariables[0]',
+        ),
+      ).toHaveValue('1');
+    });
+
+    await test.step('Undo again and verify new variable field removed', async () => {
+      await operateProcessInstancePage.undoModification();
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+      ).toBeHidden();
+    });
+
+    await test.step('Add variables to different scopes with same name', async () => {
+      await operateProcessInstancePage.addNewVariableModificationMode(
+        'newVariables[0]',
+        'test3',
+        '1',
+      );
+
+      await operateProcessInstancePage.clickFlowNode('never fails');
+      await expect(
+        page.getByText(/The Flow Node has no Variables/i),
+      ).toBeVisible();
+
+      await operateProcessInstancePage.addNewVariableModificationMode(
+        'newVariables[0]',
+        'test3',
+        '1',
+      );
+    });
+
+    await test.step('Remove one variable from summary modal', async () => {
+      await operateProcessInstancePage.clickApplyModifications();
+
+      await expect(
+        operateProcessInstancePage.getDialogVariableModificationSummaryText(
+          'test3',
+          '1',
+        ),
+      ).toHaveCount(2);
+
+      await operateProcessInstancePage.clickDialogDeleteVariableModification(1);
+
+      await operateProcessInstancePage.clickDialogCancel();
+
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+      ).toBeHidden();
+    });
+
+    await test.step('Verify first scope still has the variable', async () => {
+      await operateProcessInstancePage.navigateToRootScope();
+
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+      ).toBeVisible();
+    });
+
+    await test.step('Change new variable value and remove from summary', async () => {
+      await operateProcessInstancePage
+        .getNewVariableValueFieldSelector('newVariables[0]')
+        .type('2');
+      await page.keyboard.press('Tab');
+
+      await operateProcessInstancePage.clickApplyModifications();
+
+      await expect(
+        operateProcessInstancePage.getVariableModificationSummaryText(
+          'test3',
+          '21',
+        ),
+      ).toBeVisible();
+
+      await operateProcessInstancePage.clickDeleteVariableModification();
+
+      await operateProcessInstancePage.clickCancel();
+
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+      ).toBeHidden();
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrated process instance modifications test from operate component folder to OC test suite and refactored to use proper Page Object Model, improving maintainability and reducing code duplication.

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20225919630)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
relates to https://github.com/camunda/camunda/issues/34103
