### PR TITLE
feat: Spring boot starter jackson3

### DIFF
--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -60,6 +60,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
@@ -76,6 +82,16 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
 

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -54,18 +54,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-jackson2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
@@ -204,6 +192,16 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -76,11 +76,13 @@
     <dependency>
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/impl/CamundaJackson3ObjectMapper.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/impl/CamundaJackson3ObjectMapper.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl;
+
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.InternalClientException;
+import java.io.InputStream;
+import java.util.Map;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+
+public class CamundaJackson3ObjectMapper implements JsonMapper {
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
+      new TypeReference<Map<String, Object>>() {};
+
+  private static final TypeReference<Map<String, String>> STRING_MAP_TYPE_REFERENCE =
+      new TypeReference<Map<String, String>>() {};
+
+  private final ObjectMapper objectMapper;
+
+  public CamundaJackson3ObjectMapper() {
+    this(new ObjectMapper());
+  }
+
+  public CamundaJackson3ObjectMapper(final ObjectMapper objectMapper) {
+    this.objectMapper =
+        objectMapper
+            .rebuild()
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build();
+  }
+
+  @Override
+  public <T> T fromJson(final String json, final Class<T> typeClass) {
+    try {
+      return objectMapper.readValue(json, typeClass);
+    } catch (final JacksonException e) {
+      throw new InternalClientException(
+          String.format("Failed to deserialize json '%s' to class '%s'", json, typeClass), e);
+    }
+  }
+
+  @Override
+  public <T> T transform(final Object json, final Class<T> typeClass) {
+    try {
+      return objectMapper.convertValue(json, typeClass);
+    } catch (final IllegalArgumentException e) {
+      throw new InternalClientException(
+          String.format("Failed to transform object '%s' to class '%s'", json, typeClass), e);
+    }
+  }
+
+  @Override
+  public Map<String, Object> fromJsonAsMap(final String json) {
+    try {
+      return objectMapper.readValue(json, MAP_TYPE_REFERENCE);
+    } catch (final JacksonException e) {
+      throw new InternalClientException(
+          String.format("Failed to deserialize json '%s' to 'Map<String, Object>'", json), e);
+    }
+  }
+
+  @Override
+  public Map<String, String> fromJsonAsStringMap(final String json) {
+    try {
+      return objectMapper.readValue(json, STRING_MAP_TYPE_REFERENCE);
+    } catch (final JacksonException e) {
+      throw new InternalClientException(
+          String.format("Failed to deserialize json '%s' to 'Map<String, String>'", json), e);
+    }
+  }
+
+  @Override
+  public String toJson(final Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (final JacksonException e) {
+      throw new InternalClientException(
+          String.format("Failed to serialize object '%s' to json", value), e);
+    }
+  }
+
+  @Override
+  public String validateJson(final String propertyName, final String jsonInput) {
+    try {
+      return objectMapper.readTree(jsonInput).toString();
+    } catch (final JacksonException e) {
+      throw new InternalClientException(
+          String.format(
+              "Failed to validate json input '%s' for property '%s'", jsonInput, propertyName),
+          e);
+    }
+  }
+
+  @Override
+  public String validateJson(final String propertyName, final InputStream jsonInput) {
+    try {
+      return objectMapper.readTree(jsonInput).toString();
+    } catch (final JacksonException e) {
+      throw new InternalClientException(
+          String.format("Failed to validate json input stream for property '%s'", propertyName), e);
+    }
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaAutoConfiguration.java
@@ -35,6 +35,8 @@ import org.springframework.context.annotation.Bean;
   CamundaActuatorConfiguration.class,
   MetricsDefaultConfiguration.class,
   JsonMapperConfiguration.class,
+  Jackson3JsonMapperConfiguration.class,
+  DefaultJsonMapperConfiguration.class,
   ZeebeClientProdAutoConfiguration.class
 })
 public class CamundaAutoConfiguration {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java
@@ -48,6 +48,8 @@ import org.springframework.context.annotation.Import;
 @Import({
   AnnotationProcessorConfiguration.class,
   JsonMapperConfiguration.class,
+  Jackson3JsonMapperConfiguration.class,
+  DefaultJsonMapperConfiguration.class,
   CamundaBeanPostProcessorConfiguration.class
 })
 @EnableConfigurationProperties({CamundaClientProperties.class})

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java
@@ -50,6 +50,8 @@ import org.springframework.context.annotation.Bean;
   ExecutorServiceConfiguration.class,
   CamundaActuatorConfiguration.class,
   JsonMapperConfiguration.class,
+  Jackson3JsonMapperConfiguration.class,
+  DefaultJsonMapperConfiguration.class,
   CredentialsProviderConfiguration.class
 })
 @AutoConfigureBefore(CamundaClientAllAutoConfiguration.class)

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/DefaultJsonMapperConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/DefaultJsonMapperConfiguration.java
@@ -15,14 +15,12 @@
  */
 package io.camunda.client.spring.configuration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.CamundaObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
