### PR TITLE
refactor: backport zeebe container removal from operate

### DIFF
--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -65,9 +65,6 @@ jobs:
     runs-on: ${{ inputs.runner-type }}
     permissions: {}
     if: ${{ !startsWith(inputs.branch, 'fe-') && !(startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')) }}
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe
-      ZEEBE_TEST_DOCKER_IMAGE_TAG: current-test
     services:
       # local registry is used as this job needs to push its docker image to be used by IT
       registry:
@@ -109,15 +106,6 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild
-      - uses: ./.github/actions/build-platform-docker
-        id: build-camunda-docker
-        with:
-          # we use a local registry for pushing
-          repository: ${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          version: ${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }}
-          # push is needed to make accessible for integration tests
-          push: true
 
       # Run integration tests in parallel
       - name: Backend - ${{ inputs.test-type }}

--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -74,11 +74,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <scope>test</scope>
@@ -131,6 +126,16 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.operate.qa.backup;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.operate.util.CollectionUtil.asMap;
 import static io.camunda.webapps.backup.BackupStateDto.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.operate.util.RetryOperation;
 import io.camunda.webapps.backup.GetBackupStateResponseDto;
@@ -66,7 +65,7 @@ public class BackupRestoreTest {
   @Before
   public void setup() {
     testContext = new BackupRestoreTestContext().setZeebeIndexPrefix(INDEX_PREFIX);
-    testContext.setConnectionType("elasticsearch");
+    testContext.setDatabaseType(ConnectionTypes.ELASTICSEARCH.getType());
   }
 
   @Test
@@ -138,9 +137,7 @@ public class BackupRestoreTest {
                 new HttpHost(testContext.getExternalElsHost(), testContext.getExternalElsPort()))));
     createSnapshotRepository(testContext);
 
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    testContainerUtil.startZeebe(zeebeVersion, testContext);
+    testContainerUtil.startZeebe(testContext);
 
     operateContainer =
         testContainerUtil

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -64,7 +64,10 @@ public class BackupRestoreTest {
 
   @Before
   public void setup() {
-    testContext = new BackupRestoreTestContext().setZeebeIndexPrefix(INDEX_PREFIX);
+    testContext =
+        new BackupRestoreTestContext()
+            .setZeebeIndexPrefix(INDEX_PREFIX)
+            .setIndexPrefix(INDEX_PREFIX);
     testContext.setDatabaseType(ConnectionTypes.ELASTICSEARCH.getType());
   }
 

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -87,12 +87,6 @@
 
     <!-- TEST CONTAINERS -->
     <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-elasticsearch</artifactId>
       <scope>test</scope>
@@ -453,6 +447,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.operate;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.operate.qa.util.TestContext;
 import org.junit.After;
@@ -49,8 +47,7 @@ public class StartupIT {
     testContext.setDatabaseType("elasticsearch");
     testContainerUtil.startElasticsearch(testContext);
 
-    testContainerUtil.startZeebe(
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME), testContext);
+    testContainerUtil.startZeebe(testContext);
 
     operateContainer =
         testContainerUtil

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
@@ -7,19 +7,18 @@
  */
 package io.camunda.operate.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.TestContainerUtil.ELS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.Topology;
-import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
+import io.camunda.operate.qa.util.TestContext;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -56,7 +55,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
   @Qualifier("esClient")
   protected RestHighLevelClient esClient;
 
-  protected ZeebeContainer zeebeContainer;
+  protected TestStandaloneBroker zeebeBroker;
   @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private TestContainerUtil testContainerUtil;
   @Autowired private IndexPrefixHolder indexPrefixHolder;
@@ -151,20 +150,24 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
   @Override
   public void startZeebe() {
 
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    zeebeContainer =
-        testContainerUtil.startZeebe(
-            zeebeVersion,
-            prefix,
-            2,
-            isMultitTenancyEnabled(),
-            ConnectionTypes.ELASTICSEARCH.getType());
+    final TestContext testContext =
+        new TestContext()
+            .setInternalElsHost("localhost")
+            .setExternalElsHost("localhost")
+            .setExternalElsPort(ELS_PORT)
+            .setInternalElsPort(ELS_PORT)
+            .setIndexPrefix(prefix)
+            .setDatabaseType("elasticsearch")
+            .setPartitionCount(2)
+            .setMultitenancyEnabled(isMultitTenancyEnabled());
+
+    zeebeBroker = testContainerUtil.startZeebe(testContext);
 
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .grpcAddress(zeebeContainer.getGrpcAddress())
+            .restAddress(zeebeBroker.restAddress())
+            .grpcAddress(zeebeBroker.grpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 
@@ -187,8 +190,8 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
   }
 
   @Override
-  public ZeebeContainer getZeebeContainer() {
-    return zeebeContainer;
+  public TestStandaloneBroker getZeebeBroker() {
+    return zeebeBroker;
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.TestContainerUtil.ELS_PORT;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.componentTemplateRequestBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,12 +17,12 @@ import io.camunda.client.api.response.Topology;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
+import io.camunda.operate.qa.util.TestContext;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -48,7 +48,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   @Autowired public OperateProperties operateProperties;
   @Autowired public SearchEngineConfiguration searchEngineConfiguration;
   @Autowired protected RichOpenSearchClient richOpenSearchClient;
-  protected ZeebeContainer zeebeContainer;
+  protected TestStandaloneBroker zeebeBroker;
   @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private TestContainerUtil testContainerUtil;
   @Autowired private IndexPrefixHolder indexPrefixHolder;
@@ -126,20 +126,24 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   @Override
   public void startZeebe() {
 
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    zeebeContainer =
-        testContainerUtil.startZeebe(
-            zeebeVersion,
-            prefix,
-            2,
-            isMultitTenancyEnabled(),
-            ConnectionTypes.OPENSEARCH.getType());
+    final TestContext testContext =
+        new TestContext()
+            .setInternalElsHost("localhost")
+            .setExternalElsHost("localhost")
+            .setInternalElsPort(ELS_PORT)
+            .setExternalElsPort(ELS_PORT)
+            .setIndexPrefix(prefix)
+            .setDatabaseType(ConnectionTypes.OPENSEARCH.getType())
+            .setPartitionCount(2)
+            .setMultitenancyEnabled(isMultitTenancyEnabled());
+
+    zeebeBroker = testContainerUtil.startZeebe(testContext);
 
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .grpcAddress(zeebeContainer.getGrpcAddress())
+            .restAddress(zeebeBroker.restAddress())
+            .grpcAddress(zeebeBroker.grpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 
@@ -162,8 +166,8 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   }
 
   @Override
-  public ZeebeContainer getZeebeContainer() {
-    return zeebeContainer;
+  public TestStandaloneBroker getZeebeBroker() {
+    return zeebeBroker;
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -38,9 +38,9 @@ import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.zeebe.StandalonePartitionSupplier;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.zeebe.containers.ZeebeContainer;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -164,7 +164,7 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   @Autowired protected OperateProperties operateProperties;
   @Autowired protected OperationExecutor operationExecutor;
   protected OperateTester tester;
-  private ZeebeContainer zeebeContainer;
+  private TestStandaloneBroker zeebeBroker;
   @Autowired private TestSearchRepository testSearchRepository;
   private String workerName;
   @Autowired private MeterRegistry meterRegistry;
@@ -178,8 +178,8 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   public void before() {
     super.before();
 
-    zeebeContainer = zeebeRule.getZeebeContainer();
-    assertThat(zeebeContainer).as("zeebeContainer is not null").isNotNull();
+    zeebeBroker = zeebeRule.getZeebeBroker();
+    assertThat(zeebeBroker).as("zeebeContainer is not null").isNotNull();
 
     camundaClient = getClient();
     operateServicesAdapter =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRule.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRule.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.util;
 
 import io.camunda.client.CamundaClient;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Instant;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -63,8 +63,8 @@ public class OperateZeebeRule extends TestWatcher {
   //    this.prefix = prefix;
   //  }
   //
-  public ZeebeContainer getZeebeContainer() {
-    return operateZeebeRuleProvider.getZeebeContainer();
+  public TestStandaloneBroker getZeebeBroker() {
+    return operateZeebeRuleProvider.getZeebeBroker();
   }
 
   //  public void setOperateProperties(final OperateProperties operateProperties) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeRuleProvider.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.util;
 
 import io.camunda.client.CamundaClient;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Instant;
 import org.junit.runner.Description;
 
@@ -29,7 +29,7 @@ public interface OperateZeebeRuleProvider {
 
   String getPrefix();
 
-  ZeebeContainer getZeebeContainer();
+  TestStandaloneBroker getZeebeBroker();
 
   CamundaClient getClient();
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
@@ -7,17 +7,14 @@
  */
 package io.camunda.operate.util.j5templates;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
-
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.Topology;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 
 public abstract class ZeebeContainerManager {
@@ -26,7 +23,7 @@ public abstract class ZeebeContainerManager {
   protected final OperateProperties operateProperties;
   protected final TestContainerUtil testContainerUtil;
   protected String prefix;
-  protected ZeebeContainer zeebeContainer;
+  protected TestStandaloneBroker zeebeContainer;
   protected CamundaClient client;
   private final SecurityConfiguration securityConfiguration;
 
@@ -49,11 +46,8 @@ public abstract class ZeebeContainerManager {
     updatePrefix();
 
     // Start zeebe
-    final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
     zeebeContainer =
         testContainerUtil.startZeebe(
-            zeebeVersion,
             prefix,
             2,
             securityConfiguration.getMultiTenancy().isChecksEnabled(),
@@ -62,7 +56,7 @@ public abstract class ZeebeContainerManager {
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .grpcAddress(zeebeContainer.getGrpcAddress())
+            .grpcAddress(zeebeContainer.grpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 

--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -17,11 +17,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>operate-schema</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>webapps-schema</artifactId>
     </dependency>
 
@@ -68,11 +63,6 @@
     </dependency>
 
     <!-- TEST CONTAINERS -->
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-test-container</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-elasticsearch</artifactId>
@@ -142,10 +132,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-authentication</artifactId>
     </dependency>
@@ -160,6 +146,30 @@
     <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-qa-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-zeebe</artifactId>
     </dependency>
   </dependencies>
 

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -494,10 +494,16 @@ public class TestContainerUtil {
       final String connectionType) {
     final TestContext testContext =
         new TestContext()
+            .setIndexPrefix(prefix)
             .setZeebeIndexPrefix(prefix)
             .setPartitionCount(partitionCount)
             .setMultitenancyEnabled(multitenancyEnabled)
-            .setConnectionType(connectionType);
+            .setConnectionType(connectionType)
+            .setDatabaseType(connectionType)
+            .setExternalElsHost("host.testcontainers.internal")
+            .setExternalElsPort(9200)
+            .setInternalElsHost(ELS_NETWORK_ALIAS)
+            .setInternalElsPort(ELS_PORT);
     return startZeebe(testContext);
   }
 

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.operate.qa.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME;
 import static io.camunda.operate.util.ThreadUtil.sleepFor;
 import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
-import static org.testcontainers.images.PullPolicy.alwaysPull;
 
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.exporter.CamundaExporter;
 import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.schema.migration.SemanticVersion;
 import io.camunda.operate.util.RetryOperation;
-import io.zeebe.containers.ZeebeContainer;
-import io.zeebe.containers.ZeebePort;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.NotFoundException;
 import java.io.File;
@@ -44,7 +44,6 @@ import org.keycloak.admin.client.Keycloak;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -110,7 +109,7 @@ public class TestContainerUtil {
   private GenericContainer identityContainer;
   private GenericContainer keycloakContainer;
   private PostgreSQLContainer postgreSQLContainer;
-  private ZeebeContainer broker;
+  private TestStandaloneBroker broker;
   private GenericContainer operateContainer;
   private Keycloak keycloakClient;
 
@@ -300,7 +299,7 @@ public class TestContainerUtil {
         new ElasticsearchContainer(
                 String.format(
                     "%s:%s", DOCKER_ELASTICSEARCH_IMAGE_NAME, SUPPORTED_ELASTICSEARCH_VERSION))
-            .withNetwork(getNetwork())
+            .withNetwork(Network.SHARED)
             .withEnv("xpack.security.enabled", "false")
             .withEnv("path.repo", "~/")
             .withEnv("action.destructive_requires_name", "false")
@@ -311,7 +310,7 @@ public class TestContainerUtil {
     elsContainer.start();
     elsContainer.followOutput(new Slf4jLogConsumer(LOGGER));
 
-    testContext.setNetwork(getNetwork());
+    testContext.setNetwork(Network.SHARED);
     testContext.setExternalElsHost(elsContainer.getContainerIpAddress());
     testContext.setExternalElsPort(elsContainer.getMappedPort(ELS_PORT));
     testContext.setInternalElsHost(ELS_NETWORK_ALIAS);
@@ -365,6 +364,7 @@ public class TestContainerUtil {
         new GenericContainer<>(String.format("%s:%s", dockerImageName, version))
             .withExposedPorts(8080)
             .withNetwork(testContext.getNetwork())
+            .withExtraHost("host.testcontainer.internal", "host-gateway")
             .withCopyFileToContainer(
                 MountableFile.forHostPath(createConfigurationFile(testContext), 0775),
                 "/usr/local/operate/config/application.properties")
@@ -487,8 +487,7 @@ public class TestContainerUtil {
     return properties;
   }
 
-  public ZeebeContainer startZeebe(
-      final String version,
+  public TestStandaloneBroker startZeebe(
       final String prefix,
       final Integer partitionCount,
       final boolean multitenancyEnabled,
@@ -499,93 +498,47 @@ public class TestContainerUtil {
             .setPartitionCount(partitionCount)
             .setMultitenancyEnabled(multitenancyEnabled)
             .setConnectionType(connectionType);
-    return startZeebe(version, testContext);
+    return startZeebe(testContext);
   }
 
-  public ZeebeContainer startZeebe(final String version, final TestContext testContext) {
+  public TestStandaloneBroker startZeebe(final TestContext testContext) {
     if (broker == null) {
-      final String dockerRepo =
-          ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME);
-      LOGGER.info("************ Starting Zeebe {}:{} ************", dockerRepo, version);
-      final long startTime = System.currentTimeMillis();
-      Testcontainers.exposeHostPorts(ELS_PORT);
       broker =
-          new ZeebeContainer(DockerImageName.parse(String.format("%s:%s", dockerRepo, version)));
-      broker.withLogConsumer(new Slf4jLogConsumer(LOGGER));
-      if (testContext.getNetwork() != null) {
-        broker.withNetwork(testContext.getNetwork());
-      }
-      if (testContext.getZeebeDataFolder() != null) {
-        broker.withFileSystemBind(
-            testContext.getZeebeDataFolder().getPath(), "/usr/local/zeebe/data");
-      }
-      if ("SNAPSHOT".equals(version)) {
-        broker.withImagePullPolicy(alwaysPull());
-      }
-
-      // from 8.3.0 onwards, Zeebe is run with a non-root user in the container;
-      // this user cannot access a mounted volume that is owned by root
-      broker.withCreateContainerCmdModifier(cmd -> cmd.withUser("root"));
-
-      if ("SNAPSHOT".equals(version)
-          || "current-test".equals(version)
-          || SemanticVersion.fromVersion(version).isAtLeast("8.8.0")) {
-        configureCamundaExporter(testContext);
-      } else {
-        configureElasticsearchExporter(testContext);
-      }
-      broker
-          .withEnv("JAVA_OPTS", "-Xss256k -XX:+TieredCompilation -XX:TieredStopAtLevel=1")
-          .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
-          .withEnv("ATOMIX_LOG_LEVEL", "ERROR")
-          .withEnv("ZEEBE_CLOCK_CONTROLLED", "true")
-          .withEnv("ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK", "0.99")
-          .withEnv("ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK", "0.98")
-          .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
-          .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
-          .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME", "demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD", "demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME", "Demo")
-          .withEnv("CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL", "demo@example.com");
-
-      if (testContext.getDatabaseType() != null) {
-        final String dbType = testContext.getDatabaseType().toLowerCase();
-        broker.withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType);
-      }
-
-      if (testContext.getPartitionCount() != null) {
-        broker.withEnv(
-            "ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT",
-            String.valueOf(testContext.getPartitionCount()));
-      }
+          new TestStandaloneBroker()
+              .withAdditionalProperties(
+                  Map.of(
+                      "zeebe.log.level",
+                      "ERROR",
+                      "atomix.log.level",
+                      "ERROR",
+                      "zeebe.clock.controlled",
+                      "true"))
+              .withBrokerConfig(
+                  cfg -> {
+                    cfg.getGateway().setEnable(true);
+                    cfg.getData().setSnapshotPeriod(Duration.ofMinutes(1));
+                    if (testContext.getPartitionCount() != null) {
+                      cfg.getCluster().setPartitionsCount(testContext.getPartitionCount());
+                    }
+                  })
+              .withSecurityConfig(
+                  cfg -> {
+                    cfg.getAuthentication().setUnprotectedApi(true);
+                    cfg.getAuthorizations().setEnabled(false);
+                    final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
+                    cfg.getInitialization().setUsers(List.of(user));
+                  });
+      configureCamundaExporter(testContext);
       if (testContext.isMultitenancyEnabled() != null) {
-        broker.withEnv(
-            "ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED",
-            String.valueOf(testContext.isMultitenancyEnabled()));
-        if (testContext.isMultitenancyEnabled()) {
-          broker
-              .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE", "identity")
-              .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE", "keycloak")
-              .withEnv(
-                  "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL",
-                  IdentityTester.testContext.getInternalKeycloakBaseUrl()
-                      + "/auth/realms/camunda-platform")
-              .withEnv(
-                  "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE", "zeebe-api")
-              .withEnv(
-                  "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL",
-                  IdentityTester.testContext.getInternalIdentityBaseUrl());
-        }
+        broker.withSecurityConfig(
+            cfg -> cfg.getMultiTenancy().setChecksEnabled(testContext.isMultitenancyEnabled()));
       }
       broker.start();
 
-      LOGGER.info(
-          "\n====\nBroker startup time: {}\n====\n", (System.currentTimeMillis() - startTime));
-
       testContext.setInternalZeebeContactPoint(
-          broker.getInternalAddress(ZeebePort.GATEWAY.getPort()));
-      testContext.setZeebeGrpcAddress(broker.getGrpcAddress());
+          String.format(
+              "host.testcontainers.internal:%d", broker.mappedPort(TestZeebePort.GATEWAY)));
+      testContext.setZeebeGrpcAddress(broker.grpcAddress());
     } else {
       throw new IllegalStateException("Broker is already started. Call stopZeebe first.");
     }
@@ -593,72 +546,65 @@ public class TestContainerUtil {
   }
 
   private void configureCamundaExporter(final TestContext testContext) {
-    final String dbType = testContext.getConnectionType();
-    final String dbUrl = getElasticURL(testContext);
+    final String dbType = testContext.getDatabaseType();
 
-    broker
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-            "io.camunda.exporter.CamundaExporter")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY", "1")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1")
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_WAITPERIODBEFOREARCHIVING", "1s")
-        // unified config db type + compatibility vars
-        .withEnv("CAMUNDA_DATABASE_TYPE", dbType)
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", dbType)
-        .withEnv("CAMUNDA_OPERATE_DATABASE", dbType)
-        .withEnv("CAMUNDA_TASKLIST_DATABASE", dbType)
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE", dbType)
-        // unified config db url + compaptibility vars (elasticsearch)
-        .withEnv("CAMUNDA_DATABASE_URL", dbUrl)
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", dbUrl)
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", dbUrl)
-        // unified config db url + compaptibility vars (opensearch)
-        .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_OPERATE_OPENSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_OPERATE_ZEEBEOPENSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_TASKLIST_OPENSEARCH_URL", dbUrl)
-        .withEnv("CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_URL", dbUrl);
-    if (testContext.getZeebeIndexPrefix() != null && dbType != null) {
-      broker
-          .withEnv(
-              "CAMUNDA_DATA_SECONDARYSTORAGE_" + dbType.toUpperCase() + "_INDEXPREFIX",
-              testContext.getZeebeIndexPrefix())
-          .withEnv(
-              "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX",
-              testContext.getZeebeIndexPrefix())
-          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testContext.getZeebeIndexPrefix());
-    }
-  }
+    final String dbUrl =
+        String.format(
+            "http://%s:%s", testContext.getExternalElsHost(), testContext.getExternalElsPort());
 
-  private void configureElasticsearchExporter(final TestContext testContext) {
-    broker
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", getElasticURL(testContext))
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
-            "io.camunda.zeebe.exporter.ElasticsearchExporter")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_DEPLOYMENTDISTRIBUTION", "false")
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_MESSAGESTARTSUBSCRIPTION", "false")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_TIMER", "false")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PROCESSINSTANCECREATION", "false")
-        .withEnv(
-            "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PROCESSINSTANCEMODIFICATION", "false")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_ESCALATION", "false")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PROCESSEVENT", "false");
+    broker.withExporter(
+        CamundaExporter.class.getSimpleName().toLowerCase(),
+        cfg -> {
+          cfg.setClassName(CamundaExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "connect",
+                  Map.of(
+                      "url",
+                      dbUrl,
+                      "type",
+                      dbType,
+                      "indexPrefix",
+                      testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : "",
+                      "index",
+                      Map.of(
+                          "prefix",
+                          testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : ""),
+                      "bulk",
+                      Map.of("size", 1)),
+                  "history",
+                  Map.of("waitPeriodBeforeArchiving", "1s")));
+        });
 
-    if (testContext.getZeebeIndexPrefix() != null) {
-      broker.withEnv(
-          "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX",
-          testContext.getZeebeIndexPrefix());
-    }
+    final var secondaryStorageType = SecondaryStorageType.valueOf(dbType);
+
+    broker.withAdditionalProperties(
+        Map.of(
+            "camunda.data.secondary-storage.type",
+            secondaryStorageType,
+            "camunda.data.secondary-storage."
+                + (secondaryStorageType.name().equals("opensearch")
+                    ? "opensearch"
+                    : "elasticsearch")
+                + ".url",
+            dbUrl,
+            "camunda.data.secondary-storage."
+                + (secondaryStorageType.name().equals("opensearch")
+                    ? "opensearch"
+                    : "elasticsearch")
+                + ".index-prefix",
+            testContext.getIndexPrefix() != null ? testContext.getIndexPrefix() : ""));
+
+    broker.withAdditionalProperties(
+        Map.of(
+            "camunda.database.type",
+            dbType,
+            "camunda.operate.database",
+            dbType,
+            "camunda.tasklist.database",
+            dbType,
+            "camunda.database.url",
+            dbUrl));
   }
 
   public void stopZeebeAndOperate(final TestContext testContext) {
@@ -710,7 +656,7 @@ public class TestContainerUtil {
         throw new RuntimeException(e);
       } finally {
         try {
-          broker.shutdownGracefully(Duration.ofSeconds(3));
+          broker.close();
         } catch (final Exception ex) {
           LOGGER.error("broker.shutdownGracefully failed", ex);
           // ignore

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContext.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContext.java
@@ -39,6 +39,7 @@ public class TestContext<T extends TestContext<T>> {
   private String internalZeebeContactPoint;
 
   private String zeebeIndexPrefix = "zeebe-record";
+  private String indexPrefix;
 
   private String externalOperateHost;
   private Integer externalOperatePort;
@@ -55,8 +56,9 @@ public class TestContext<T extends TestContext<T>> {
     return databaseType;
   }
 
-  public void setDatabaseType(final String databaseType) {
+  public T setDatabaseType(final String databaseType) {
     this.databaseType = databaseType;
+    return (T) this;
   }
 
   public File getZeebeDataFolder() {
@@ -245,6 +247,15 @@ public class TestContext<T extends TestContext<T>> {
 
   public T setZeebeIndexPrefix(final String zeebeIndexPrefix) {
     this.zeebeIndexPrefix = zeebeIndexPrefix;
+    return (T) this;
+  }
+
+  public String getIndexPrefix() {
+    return indexPrefix;
+  }
+
+  public T setIndexPrefix(final String indexPrefix) {
+    this.indexPrefix = indexPrefix;
     return (T) this;
   }
 

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/migration/AbstractTestFixture.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/migration/AbstractTestFixture.java
@@ -9,13 +9,13 @@ package io.camunda.operate.qa.util.migration;
 
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.operate.qa.util.TestContext;
-import io.zeebe.containers.ZeebeContainer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.testcontainers.containers.GenericContainer;
 
 public abstract class AbstractTestFixture implements TestFixture {
 
-  protected ZeebeContainer broker;
+  protected TestStandaloneBroker broker;
   protected GenericContainer<?> operateContainer;
   protected TestContext testContext;
   @Autowired private TestContainerUtil testContainerUtil;
@@ -26,7 +26,7 @@ public abstract class AbstractTestFixture implements TestFixture {
   }
 
   protected void startZeebeAndOperate() {
-    broker = testContainerUtil.startZeebe(getVersion(), testContext);
+    broker = testContainerUtil.startZeebe(testContext);
     operateContainer = testContainerUtil.startOperate(getVersion(), testContext);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport removal of zeebe container from Operate ITs as done in https://github.com/camunda/camunda/pull/41780

The failing test is already reported in https://github.com/camunda/camunda/issues/42697

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
