### PR TITLE
feat: Add rootProcessInstanceKey to process instance records

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -122,6 +122,11 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     return Set.of();
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return -1L; // not used in Optimize
+  }
+
   public void setParentElementInstanceKey(final long parentElementInstanceKey) {
     this.parentElementInstanceKey = parentElementInstanceKey;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
@@ -29,6 +29,15 @@ public interface BpmnElementContext {
 
   long getProcessDefinitionKey();
 
+  /**
+   * Returns the key of the root process instance in the hierarchy.
+   *
+   * <p><b>Warning:</b> This value is only set for process instance records created after version
+   * 8.9.0 and part of hierarchies created after that version. For older process instances, the
+   * method will return -1.
+   */
+  long getRootProcessInstanceKey();
+
   int getProcessVersion();
 
   DirectBuffer getBpmnProcessId();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
@@ -53,6 +53,11 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return recordValue.getRootProcessInstanceKey();
+  }
+
+  @Override
   public int getProcessVersion() {
     return recordValue.getVersion();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -668,7 +668,8 @@ public final class BpmnStateTransitionBehavior {
         .setParentElementInstanceKey(context.getElementInstanceKey())
         .setElementId(process.getProcess().getId())
         .setBpmnElementType(process.getProcess().getElementType())
-        .setTenantId(context.getTenantId());
+        .setTenantId(context.getTenantId())
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -240,6 +240,7 @@ public final class EventHandle {
         .setProcessDefinitionKey(process.getKey())
         .setVersion(process.getVersion())
         .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(processInstanceKey)
         .setElementId(process.getProcess().getId())
         .setBpmnElementType(process.getProcess().getElementType())
         .setTenantId(tenantId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -93,17 +93,17 @@ public class ProcessInstanceCreationHelper {
 
   public ProcessInstanceRecord initProcessInstanceRecord(
       final DeployedProcess process, final long processInstanceKey, final Set<String> tags) {
-    final var newProcessInstance = new ProcessInstanceRecord();
-    newProcessInstance.setBpmnProcessId(process.getBpmnProcessId());
-    newProcessInstance.setVersion(process.getVersion());
-    newProcessInstance.setProcessDefinitionKey(process.getKey());
-    newProcessInstance.setProcessInstanceKey(processInstanceKey);
-    newProcessInstance.setBpmnElementType(BpmnElementType.PROCESS);
-    newProcessInstance.setElementId(process.getProcess().getId());
-    newProcessInstance.setFlowScopeKey(-1);
-    newProcessInstance.setTenantId(process.getTenantId());
-    newProcessInstance.setTags(tags);
-    return newProcessInstance;
+    return new ProcessInstanceRecord()
+        .setBpmnProcessId(process.getBpmnProcessId())
+        .setVersion(process.getVersion())
+        .setProcessDefinitionKey(process.getKey())
+        .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(processInstanceKey)
+        .setBpmnElementType(BpmnElementType.PROCESS)
+        .setElementId(process.getProcess().getId())
+        .setFlowScopeKey(-1)
+        .setTenantId(process.getTenantId())
+        .setTags(tags);
   }
 
   private Either<Rejection, DeployedProcess> getProcess(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -160,7 +160,8 @@ public final class BusinessRuleTaskTest {
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)
-        .hasTenantId(tenantId);
+        .hasTenantId(tenantId)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1269,6 +1269,52 @@ public final class CallActivityTest {
         .hasValue("%d".formatted(CUSTOM_CALL_ACTIVITY_DEPTH + 1));
   }
 
+  @Test
+  public void shouldSetRootProcessInstanceKeyInProcessInstanceRecordsAcrossHierarchy() {
+    // given
+    final var rootProcessId = "wf-root-three-levels";
+    final var rootProcess =
+        Bpmn.createExecutableProcess(rootProcessId)
+            .startEvent()
+            .callActivity("call-parent", c -> c.zeebeProcessId(PROCESS_ID_PARENT))
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-root.bpmn", rootProcess)
+        .withXmlResource("wf-parent.bpmn", parentProcess(CallActivityBuilder::done))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
+        .deploy();
+
+    // when
+    final long rootInstanceKey = ENGINE.processInstance().ofBpmnProcessId(rootProcessId).create();
+
+    final var rootInstanceRecords = getInstancesOf(rootInstanceKey);
+    final var parentInstanceKey = getChildInstanceOf(rootInstanceKey).getProcessInstanceKey();
+    final var parentInstanceRecords = getInstancesOf(parentInstanceKey);
+    final var grandchildProcessInstanceKey =
+        getChildInstanceOf(parentInstanceKey).getProcessInstanceKey();
+    final var grandchildInstanceRecords = getInstancesOf(grandchildProcessInstanceKey);
+
+    // then
+    assertThat(rootInstanceRecords)
+        .hasSize(13)
+        .allSatisfy(
+            instance ->
+                assertThat(instance.getRootProcessInstanceKey()).isEqualTo(rootInstanceKey));
+    assertThat(parentInstanceRecords)
+        .hasSize(13)
+        .allSatisfy(
+            instance ->
+                assertThat(instance.getRootProcessInstanceKey()).isEqualTo(rootInstanceKey));
+    assertThat(grandchildInstanceRecords)
+        .hasSize(13)
+        .allSatisfy(
+            instance ->
+                assertThat(instance.getRootProcessInstanceKey()).isEqualTo(rootInstanceKey));
+  }
+
   private void deployDefaultParentAndChildProcess() {
     final var parentProcess = parentProcess(CallActivityBuilder::done);
 
@@ -1308,6 +1354,13 @@ public final class CallActivityTest {
         .withParentProcessInstanceKey(processInstanceKey)
         .getFirst()
         .getValue();
+  }
+
+  private List<ProcessInstanceRecordValue> getInstancesOf(final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .map(Record::getValue)
+        .toList();
   }
 
   private long getCallActivityInstanceKey(final long processInstanceKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1293,9 +1293,9 @@ public final class CallActivityTest {
     final var rootInstanceRecords = getInstancesOf(rootInstanceKey);
     final var parentInstanceKey = getChildInstanceOf(rootInstanceKey).getProcessInstanceKey();
     final var parentInstanceRecords = getInstancesOf(parentInstanceKey);
-    final var grandchildProcessInstanceKey =
+    final var childProcessInstanceKey =
         getChildInstanceOf(parentInstanceKey).getProcessInstanceKey();
-    final var grandchildInstanceRecords = getInstancesOf(grandchildProcessInstanceKey);
+    final var childInstanceRecords = getInstancesOf(childProcessInstanceKey);
 
     // then
     assertThat(rootInstanceRecords)
@@ -1308,7 +1308,7 @@ public final class CallActivityTest {
         .allSatisfy(
             instance ->
                 assertThat(instance.getRootProcessInstanceKey()).isEqualTo(rootInstanceKey));
-    assertThat(grandchildInstanceRecords)
+    assertThat(childInstanceRecords)
         .hasSize(13)
         .allSatisfy(
             instance ->

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -111,7 +111,8 @@ public final class CamundaUserTaskTest {
         .hasBpmnElementType(BpmnElementType.USER_TASK)
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId(PROCESS_ID)
-        .hasProcessInstanceKey(processInstanceKey);
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskTest.java
@@ -95,7 +95,8 @@ public final class JobBasedUserTaskTest {
         .hasBpmnElementType(BpmnElementType.USER_TASK)
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId(PROCESS_ID)
-        .hasProcessInstanceKey(processInstanceKey);
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
@@ -130,7 +130,8 @@ public class JobWorkerElementMultiTenantTest {
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId("process")
         .hasProcessInstanceKey(processInstanceKey)
-        .hasTenantId(tenantId);
+        .hasTenantId(tenantId)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementTest.java
@@ -105,7 +105,8 @@ public final class JobWorkerElementTest {
         .hasBpmnElementType(elementBuilder.getElementType())
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId("process")
-        .hasProcessInstanceKey(processInstanceKey);
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
@@ -98,7 +98,8 @@ public final class ScriptTaskExpressionTest {
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)
-        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test
@@ -137,6 +138,7 @@ public final class ScriptTaskExpressionTest {
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasTenantId(tenantId);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -180,7 +180,8 @@ public class InterruptingEventSubprocessTest {
         .hasBpmnElementType(BpmnElementType.START_EVENT)
         .hasElementId("event_sub_start")
         .hasVersion(currentProcess.getVersion())
-        .hasFlowScopeKey(subProcessActivated.getKey());
+        .hasFlowScopeKey(subProcessActivated.getKey())
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     assertEventSubprocessLifecycle(processInstanceKey);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
@@ -193,7 +193,8 @@ public class NonInterruptingEventSubprocessTest {
         .hasBpmnElementType(BpmnElementType.START_EVENT)
         .hasElementId("event_sub_start")
         .hasVersion(currentProcess.getVersion())
-        .hasFlowScopeKey(subProcessActivated.getKey());
+        .hasFlowScopeKey(subProcessActivated.getKey())
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     assertEventSubprocessLifecycle(processInstanceKey);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventTest.java
@@ -100,7 +100,8 @@ public final class MessageStartEventTest {
         .hasBpmnProcessId(processInstance.getValue().getBpmnProcessId())
         .hasVersion(processInstance.getValue().getVersion())
         .hasProcessInstanceKey(processInstance.getKey())
-        .hasFlowScopeKey(processInstance.getKey());
+        .hasFlowScopeKey(processInstance.getKey())
+        .hasRootProcessInstanceKey(processInstance.getKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -120,6 +120,7 @@ public class TenantAwareBusinessRuleTaskTest {
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasTenantId(tenantOne);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -119,6 +119,7 @@ public final class CancelProcessInstanceTest {
         .hasBpmnProcessId("PROCESS")
         .hasVersion(1)
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasElementId("PROCESS");
 
     final List<Record<ProcessInstanceRecordValue>> processEvents =
@@ -243,6 +244,7 @@ public final class CancelProcessInstanceTest {
         .hasBpmnProcessId("PROCESS")
         .hasVersion(1)
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasElementId("task");
   }
 
@@ -321,6 +323,7 @@ public final class CancelProcessInstanceTest {
         .hasBpmnProcessId("shouldCancelIntermediateCatchEvent")
         .hasVersion(1)
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasElementId("shouldCancelIntermediateCatchEvent");
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -422,7 +422,8 @@ public class CreateProcessInstanceAnywhereTest {
         .hasElementId("task")
         .hasFlowScopeKey(processInstanceKey)
         .hasParentProcessInstanceKey(-1L)
-        .hasParentElementInstanceKey(-1L);
+        .hasParentElementInstanceKey(-1L)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test
@@ -463,6 +464,7 @@ public class CreateProcessInstanceAnywhereTest {
                     .hasBpmnProcessId(deployedProcess.getBpmnProcessId())
                     .hasVersion(deployedProcess.getVersion())
                     .hasProcessInstanceKey(processInstanceKey)
+                    .hasRootProcessInstanceKey(processInstanceKey)
                     .hasBpmnElementType(BpmnElementType.PROCESS)
                     .hasElementId(PROCESS_ID)
                     .hasFlowScopeKey(-1L)
@@ -485,6 +487,7 @@ public class CreateProcessInstanceAnywhereTest {
                     .hasBpmnProcessId(deployedProcess.getBpmnProcessId())
                     .hasVersion(deployedProcess.getVersion())
                     .hasProcessInstanceKey(processInstanceKey)
+                    .hasRootProcessInstanceKey(processInstanceKey)
                     .hasBpmnElementType(BpmnElementType.SUB_PROCESS)
                     .hasElementId("subprocess")
                     .hasFlowScopeKey(processInstanceKey)
@@ -504,6 +507,7 @@ public class CreateProcessInstanceAnywhereTest {
         .hasBpmnProcessId(deployedProcess.getBpmnProcessId())
         .hasVersion(deployedProcess.getVersion())
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasBpmnElementType(BpmnElementType.MANUAL_TASK)
         .hasElementId("task")
         .hasFlowScopeKey(subprocessElementInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -79,6 +79,7 @@ public final class CreateProcessInstanceTest {
         .hasFlowScopeKey(-1)
         .hasBpmnProcessId("process")
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     assertThat(value.getCallingElementPath()).isEmpty();
@@ -263,6 +264,7 @@ public final class CreateProcessInstanceTest {
         .hasFlowScopeKey(-1)
         .hasBpmnProcessId("process")
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasTags("businessKey:1234", "priority:high");
   }
@@ -306,7 +308,8 @@ public final class CreateProcessInstanceTest {
         .hasBpmnElementType(BpmnElementType.START_EVENT)
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId("process")
-        .hasProcessInstanceKey(processInstanceKey);
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test
@@ -371,7 +374,8 @@ public final class CreateProcessInstanceTest {
         .hasBpmnElementType(BpmnElementType.SEQUENCE_FLOW)
         .hasFlowScopeKey(processInstanceKey)
         .hasBpmnProcessId("process")
-        .hasProcessInstanceKey(processInstanceKey);
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalEndEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalEndEventTest.java
@@ -70,6 +70,7 @@ public class SignalEndEventTest {
         .hasBpmnProcessId(PROCESS)
         .hasVersion(processInstance.getValue().getVersion())
         .hasProcessInstanceKey(processInstance.getKey())
+        .hasRootProcessInstanceKey(processInstance.getKey())
         .hasBpmnEventType(BpmnEventType.SIGNAL)
         .hasElementId("end")
         .hasFlowScopeKey(processInstance.getKey());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
@@ -74,6 +74,7 @@ public class SignalIntermediateThrowEventTest {
         .hasBpmnProcessId(PROCESS)
         .hasVersion(processInstance.getValue().getVersion())
         .hasProcessInstanceKey(processInstance.getKey())
+        .hasRootProcessInstanceKey(processInstance.getKey())
         .hasBpmnEventType(BpmnEventType.SIGNAL)
         .hasElementId("signal_throw_event")
         .hasFlowScopeKey(processInstance.getKey());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalStartEventTest.java
@@ -67,6 +67,7 @@ public class SignalStartEventTest {
         .hasBpmnProcessId(processInstance.getValue().getBpmnProcessId())
         .hasVersion(processInstance.getValue().getVersion())
         .hasProcessInstanceKey(processInstance.getKey())
+        .hasRootProcessInstanceKey(processInstance.getKey())
         .hasBpmnEventType(BpmnEventType.SIGNAL)
         .hasElementId("start")
         .hasFlowScopeKey(processInstance.getKey());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -592,7 +592,8 @@ public final class TimerStartEventTest {
     Assertions.assertThat(lastRecord)
         .hasVersion(2)
         .hasBpmnProcessId("process")
-        .hasProcessInstanceKey(processInstanceKey);
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -47,7 +47,8 @@ public class ProcessInstanceElementMigratedApplierTest {
             .setVersion(1)
             .setElementId("process")
             .setBpmnElementType(BpmnElementType.PROCESS)
-            .setProcessInstanceKey(2L);
+            .setProcessInstanceKey(2L)
+            .setRootProcessInstanceKey(4L);
     elementInstanceState.createInstance(
         new ElementInstance(
             processInstance.getProcessInstanceKey(),
@@ -76,6 +77,7 @@ public class ProcessInstanceElementMigratedApplierTest {
         .hasProcessInstanceKey(processInstance.getProcessInstanceKey())
         .hasParentElementInstanceKey(processInstance.getParentElementInstanceKey())
         .hasParentProcessInstanceKey(processInstance.getParentProcessInstanceKey())
+        .hasRootProcessInstanceKey(processInstance.getRootProcessInstanceKey())
         .hasTenantId(processInstance.getTenantId())
         .hasBpmnElementType(processInstance.getBpmnElementType())
         .hasBpmnEventType(processInstance.getBpmnEventType())

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
@@ -50,6 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
           .addMixIn(
@@ -72,6 +74,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
   private static final String TERMINATE_INSTRUCTIONS_ELEMENT_ID_PROPERTY = "elementId";
+  private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
   private final List<BulkOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -211,6 +214,9 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})
   private static final class ProcessInstanceModificationMixin {}
+
+  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
+  private static final class IgnoreRootProcessInstanceKeyMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -63,6 +63,9 @@
             },
             "tags": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -255,13 +255,11 @@ final class ElasticsearchExporterIT {
         || valueType == ValueType.JOB) {
       final var response = testClient.getExportedDocumentFor(record);
       assertThat(response)
-          .extracting(
-              GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
+          .extracting(GetResponse::index, GetResponse::id, GetResponse::routing)
           .containsExactly(
               indexRouter.indexFor(record),
               indexRouter.idFor(record),
-              String.valueOf(record.getPartitionId()),
-              record);
+              String.valueOf(record.getPartitionId()));
     } else {
       assertThatThrownBy(() -> testClient.getExportedDocumentFor(record))
           .isInstanceOf(ElasticsearchException.class)

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
@@ -52,6 +53,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
           .addMixIn(
@@ -72,6 +74,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
   private static final String TERMINATE_INSTRUCTIONS_ELEMENT_ID_PROPERTY = "elementId";
+  private static final String ROOT_PROCESS_INSTANCE_KEY_PROPERTY = "rootProcessInstanceKey";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -212,6 +215,9 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})
   private static final class ProcessInstanceModificationMixin {}
+
+  @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})
+  private static final class IgnoreRootProcessInstanceKeyMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -63,6 +63,9 @@
             },
             "tags": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -331,13 +331,11 @@ final class OpensearchExporterIT {
         || valueType == ValueType.JOB) {
       final var response = testClient.getExportedDocumentFor(record);
       assertThat(response)
-          .extracting(
-              GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
+          .extracting(GetResponse::index, GetResponse::id, GetResponse::routing)
           .containsExactly(
               indexRouter.indexFor(record),
               indexRouter.idFor(record),
-              String.valueOf(record.getPartitionId()),
-              record);
+              String.valueOf(record.getPartitionId()));
     } else {
       assertThatThrownBy(() -> testClient.getExportedDocumentFor(record))
           .isInstanceOf(OpenSearchException.class)

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -56,6 +56,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
       new StringValue("processDefinitionPath");
   public static final StringValue CALLING_ELEMENT_PATH_KEY = new StringValue("callingElementPath");
   public static final StringValue TAGS_KEY = new StringValue("tags");
+  public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -91,8 +93,11 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> tagsProp =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
 
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY, -1L);
+
   public ProcessInstanceRecord() {
-    super(15);
+    super(16);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -107,7 +112,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(elementInstancePathProp)
         .declareProperty(processDefinitionPathProp)
         .declareProperty(callingElementPathProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -122,6 +128,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     parentProcessInstanceKeyProp.setValue(record.getParentProcessInstanceKey());
     parentElementInstanceKeyProp.setValue(record.getParentElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   @JsonIgnore
@@ -266,6 +273,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     if (tags != null) {
       tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
     }
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1874,6 +1874,7 @@ final class JsonSerializableToJsonTest {
               final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
               final var processDefinitionPath = List.of(101L, 102L);
               final var callingElementPath = List.of(12345, 67890);
+              final var rootProcessInstanceKey = 9999L;
 
               return new ProcessInstanceRecord()
                   .setElementId(elementId)
@@ -1889,7 +1890,8 @@ final class JsonSerializableToJsonTest {
                   .setElementInstancePath(elementInstancePath)
                   .setProcessDefinitionPath(processDefinitionPath)
                   .setCallingElementPath(callingElementPath)
-                  .setTags(Set.of("tag1", "tag2"));
+                  .setTags(Set.of("tag1", "tag2"))
+                  .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
                 {
@@ -1907,7 +1909,8 @@ final class JsonSerializableToJsonTest {
                   "elementInstancePath":[[101, 102], [103, 104]],
                   "processDefinitionPath": [101, 102],
                   "callingElementPath": [12345, 67890],
-                  "tags": ["tag1", "tag2"]
+                  "tags": ["tag1", "tag2"],
+                  "rootProcessInstanceKey": 9999
                 }
                 """
       },
@@ -1936,7 +1939,8 @@ final class JsonSerializableToJsonTest {
                   "elementInstancePath":[],
                   "processDefinitionPath": [],
                   "callingElementPath": [],
-                  "tags": []
+                  "tags": [],
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
@@ -56,6 +56,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
       new StringValue("processDefinitionPath");
   public static final StringValue CALLING_ELEMENT_PATH_KEY = new StringValue("callingElementPath");
   public static final StringValue TAGS_KEY = new StringValue("tags");
+  public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -91,8 +93,11 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> tagsProp =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
 
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY, -1L);
+
   public ProcessInstanceRecord() {
-    super(15);
+    super(16);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -107,7 +112,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(elementInstancePathProp)
         .declareProperty(processDefinitionPathProp)
         .declareProperty(callingElementPathProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -122,6 +128,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     parentProcessInstanceKeyProp.setValue(record.getParentProcessInstanceKey());
     parentElementInstanceKeyProp.setValue(record.getParentElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
+    rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
   }
 
   @JsonIgnore
@@ -266,6 +273,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     if (tags != null) {
       tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
     }
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -179,4 +179,17 @@ public interface ProcessInstanceRecordValue
    * @return a set of tags associated with this process instance
    */
   Set<String> getTags();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for process instance records created after version 8.9.0
+   * and part of hierarchies created after that version. For older process instances, the method
+   * will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 422]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 448]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 423);
+    final var recordBatch = new RecordBatch((count, size) -> size < 449);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request introduces the concept of a "rootProcessInstanceKey" to process instance throughout the Zeebe engine. The main goal is to consistently track the originating (root) process instance across process hierarchies, including when processes are started via call activities.
**Important:** the process instance records created in previous version or created in new version but belongs to hierarchy initialized in previous versions, will not have the field populated and will default to `-1`.

Added `getRootProcessInstanceKey()` method to the BpmnElementContext to retrieve the rootProcessInstanceKey from the contextual element.
Updated the process-instance zeebe-record index templates to include this field and be exported by the legacy ElasticSearch and OpenSearch exporters. The field is excluded from serialization for the previous version's records for backward compatibility.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41655
