### PR TITLE
Delete process instance related data from ES and OS

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -418,6 +418,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   }
 
   @Override
+  public <T extends IndexDescriptor> T getIndexDescriptor(final Class<T> descriptorClass) {
+    return indexDescriptors.get(descriptorClass);
+  }
+
+  @Override
   public Set<ExportHandler<?, ?>> getExportHandlers() {
     // Register all handlers here
     return Collections.unmodifiableSet(exportHandlers);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -57,6 +57,13 @@ public interface ExporterResourceProvider {
   <T extends IndexTemplateDescriptor> T getIndexTemplateDescriptor(Class<T> descriptorClass);
 
   /**
+   * @param descriptorClass the expected descriptor type
+   * @return the index descriptor instance for the given class.
+   * @param <T> the expected descriptor type
+   */
+  <T extends IndexDescriptor> T getIndexDescriptor(Class<T> descriptorClass);
+
+  /**
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
    */
   Set<ExportHandler<?, ?>> getExportHandlers();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -41,6 +41,7 @@ import io.camunda.exporter.tasks.incident.OpenSearchIncidentUpdateRepository;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
@@ -403,7 +404,13 @@ public final class BackgroundTaskManagerFactory {
         .forEach(dependantTemplates::add);
 
     return buildHistoryDeletionTask(
-        new HistoryDeletionJob(dependantTemplates, executor, historyDeletionRepository, logger));
+        new HistoryDeletionJob(
+            dependantTemplates,
+            executor,
+            historyDeletionRepository,
+            logger,
+            resourceProvider.getIndexDescriptor(HistoryDeletionIndex.class),
+            resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class)));
   }
 
   private ReschedulingTask buildHistoryDeletionTask(final BackgroundTask task) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -16,11 +16,9 @@ import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
-import java.util.Map;
-import java.util.Objects;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
 
@@ -60,15 +58,10 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
             (response) -> {
               final var hits = response.hits().hits();
               if (hits.isEmpty()) {
-                return CompletableFuture.completedFuture(new HistoryDeletionBatch(Map.of()));
+                return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
               }
-              final var ids =
-                  hits.stream()
-                      .collect(
-                          Collectors.toMap(
-                              Hit::id,
-                              hit -> Objects.requireNonNull(hit.source()).getResourceType()));
-              return CompletableFuture.completedFuture(new HistoryDeletionBatch(ids));
+              final var deletionEntities = hits.stream().map(Hit::source).toList();
+              return CompletableFuture.completedFuture(new HistoryDeletionBatch(deletionEntities));
             },
             executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.historydeletion;
 
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.util.List;
 
 /**
@@ -15,4 +16,12 @@ import java.util.List;
  *
  * @param historyDeletionEntities List of entities marked for deletion
  */
