### PR TITLE
[Backport stable/8.7] feat: extend blocked stream processor message with the current status

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -194,6 +194,17 @@ public final class ProcessingStateMachine {
     clock = context.getClock();
   }
 
+  String describeCurrentState() {
+    if (errorHandlingPhase != ErrorHandlingPhase.NO_ERROR) {
+      return String.format(
+          "in error handling phase %s for '%s %s'", errorHandlingPhase, currentRecord, metadata);
+    } else if (inProcessing) {
+      return String.format("processing '%s %s'", currentRecord, metadata);
+    } else {
+      return String.format("finished processing '%s %s'", currentRecord, metadata);
+    }
+  }
+
   private void skipRecord() {
     notifySkippedListener(currentRecord);
     markProcessingCompleted();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -322,6 +322,13 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
     return lastReplayedEventPosition;
   }
 
+  String describeCurrentState() {
+    return switch (currentState) {
+      case AWAIT_RECORD -> "awaiting record to replay";
+      case REPLAY_EVENT -> "replaying event %s".formatted(typedEvent);
+    };
+  }
+
   public void close() {
     logStream.removeRecordAvailableListener(this);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -498,7 +498,15 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
     // If healthCheckTick was not invoked it indicates the actor is blocked in a runUntilDone loop.
     if (ActorClock.currentTimeMillis() - lastTickTime > HEALTH_CHECK_TICK_DURATION.toMillis() * 2) {
-      return HealthReport.unhealthy(this).withMessage("actor appears blocked", instant);
+      final StringBuilder message = new StringBuilder("actor appears blocked, ");
+      if (processingStateMachine != null) {
+        message.append(processingStateMachine.describeCurrentState());
+      } else if (replayStateMachine != null) {
+        message.append(replayStateMachine.describeCurrentState());
+      } else {
+        message.append("in phase ").append(streamProcessorContext.getStreamProcessorPhase());
+      }
+      return HealthReport.unhealthy(this).withMessage(message.toString(), instant);
     } else if (streamProcessorContext.getStreamProcessorPhase() == Phase.FAILED) {
       return HealthReport.unhealthy(this).withMessage("in failed phase", instant);
     } else {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorHealthTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorHealthTest.java
@@ -9,26 +9,37 @@ package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthReport;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 @ExtendWith(StreamPlatformExtension.class)
 public class StreamProcessorHealthTest {
 
   @SuppressWarnings("unused") // injected by the extension
   private StreamPlatform streamPlatform;
+
+  @SuppressWarnings("unused") // injected by the extension
+  private ControlledActorClock actorClock;
 
   private StreamProcessor streamProcessor;
 
@@ -125,5 +136,127 @@ public class StreamProcessorHealthTest {
     // then
     Awaitility.await("wait to become unhealthy")
         .until(() -> healthReport.get() != null && healthReport.get().isUnhealthy());
+  }
+
+  @Nested
+  final class BlockedActorDetectionTest {
+
+    @BeforeEach
+    void setup() {
+      // Ensure the clock is behind the real time to trigger blocked detection quickly
+      // We must do this before each test to ensure that the health check ticker runs immediately.
+      actorClock.setCurrentTime(Instant.ofEpochMilli(1765200166956L));
+    }
+
+    @Test
+    void shouldDetectBlockedActorDuringProcessing() {
+      // given
+      streamProcessor = streamPlatform.startStreamProcessor();
+      final var mockProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+      final var block = new CountDownLatch(1);
+
+      // when - processing blocks indefinitely
+      when(mockProcessor.process(any(), any()))
+          .thenAnswer(
+              invocation -> {
+                block.await();
+                return EmptyProcessingResult.INSTANCE;
+              });
+
+      streamPlatform.writeBatch(
+          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+      // then - should detect a blocked actor and report unhealthy
+      try {
+        Awaitility.await("wait for blocked actor detection")
+            .atMost(Duration.ofSeconds(5))
+            .untilAsserted(
+                () -> {
+                  final var healthReport = streamProcessor.getHealthReport();
+                  assertThat(healthReport.isUnhealthy()).isTrue();
+                  assertThat(healthReport.getIssue()).isNotNull();
+                  assertThat(healthReport.getIssue().message())
+                      .isEqualTo(
+                          "actor appears blocked, processing 'LoggedEvent [position=1, key=1, timestamp=1765200166956, sourceEventPosition=-1] RecordMetadata{recordType=COMMAND, valueType=PROCESS_INSTANCE, intent=ACTIVATE_ELEMENT, authorization={\"format\":\"UNKNOWN\",\"authData\":\"***\",\"claims\":\"***\"}}'");
+                });
+      } finally {
+        block.countDown();
+      }
+    }
+
+    @Test
+    void shouldDetectBlockedActorDuringReplay() {
+      // given
+      final var mockProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+      final var block = new CountDownLatch(1);
+
+      // Set up blocking replay behavior using doAnswer for void method
+      Mockito.doAnswer(
+              invocation -> {
+                block.await();
+                return null;
+              })
+          .when(mockProcessor)
+          .replay(any());
+
+      // Write an event before starting replay mode
+      streamPlatform.writeBatch(
+          RecordToWrite.event().processInstance(ELEMENT_ACTIVATED, Records.processInstance(1)));
+
+      // when - start in replay mode
+      streamProcessor = streamPlatform.startStreamProcessorInReplayOnlyMode();
+
+      actorClock.addTime(Duration.ofSeconds(20));
+
+      // then - should detect a blocked actor during replay
+      try {
+        Awaitility.await("wait for blocked actor detection during replay")
+            .atMost(Duration.ofSeconds(15))
+            .untilAsserted(
+                () ->
+                    assertThat(streamProcessor.getHealthReport().getIssue().message())
+                        .isEqualTo(
+                            "actor appears blocked, replaying event TypedRecordImpl{metadata=RecordMetadata{recordType=EVENT, valueType=PROCESS_INSTANCE, intent=ELEMENT_ACTIVATED, authorization={\"format\":\"UNKNOWN\",\"authData\":\"***\",\"claims\":\"***\"}}, value={\"bpmnElementType\":\"UNSPECIFIED\",\"elementId\":\"\",\"bpmnProcessId\":\"processId\",\"version\":-1,\"processDefinitionKey\":-1,\"processInstanceKey\":1,\"flowScopeKey\":-1,\"bpmnEventType\":\"UNSPECIFIED\",\"parentProcessInstanceKey\":-1,\"parentElementInstanceKey\":-1,\"tenantId\":\"<default>\",\"elementInstancePath\":[],\"processDefinitionPath\":[],\"callingElementPath\":[],\"tags\":[]}}"));
+      } finally {
+        block.countDown();
+      }
+    }
+
+    @Test
+    void shouldRecoverAfterBlockingOperationCompletes() {
+      // given
+      streamProcessor = streamPlatform.startStreamProcessor();
+      final var mockProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+      final var block = new CountDownLatch(1);
+
+      when(mockProcessor.process(any(), any()))
+          .thenAnswer(
+              invocation -> {
+                block.await();
+                return EmptyProcessingResult.INSTANCE;
+              });
+
+      streamPlatform.writeBatch(
+          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+      // when - resetting the clock & unblocking processing after detecting a blocked actor
+      try {
+        Awaitility.await("wait for blocked actor detection")
+            .atMost(Duration.ofSeconds(15))
+            .untilAsserted(
+                () ->
+                    assertThat(streamProcessor.getHealthReport().getIssue().message())
+                        .contains("actor appears blocked, processing"));
+        actorClock.reset();
+      } finally {
+        // Unblock processing
+        block.countDown();
+      }
+
+      // then - should recover and become healthy again
+      Awaitility.await("wait for recovery after blocking operation completes")
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(() -> assertThat(streamProcessor.getHealthReport().isHealthy()).isTrue());
+    }
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorHealthTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorHealthTest.java
@@ -176,8 +176,9 @@ public class StreamProcessorHealthTest {
                   assertThat(healthReport.isUnhealthy()).isTrue();
                   assertThat(healthReport.getIssue()).isNotNull();
                   assertThat(healthReport.getIssue().message())
-                      .isEqualTo(
-                          "actor appears blocked, processing 'LoggedEvent [position=1, key=1, timestamp=1765200166956, sourceEventPosition=-1] RecordMetadata{recordType=COMMAND, valueType=PROCESS_INSTANCE, intent=ACTIVATE_ELEMENT, authorization={\"format\":\"UNKNOWN\",\"authData\":\"***\",\"claims\":\"***\"}}'");
+                      .startsWith("actor appears blocked, processing")
+                      .contains("position=1")
+                      .contains("ACTIVATE_ELEMENT");
                 });
       } finally {
         block.countDown();
@@ -215,8 +216,9 @@ public class StreamProcessorHealthTest {
             .untilAsserted(
                 () ->
                     assertThat(streamProcessor.getHealthReport().getIssue().message())
-                        .isEqualTo(
-                            "actor appears blocked, replaying event TypedRecordImpl{metadata=RecordMetadata{recordType=EVENT, valueType=PROCESS_INSTANCE, intent=ELEMENT_ACTIVATED, authorization={\"format\":\"UNKNOWN\",\"authData\":\"***\",\"claims\":\"***\"}}, value={\"bpmnElementType\":\"UNSPECIFIED\",\"elementId\":\"\",\"bpmnProcessId\":\"processId\",\"version\":-1,\"processDefinitionKey\":-1,\"processInstanceKey\":1,\"flowScopeKey\":-1,\"bpmnEventType\":\"UNSPECIFIED\",\"parentProcessInstanceKey\":-1,\"parentElementInstanceKey\":-1,\"tenantId\":\"<default>\",\"elementInstancePath\":[],\"processDefinitionPath\":[],\"callingElementPath\":[],\"tags\":[]}}"));
+                        .startsWith("actor appears blocked, replaying event")
+                        .contains("ELEMENT_ACTIVATED")
+                        .contains("PROCESS_INSTANCE"));
       } finally {
         block.countDown();
       }


### PR DESCRIPTION
# Description
Backport of #42265 to `stable/8.7`.

relates to #41845