### PR TITLE
42326 expose auditlog config

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -98,6 +98,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/configuration/src/main/java/io/camunda/configuration/AuditLog.java
+++ b/configuration/src/main/java/io/camunda/configuration/AuditLog.java
@@ -10,6 +10,7 @@ package io.camunda.configuration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
+/** Configuration for audit logging, including separate settings for user and client operations. */
 public class AuditLog {
   private boolean enabled = true;
 
@@ -40,6 +41,7 @@ public class AuditLog {
     this.user = user;
   }
 
+  /** Converts this configuration to an {@link AuditLogConfiguration} for the exporter. */
   public AuditLogConfiguration toConfiguration() {
     final AuditLogConfiguration auditLogConfiguration = new AuditLogConfiguration();
     auditLogConfiguration.setEnabled(isEnabled());

--- a/configuration/src/main/java/io/camunda/configuration/AuditLog.java
+++ b/configuration/src/main/java/io/camunda/configuration/AuditLog.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class AuditLog {
+  private boolean enabled = true;
+
+  @NestedConfigurationProperty private AuditLogEntry user = new AuditLogEntry();
+  @NestedConfigurationProperty private AuditLogEntry client = new AuditLogEntry();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public AuditLogEntry getClient() {
+    return client;
+  }
+
+  public void setClient(final AuditLogEntry client) {
+    this.client = client;
+  }
+
+  public AuditLogEntry getUser() {
+    return user;
+  }
+
+  public void setUser(final AuditLogEntry user) {
+    this.user = user;
+  }
+
+  public AuditLogConfiguration toConfiguration() {
+    final AuditLogConfiguration auditLogConfiguration = new AuditLogConfiguration();
+    auditLogConfiguration.setEnabled(isEnabled());
+    auditLogConfiguration
+        .getClient()
+        .setCategories(getClient().getCategories())
+        .setExcludes(getClient().getExcludes());
+    auditLogConfiguration
+        .getUser()
+        .setCategories(getUser().getCategories())
+        .setExcludes(getUser().getExcludes());
+    return auditLogConfiguration;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/AuditLogEntry.java
+++ b/configuration/src/main/java/io/camunda/configuration/AuditLogEntry.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
+import java.util.Set;
+
+public class AuditLogEntry {
+  private Set<AuditLogOperationCategory> categories =
+      Set.of(
+          AuditLogOperationCategory.OPERATOR,
+          AuditLogOperationCategory.USER_TASK,
+          AuditLogOperationCategory.ADMIN);
+  private Set<AuditLogEntityType> excludes = Set.of(); // e.g. AuditLogEntityType.VARIABLE
+
+  public Set<AuditLogOperationCategory> getCategories() {
+    return categories;
+  }
+
+  public void setCategories(final Set<AuditLogOperationCategory> categories) {
+    this.categories = categories;
+  }
+
+  public Set<AuditLogEntityType> getExcludes() {
+    return excludes;
+  }
+
+  public void setExcludes(final Set<AuditLogEntityType> excludes) {
+    this.excludes = excludes;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/AuditLogEntry.java
+++ b/configuration/src/main/java/io/camunda/configuration/AuditLogEntry.java
@@ -11,6 +11,10 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import java.util.Set;
 
+/**
+ * Configuration for audit log filtering by operation categories and entity type exclusions. Used
+ * for both user and client audit logging.
+ */
 public class AuditLogEntry {
   private Set<AuditLogOperationCategory> categories =
       Set.of(

--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -22,6 +22,9 @@ public class Data {
   /** How often we take snapshots of streams (time unit) */
   private Duration snapshotPeriod = Duration.ofMinutes(5);
 
+  /** This section allows to configure the audit log setup. */
+  @NestedConfigurationProperty private AuditLog auditLog = new AuditLog();
+
   /** This section allows to configure primary Zeebe's data storage. */
   @NestedConfigurationProperty private PrimaryStorage primaryStorage = new PrimaryStorage();
 
@@ -33,6 +36,14 @@ public class Data {
 
   /** This section allows configuring exporters */
   private Map<String, Exporter> exporters = new HashMap<>();
+
+  public AuditLog getAuditLog() {
+    return auditLog;
+  }
+
+  public void setAuditLog(final AuditLog auditLog) {
+    this.auditLog = auditLog;
+  }
 
   public Duration getSnapshotPeriod() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/Export.java
+++ b/configuration/src/main/java/io/camunda/configuration/Export.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DE
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.time.Duration;
 import java.util.Set;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.ResolvableType;
 
 public class Export {
@@ -21,8 +20,6 @@ public class Export {
       Set.of("zeebe.broker.exporting.distributionInterval");
   private static final Set<String> LEGACY_SKIP_RECORDS_PROPERTIES =
       Set.of("zeebe.broker.exporting.skipRecords");
-
-  @NestedConfigurationProperty private AuditLog auditLog = new AuditLog();
 
   /**
    * Configures the rate at which exporter positions are distributed to the followers. This is
@@ -40,14 +37,6 @@ public class Export {
    * The value is a comma-separated list of records ids to skip. Whitespace is ignored.
    */
   private Set<Long> skipRecords = Set.of();
-
-  public AuditLog getAuditLog() {
-    return auditLog;
-  }
-
-  public void setAuditLog(final AuditLog auditLog) {
-    this.auditLog = auditLog;
-  }
 
   public Duration getDistributionInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/Export.java
+++ b/configuration/src/main/java/io/camunda/configuration/Export.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DE
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.time.Duration;
 import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.ResolvableType;
 
 public class Export {
@@ -20,6 +21,8 @@ public class Export {
       Set.of("zeebe.broker.exporting.distributionInterval");
   private static final Set<String> LEGACY_SKIP_RECORDS_PROPERTIES =
       Set.of("zeebe.broker.exporting.skipRecords");
+
+  @NestedConfigurationProperty private AuditLog auditLog = new AuditLog();
 
   /**
    * Configures the rate at which exporter positions are distributed to the followers. This is
@@ -37,6 +40,14 @@ public class Export {
    * The value is a comma-separated list of records ids to skip. Whitespace is ignored.
    */
   private Set<Long> skipRecords = Set.of();
+
+  public AuditLog getAuditLog() {
+    return auditLog;
+  }
+
+  public void setAuditLog(final AuditLog auditLog) {
+    this.auditLog = auditLog;
+  }
 
   public Duration getDistributionInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -892,7 +892,7 @@ public class BrokerBasedPropertiesOverride {
     setArg(args, "bulk.size", database.getBulk().getSize());
     setArg(args, "bulk.memoryLimit", database.getBulk().getMemoryLimit().toMegabytes());
 
-    final var auditLog = unifiedConfiguration.getCamunda().getData().getExport().getAuditLog();
+    final var auditLog = unifiedConfiguration.getCamunda().getData().getAuditLog();
     exporter.setArgs(
         ExporterConfiguration.of(io.camunda.exporter.config.ExporterConfiguration.class, args)
             .apply(config -> config.setAuditLog(auditLog.toConfiguration()))
@@ -975,7 +975,7 @@ public class BrokerBasedPropertiesOverride {
     setArgIfNotNull(
         args, "batchOperationItemInsertBlockSize", database.getBatchOperationItemInsertBlockSize());
 
-    final var auditLog = unifiedConfiguration.getCamunda().getData().getExport().getAuditLog();
+    final var auditLog = unifiedConfiguration.getCamunda().getData().getAuditLog();
     exporter.setArgs(
         ExporterConfiguration.of(io.camunda.exporter.rdbms.ExporterConfiguration.class, args)
             .apply(config -> config.setAuditLog(auditLog.toConfiguration()))

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -893,12 +893,10 @@ public class BrokerBasedPropertiesOverride {
     setArg(args, "bulk.memoryLimit", database.getBulk().getMemoryLimit().toMegabytes());
 
     final var auditLog = unifiedConfiguration.getCamunda().getData().getExport().getAuditLog();
-    final var camundaExporterConfiguration =
-        ExporterConfiguration.fromArgs(
-            io.camunda.exporter.config.ExporterConfiguration.class, args);
-    camundaExporterConfiguration.setAuditLog(auditLog.toConfiguration());
-
-    exporter.setArgs(ExporterConfiguration.asArgs(camundaExporterConfiguration));
+    exporter.setArgs(
+        ExporterConfiguration.of(io.camunda.exporter.config.ExporterConfiguration.class, args)
+            .apply(config -> config.setAuditLog(auditLog.toConfiguration()))
+            .toArgs());
   }
 
   private void populateRdbmsExporter(final BrokerBasedProperties override) {
@@ -978,12 +976,10 @@ public class BrokerBasedPropertiesOverride {
         args, "batchOperationItemInsertBlockSize", database.getBatchOperationItemInsertBlockSize());
 
     final var auditLog = unifiedConfiguration.getCamunda().getData().getExport().getAuditLog();
-    final var rdbmsExporterConfiguration =
-        ExporterConfiguration.fromArgs(io.camunda.exporter.rdbms.ExporterConfiguration.class, args);
-    rdbmsExporterConfiguration.setAuditLog(auditLog.toConfiguration());
-
-    final var newArgs = ExporterConfiguration.asArgs(rdbmsExporterConfiguration);
-    exporter.setArgs(newArgs);
+    exporter.setArgs(
+        ExporterConfiguration.of(io.camunda.exporter.rdbms.ExporterConfiguration.class, args)
+            .apply(config -> config.setAuditLog(auditLog.toConfiguration()))
+            .toArgs());
   }
 
   private void populateFromMonitoring(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
@@ -97,12 +97,12 @@ class AuditLogTest {
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=rdbms",
-        "camunda.data.export.audit-log.enabled=false",
-        "camunda.data.export.audit-log.user.categories[0]=OPERATOR",
-        "camunda.data.export.audit-log.user.categories[1]=USER_TASK",
-        "camunda.data.export.audit-log.user.excludes[0]=VARIABLE",
-        "camunda.data.export.audit-log.client.categories[0]=ADMIN",
-        "camunda.data.export.audit-log.client.excludes[0]=PROCESS_INSTANCE"
+        "camunda.data.audit-log.enabled=false",
+        "camunda.data.audit-log.user.categories[0]=OPERATOR",
+        "camunda.data.audit-log.user.categories[1]=USER_TASK",
+        "camunda.data.audit-log.user.excludes[0]=VARIABLE",
+        "camunda.data.audit-log.client.categories[0]=ADMIN",
+        "camunda.data.audit-log.client.excludes[0]=PROCESS_INSTANCE"
       })
   class RDBMSExporterTest {
     @Test
@@ -136,12 +136,12 @@ class AuditLogTest {
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.export.audit-log.enabled=true",
-        "camunda.data.export.audit-log.user.categories[0]=OPERATOR",
-        "camunda.data.export.audit-log.user.categories[1]=ADMIN",
-        "camunda.data.export.audit-log.user.excludes[0]=INCIDENT",
-        "camunda.data.export.audit-log.client.categories[0]=USER_TASK",
-        "camunda.data.export.audit-log.client.excludes[0]=USER"
+        "camunda.data.audit-log.enabled=true",
+        "camunda.data.audit-log.user.categories[0]=OPERATOR",
+        "camunda.data.audit-log.user.categories[1]=ADMIN",
+        "camunda.data.audit-log.user.excludes[0]=INCIDENT",
+        "camunda.data.audit-log.client.categories[0]=USER_TASK",
+        "camunda.data.audit-log.client.excludes[0]=USER"
       })
   class CamundaExporterTest {
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
@@ -26,47 +26,50 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 class AuditLogTest {
 
   @Test
-  void isEnabled() {
+  void shouldBeEnabledByDefault() {
     final AuditLog auditLog = new AuditLog();
+
     assertThat(auditLog.isEnabled()).as("AuditLog should be enabled by default").isTrue();
   }
 
   @Test
-  void getClient() {
+  void shouldHaveClientDefaults() {
     final AuditLog auditLog = new AuditLog();
-    final Set<AuditLogOperationCategory> expectedCategories =
-        Set.of(
-            AuditLogOperationCategory.OPERATOR,
-            AuditLogOperationCategory.USER_TASK,
-            AuditLogOperationCategory.ADMIN);
+
     assertThat(auditLog.getClient().getCategories())
         .as("All categories should be enabled for client by default")
-        .isEqualTo(expectedCategories);
+        .isEqualTo(
+            Set.of(
+                AuditLogOperationCategory.OPERATOR,
+                AuditLogOperationCategory.USER_TASK,
+                AuditLogOperationCategory.ADMIN));
     assertThat(auditLog.getClient().getExcludes())
         .as("No excludes should be set for client by default")
         .isEmpty();
   }
 
   @Test
-  void getUser() {
+  void shouldHaveUserDefaults() {
     final AuditLog auditLog = new AuditLog();
-    final Set<AuditLogOperationCategory> expectedCategories =
-        Set.of(
-            AuditLogOperationCategory.OPERATOR,
-            AuditLogOperationCategory.USER_TASK,
-            AuditLogOperationCategory.ADMIN);
+
     assertThat(auditLog.getUser().getCategories())
         .as("All categories should be enabled for user by default")
-        .isEqualTo(expectedCategories);
+        .isEqualTo(
+            Set.of(
+                AuditLogOperationCategory.OPERATOR,
+                AuditLogOperationCategory.USER_TASK,
+                AuditLogOperationCategory.ADMIN));
     assertThat(auditLog.getUser().getExcludes())
         .as("No excludes should be set for user by default")
         .isEmpty();
   }
 
   @Test
-  void toConfiguration() {
+  void shouldConvertToAuditLogConfiguration() {
     final AuditLog auditLog = new AuditLog();
+
     final AuditLogConfiguration config = auditLog.toConfiguration();
+
     assertThat(config.isEnabled())
         .as("AuditLogConfiguration should be enabled by default")
         .isEqualTo(auditLog.isEnabled());

--- a/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/AuditLogTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class AuditLogTest {
+
+  @Test
+  void isEnabled() {
+    final AuditLog auditLog = new AuditLog();
+    assertThat(auditLog.isEnabled()).as("AuditLog should be enabled by default").isTrue();
+  }
+
+  @Test
+  void getClient() {
+    final AuditLog auditLog = new AuditLog();
+    final Set<AuditLogOperationCategory> expectedCategories =
+        Set.of(
+            AuditLogOperationCategory.OPERATOR,
+            AuditLogOperationCategory.USER_TASK,
+            AuditLogOperationCategory.ADMIN);
+    assertThat(auditLog.getClient().getCategories())
+        .as("All categories should be enabled for client by default")
+        .isEqualTo(expectedCategories);
+    assertThat(auditLog.getClient().getExcludes())
+        .as("No excludes should be set for client by default")
+        .isEmpty();
+  }
+
+  @Test
+  void getUser() {
+    final AuditLog auditLog = new AuditLog();
+    final Set<AuditLogOperationCategory> expectedCategories =
+        Set.of(
+            AuditLogOperationCategory.OPERATOR,
+            AuditLogOperationCategory.USER_TASK,
+            AuditLogOperationCategory.ADMIN);
+    assertThat(auditLog.getUser().getCategories())
+        .as("All categories should be enabled for user by default")
+        .isEqualTo(expectedCategories);
+    assertThat(auditLog.getUser().getExcludes())
+        .as("No excludes should be set for user by default")
+        .isEmpty();
+  }
+
+  @Test
+  void toConfiguration() {
+    final AuditLog auditLog = new AuditLog();
+    final AuditLogConfiguration config = auditLog.toConfiguration();
+    assertThat(config.isEnabled())
+        .as("AuditLogConfiguration should be enabled by default")
+        .isEqualTo(auditLog.isEnabled());
+    assertThat(config.getClient().getCategories())
+        .as("Client categories should match")
+        .isEqualTo(auditLog.getClient().getCategories());
+    assertThat(config.getUser().getCategories())
+        .as("User categories should match")
+        .isEqualTo(auditLog.getUser().getCategories());
+    assertThat(config.getClient().getExcludes())
+        .as("Client excludes should match")
+        .isEqualTo(auditLog.getClient().getExcludes());
+    assertThat(config.getUser().getExcludes())
+        .as("User excludes should match")
+        .isEqualTo(auditLog.getUser().getExcludes());
+  }
+
+  @Nested
+  @ActiveProfiles({"broker"})
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+        "camunda.data.export.audit-log.enabled=false",
+        "camunda.data.export.audit-log.user.categories[0]=OPERATOR",
+        "camunda.data.export.audit-log.user.categories[1]=USER_TASK",
+        "camunda.data.export.audit-log.user.excludes[0]=VARIABLE",
+        "camunda.data.export.audit-log.client.categories[0]=ADMIN",
+        "camunda.data.export.audit-log.client.excludes[0]=PROCESS_INSTANCE"
+      })
+  class RDBMSExporterTest {
+    @Test
+    void shouldPopulateWithAuditLog(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getRdbmsExporter();
+
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getAuditLog().isEnabled()).isFalse();
+      assertThat(config.getAuditLog().getUser().getCategories())
+          .containsExactlyInAnyOrder(
+              AuditLogOperationCategory.OPERATOR, AuditLogOperationCategory.USER_TASK);
+      assertThat(config.getAuditLog().getUser().getExcludes())
+          .containsExactlyInAnyOrder(AuditLogEntityType.VARIABLE);
+      assertThat(config.getAuditLog().getClient().getCategories())
+          .containsExactlyInAnyOrder(AuditLogOperationCategory.ADMIN);
+      assertThat(config.getAuditLog().getClient().getExcludes())
+          .containsExactlyInAnyOrder(AuditLogEntityType.PROCESS_INSTANCE);
+    }
+  }
+
+  @Nested
+  @ActiveProfiles({"broker"})
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.export.audit-log.enabled=true",
+        "camunda.data.export.audit-log.user.categories[0]=OPERATOR",
+        "camunda.data.export.audit-log.user.categories[1]=ADMIN",
+        "camunda.data.export.audit-log.user.excludes[0]=INCIDENT",
+        "camunda.data.export.audit-log.client.categories[0]=USER_TASK",
+        "camunda.data.export.audit-log.client.excludes[0]=USER"
+      })
+  class CamundaExporterTest {
+    @Test
+    void shouldPopulateWithAuditLog(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getCamundaExporter();
+
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getAuditLog().isEnabled()).isTrue();
+      assertThat(config.getAuditLog().getUser().getCategories())
+          .containsExactlyInAnyOrder(
+              AuditLogOperationCategory.OPERATOR, AuditLogOperationCategory.ADMIN);
+      assertThat(config.getAuditLog().getUser().getExcludes())
+          .containsExactlyInAnyOrder(AuditLogEntityType.INCIDENT);
+      assertThat(config.getAuditLog().getClient().getCategories())
+          .containsExactlyInAnyOrder(AuditLogOperationCategory.USER_TASK);
+      assertThat(config.getAuditLog().getClient().getExcludes())
+          .containsExactlyInAnyOrder(AuditLogEntityType.USER);
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -64,7 +64,47 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
     }
   }
 
+  /**
+   * Creates a fluent API wrapper for convenient configuration mapping. Enables chaining operations
+   * like: <code>
+   * ExporterConfiguration.of(ConfigClass.class, args)
+   *     .map(config -> { config.setSomething(...); return config; })
+   *     .toArgs()
+   * </code>
+   */
+  public static <T> ConfigurationMapper<T> of(
+      final Class<T> configClass, final Map<String, Object> values) {
+    return new ConfigurationMapper<>(fromArgs(configClass, values));
+  }
+
   public static <T> Map<String, Object> asArgs(final T config) {
     return MAPPER.convertValue(config, new TypeReference<>() {});
+  }
+
+  /**
+   * Fluent API wrapper for configuration mapping operations. Allows chaining transformations before
+   * converting back to args map.
+   */
+  public static class ConfigurationMapper<T> {
+    private final T config;
+
+    private ConfigurationMapper(final T config) {
+      this.config = config;
+    }
+
+    public ConfigurationMapper apply(final java.util.function.Consumer<T> mapper) {
+      mapper.accept(config);
+      return this;
+    }
+
+    /** Returns the wrapped configuration object. */
+    public T get() {
+      return config;
+    }
+
+    /** Converts the configuration back to an args map. */
+    public Map<String, Object> toArgs() {
+      return asArgs(config);
+    }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -91,8 +91,6 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
   }
 
   public static <T> Map<String, Object> asArgs(final T config) {
-    // Use ReflectUtil to extract fields, preserving all object types (Duration, Path, etc.)
-    // This avoids Jackson's serialization which would cause infinite recursion
     return MAPPER.convertValue(config, Map.class);
   }
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfiguration.java
@@ -38,7 +38,14 @@ public final class AuditLogConfiguration {
 
   @Override
   public String toString() {
-    return "AuditLogConfiguration{" + "user=" + user + ", client=" + client + '}';
+    return "AuditLogConfiguration{"
+        + "enabled="
+        + enabled
+        + ", user="
+        + user
+        + ", client="
+        + client
+        + '}';
   }
 
   public boolean isEnabled() {

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfiguration.java
@@ -13,6 +13,8 @@ import java.util.Set;
 
 public final class AuditLogConfiguration {
 
+  private boolean enabled = true;
+
   private ActorAuditLogConfiguration user = new ActorAuditLogConfiguration();
   private ActorAuditLogConfiguration client = new ActorAuditLogConfiguration();
 
@@ -40,7 +42,12 @@ public final class AuditLogConfiguration {
   }
 
   public boolean isEnabled() {
-    return !(getUser().getCategories().isEmpty() && getClient().getCategories().isEmpty());
+    return enabled
+        && !(getUser().getCategories().isEmpty() && getClient().getCategories().isEmpty());
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
   }
 
   public boolean isEnabled(final AuditLogInfo auditLog) {
@@ -57,10 +64,10 @@ public final class AuditLogConfiguration {
   public static final class ActorAuditLogConfiguration {
     private Set<AuditLogOperationCategory> categories =
         Set.of(
+            AuditLogOperationCategory.ADMIN,
             AuditLogOperationCategory.OPERATOR,
-            AuditLogOperationCategory.USER_TASK,
-            AuditLogOperationCategory.ADMIN);
-    private Set<AuditLogEntityType> excludes = Set.of(AuditLogEntityType.VARIABLE);
+            AuditLogOperationCategory.USER_TASK);
+    private Set<AuditLogEntityType> excludes = Set.of();
 
     public Set<AuditLogEntityType> getExcludes() {
       return excludes;

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
@@ -23,6 +23,21 @@ import org.junit.jupiter.api.Test;
 class AuditLogConfigurationTest {
 
   @Test
+  void shouldBeEnabledByDefault() {
+    final var config = new AuditLogConfiguration();
+
+    assertThat(config.isEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldBeDisabled() {
+    final var config = new AuditLogConfiguration();
+    config.setEnabled(false);
+
+    assertThat(config.isEnabled()).isFalse();
+  }
+
+  @Test
   void shouldHaveDefaultUserAndClientConfigurations() {
     final var config = new AuditLogConfiguration();
 
@@ -184,10 +199,10 @@ class AuditLogConfigurationTest {
     }
 
     @Test
-    void shouldHaveDefaultExcludes() {
+    void shouldNotHaveDefaultExcludes() {
       final var config = new ActorAuditLogConfiguration();
 
-      assertThat(config.getExcludes()).containsExactly(AuditLogEntityType.VARIABLE);
+      assertThat(config.getExcludes()).isEmpty();
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -355,7 +355,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors
                     .get(CorrelatedMessageSubscriptionTemplate.class)
                     .getFullQualifiedName())));
-    addAuditLogHandlers(new AuditLogConfiguration());
+
+    addAuditLogHandlers(configuration.getAuditLog());
 
     if (configuration.getBatchOperation().isExportItemsOnCreation()) {
       // only add this handler when the items are exported on creation

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -157,6 +157,8 @@ public class ExporterConfiguration {
         + postExport
         + ", batchOperation="
         + batchOperation
+        + ", auditLog="
+        + auditLog
         + '}';
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.config;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 
 public class ExporterConfiguration {
 
@@ -24,7 +25,16 @@ public class ExporterConfiguration {
   private PostExportConfiguration postExport = new PostExportConfiguration();
   private IncidentNotifierConfiguration notifier = new IncidentNotifierConfiguration();
   private BatchOperationConfiguration batchOperation = new BatchOperationConfiguration();
+  private AuditLogConfiguration auditLog = new AuditLogConfiguration();
   private boolean createSchema = true;
+
+  public AuditLogConfiguration getAuditLog() {
+    return auditLog;
+  }
+
+  public void setAuditLog(final AuditLogConfiguration auditLog) {
+    this.auditLog = auditLog;
+  }
 
   public ConnectConfiguration getConnect() {
     return connect;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.rdbms;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryConfig;
 import io.camunda.zeebe.exporter.api.ExporterException;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,22 +20,30 @@ public class ExporterConfiguration {
   public static final int DEFAULT_CLEANUP_BATCH_SIZE = 1000;
   public static final int DEFAULT_MAX_CACHE_SIZE = 10_000;
 
+  // AuditLog
+  private AuditLogConfiguration auditLog = new AuditLogConfiguration();
+
   private Duration flushInterval = DEFAULT_FLUSH_INTERVAL;
   private int queueSize = RdbmsWriterConfig.DEFAULT_QUEUE_SIZE;
   private int queueMemoryLimit = RdbmsWriterConfig.DEFAULT_QUEUE_MEMORY_LIMIT;
-
   private HistoryConfiguration history = new HistoryConfiguration();
-
   // batch operation configuration
   private boolean exportBatchOperationItemsOnCreation =
       RdbmsWriterConfig.DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
   private int batchOperationItemInsertBlockSize =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
-
   // caches
   private CacheConfiguration processCache = new CacheConfiguration();
   private CacheConfiguration decisionRequirementsCache = new CacheConfiguration();
   private CacheConfiguration batchOperationCache = new CacheConfiguration();
+
+  public AuditLogConfiguration getAuditLog() {
+    return auditLog;
+  }
+
+  public void setAuditLog(final AuditLogConfiguration auditLog) {
+    this.auditLog = auditLog;
+  }
 
   public Duration getFlushInterval() {
     return flushInterval;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -22,7 +22,6 @@ public class ExporterConfiguration {
 
   // AuditLog
   private AuditLogConfiguration auditLog = new AuditLogConfiguration();
-
   private Duration flushInterval = DEFAULT_FLUSH_INTERVAL;
   private int queueSize = RdbmsWriterConfig.DEFAULT_QUEUE_SIZE;
   private int queueMemoryLimit = RdbmsWriterConfig.DEFAULT_QUEUE_MEMORY_LIMIT;
@@ -205,6 +204,32 @@ public class ExporterConfiguration {
     if (duration.isNegative() || duration.isZero()) {
       errors.add(String.format("%s must be a positive duration but was %s", name, duration));
     }
+  }
+
+  @Override
+  public String toString() {
+    return "ExporterConfiguration{"
+        + "auditLog="
+        + auditLog
+        + ", flushInterval="
+        + flushInterval
+        + ", queueSize="
+        + queueSize
+        + ", queueMemoryLimit="
+        + queueMemoryLimit
+        + ", history="
+        + history
+        + ", exportBatchOperationItemsOnCreation="
+        + exportBatchOperationItemsOnCreation
+        + ", batchOperationItemInsertBlockSize="
+        + batchOperationItemInsertBlockSize
+        + ", processCache="
+        + processCache
+        + ", decisionRequirementsCache="
+        + decisionRequirementsCache
+        + ", batchOperationCache="
+        + batchOperationCache
+        + '}';
   }
 
   public static class CacheConfiguration {


### PR DESCRIPTION
## Description

- [x] make the audit log config available via unified config
- [x] pass the audit log config to rdbms and camunda exporter
- [x] add tests for handling the audit log config
- [x] set config defaults to
  - is enabled
  - log all categories
  - exclude no entity types

Example:
```
camunda.data.audit-log.enabled=false
camunda.data.audit-log.user.categories[0]=OPERATOR
camunda.data.audit-log.user.categories[1]=USER_TASK
camunda.data.audit-log.user.excludes[0]=VARIABLE
camunda.data.audit-log.client.categories[0]=ADMIN
camunda.data.audit-log.client.excludes[0]=PROCESS_INSTANCE
```

⚠️ **to be decided**
-  if this should live under `camunda.data.export.audit-log` or somewhere else
- how we should finally call the categories
- if we should include `UNKNOWN` in the default categories list

## Related issues

closes #42326 