-public record HistoryDeletionBatch(List<HistoryDeletionEntity> historyDeletionEntities) {}
+public record HistoryDeletionBatch(List<HistoryDeletionEntity> historyDeletionEntities) {
+
+  List<Long> getProcessInstanceIds() {
+    return historyDeletionEntities.stream()
+        .filter(entity -> entity.getResourceType().equals(HistoryDeletionType.PROCESS_INSTANCE))
+        .map(HistoryDeletionEntity::getResourceKey)
+        .toList();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
@@ -18,10 +18,17 @@ import java.util.List;
  */
 public record HistoryDeletionBatch(List<HistoryDeletionEntity> historyDeletionEntities) {
 
-  List<Long> getProcessInstanceIds() {
+  List<Long> getResourceKeys(final HistoryDeletionType historyDeletionType) {
     return historyDeletionEntities.stream()
-        .filter(entity -> entity.getResourceType().equals(HistoryDeletionType.PROCESS_INSTANCE))
+        .filter(entity -> entity.getResourceType().equals(historyDeletionType))
         .map(HistoryDeletionEntity::getResourceKey)
+        .toList();
+  }
+
+  List<String> getHistoryDeletionIds(final HistoryDeletionType historyDeletionType) {
+    return historyDeletionEntities.stream()
+        .filter(entity -> entity.getResourceType().equals(historyDeletionType))
+        .map(HistoryDeletionEntity::getId)
         .toList();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
-import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
-import java.util.Map;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import java.util.List;
 
 /**
- * Represents a batch of resource IDs to be deleted from the history.
+ * Represents a batch of entities to be deleted from the history.
  *
- * @param ids Map of resource IDs marked for deletion and their corresponding deletion type.
+ * @param historyDeletionEntities List of entities marked for deletion
  */
-public record HistoryDeletionBatch(Map<String, HistoryDeletionType> ids) {}
+public record HistoryDeletionBatch(List<HistoryDeletionEntity> historyDeletionEntities) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -106,7 +106,7 @@ public class HistoryDeletionJob implements BackgroundTask {
     return CompletableFuture.allOf(deletionFutures.toArray(CompletableFuture[]::new))
         .thenCompose(
             ignored -> {
-              final var dependentSourceIdx = listViewTemplate.getFullQualifiedName();
+              final var dependentSourceIdx = listViewTemplate.getIndexPattern();
               final var dependentIdFieldName = ListViewTemplate.PROCESS_INSTANCE_KEY;
               return deleterRepository.deleteDocumentsByField(
                   dependentSourceIdx, dependentIdFieldName, processInstanceKeys);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -51,10 +51,9 @@ public class HistoryDeletionJob implements BackgroundTask {
   }
 
   private CompletionStage<Integer> deleteBatch(final HistoryDeletionBatch batch) {
-    logger.trace("Deleting history for process instances with ids: {}", batch.ids());
-    // TODO perform actual deletion
-    //  ES: https://github.com/camunda/camunda/issues/41105
-    //  OS: https://github.com/camunda/camunda/issues/41109
+    logger.trace(
+        "Deleting history for process instances with historyDeletionEntities: {}",
+        batch.historyDeletionEntities());
     return CompletableFuture.completedFuture(0);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -25,10 +25,28 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    */
   CompletableFuture<HistoryDeletionBatch> getNextBatch();
 
+  /**
+   * Deletes documents from the specified index where the given field matches any of the provided
+   * values.
+   *
+   * @param sourceIndexName The index to delete the documents from
+   * @param idFieldName The field name to match against
+   * @param fieldValues The values to match for deletion
+   * @return a {@link CompletableFuture} indicating whether the deletion was successful
+   */
+  CompletableFuture<Boolean> deleteDocumentsByField(
+      final String sourceIndexName, final String idFieldName, final List<Long> fieldValues);
+
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
     public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
       return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> deleteDocumentsByField(
+        final String sourceIndexName, final String idFieldName, final List<Long> fieldValues) {
+      return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /** Repository for querying and managing history deletion requests. */
@@ -28,7 +28,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
     public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
-      return CompletableFuture.completedFuture(new HistoryDeletionBatch(Map.of()));
+      return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -34,8 +34,18 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    * @param fieldValues The values to match for deletion
    * @return a {@link CompletableFuture} indicating whether the deletion was successful
    */
-  CompletableFuture<Boolean> deleteDocumentsByField(
+  CompletableFuture<List<Long>> deleteDocumentsByField(
       final String sourceIndexName, final String idFieldName, final List<Long> fieldValues);
+
+  /**
+   * Deletes documents from the specified index by their IDs.
+   *
+   * @param sourceIndexName The index to delete the documents from
+   * @param ids The list of document IDs to delete
+   * @return a {@link CompletableFuture} indicating whether the deletion was successful
+   */
+  CompletableFuture<Integer> deleteDocumentsById(
+      final String sourceIndexName, final List<String> ids);
 
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
@@ -44,9 +54,15 @@ public interface HistoryDeletionRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletableFuture<Boolean> deleteDocumentsByField(
+    public CompletableFuture<List<Long>> deleteDocumentsByField(
         final String sourceIndexName, final String idFieldName, final List<Long> fieldValues) {
-      return CompletableFuture.completedFuture(true);
+      return CompletableFuture.completedFuture(fieldValues);
+    }
+
+    @Override
+    public CompletableFuture<Integer> deleteDocumentsById(
+        final String sourceIndexName, final List<String> ids) {
+      return CompletableFuture.completedFuture(0);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -32,7 +32,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    * @param sourceIndexName The index to delete the documents from
    * @param idFieldName The field name to match against
    * @param fieldValues The values to match for deletion
-   * @return a {@link CompletableFuture} indicating whether the deletion was successful
+   * @return a {@link CompletableFuture} containing the field values
    */
   CompletableFuture<List<Long>> deleteDocumentsByField(
       final String sourceIndexName, final String idFieldName, final List<Long> fieldValues);
@@ -42,7 +42,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    *
    * @param sourceIndexName The index to delete the documents from
    * @param ids The list of document IDs to delete
-   * @return a {@link CompletableFuture} indicating whether the deletion was successful
+   * @return a {@link CompletableFuture} containing th number of entities that were deleted
    */
   CompletableFuture<Integer> deleteDocumentsById(
       final String sourceIndexName, final List<String> ids);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -68,6 +68,12 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
             executor);
   }
 
+  @Override
+  public CompletableFuture<Boolean> deleteDocumentsByField(
+      final String sourceIndexName, final String idFieldName, final List<Long> fieldValues) {
+    return CompletableFuture.completedFuture(true);
+  }
+
   private SearchRequest createSearchRequest() {
     return createSearchRequest(indexDescriptor.getFullQualifiedName());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -69,9 +69,15 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<Boolean> deleteDocumentsByField(
+  public CompletableFuture<List<Long>> deleteDocumentsByField(
       final String sourceIndexName, final String idFieldName, final List<Long> fieldValues) {
-    return CompletableFuture.completedFuture(true);
+    return CompletableFuture.completedFuture(fieldValues);
+  }
+
+  @Override
+  public CompletableFuture<Integer> deleteDocumentsById(
+      final String sourceIndexName, final List<String> ids) {
+    return CompletableFuture.completedFuture(0);
   }
 
   private SearchRequest createSearchRequest() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -14,11 +14,9 @@ import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import java.io.IOException;
-import java.util.Map;
-import java.util.Objects;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.FieldValue;
@@ -62,15 +60,10 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
             (response) -> {
               final var hits = response.hits().hits();
               if (hits.isEmpty()) {
-                return CompletableFuture.completedFuture(new HistoryDeletionBatch(Map.of()));
+                return CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of()));
               }
-              final var ids =
-                  hits.stream()
-                      .collect(
-                          Collectors.toMap(
-                              Hit::id,
-                              hit -> Objects.requireNonNull(hit.source()).getResourceType()));
-              return CompletableFuture.completedFuture(new HistoryDeletionBatch(ids));
+              final var deletionEntities = hits.stream().map(Hit::source).toList();
+              return CompletableFuture.completedFuture(new HistoryDeletionBatch(deletionEntities));
             },
             executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -21,6 +21,8 @@ import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
@@ -71,13 +73,65 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
   @Override
   public CompletableFuture<List<Long>> deleteDocumentsByField(
       final String sourceIndexName, final String idFieldName, final List<Long> fieldValues) {
-    return CompletableFuture.completedFuture(fieldValues);
+    final var deleteRequest =
+        new DeleteByQueryRequest.Builder()
+            .index(sourceIndexName)
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .query(
+                q ->
+                    q.terms(
+                        t ->
+                            t.field(idFieldName)
+                                .terms(
+                                    v ->
+                                        v.value(
+                                            fieldValues.stream().map(FieldValue::of).toList()))))
+            .build();
+
+    return sendRequestAsync(
+        () ->
+            client
+                .deleteByQuery(deleteRequest)
+                .thenComposeAsync(
+                    (response) -> {
+                      if (!response.failures().isEmpty()) {
+                        final var errorMessage =
+                            "Deleting documents from index '%s' by field '%s' failed with failures: %s"
+                                .formatted(sourceIndexName, idFieldName, response.failures());
+                        logger.error(errorMessage);
+                        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                      }
+                      return CompletableFuture.completedFuture(fieldValues);
+                    },
+                    executor));
   }
 
   @Override
   public CompletableFuture<Integer> deleteDocumentsById(
       final String sourceIndexName, final List<String> ids) {
-    return CompletableFuture.completedFuture(0);
+    final var bulkRequestBuilder = new BulkRequest.Builder();
+
+    ids.forEach(
+        id -> bulkRequestBuilder.operations(op -> op.delete(d -> d.index(sourceIndexName).id(id))));
+
+    return sendRequestAsync(
+        () ->
+            client
+                .bulk(bulkRequestBuilder.build())
+                .thenComposeAsync(
+                    response -> {
+                      if (response.errors()) {
+                        final var errorMessage =
+                            "Bulk deleting documents from index '%s' by ids '%s' failed with errors: %s"
+                                .formatted(sourceIndexName, ids, response.items());
+                        logger.error(errorMessage);
+                        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                      }
+                      final var deleted = response.items().size();
+                      return CompletableFuture.completedFuture(deleted);
+                    },
+                    executor));
   }
 
   private SearchRequest createSearchRequest() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class HistoryDeletionJobTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HistoryDeletionJobTest.class);
+  private HistoryDeletionJob job;
+  private HistoryDeletionRepository repository;
+  private final Executor executor = Runnable::run;
+  private List<ProcessInstanceDependant> dependants;
+  private HistoryDeletionIndex historyDeletionIndex;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(HistoryDeletionRepository.class);
+    final TestExporterResourceProvider resourceProvider =
+        new TestExporterResourceProvider("", true);
+    historyDeletionIndex = resourceProvider.getIndexDescriptor(HistoryDeletionIndex.class);
+    final ListViewTemplate listViewTemplate =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    dependants =
+        resourceProvider.getIndexTemplateDescriptors().stream()
+            .filter(ProcessInstanceDependant.class::isInstance)
+            .map(ProcessInstanceDependant.class::cast)
+            .toList();
+    job =
+        new HistoryDeletionJob(
+            dependants, executor, repository, LOGGER, historyDeletionIndex, listViewTemplate);
+  }
+
+  @Test
+  void shouldReturnZeroIfNothingToDelete() {
+    // given empty batch
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of())));
+
+    // when
+    final var count = job.execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count).isEqualTo(0);
+  }
+
+  @Test
+  void shouldDeleteProcessInstanceHistory() {
+    // given
+    final var entity1 =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    final var entity2 =
+        new HistoryDeletionEntity()
+            .setId("id2")
+            .setResourceKey(2L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(
+            CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity1, entity2))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    dependants.stream()
+        .filter(t -> !(t instanceof OperationTemplate))
+        .forEach(
+            dependant ->
+                verify(repository)
+                    .deleteDocumentsByField(
+                        dependant.getFullQualifiedName() + "*",
+                        dependant.getProcessInstanceDependantField(),
+                        List.of(entity1.getResourceKey(), entity2.getResourceKey())));
+    verify(repository)
+        .deleteDocumentsById(
+            historyDeletionIndex.getFullQualifiedName(), List.of(entity1.getId(), entity2.getId()));
+  }
+
+  @Test
+  void shouldNotDeleteFromDeletionIndexIfPiDeletionFailed() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed deleting")));
+
+    // when
+    job.execute().exceptionally(ex -> 0).toCompletableFuture().join();
+
+    // then
+    dependants.stream()
+        .filter(t -> !(t instanceof OperationTemplate))
+        .forEach(
+            dependant ->
+                verify(repository)
+                    .deleteDocumentsByField(
+                        dependant.getFullQualifiedName() + "*",
+                        dependant.getProcessInstanceDependantField(),
+                        List.of(entity.getResourceKey())));
+    verify(repository, never()).deleteDocumentsById(any(), any());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.historydeletion;
 import static io.camunda.search.test.utils.SearchDBExtension.HISTORY_DELETION_ID_PREFIX;
 import static io.camunda.search.test.utils.SearchDBExtension.create;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
@@ -98,8 +99,8 @@ abstract class HistoryDeletionRepositoryIT {
     // then
     assertThat(future)
         .succeedsWithin(REQUEST_TIMEOUT)
-        .extracting(HistoryDeletionBatch::ids)
-        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .extracting(HistoryDeletionBatch::historyDeletionEntities)
+        .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
         .isEmpty();
   }
 
@@ -115,10 +116,10 @@ abstract class HistoryDeletionRepositoryIT {
     // then
     assertThat(future)
         .succeedsWithin(REQUEST_TIMEOUT)
-        .extracting(HistoryDeletionBatch::ids)
-        .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .hasSize(1)
-        .containsEntry(entityId, HistoryDeletionType.PROCESS_INSTANCE);
+        .extracting(HistoryDeletionBatch::historyDeletionEntities)
+        .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
+        .extracting(HistoryDeletionEntity::getId, HistoryDeletionEntity::getResourceType)
+        .containsOnly(tuple(entityId, HistoryDeletionType.PROCESS_INSTANCE));
   }
 
   @Test
@@ -133,8 +134,8 @@ abstract class HistoryDeletionRepositoryIT {
     // then
     assertThat(future)
         .succeedsWithin(REQUEST_TIMEOUT)
-        .extracting(HistoryDeletionBatch::ids)
-        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .extracting(HistoryDeletionBatch::historyDeletionEntities)
+        .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
         .isEmpty();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
@@ -22,21 +22,21 @@ import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 abstract class HistoryDeletionRepositoryIT {
 
   public static final int PARTITION_ID = 1;
   @RegisterExtension protected static SearchDBExtension searchDB = create();
-  private static final Logger LOGGER = LoggerFactory.getLogger(HistoryDeletionRepositoryIT.class);
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   protected final HistoryDeletionIndex historyDeletionIndex;
   @AutoClose protected final ClientAdapter clientAdapter;
@@ -74,17 +74,19 @@ abstract class HistoryDeletionRepositoryIT {
   protected abstract HistoryDeletionRepository createRepository(
       final String indexPrefix, final int partitionId);
 
-  private void createHistoryDeletionEntity(final String id) throws IOException {
-    createHistoryDeletionEntity(id, PARTITION_ID);
+  private HistoryDeletionEntity createHistoryDeletionEntity() throws IOException {
+    return createHistoryDeletionEntity(PARTITION_ID);
   }
 
-  private void createHistoryDeletionEntity(final String id, final int partitionId)
+  private HistoryDeletionEntity createHistoryDeletionEntity(final int partitionId)
       throws IOException {
     final var entity = new HistoryDeletionEntity();
-    entity.setId(id);
+    entity.setId(UUID.randomUUID().toString());
     entity.setPartitionId(partitionId);
+    entity.setResourceKey(ThreadLocalRandom.current().nextLong());
     entity.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
     index(entity);
+    return entity;
   }
 
   protected abstract void index(final HistoryDeletionEntity entity) throws IOException;
@@ -107,8 +109,7 @@ abstract class HistoryDeletionRepositoryIT {
   @Test
   void shouldGetEntitiesToDelete() throws IOException {
     // given
-    final var entityId = UUID.randomUUID().toString();
-    createHistoryDeletionEntity(entityId);
+    final var entity = createHistoryDeletionEntity();
 
     // when
     final var future = repository.getNextBatch();
@@ -119,14 +120,13 @@ abstract class HistoryDeletionRepositoryIT {
         .extracting(HistoryDeletionBatch::historyDeletionEntities)
         .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
         .extracting(HistoryDeletionEntity::getId, HistoryDeletionEntity::getResourceType)
-        .containsOnly(tuple(entityId, HistoryDeletionType.PROCESS_INSTANCE));
+        .containsOnly(tuple(entity.getId(), HistoryDeletionType.PROCESS_INSTANCE));
   }
 
   @Test
   void shouldNotFindEntitiesForOtherPartitions() throws IOException {
     // given
-    final var entityId = UUID.randomUUID().toString();
-    createHistoryDeletionEntity(entityId, 2);
+    createHistoryDeletionEntity(2);
 
     // when
     final var future = repository.getNextBatch();
@@ -137,5 +137,49 @@ abstract class HistoryDeletionRepositoryIT {
         .extracting(HistoryDeletionBatch::historyDeletionEntities)
         .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
         .isEmpty();
+  }
+
+  @Test
+  void shouldDeleteDocumentsByFieldValue() throws IOException {
+    // given
+    final var entity1 = createHistoryDeletionEntity();
+    final var entity2 = createHistoryDeletionEntity();
+
+    // when
+    repository.deleteDocumentsByField(
+        historyDeletionIndex.getFullQualifiedName(),
+        HistoryDeletionIndex.RESOURCE_KEY,
+        List.of(entity1.getResourceKey(), entity2.getResourceKey()));
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(repository.getNextBatch())
+                    .succeedsWithin(REQUEST_TIMEOUT)
+                    .extracting(HistoryDeletionBatch::historyDeletionEntities)
+                    .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldDeleteDocumentsById() throws IOException {
+    // given
+    final var entity1 = createHistoryDeletionEntity();
+    final var entity2 = createHistoryDeletionEntity();
+
+    // when
+    repository.deleteDocumentsById(
+        historyDeletionIndex.getFullQualifiedName(), List.of(entity1.getId(), entity2.getId()));
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(repository.getNextBatch())
+                    .succeedsWithin(REQUEST_TIMEOUT)
+                    .extracting(HistoryDeletionBatch::historyDeletionEntities)
+                    .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
+                    .isEmpty());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
@@ -62,6 +62,11 @@ public class TestExporterResourceProvider implements ExporterResourceProvider {
   }
 
   @Override
+  public <T extends IndexDescriptor> T getIndexDescriptor(final Class<T> descriptorClass) {
+    return indexDescriptors.get(descriptorClass);
+  }
+
+  @Override
   public Set<ExportHandler<?, ?>> getExportHandlers() {
     return Set.of();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the implementation to the `HistoryDeletionJob`. The job already queried the PIs that need to be deleted. With this PR we perform the actual deletion. For a process instance this results in 3 requests to ES per batch. The first request will delete all the PI related data from the leaves (variables, messages, etc). The second request will remove the PI itself from the list view. The final request will remove the PIs from the history-deletion index. At this point the deletion is finalized.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41105 
closes #41109 