@@ -31,16 +29,17 @@ import org.springframework.context.annotation.Bean;
     name = {
       "org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration",
       "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
-      "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
+      "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration",
+      "io.camunda.client.spring.configuration.JsonMapperConfiguration",
+      "io.camunda.client.spring.configuration.Jackson3JsonMapperConfiguration"
     })
-public class JsonMapperConfiguration {
-  private static final Logger LOG = LoggerFactory.getLogger(JsonMapperConfiguration.class);
+public class DefaultJsonMapperConfiguration {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultJsonMapperConfiguration.class);
 
   @Bean(name = "camundaJsonMapper")
   @ConditionalOnMissingBean
-  @ConditionalOnBean(ObjectMapper.class)
-  public JsonMapper jsonMapper(final ObjectMapper objectMapper) {
+  public JsonMapper jsonMapper() {
     LOG.debug("Using jackson 2 to configure Camunda client json mapper");
-    return new CamundaObjectMapper(objectMapper.copy());
+    return new CamundaObjectMapper();
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/Jackson3JsonMapperConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/Jackson3JsonMapperConfiguration.java
@@ -15,32 +15,35 @@
  */
 package io.camunda.client.spring.configuration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.impl.CamundaJackson3ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import tools.jackson.databind.ObjectMapper;
 
+@ConditionalOnClass(name = "tools.jackson.databind.ObjectMapper")
 @AutoConfiguration
 @AutoConfigureAfter(
     name = {
       "org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration",
       "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
-      "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
+      "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration",
+      "io.camunda.client.spring.configuration.JsonMapperConfiguration"
     })
-public class JsonMapperConfiguration {
-  private static final Logger LOG = LoggerFactory.getLogger(JsonMapperConfiguration.class);
+public class Jackson3JsonMapperConfiguration {
+  private static final Logger LOG = LoggerFactory.getLogger(Jackson3JsonMapperConfiguration.class);
 
   @Bean(name = "camundaJsonMapper")
   @ConditionalOnMissingBean
   @ConditionalOnBean(ObjectMapper.class)
   public JsonMapper jsonMapper(final ObjectMapper objectMapper) {
-    LOG.debug("Using jackson 2 to configure Camunda client json mapper");
-    return new CamundaObjectMapper(objectMapper.copy());
+    LOG.debug("Using jackson 3 to configure Camunda client json mapper");
+    return new CamundaJackson3ObjectMapper(objectMapper);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/JsonMapperConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/JsonMapperConfiguration.java
@@ -17,6 +17,7 @@ package io.camunda.client.spring.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.impl.CamundaJackson3ObjectMapper;
 import io.camunda.client.impl.CamundaObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -28,21 +29,29 @@ import org.springframework.context.annotation.Bean;
 @AutoConfigureAfter(
     name = {
       "org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration",
-      "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration"
+      "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
+      "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
     })
 public class JsonMapperConfiguration {
   final ObjectMapper objectMapper;
+  final tools.jackson.databind.ObjectMapper jackson3ObjectMapper;
 
   @Autowired
-  public JsonMapperConfiguration(@Autowired(required = false) final ObjectMapper objectMapper) {
+  public JsonMapperConfiguration(
+      @Autowired(required = false) final ObjectMapper objectMapper,
+      @Autowired(required = false) final tools.jackson.databind.ObjectMapper jackson3ObjectMapper) {
     this.objectMapper = objectMapper;
+    this.jackson3ObjectMapper = jackson3ObjectMapper;
   }
 
   @Bean(name = "camundaJsonMapper")
   @ConditionalOnMissingBean
   public JsonMapper jsonMapper() {
-    if (objectMapper == null) {
+    if (objectMapper == null && jackson3ObjectMapper == null) {
       return new CamundaObjectMapper();
+    }
+    if (jackson3ObjectMapper != null) {
+      return new CamundaJackson3ObjectMapper(jackson3ObjectMapper);
     }
     return new CamundaObjectMapper(objectMapper.copy());
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/JsonMapperConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/JsonMapperConfiguration.java
@@ -50,9 +50,9 @@ public class JsonMapperConfiguration {
     if (objectMapper == null && jackson3ObjectMapper == null) {
       return new CamundaObjectMapper();
     }
-    if (jackson3ObjectMapper != null) {
-      return new CamundaJackson3ObjectMapper(jackson3ObjectMapper);
+    if (objectMapper != null) {
+      return new CamundaObjectMapper(objectMapper.copy());
     }
-    return new CamundaObjectMapper(objectMapper.copy());
+    return new CamundaJackson3ObjectMapper(jackson3ObjectMapper);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/JsonMapperConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/JsonMapperConfiguration.java
@@ -33,8 +33,8 @@ import org.springframework.context.annotation.Bean;
       "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
     })
 public class JsonMapperConfiguration {
-  final ObjectMapper objectMapper;
-  final tools.jackson.databind.ObjectMapper jackson3ObjectMapper;
+  private final ObjectMapper objectMapper;
+  private final tools.jackson.databind.ObjectMapper jackson3ObjectMapper;
 
   @Autowired
   public JsonMapperConfiguration(

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/impl/CamundaObjectMapperTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/impl/CamundaObjectMapperTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class CamundaObjectMapperTest {
+
+  @Test
+  public void shouldReturnEmptyObject() {
+    // Given
+    final CamundaJackson3ObjectMapper camundaObjectMapper = new CamundaJackson3ObjectMapper();
+    final TestObject testObject = new TestObject();
+    testObject.setObject(new Object());
+    // When
+    final String actual = camundaObjectMapper.toJson(testObject);
+    // Then
+    assertThat(actual).isEqualTo("{\"object\":{}}");
+  }
+
+  public static final class TestObject {
+    private Object object;
+
+    public Object getObject() {
+      return object;
+    }
+
+    public void setObject(final Object object) {
+      this.object = object;
+    }
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
@@ -22,18 +22,37 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.impl.CamundaJackson3ObjectMapper;
 import io.camunda.client.spring.configuration.JsonMapperConfigurationTest.OverrideObjectMapper.JacksonConfiguration;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 public class JsonMapperConfigurationTest {
+
+  @Nested
+  @SpringBootTest(classes = {JsonMapperConfiguration.class, JacksonAutoConfiguration.class})
+  class JacksonSpringBoot {
+    @Autowired JsonMapperConfiguration config;
+    @Autowired JsonMapper jsonMapper;
+
+    @Test
+    void shouldUseAutoConfiguredObjectMapper() {
+      assertThat(config.jackson3ObjectMapper).isNotNull();
+    }
+
+    @Test
+    void shouldUseCamundaJackson3ObjectMapper() {
+      assertThat(jsonMapper).isInstanceOf(CamundaJackson3ObjectMapper.class);
+    }
+  }
 
   @Nested
   @SpringBootTest(classes = {JsonMapperConfiguration.class, Jackson2AutoConfiguration.class})

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
@@ -41,9 +41,10 @@ public class JsonMapperConfigurationTest {
   @Nested
   @SpringBootTest(
       classes = {
-        JsonMapperConfiguration.class,
         JacksonAutoConfiguration.class,
-        Jackson2AutoConfiguration.class
+        Jackson2AutoConfiguration.class,
+        JsonMapperConfiguration.class,
+        Jackson3JsonMapperConfiguration.class
       })
   class BothJacksonVersionsSpringBoot {
     @Autowired JsonMapper jsonMapper;
@@ -63,7 +64,12 @@ public class JsonMapperConfigurationTest {
   }
 
   @Nested
-  @SpringBootTest(classes = {JsonMapperConfiguration.class, JacksonAutoConfiguration.class})
+  @SpringBootTest(
+      classes = {
+        JacksonAutoConfiguration.class,
+        JsonMapperConfiguration.class,
+        Jackson3JsonMapperConfiguration.class
+      })
   class JacksonSpringBoot {
     @Autowired JsonMapper jsonMapper;
     @Autowired tools.jackson.databind.ObjectMapper objectMapper;
@@ -80,7 +86,7 @@ public class JsonMapperConfigurationTest {
   }
 
   @Nested
-  @SpringBootTest(classes = {JsonMapperConfiguration.class, Jackson2AutoConfiguration.class})
+  @SpringBootTest(classes = {Jackson2AutoConfiguration.class, JsonMapperConfiguration.class})
   class Jackson2SpringBoot {
     @Autowired com.fasterxml.jackson.databind.ObjectMapper objectMapper;
     @Autowired JsonMapper jsonMapper;
@@ -89,6 +95,17 @@ public class JsonMapperConfigurationTest {
     void shouldUseAutoConfiguredObjectMapper() {
       assertThat(objectMapper).isNotNull();
     }
+
+    @Test
+    void shouldUseCamundaJackson2ObjectMapper() {
+      assertThat(jsonMapper).isInstanceOf(CamundaObjectMapper.class);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(classes = {DefaultJsonMapperConfiguration.class})
+  class DefaultSpringBoot {
+    @Autowired JsonMapper jsonMapper;
 
     @Test
     void shouldUseCamundaJackson2ObjectMapper() {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
@@ -39,6 +39,30 @@ import org.springframework.context.annotation.Configuration;
 public class JsonMapperConfigurationTest {
 
   @Nested
+  @SpringBootTest(
+      classes = {
+        JsonMapperConfiguration.class,
+        JacksonAutoConfiguration.class,
+        Jackson2AutoConfiguration.class
+      })
+  class BothJacksonVersionsSpringBoot {
+    @Autowired JsonMapper jsonMapper;
+    @Autowired tools.jackson.databind.ObjectMapper objectMapper;
+    @Autowired com.fasterxml.jackson.databind.ObjectMapper jackson2ObjectMapper;
+
+    @Test
+    void shouldUseAutoConfiguredObjectMapper() {
+      assertThat(objectMapper).isNotNull();
+      assertThat(jackson2ObjectMapper).isNotNull();
+    }
+
+    @Test
+    void shouldUseCamundaObjectMapper() {
+      assertThat(jsonMapper).isInstanceOf(CamundaObjectMapper.class);
+    }
+  }
+
+  @Nested
   @SpringBootTest(classes = {JsonMapperConfiguration.class, JacksonAutoConfiguration.class})
   class JacksonSpringBoot {
     @Autowired JsonMapper jsonMapper;

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/JsonMapperConfigurationTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.CamundaJackson3ObjectMapper;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.spring.configuration.JsonMapperConfigurationTest.OverrideObjectMapper.JacksonConfiguration;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,12 +41,12 @@ public class JsonMapperConfigurationTest {
   @Nested
   @SpringBootTest(classes = {JsonMapperConfiguration.class, JacksonAutoConfiguration.class})
   class JacksonSpringBoot {
-    @Autowired JsonMapperConfiguration config;
     @Autowired JsonMapper jsonMapper;
+    @Autowired tools.jackson.databind.ObjectMapper objectMapper;
 
     @Test
     void shouldUseAutoConfiguredObjectMapper() {
-      assertThat(config.jackson3ObjectMapper).isNotNull();
+      assertThat(objectMapper).isNotNull();
     }
 
     @Test
@@ -57,11 +58,17 @@ public class JsonMapperConfigurationTest {
   @Nested
   @SpringBootTest(classes = {JsonMapperConfiguration.class, Jackson2AutoConfiguration.class})
   class Jackson2SpringBoot {
-    @Autowired JsonMapperConfiguration config;
+    @Autowired com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    @Autowired JsonMapper jsonMapper;
 
     @Test
     void shouldUseAutoConfiguredObjectMapper() {
-      assertThat(config.objectMapper).isNotNull();
+      assertThat(objectMapper).isNotNull();
+    }
+
+    @Test
+    void shouldUseCamundaJackson2ObjectMapper() {
+      assertThat(jsonMapper).isInstanceOf(CamundaObjectMapper.class);
     }
   }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -68,6 +68,7 @@
     <version.identity>8.9.0-alpha3</version.identity>
     <version.instancio>5.5.1</version.instancio>
     <version.jackson>2.21.0</version.jackson>
+    <version.jackson3>3.0.3</version.jackson3>
     <version.json-base>3.0.0</version.json-base>
     <version.json-flattener>0.18.0</version.json-flattener>
     <version.junit>5.14.2</version.junit>
@@ -1020,6 +1021,14 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${version.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson3}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Description

This PR updates the Spring Boot starter to allow for an opt-in to use jackson3 instead of jackson2 if desired.

The future plan would be to move the according json mapper implementation to the plain java client as soon as it is able to use Java 17 as a baseline.

Therefore, the package names have been selected to match with the plain java client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42163
