### PR TITLE
refactor: disable audit log logger

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AuditLogHandler.java
@@ -83,11 +83,13 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
     final var info = AuditLogInfo.of(record);
 
     if (info.actor() == null) {
-      LOG.warn(
-          "Record {}/{} at position {} cannot be audited because actor information is missing.",
-          record.getValueType(),
-          record.getIntent(),
-          record.getPosition());
+      // TODO: enable logging after ensuring all expected events are correctly captured
+      //      LOG.warn(
+      //          "Record {}/{} at position {} cannot be audited because actor information is
+      // missing.",
+      //          record.getValueType(),
+      //          record.getIntent(),
+      //          record.getPosition());
 
       return false;
     }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/AuditLogExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/AuditLogExportHandler.java
@@ -49,11 +49,13 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
     final var info = AuditLogInfo.of(record);
 
     if (info.actor() == null) {
-      LOG.warn(
-          "Record {}/{} at position {} cannot be audited because actor information is missing.",
-          record.getValueType(),
-          record.getIntent(),
-          record.getPosition());
+      // TODO: enable logging after ensuring all expected events are correctly captured
+      //      LOG.warn(
+      //          "Record {}/{} at position {} cannot be audited because actor information is
+      // missing.",
+      //          record.getValueType(),
+      //          record.getIntent(),
+      //          record.getPosition());
 
       return false;
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Disable the logger for the Audit Log handlers in the Camunda and RDBMS exporters until all expected
Zeebe events and rejections are correctly captured and handled.

Currently, the logger is creating a lot of noise for events with incomplete authorization claims data.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/42325
