### PR TITLE
[Design Prototype] Improve Operate process instance layout responsiveness

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/styled.ts
@@ -9,6 +9,7 @@
 import styled from 'styled-components';
 import {PanelHeader as BasePanelHeader} from 'modules/components/PanelHeader';
 import {ErrorMessage as BaseErrorMessage} from 'modules/components/ErrorMessage';
+import {BREAKPOINTS} from 'modules/constants';
 
 const Container = styled.div`
   border-right: solid 1px var(--cds-border-subtle-01);
@@ -16,6 +17,14 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+
+  @media (max-width: ${BREAKPOINTS.lg - 1}px) {
+    border-right: none;
+    border-bottom: solid 1px var(--cds-border-subtle-01);
+  }
 `;
 
 const PanelHeader = styled(BasePanelHeader)`

--- a/operate/client/src/App/ProcessInstance/TopPanel/styled.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/styled.ts
@@ -18,6 +18,7 @@ const DiagramPanel = styled.div`
   display: flex;
   position: relative;
   flex-grow: 1;
+  z-index: 0;
 `;
 
 export {Container, DiagramPanel};

--- a/operate/client/src/App/ProcessInstance/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/styled.tsx
@@ -8,12 +8,20 @@
 
 import styled from 'styled-components';
 import {Stack} from '@carbon/react';
+import {BREAKPOINTS} from 'modules/constants';
 
-const BottomPanel = styled.div<{$shouldExpandPanel?: boolean}>`
-  display: grid;
-  grid-template-columns: ${({$shouldExpandPanel}) =>
-    $shouldExpandPanel ? '1.1fr 1.9fr' : '1fr 1fr'};
+const BottomPanel = styled.div`
   height: 100%;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+`;
+
+const BottomPanelStacked = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
 `;
 
 const ModificationFooter = styled.div`
@@ -28,4 +36,4 @@ const Buttons = styled(Stack)`
   margin-left: auto;
 `;
 
-export {BottomPanel, ModificationFooter, Buttons};
+export {BottomPanel, BottomPanelStacked, ModificationFooter, Buttons};

--- a/operate/client/src/index.scss
+++ b/operate/client/src/index.scss
@@ -48,7 +48,7 @@ body,
 }
 
 #root {
-  min-width: 960px;
+  min-width: 672px;
   min-height: 540px;
 }
 

--- a/operate/client/src/modules/components/InstanceHeader/styled.ts
+++ b/operate/client/src/modules/components/InstanceHeader/styled.ts
@@ -12,6 +12,7 @@ import {
   SkeletonText as BaseSkeletonText,
   SkeletonIcon as BaseSkeletonIcon,
 } from '@carbon/react';
+import {BREAKPOINTS} from 'modules/constants';
 
 const Table = styled.table`
   width: 100%;
@@ -20,6 +21,13 @@ const Table = styled.table`
   border-collapse: separate;
   border-spacing: var(--cds-spacing-01);
   color: var(--cds-text-secondary);
+
+  @media (max-width: ${BREAKPOINTS.lg - 1}px) {
+    th:nth-child(n + 3),
+    td:nth-child(n + 3) {
+      display: none;
+    }
+  }
 `;
 
 const Th = styled.th`

--- a/operate/client/src/modules/constants.ts
+++ b/operate/client/src/modules/constants.ts
@@ -57,6 +57,16 @@ const COLLAPSABLE_PANEL_HEADER_HEIGHT = 'var(--cds-spacing-09)';
 const ARROW_ICON_WIDTH = 'var(--cds-spacing-08)';
 const DEFAULT_TENANT = '<default>';
 
+// Carbon Design System breakpoints (in pixels)
+// These match Carbon's default breakpoint values
+const BREAKPOINTS = {
+  sm: 320,
+  md: 672,
+  lg: 1056,
+  xlg: 1312,
+  max: 1584,
+} as const;
+
 export {
   ACTIVE_OPERATION_STATES,
   TOKEN_OPERATIONS,
@@ -69,4 +79,5 @@ export {
   COLLAPSABLE_PANEL_HEADER_HEIGHT,
   ARROW_ICON_WIDTH,
   DEFAULT_TENANT,
+  BREAKPOINTS,
 };


### PR DESCRIPTION
Refactored process instance panels to use responsive layouts based on Carbon Design System breakpoints. Introduced a stacked layout for the bottom panel on smaller screens and updated styles for better mobile support. Adjusted minimum root width and hid header columns on small screens for improved usability.


https://github.com/user-attachments/assets/51a30ad7-8830-4f2e-b01b-f5255a681e1f


## Related issues
https://github.com/camunda/camunda/issues/40242
