### PR TITLE
Improve performance when deploying a process that already has many versions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -99,7 +99,7 @@ public class StartEventSubscriptionManager {
   private void closeConditionalExistingStartEventSubscriptions(
       final ProcessMetadata processRecord) {
     final DeployedProcess lastConditionalProcess =
-        findLastStartProcess(processRecord, ExecutableCatchEventElement::isConditional);
+        findPreviousVersionOfProcess(processRecord, ExecutableCatchEventElement::isConditional);
     if (lastConditionalProcess == null) {
       return;
     }
@@ -119,7 +119,7 @@ public class StartEventSubscriptionManager {
 
   private void closeMessageExistingStartEventSubscriptions(final ProcessMetadata processRecord) {
     final DeployedProcess lastMsgProcess =
-        findLastStartProcess(processRecord, ExecutableCatchEventElement::isMessage);
+        findPreviousVersionOfProcess(processRecord, ExecutableCatchEventElement::isMessage);
     if (lastMsgProcess == null) {
       return;
     }
@@ -139,7 +139,7 @@ public class StartEventSubscriptionManager {
 
   private void closeSignalExistingStartEventSubscriptions(final ProcessMetadata processRecord) {
     final DeployedProcess lastSignalProcess =
-        findLastStartProcess(processRecord, ExecutableCatchEventElement::isSignal);
+        findPreviousVersionOfProcess(processRecord, ExecutableCatchEventElement::isSignal);
     if (lastSignalProcess == null) {
       return;
     }
@@ -155,17 +155,17 @@ public class StartEventSubscriptionManager {
                 subscription.getKey(), SignalSubscriptionIntent.DELETED, subscription.getRecord()));
   }
 
-  private DeployedProcess findLastStartProcess(
+  private DeployedProcess findPreviousVersionOfProcess(
       final ProcessMetadata processRecord,
       final Predicate<ExecutableCatchEventElement> hasStartEventMatching) {
     for (int version = processRecord.getVersion() - 1; version > 0; --version) {
-      final DeployedProcess lastStartProcess =
+      final DeployedProcess previousVersionOfProcess =
           processState.getProcessByProcessIdAndVersion(
               processRecord.getBpmnProcessIdBuffer(), version, processRecord.getTenantId());
-      if (lastStartProcess != null
-          && lastStartProcess.getProcess().getStartEvents().stream()
+      if (previousVersionOfProcess != null
+          && previousVersionOfProcess.getProcess().getStartEvents().stream()
               .anyMatch(hasStartEventMatching)) {
-        return lastStartProcess;
+        return previousVersionOfProcess;
       }
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public class StartEventSubscriptionManager {
@@ -158,18 +159,27 @@ public class StartEventSubscriptionManager {
   private DeployedProcess findPreviousVersionOfProcess(
       final ProcessMetadata processRecord,
       final Predicate<ExecutableCatchEventElement> hasStartEventMatching) {
-    for (int version = processRecord.getVersion() - 1; version > 0; --version) {
-      final DeployedProcess previousVersionOfProcess =
-          processState.getProcessByProcessIdAndVersion(
-              processRecord.getBpmnProcessIdBuffer(), version, processRecord.getTenantId());
-      if (previousVersionOfProcess != null
-          && previousVersionOfProcess.getProcess().getStartEvents().stream()
-              .anyMatch(hasStartEventMatching)) {
-        return previousVersionOfProcess;
-      }
+    final Optional<Integer> processVersionBefore =
+        processState.findProcessVersionBefore(
+            processRecord.getBpmnProcessId(),
+            processRecord.getVersion(),
+            processRecord.getTenantId());
+    if (processVersionBefore.isEmpty()) {
+      return null;
     }
 
-    return null;
+    final var previousVersionOfProcess =
+        processState.getProcessByProcessIdAndVersion(
+            processRecord.getBpmnProcessIdBuffer(),
+            processVersionBefore.get(),
+            processRecord.getTenantId());
+    final var hasMatchingStartEvent =
+        previousVersionOfProcess.getProcess().getStartEvents().stream()
+            .anyMatch(hasStartEventMatching);
+    if (!hasMatchingStartEvent) {
+      return null;
+    }
+    return previousVersionOfProcess;
   }
 
   private void openStartEventSubscriptions(final ProcessMetadata processRecord) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This resolves a long standing bug that placed a practical limit on the number of processes that could be deployed. The bug resulted in a dramatic increase of the processing latency when deploying a process when already many versions of that process were known. This latency could exceed seconds already around 1000 process versions.

[Tests](https://github.com/camunda/camunda/issues/11253#issuecomment-3492427834) that previously showed dramatic latency changes from ~20ms to >2s at around 966 deployed versions, show that now we can deploy 10k+ processes all with the same latency (~20-30ms).

This PR does not provide a test case (except for the one linked above), because such a performance test is too slow for running CI. The functionality is covered by many other test cases already.

The root cause of the bug was an expensive cleanup for start event subscriptions. Start event subscriptions should be open for the latest version only, so those of previous versions have to be closed. This was achieved by looping over all previous versions and unsubscribing from those with start events. To check if the process even had start events to subscribe to it needed an ExecutableProcess (one that is transformed). These are cached as transformation is expensive. So, if the cache size (default 1000) would be exceeded by the number of deployed processes, additional effort on transformation was needed for every cache miss. To make matters worse, this code had to be executed several times for the different start event types.

After careful considerations, we believe it's safe to replace this expensive logic with a much simpler approach. Only look up the previous version to unsubscribe from. This is safe as long as we guarantee that we subscribe to the latest version only (https://github.com/camunda/camunda/issues/11253#issuecomment-3496204374). We're confident that we can guarantee this (https://github.com/camunda/camunda/issues/11253#issuecomment-3654600955).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #11253
