### PR TITLE
feat: Add rdbms health contributor

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -438,8 +438,8 @@ public class RdbmsConfiguration {
     };
   }
 
-  @Bean(name = "rdbms")
-  HealthContributor dbHealthContributor(final DataSource dataSource) {
+  @Bean
+  HealthContributor rdbmsStatusHealthIndicator(final DataSource dataSource) {
     // Equivalent to what Boot would normally wire for "db"
     return new DataSourceHealthIndicator(dataSource);
   }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -86,6 +86,8 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.actuate.health.HealthContributor;
+import org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -434,5 +436,11 @@ public class RdbmsConfiguration {
         LOG.debug("JDBC Spec: {}.{}", meta.getJDBCMajorVersion(), meta.getJDBCMinorVersion());
       }
     };
+  }
+
+  @Bean(name = "rdbms")
+  HealthContributor dbHealthContributor(final DataSource dataSource) {
+    // Equivalent to what Boot would normally wire for "db"
+    return new DataSourceHealthIndicator(dataSource);
   }
 }


### PR DESCRIPTION
## Description

* Adds an rdbms health contirbutor, similar to the default SpringBoot `DatasourceHealthIndicator`
* When secondary storage type is `rdbms` the health contributor is active

## Related issues

closes #40377
