### PR TITLE
feat: environment variables to configure alternative authorization server settings

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
@@ -39,6 +39,9 @@ public final class CamundaClientEnvironmentVariables {
   public static final String OAUTH_ENV_TOKEN_SCOPE = "CAMUNDA_TOKEN_SCOPE";
   public static final String OAUTH_ENV_TOKEN_RESOURCE = "CAMUNDA_TOKEN_RESOURCE";
   public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "CAMUNDA_AUTHORIZATION_SERVER_URL";
+  public static final String OAUTH_ENV_WELL_KNOWN_CONFIGURATION_URL =
+      "CAMUNDA_WELL_KNOWN_CONFIGURATION_URL";
+  public static final String OAUTH_ENV_ISSUER_URL = "CAMUNDA_ISSUER_URL";
   public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH =
       "CAMUNDA_SSL_CLIENT_KEYSTORE_PATH";
   public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET =

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -25,6 +25,7 @@ import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CONNECT_TIMEOUT;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_ISSUER_URL;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_READ_TIMEOUT;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH;
@@ -34,6 +35,7 @@ import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_AUDIENCE;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_RESOURCE;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_SCOPE;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_WELL_KNOWN_CONFIGURATION_URL;
 import static java.lang.Math.toIntExact;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -542,6 +544,9 @@ public final class OAuthCredentialsProviderBuilder {
         this::authorizationServerUrl,
         OAUTH_ENV_AUTHORIZATION_SERVER,
         LegacyZeebeClientEnvironmentVariables.OAUTH_ENV_AUTHORIZATION_SERVER);
+    applyEnvironmentValueIfNotNull(
+        this::wellKnownConfigurationUrl, OAUTH_ENV_WELL_KNOWN_CONFIGURATION_URL);
+    applyEnvironmentValueIfNotNull(this::issuerUrl, OAUTH_ENV_ISSUER_URL);
     applyEnvironmentValueIfNotNull(
         this::keystorePath,
         OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds missing environment variables to configure the alternative authorization server urls (well-known-configuration url and issuer url).

This came up when attempting to document these new options.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
