### PR TITLE
ci: use committer date instead of author date for staleness checks

### DIFF
--- a/.ci/scripts/outdated-pr-scripts/process-pr.sh
+++ b/.ci/scripts/outdated-pr-scripts/process-pr.sh
@@ -45,7 +45,7 @@ while IFS=' ' read -r pr_number branch_name base_branch repo_owner; do
   # Check branch staleness - only for internal branches that exist
   latest_age_days=0
   if [[ "$repo_owner" == "${GITHUB_REPOSITORY_OWNER}" ]] && git rev-parse --verify "origin/$branch_name" >/dev/null 2>&1; then
-    latest_commit_date=$(git log origin/"$base_branch"..origin/"$branch_name" --pretty=format:"%ai" | head -1 2>/dev/null || echo "")
+    latest_commit_date=$(git log origin/"$base_branch"..origin/"$branch_name" --pretty=format:"%ci" | head -1 2>/dev/null || echo "")
     latest_commit_timestamp=$("$DATE_PROGRAM" -d "$latest_commit_date" +%s 2>/dev/null || echo "0")
     current_timestamp=$("$DATE_PROGRAM" +%s)
     latest_age_days=$(( (current_timestamp - latest_commit_timestamp) / 86400 ))


### PR DESCRIPTION
Otherwise PRs that are rebased will look stale if there were no new actual commits in some time.  e.g. if a commit was made two weeks ago, but had been rebased on top of `main` it would appear stale - even though it was up-to-date.

You can see the difference in dates here:
```
$ git log --format=fuller
commit ceca2b00cd9e081f35d7f79cda9e1acfb94ad6db (HEAD -> 39202-lower-severity-logging-for-incident-update-task, origin/39202-lower-severity-logging-for-incident-update-task)
Author:     John Montgomery <john.montgomery@camunda.com>
AuthorDate: Fri Dec 12 09:59:49 2025 +0000
Commit:     John Montgomery <john.montgomery@camunda.com>
CommitDate: Tue Dec 16 09:13:39 2025 +0000

    feat: add metric for how many docs updated when updating incidents
```

and `git log --pretty=format:"%ci"` matches `CommitDate` (vs `%ai` for `AuthorDate`)