### PR TITLE
test: migrate decisionNavigation.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -14,6 +14,8 @@ import {TaskPanelPageV1} from '@pages/v1/TaskPanelPage';
 import {LoginPage} from '@pages/LoginPage';
 import {OperateProcessesPage} from '@pages/OperateProcessesPage';
 import {OperateProcessInstancePage} from '@pages/OperateProcessInstancePage';
+import {OperateDecisionInstancePage} from '@pages/OperateDecisionInstancePage';
+import {OperateDecisionsPage} from '@pages/OperateDecisionsPage';
 import {OperateFiltersPanelPage} from '@pages/OperateFiltersPanelPage';
 import {OperateDashboardPage} from '@pages/OperateDashboardPage';
 import {OperateDiagramPage} from '@pages/OperateDiagramPage';
@@ -48,6 +50,8 @@ type PlaywrightFixtures = {
   tasklistProcessesPageV1: TasklistProcessesPageV1;
   operateProcessesPage: OperateProcessesPage;
   operateProcessInstancePage: OperateProcessInstancePage;
+  operateDecisionInstancePage: OperateDecisionInstancePage;
+  operateDecisionsPage: OperateDecisionsPage;
   operateFiltersPanelPage: OperateFiltersPanelPage;
   operateDashboardPage: OperateDashboardPage;
   operateDiagramPage: OperateDiagramPage;
@@ -104,6 +108,12 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateProcessInstancePage: async ({page}, use) => {
     await use(new OperateProcessInstancePage(page));
+  },
+  operateDecisionInstancePage: async ({page}, use) => {
+    await use(new OperateDecisionInstancePage(page));
+  },
+  operateDecisionsPage: async ({page}, use) => {
+    await use(new OperateDecisionsPage(page));
   },
   operateOperationPanelPage: async ({page}, use) => {
     await use(new OperateOperationPanelPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
@@ -35,7 +35,7 @@ class OperateDecisionInstancePage {
   }
 
   async getDecisionInstanceId(): Promise<string> {
-    return this.instanceHeader.getByRole('cell').nth(6).innerText();
+    return this.instanceHeader.getByRole('cell').nth(1).innerText();
   }
 
   async gotoDecisionInstancePage(options: {id: string}): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+class OperateDecisionInstancePage {
+  private page: Page;
+  readonly decisionPanel: Locator;
+  readonly popover: Locator;
+  readonly closeDrdPanelButton: Locator;
+  readonly instanceHeader: Locator;
+  readonly viewProcessInstanceLink: (processInstanceKey: string) => Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.decisionPanel = page.getByTestId('decision-panel');
+    this.popover = page.getByTestId('popover');
+    this.closeDrdPanelButton = page.getByRole('button', {
+      name: /close drd panel/i,
+    });
+    this.instanceHeader = page.getByTestId('instance-header');
+    this.viewProcessInstanceLink = (processInstanceKey: string) =>
+      page.getByRole('link', {
+        name: `View process instance ${processInstanceKey}`,
+      });
+  }
+
+  async closeDrdPanel(): Promise<void> {
+    await this.closeDrdPanelButton.click();
+  }
+
+  async getDecisionInstanceId(): Promise<string> {
+    return this.instanceHeader.getByRole('cell').nth(6).innerText();
+  }
+
+  async gotoDecisionInstancePage(options: {id: string}): Promise<void> {
+    await this.page.goto(`/decisions/${options.id}`);
+  }
+
+  async clickViewProcessInstanceLink(
+    processInstanceKey: string,
+  ): Promise<void> {
+    await this.viewProcessInstanceLink(processInstanceKey).click();
+  }
+}
+
+export {OperateDecisionInstancePage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+class OperateDecisionsPage {
+  private page: Page;
+  readonly viewDecisionInstanceLink: (decisionInstanceId: string) => Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.viewDecisionInstanceLink = (decisionInstanceId: string) =>
+      page.getByRole('link', {
+        name: `View decision instance ${decisionInstanceId}`,
+      });
+  }
+
+  async clickViewDecisionInstanceLink(
+    decisionInstanceId: string,
+  ): Promise<void> {
+    await this.viewDecisionInstanceLink(decisionInstanceId).click();
+  }
+
+  async gotoDecisionsPage(): Promise<void> {
+    await this.page.goto('/decisions');
+  }
+}
+
+export {OperateDecisionsPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -21,6 +21,7 @@ export class OperateDiagramPage {
   readonly monacoScrollableElement: Locator;
   readonly showIncidentButton: Locator;
   readonly showMetadataButton: Locator;
+  readonly viewRootCauseDecisionLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -43,6 +44,9 @@ export class OperateDiagramPage {
     });
     this.showMetadataButton = this.popover.getByRole('button', {
       name: 'show more metadata',
+    });
+    this.viewRootCauseDecisionLink = this.page.getByRole('link', {
+      name: /View root cause decision/i,
     });
   }
 
@@ -214,5 +218,14 @@ export class OperateDiagramPage {
 
   async closeMetadataModal(): Promise<void> {
     await this.metadataModalCloseButton.click();
+  }
+
+  async clickViewRootCauseDecisionLink(): Promise<void> {
+    await this.viewRootCauseDecisionLink.scrollIntoViewIfNeeded();
+    await this.viewRootCauseDecisionLink.waitFor({
+      state: 'visible',
+      timeout: 30000,
+    });
+    await this.viewRootCauseDecisionLink.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -12,6 +12,7 @@ class OperateHomePage {
   private page: Page;
   readonly operateBanner: Locator;
   readonly processesTab: Locator;
+  readonly decisionsTab: Locator;
   readonly informationDialog: Locator;
   readonly editVariableButton: Locator;
   readonly variableValueInput: Locator;
@@ -22,6 +23,7 @@ class OperateHomePage {
     this.page = page;
     this.operateBanner = page.getByRole('link', {name: 'Camunda logo Operate'});
     this.processesTab = page.getByRole('link', {name: 'Processes'});
+    this.decisionsTab = page.getByRole('link', {name: 'Decisions'});
     this.informationDialog = page.getByRole('button', {
       name: 'Close this dialog',
     });
@@ -36,6 +38,10 @@ class OperateHomePage {
 
   async clickProcessesTab(): Promise<void> {
     await this.processesTab.click();
+  }
+
+  async clickDecisionsTab(): Promise<void> {
+    await this.decisionsTab.click();
   }
 
   async clickEditVariableButton(variableName: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -70,8 +70,6 @@ class OperateProcessInstancePage {
   readonly addVariableModificationButton: Locator;
   readonly modalDialog: Locator;
   readonly noVariablesText: Locator;
-  readonly popover: Locator;
-  readonly viewRootCauseDecisionLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -177,10 +175,6 @@ class OperateProcessInstancePage {
     });
     this.modalDialog = page.getByRole('dialog');
     this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
-    this.viewRootCauseDecisionLink = page.getByRole('link', {
-      name: /View root cause decision/i,
-    });
-    this.popover = page.getByTestId('popover');
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -592,15 +586,6 @@ class OperateProcessInstancePage {
     for (const elementId of elementIds) {
       await expect(this.getDiagramElement(elementId)).toBeVisible();
     }
-  }
-
-  async clickViewRootCauseDecisionLink(): Promise<void> {
-    await this.viewRootCauseDecisionLink.scrollIntoViewIfNeeded();
-    await this.viewRootCauseDecisionLink.waitFor({
-      state: 'visible',
-      timeout: 30000,
-    });
-    await this.viewRootCauseDecisionLink.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -70,6 +70,8 @@ class OperateProcessInstancePage {
   readonly addVariableModificationButton: Locator;
   readonly modalDialog: Locator;
   readonly noVariablesText: Locator;
+  readonly popover: Locator;
+  readonly viewRootCauseDecisionLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -175,6 +177,10 @@ class OperateProcessInstancePage {
     });
     this.modalDialog = page.getByRole('dialog');
     this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
+    this.viewRootCauseDecisionLink = page.getByRole('link').filter({
+      hasText: /view root cause decision/i,
+    });
+    this.popover = page.getByTestId('popover');
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -565,6 +571,10 @@ class OperateProcessInstancePage {
     return this.diagram.locator(`[data-element-id="${elementId}"]`);
   }
 
+  async clickDiagramElement(elementId: string): Promise<void> {
+    await this.getDiagramElement(elementId).click();
+  }
+
   async getDiagramElementBadge(elementId: string) {
     return this.page.$(`[data-element-id="${elementId}"] .badge`);
   }
@@ -582,6 +592,14 @@ class OperateProcessInstancePage {
     for (const elementId of elementIds) {
       await expect(this.getDiagramElement(elementId)).toBeVisible();
     }
+  }
+
+  async clickViewRootCauseDecisionLink(): Promise<void> {
+    await this.viewRootCauseDecisionLink.waitFor({
+      state: 'visible',
+      timeout: 30000,
+    });
+    await this.viewRootCauseDecisionLink.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -177,8 +177,8 @@ class OperateProcessInstancePage {
     });
     this.modalDialog = page.getByRole('dialog');
     this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
-    this.viewRootCauseDecisionLink = page.getByRole('link').filter({
-      hasText: /view root cause decision/i,
+    this.viewRootCauseDecisionLink = page.getByRole('link', {
+      name: /View root cause decision/i,
     });
     this.popover = page.getByTestId('popover');
   }
@@ -595,6 +595,7 @@ class OperateProcessInstancePage {
   }
 
   async clickViewRootCauseDecisionLink(): Promise<void> {
+    await this.viewRootCauseDecisionLink.scrollIntoViewIfNeeded();
     await this.viewRootCauseDecisionLink.waitFor({
       state: 'visible',
       timeout: 30000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -287,7 +287,7 @@ class OperateProcessesPage {
     const button = this.getRetryInstanceButton(processInstanceKey);
     try {
       await button.click({timeout: 30000});
-    } catch (error) {
+    } catch {
       await button.scrollIntoViewIfNeeded({timeout: 60000});
       await button.click({timeout: 60000});
     }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoice.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoice.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0h0cvk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="invoice" name="DMN invoice" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1950eph</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1950eph" sourceRef="StartEvent_1" targetRef="Activity_1tjwahx" />
+    <bpmn:businessRuleTask id="Activity_1tjwahx" name="Define approver">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="invoiceAssignApprover" resultVariable="approverGroups" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1950eph</bpmn:incoming>
+      <bpmn:outgoing>Flow_0932klu</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:endEvent id="Event_1ymurqn">
+      <bpmn:incoming>Flow_1k2uryn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0932klu" sourceRef="Activity_1tjwahx" targetRef="Activity_11ptrz9" />
+    <bpmn:sequenceFlow id="Flow_1k2uryn" sourceRef="Activity_11ptrz9" targetRef="Event_1ymurqn" />
+    <bpmn:userTask id="Activity_11ptrz9" name="Check invoice">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition candidateGroups="=approverGroups" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0932klu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1k2uryn</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="invoice">
+      <bpmndi:BPMNEdge id="Flow_0932klu_di" bpmnElement="Flow_0932klu">
+        <di:waypoint x="380" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1950eph_di" bpmnElement="Flow_1950eph">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="280" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k2uryn_di" bpmnElement="Flow_1k2uryn">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="582" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fbk7jp_di" bpmnElement="Activity_1tjwahx">
+        <dc:Bounds x="280" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ymurqn_di" bpmnElement="Event_1ymurqn">
+        <dc:Bounds x="582" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0787kv0_di" bpmnElement="Activity_11ptrz9">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoiceBusinessDecisions.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/invoiceBusinessDecisions.dmn
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="invoiceBusinessDecisions" name="Invoice Business Decisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+  <decision id="invoiceClassification" name="Invoice Classification">
+    <decisionTable id="decisionTable">
+      <input id="clause1" label="Invoice Amount" camunda:inputVariable="">
+        <inputExpression id="inputExpression1" typeRef="double">
+          <text>assert(amount,amount!=null)</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_15qmk0v" label="Invoice Category" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_1oi86cw" typeRef="string">
+          <text>invoiceCategory</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0kisa67">
+          <text>"Travel Expenses","Misc","Software License Costs"</text>
+        </inputValues>
+      </input>
+      <output id="clause3" label="Classification" name="invoiceClassification" typeRef="string">
+        <outputValues id="UnaryTests_08dl8wf">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_1of5a87">
+        <inputEntry id="LiteralExpression_0yrqmtg">
+          <text>&lt; 250</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06edsin">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_046antl">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ak4z14">
+        <inputEntry id="LiteralExpression_0qmsef6">
+          <text>[250..1000]</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09b743h">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05xxvip">
+          <text>"budget"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-4">
+        <inputEntry id="UnaryTests_0le0gl8">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pukamj">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1e76ugx">
+          <text>"exceptional"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0cuxolz">
+        <inputEntry id="LiteralExpression_05lyjk7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ve4z34">
+          <text>"Travel Expenses"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1bq8m03">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-2">
+        <inputEntry id="UnaryTests_1nssdlk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ppb4l">
+          <text>"Software License Costs"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0y00iih">
+          <text>"budget"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="invoiceAssignApprover" name="Assign Approver Group">
+    <informationRequirement id="InformationRequirement_1kkeocv">
+      <requiredDecision href="#invoiceClassification" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_16o85h8" hitPolicy="COLLECT">
+      <input id="InputClause_0og2hn3" label="Invoice Classification" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_1vywt5q" typeRef="string">
+          <text>invoiceClassification</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0by7qiy">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1cthd0w" label="Approver Group" name="result" typeRef="string">
+        <outputValues id="UnaryTests_1ulmk9p">
+          <text>"management","accounting","sales"</text>
+        </outputValues>
+      </output>
+      <rule id="row-49839158-1">
+        <inputEntry id="UnaryTests_18ifczd">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0sgxulk">
+          <text>"accounting"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-6">
+        <inputEntry id="UnaryTests_0kfae8g">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1iksrro">
+          <text>"sales"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-5">
+        <inputEntry id="UnaryTests_08cevwi">
+          <text>"budget", "exceptional"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c7hz8g">
+          <text>"management"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1cuuevk">
+      <dmndi:DMNShape id="DMNShape_1abvt5s" dmnElementRef="invoiceClassification">
+        <dc:Bounds height="55" width="100" x="153" y="215" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1ay7af5" dmnElementRef="invoiceAssignApprover">
+        <dc:Bounds height="55" width="100" x="224" y="84" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_1wn1950" dmnElementRef="InformationRequirement_1kkeocv">
+        <di:waypoint x="218" y="215" />
+        <di:waypoint x="258" y="139" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let processInstanceWithFailedDecision: ProcessInstance;
+let calledDecisionInstanceId: string;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/invoiceBusinessDecisions.dmn',
+    './resources/invoice.bpmn',
+  ]);
+
+  processInstanceWithFailedDecision = await createSingleInstance('invoice', 1);
+
+  await sleep(2000);
+});
+
+test.describe('Decision Navigation', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Navigation between process and decision', async ({
+    operateProcessInstancePage,
+    operateDecisionInstancePage,
+    operateDecisionsPage,
+    operateHomePage,
+  }) => {
+    const processInstanceKey =
+      processInstanceWithFailedDecision.processInstanceKey;
+
+    await test.step('Navigate to process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+    });
+
+    await test.step('Verify process diagram is visible', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeInViewport();
+      await expect(
+        operateProcessInstancePage.getDiagramElement('Activity_1tjwahx'),
+      ).toBeVisible();
+    });
+
+    await test.step('Wait for incidents banner to be visible', async () => {
+      await expect
+        .poll(
+          async () => {
+            return await operateProcessInstancePage.incidentsBanner.isVisible();
+          },
+          {timeout: 30000},
+        )
+        .toBe(true);
+    });
+
+    await test.step('Click on business rule task in diagram', async () => {
+      await operateProcessInstancePage.clickDiagramElement('Activity_1tjwahx');
+    });
+
+    await test.step('Verify popover appears and navigate to decision', async () => {
+      await expect(operateProcessInstancePage.popover).toBeVisible();
+      await operateProcessInstancePage.clickViewRootCauseDecisionLink();
+    });
+
+    await test.step('Verify decision panel is visible', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
+      ).toBeVisible();
+    });
+
+    await test.step('Get decision instance ID', async () => {
+      calledDecisionInstanceId =
+        await operateDecisionInstancePage.getDecisionInstanceId();
+    });
+
+    await test.step('Close decision panel and return to process', async () => {
+      await operateDecisionInstancePage.closeDrdPanel();
+      await operateDecisionInstancePage.clickViewProcessInstanceLink(
+        processInstanceKey,
+      );
+    });
+
+    await test.step('Verify back to process instance view', async () => {
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          processInstanceKey,
+          {exact: true},
+        ),
+      ).toBeVisible();
+
+      await expect(operateProcessInstancePage.diagram).toBeInViewport();
+
+      await expect(
+        operateProcessInstancePage.getDiagramElement('Activity_1tjwahx'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to decisions section', async () => {
+      await operateHomePage.clickDecisionsTab();
+    });
+
+    await test.step('View specific decision instance', async () => {
+      await operateDecisionsPage.clickViewDecisionInstanceLink(
+        calledDecisionInstanceId,
+      );
+    });
+
+    await test.step('Verify decision panel is visible again', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -12,6 +12,7 @@ import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -81,7 +82,34 @@ test.describe('Decision Navigation', () => {
     });
 
     await test.step('Verify popover appears and navigate to decision', async () => {
-      await expect(operateProcessInstancePage.popover).toBeVisible();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessInstancePage.popover).toBeVisible();
+        },
+        onFailure: async () => {
+          await operateProcessInstancePage.clickDiagramElement(
+            'Activity_1tjwahx',
+          );
+          await operateProcessInstancePage.clickDiagramElement(
+            'Activity_1tjwahx',
+          );
+        },
+      });
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.viewRootCauseDecisionLink,
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await operateProcessInstancePage.clickDiagramElement(
+            'Activity_1tjwahx',
+          );
+          await operateProcessInstancePage.clickDiagramElement(
+            'Activity_1tjwahx',
+          );
+        },
+      });
       await operateProcessInstancePage.clickViewRootCauseDecisionLink();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -49,6 +49,7 @@ test.describe('Decision Navigation', () => {
     operateDecisionInstancePage,
     operateDecisionsPage,
     operateHomePage,
+    operateDiagramPage,
   }) => {
     const processInstanceKey =
       processInstanceWithFailedDecision.processInstanceKey;
@@ -84,7 +85,7 @@ test.describe('Decision Navigation', () => {
     await test.step('Verify popover appears and navigate to decision', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(operateProcessInstancePage.popover).toBeVisible();
+          await expect(operateDiagramPage.popover).toBeVisible();
         },
         onFailure: async () => {
           await operateProcessInstancePage.clickDiagramElement(
@@ -98,7 +99,7 @@ test.describe('Decision Navigation', () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(
-            operateProcessInstancePage.viewRootCauseDecisionLink,
+            operateDiagramPage.viewRootCauseDecisionLink,
           ).toBeVisible();
         },
         onFailure: async () => {
@@ -110,7 +111,7 @@ test.describe('Decision Navigation', () => {
           );
         },
       });
-      await operateProcessInstancePage.clickViewRootCauseDecisionLink();
+      await operateDiagramPage.clickViewRootCauseDecisionLink();
     });
 
     await test.step('Verify decision panel is visible', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -67,7 +67,7 @@ test.describe('Process Instance', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Resolve an incident', async ({page, operateProcessInstancePage}) => {
+  test('Resolve an incident', async ({operateProcessInstancePage}) => {
     await test.step('Navigate to process instance with incident', async () => {
       await operateProcessInstancePage.gotoProcessInstancePage({
         id: instanceWithIncidentToResolve.processInstanceKey,
@@ -96,9 +96,7 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.saveVariableButton.click();
 
       await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
-      await expect(
-        operateProcessInstancePage.variableSpinner,
-      ).not.toBeVisible();
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden();
     });
 
     await test.step('Retry one incident to resolve it', async () => {
@@ -126,7 +124,7 @@ test.describe('Process Instance', () => {
       ).toBeVisible();
       await expect(
         operateProcessInstancePage.incidentsTable.getByText(/where to go\?/i),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
 
     await test.step('Add variable isCool', async () => {
@@ -139,9 +137,7 @@ test.describe('Process Instance', () => {
 
       await operateProcessInstancePage.saveVariableButton.click();
       await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
-      await expect(
-        operateProcessInstancePage.variableSpinner,
-      ).not.toBeVisible();
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden();
     });
 
     await test.step('Retry second incident to resolve it', async () => {
@@ -155,15 +151,13 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Expect all incidents resolved', async () => {
-      await expect(
-        operateProcessInstancePage.incidentsBanner,
-      ).not.toBeVisible();
-      await expect(operateProcessInstancePage.incidentsTable).not.toBeVisible();
+      await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+      await expect(operateProcessInstancePage.incidentsTable).toBeHidden();
       await expect(operateProcessInstancePage.completedIcon).toBeVisible();
     });
   });
 
-  test('Cancel an instance', async ({page, operateProcessInstancePage}) => {
+  test('Cancel an instance', async ({operateProcessInstancePage}) => {
     const instanceId = instanceWithIncidentToCancel.processInstanceKey;
 
     await test.step('Navigate to process instance with incident', async () => {
@@ -183,9 +177,7 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.cancelInstance(instanceId);
 
       await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
-      await expect(
-        operateProcessInstancePage.operationSpinner,
-      ).not.toBeVisible();
+      await expect(operateProcessInstancePage.operationSpinner).toBeHidden();
     });
 
     await test.step('Verify instance is canceled', async () => {
@@ -195,9 +187,9 @@ test.describe('Process Instance', () => {
 
       await expect(operateProcessInstancePage.terminatedIcon).toBeVisible();
 
-      await expect(
-        await operateProcessInstancePage.endDateField.innerText(),
-      ).toMatch(DATE_REGEX);
+      expect(await operateProcessInstancePage.endDateField.innerText()).toMatch(
+        DATE_REGEX,
+      );
     });
   });
 
@@ -243,9 +235,7 @@ test.describe('Process Instance', () => {
       await expect(
         diagram.getByText('submit application', {exact: false}),
       ).toBeVisible();
-      await expect(
-        diagram.getByText('fill form', {exact: false}),
-      ).not.toBeVisible();
+      await expect(diagram.getByText('fill form', {exact: false})).toBeHidden();
     });
 
     await test.step('Navigate back to start event', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -229,9 +229,11 @@ test.describe('Processes', () => {
         `${baseUrl}/operate/processes?process=testProcess&version=1`,
       );
 
-      await expect(operateDiagramPage.diagramSpinner).toBeVisible();
+      await expect(operateFiltersPanelPage.processNameFilter).toBeDisabled({
+        timeout: 30000,
+      });
 
-      await expect(operateFiltersPanelPage.processNameFilter).toBeDisabled();
+      await expect(operateDiagramPage.diagramSpinner).toBeVisible();
     });
 
     await test.step('Deploy new process and verify it loads', async () => {
@@ -240,16 +242,16 @@ test.describe('Processes', () => {
 
       await expect(operateDiagramPage.diagram).toBeInViewport({timeout: 20000});
 
-      await expect(operateDiagramPage.diagramSpinner).not.toBeVisible();
+      await expect(operateDiagramPage.diagramSpinner).toBeHidden();
 
       await expect(
         operateProcessesPage.noMatchingInstancesMessage,
       ).toBeVisible();
 
       await expect(operateFiltersPanelPage.processNameFilter).toBeEnabled();
-      await expect(operateFiltersPanelPage.processNameFilter).toHaveValue(
-        'Test Process',
-      );
+      await expect
+        .poll(() => operateFiltersPanelPage.processNameFilter.inputValue())
+        .toBe('Test Process');
     });
   });
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrates `decisionNavigation.spec.ts` from the Operate component folder to the c8-orchestration-cluster-e2e-test-suite following POM patterns.

## Changes
- **Test Migration**
- **New Page Objects**: 
  - `OperateDecisionInstancePage.ts` - Decision instance interactions
  - `OperateDecisionsPage.ts` - Decisions list navigation
- **Resolve Falkiness**: update `Wait for process creation` test

🧪  [Test Run](https://github.com/camunda/camunda/actions/runs/20263449364)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/34101
