### PR TITLE
Use dedicated migration client secret for identity migration job

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -296,6 +296,7 @@ jobs:
           export POSTGRESQL_ADMIN_PASSWORD
           POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
           export POSTGRESQL_KEYCLOAK_PASSWORD
+          MIGRATION_SECRET=$(openssl rand -hex 32)
           kubectl create secret generic camunda-credentials \
           --namespace $release \
           --from-literal=identity-optimize-client-token="$OPTIMIZE_SECRET" \
@@ -303,7 +304,8 @@ jobs:
           --from-literal=identity-orchestration-client-token="$ORCHESTRATION_SECRET" \
           --from-literal=identity-keycloak-admin-password="$KEYCLOAK_ADMIN_SECRET" \
           --from-literal=identity-keycloak-postgresql-admin-password="$POSTGRESQL_ADMIN_PASSWORD" \
-          --from-literal=identity-keycloak-postgresql-user-password="$POSTGRESQL_KEYCLOAK_PASSWORD"
+          --from-literal=identity-keycloak-postgresql-user-password="$POSTGRESQL_KEYCLOAK_PASSWORD" \
+          --from-literal=identity-migration-client-secret="$MIGRATION_SECRET"
 
       - name: Upgrade platform
         id: upgrade-platform
@@ -329,7 +331,7 @@ jobs:
           --set orchestration.migration.data.enabled=true \
           --set orchestration.migration.identity.enabled=true \
           --set orchestration.migration.identity.secret.existingSecret=camunda-credentials \
-          --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
+          --set orchestration.migration.identity.secret.existingSecretKey=identity-migration-client-secret \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

he Helm upgrade in namespace scheduled-release-migration times out because the Job scheduled-release-migration-zeebe-migration-identity hits BackoffLimitExceeded. Its logs show repeated 401 invalid_client errors when calling the token endpoint.
From the Helm chart, the identity migration Job authenticates as client_id = migration, but our workflow wires its secret from identity-orchestration-client-token [here](https://github.com/camunda/camunda/blob/abecce4fad74c59ed938859c6a6fc80c6a20c62a/.github/workflows/camunda-release-migration-test.yml#L330-L332) (Zeebe/orchestration client), not from the dedicated migration client secret default key identity-migration-client-secret [here](https://github.com/camunda/camunda-platform-helm/blob/53d6200858ea02c1f977a69ec043c50a934a1173/charts/camunda-platform-8.8/templates/common/secret-camunda.yaml#L96-L101).

Use dedicated migration client secret instead of reusing orchestration token so the zeebe-migration-identity job authenticates as the migration client and no longer fails with 401 invalid_client during the scheduled release migration test.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
