### PR TITLE
Keep track of process instances to delete in RDBMS

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -851,4 +851,26 @@
     </modifySql>
   </changeSet>
 
+  <changeSet id="create_history_deletion_table" author="camunda">
+    <createTable tableName="${prefix}HISTORY_DELETION">
+      <column name="RESOURCE_KEY" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="BATCH_OPERATION_KEY" type="BIGINT">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="RESOURCE_TYPE" type="VARCHAR(50)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="PARTITION_ID" type="NUMBER">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createIndex tableName="${prefix}HISTORY_DELETION" indexName="${prefix}IDX_HISTORY_DELETION_PARTITION_ID">
+      <column name="PARTITION_ID"/>
+    </createIndex>
+
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -867,10 +867,6 @@
       </column>
     </createTable>
 
-    <createIndex tableName="${prefix}HISTORY_DELETION" indexName="${prefix}IDX_HISTORY_DELETION_PARTITION_ID">
-      <column name="PARTITION_ID"/>
-    </createIndex>
-
   </changeSet>
 
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -20,6 +20,7 @@ import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.read.service.FormDbReader;
 import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
 import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
@@ -84,6 +85,7 @@ public class RdbmsService {
       processDefinitionInstanceStatisticsDbReader;
   private final ProcessDefinitionInstanceVersionStatisticsDbReader
       processDefinitionInstanceVersionStatisticsDbReader;
+  private final HistoryDeletionDbReader historyDeletionDbReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -120,7 +122,8 @@ public class RdbmsService {
       final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader,
       final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsDbReader,
       final ProcessDefinitionInstanceVersionStatisticsDbReader
-          processDefinitionInstanceVersionStatisticsDbReader) {
+          processDefinitionInstanceVersionStatisticsDbReader,
+      final HistoryDeletionDbReader historyDeletionDbReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.auditLogReader = auditLogReader;
     this.authorizationReader = authorizationReader;
@@ -156,6 +159,7 @@ public class RdbmsService {
     this.processDefinitionInstanceStatisticsDbReader = processDefinitionInstanceStatisticsDbReader;
     this.processDefinitionInstanceVersionStatisticsDbReader =
         processDefinitionInstanceVersionStatisticsDbReader;
+    this.historyDeletionDbReader = historyDeletionDbReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -291,6 +295,10 @@ public class RdbmsService {
   public ProcessDefinitionInstanceVersionStatisticsDbReader
       getProcessDefinitionInstanceVersionStatisticsReader() {
     return processDefinitionInstanceVersionStatisticsDbReader;
+  }
+
+  public HistoryDeletionDbReader getHistoryDeletionDbReader() {
+    return historyDeletionDbReader;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -57,7 +57,8 @@ public final class RdbmsTableNames {
           "USER_TASK_TAG",
           "USER_TASK",
           "USER_",
-          "VARIABLE");
+          "VARIABLE",
+          "HISTORY_DELETION");
 
   private RdbmsTableNames() {
     // Utility class - prevent instantiation

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HistoryDeletionDbReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HistoryDeletionDbReader.class);
+  private final HistoryDeletionMapper historyDeletionMapper;
+
+  public HistoryDeletionDbReader(HistoryDeletionMapper historyDeletionMapper) {
+    this.historyDeletionMapper = historyDeletionMapper;
+  }
+
+  public List<HistoryDeletionDbModel> getNextBatch(final int partitionId, final int limit) {
+    LOG.trace(
+        "[RDBMS DB] Fetch first {} history deletion records from partition {}", limit, partitionId);
+
+    return historyDeletionMapper.getHistoryDeletionBatch(partitionId, limit);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/HistoryDeletionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/HistoryDeletionMapper.java
@@ -8,9 +8,13 @@
 package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import java.util.List;
 import org.apache.ibatis.annotations.Param;
 
 public interface HistoryDeletionMapper {
+
+  List<HistoryDeletionDbModel> getHistoryDeletionBatch(
+      @Param("partitionId") int partitionId, @Param("limit") int limit);
 
   void insert(HistoryDeletionDbModel historyDeletion);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/HistoryDeletionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/HistoryDeletionMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import org.apache.ibatis.annotations.Param;
+
+public interface HistoryDeletionMapper {
+
+  void insert(HistoryDeletionDbModel historyDeletion);
+
+  int delete(
+      @Param("resourceKey") long resourceKey, @Param("batchOperationKey") long batchOperationKey);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -39,6 +39,7 @@ import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
 import io.camunda.db.rdbms.write.service.FormWriter;
 import io.camunda.db.rdbms.write.service.GroupWriter;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
+import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
 import io.camunda.db.rdbms.write.service.IncidentWriter;
 import io.camunda.db.rdbms.write.service.JobWriter;
 import io.camunda.db.rdbms.write.service.MappingRuleWriter;
@@ -85,6 +86,7 @@ public class RdbmsWriter {
   private final UsageMetricTUWriter usageMetricTUWriter;
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final CorrelatedMessageSubscriptionWriter correlatedMessageSubscriptionWriter;
+  private final HistoryDeletionWriter historyDeletionWriter;
 
   private final HistoryCleanupService historyCleanupService;
   private final RdbmsWriterMetrics metrics;
@@ -152,6 +154,7 @@ public class RdbmsWriter {
         new CorrelatedMessageSubscriptionWriter(
             executionQueue, correlatedMessageSubscriptionMapper);
     clusterVariableWriter = new ClusterVariableWriter(executionQueue, vendorDatabaseProperties);
+    historyDeletionWriter = new HistoryDeletionWriter(executionQueue);
 
     historyCleanupService =
         new HistoryCleanupService(
@@ -270,6 +273,10 @@ public class RdbmsWriter {
 
   public CorrelatedMessageSubscriptionWriter getCorrelatedMessageSubscriptionWriter() {
     return correlatedMessageSubscriptionWriter;
+  }
+
+  public HistoryDeletionWriter getHistoryDeletionWriter() {
+    return historyDeletionWriter;
   }
 
   public ExporterPositionService getExporterPositionService() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionDbModel.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+
+public record HistoryDeletionDbModel(
+    Long resourceKey,
+    HistoryDeletionType resourceType,
+    Long batchOperationKey,
+    Integer partitionId) {
+
+  public static final String ID_PATTERN = "%s_%s";
+
+  public String getId() {
+    return String.format(ID_PATTERN, batchOperationKey, resourceKey);
+  }
+
+  public static class Builder implements ObjectBuilder<HistoryDeletionDbModel> {
+
+    private long resourceKey;
+    private HistoryDeletionType resourceType;
+    private long batchOperationKey;
+    private int partitionId;
+
+    public Builder resourceKey(final long resourceKey) {
+      this.resourceKey = resourceKey;
+      return this;
+    }
+
+    public Builder resourceType(final HistoryDeletionType resourceType) {
+      this.resourceType = resourceType;
+      return this;
+    }
+
+    public Builder batchOperationKey(final long batchOperationKey) {
+      this.batchOperationKey = batchOperationKey;
+      return this;
+    }
+
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    @Override
+    public HistoryDeletionDbModel build() {
+      return new HistoryDeletionDbModel(resourceKey, resourceType, batchOperationKey, partitionId);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionDbModel.java
@@ -8,11 +8,10 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
-import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 
 public record HistoryDeletionDbModel(
     Long resourceKey,
-    HistoryDeletionType resourceType,
+    HistoryDeletionTypeDbModel resourceType,
     Long batchOperationKey,
     Integer partitionId) {
 
@@ -25,7 +24,7 @@ public record HistoryDeletionDbModel(
   public static class Builder implements ObjectBuilder<HistoryDeletionDbModel> {
 
     private long resourceKey;
-    private HistoryDeletionType resourceType;
+    private HistoryDeletionTypeDbModel resourceType;
     private long batchOperationKey;
     private int partitionId;
 
@@ -34,7 +33,7 @@ public record HistoryDeletionDbModel(
       return this;
     }
 
-    public Builder resourceType(final HistoryDeletionType resourceType) {
+    public Builder resourceType(final HistoryDeletionTypeDbModel resourceType) {
       this.resourceType = resourceType;
       return this;
     }
@@ -53,5 +52,12 @@ public record HistoryDeletionDbModel(
     public HistoryDeletionDbModel build() {
       return new HistoryDeletionDbModel(resourceKey, resourceType, batchOperationKey, partitionId);
     }
+  }
+
+  public enum HistoryDeletionTypeDbModel {
+    PROCESS_INSTANCE,
+    PROCESS_DEFINITION,
+    DECISION_INSTANCE,
+    DECISION_DEFINITION
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -18,6 +18,7 @@ public enum ContextType {
   FLOW_NODE(false),
   FORM(false),
   GROUP(false),
+  HISTORY_DELETION(false),
   INCIDENT(false),
   JOB(false),
   MAPPING_RULE(false),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.Map;
+
+public class HistoryDeletionWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public HistoryDeletionWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final HistoryDeletionDbModel dbModel) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.HISTORY_DELETION,
+            WriteStatementType.INSERT,
+            dbModel.getId(),
+            "io.camunda.db.rdbms.sql.HistoryDeletionMapper.insert",
+            dbModel));
+  }
+
+  public void delete(final long resourceKey, final long batchOperationKey) {
+    // Create a composite key for the QueueItem identifier
+    final String id =
+        String.format(HistoryDeletionDbModel.ID_PATTERN, batchOperationKey, resourceKey);
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.HISTORY_DELETION,
+            WriteStatementType.DELETE,
+            id,
+            "io.camunda.db.rdbms.sql.HistoryDeletionMapper.delete",
+            Map.of("resourceKey", resourceKey, "batchOperationKey", batchOperationKey)));
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
@@ -15,7 +15,7 @@
   <resultMap id="historyDeletionResultMap" type="io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel">
     <constructor>
       <idArg column="RESOURCE_KEY" javaType="java.lang.Long"/>
-      <arg column="RESOURCE_TYPE" javaType="io.camunda.zeebe.protocol.record.value.HistoryDeletionType"/>
+      <arg column="RESOURCE_TYPE" javaType="io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel$HistoryDeletionTypeDbModel"/>
       <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
       <arg column="PARTITION_ID" javaType="java.lang.Integer"/>
     </constructor>
@@ -52,10 +52,13 @@
 
   <select id="getHistoryDeletionBatch" databaseId="oracle" resultMap="historyDeletionResultMap">
     SELECT *
-    FROM ${prefix}HISTORY_DELETION
-    WHERE PARTITION_ID = #{partitionId}
-      AND ROWNUM &lt;= #{limit}
-    ORDER BY BATCH_OPERATION_KEY, RESOURCE_KEY
+    FROM (
+           SELECT *
+           FROM ${prefix}HISTORY_DELETION
+           WHERE PARTITION_ID = #{partitionId}
+           ORDER BY BATCH_OPERATION_KEY, RESOURCE_KEY
+         )
+    WHERE ROWNUM &lt;= #{limit}
   </select>
 
   <delete id="delete">

--- a/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="io.camunda.db.rdbms.sql.HistoryDeletionMapper">
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel">
+    INSERT INTO ${prefix}HISTORY_DELETION (
+      RESOURCE_KEY,
+      BATCH_OPERATION_KEY,
+      RESOURCE_TYPE,
+      PARTITION_ID
+    ) VALUES (
+      #{resourceKey},
+      #{batchOperationKey},
+      #{resourceType},
+      #{partitionId}
+    )
+  </insert>
+
+  <delete id="delete">
+    DELETE FROM ${prefix}HISTORY_DELETION
+    WHERE RESOURCE_KEY = #{resourceKey}
+      AND BATCH_OPERATION_KEY = #{batchOperationKey}
+  </delete>
+
+</mapper>

--- a/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
@@ -12,6 +12,15 @@
 
 <mapper namespace="io.camunda.db.rdbms.sql.HistoryDeletionMapper">
 
+  <resultMap id="historyDeletionResultMap" type="io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel">
+    <constructor>
+      <idArg column="RESOURCE_KEY" javaType="java.lang.Long"/>
+      <arg column="RESOURCE_TYPE" javaType="io.camunda.zeebe.protocol.record.value.HistoryDeletionType"/>
+      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
+      <arg column="PARTITION_ID" javaType="java.lang.Integer"/>
+    </constructor>
+  </resultMap>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel">
     INSERT INTO ${prefix}HISTORY_DELETION (
       RESOURCE_KEY,
@@ -25,6 +34,29 @@
       #{partitionId}
     )
   </insert>
+
+  <select id="getHistoryDeletionBatch" resultMap="historyDeletionResultMap">
+    SELECT *
+    FROM ${prefix}HISTORY_DELETION
+    WHERE PARTITION_ID = #{partitionId}
+    ORDER BY BATCH_OPERATION_KEY, RESOURCE_KEY
+    LIMIT #{limit}
+  </select>
+
+  <select id="getHistoryDeletionBatch" databaseId="mssql" resultMap="historyDeletionResultMap">
+    SELECT TOP (#{limit}) *
+    FROM ${prefix}HISTORY_DELETION
+    WHERE PARTITION_ID = #{partitionId}
+    ORDER BY BATCH_OPERATION_KEY, RESOURCE_KEY
+  </select>
+
+  <select id="getHistoryDeletionBatch" databaseId="oracle" resultMap="historyDeletionResultMap">
+    SELECT *
+    FROM ${prefix}HISTORY_DELETION
+    WHERE PARTITION_ID = #{partitionId}
+      AND ROWNUM &lt;= #{limit}
+    ORDER BY BATCH_OPERATION_KEY, RESOURCE_KEY
+  </select>
 
   <delete id="delete">
     DELETE FROM ${prefix}HISTORY_DELETION

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReaderTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
+import org.junit.jupiter.api.Test;
+
+class HistoryDeletionDbReaderTest {
+  private final HistoryDeletionMapper historyDeletionMapper = mock(HistoryDeletionMapper.class);
+  private final HistoryDeletionDbReader historyDeletionDbReader =
+      new HistoryDeletionDbReader(historyDeletionMapper);
+
+  @Test
+  void shouldReturnEmptyList() {
+    final var nextBatch = historyDeletionDbReader.getNextBatch(0, 1);
+    assertThat(nextBatch).isEmpty();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HistoryDeletionWriterTest {
+
+  private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
+  private final HistoryDeletionWriter writer = new HistoryDeletionWriter(executionQueue);
+
+  @Test
+  void shouldInsertHistoryDeletion() {
+    final var model = mock(HistoryDeletionDbModel.class);
+    when(model.getId()).thenReturn("2251799813685385");
+
+    writer.create(model);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.HISTORY_DELETION,
+                    WriteStatementType.INSERT,
+                    "2251799813685385",
+                    "io.camunda.db.rdbms.sql.HistoryDeletionMapper.insert",
+                    model)));
+  }
+
+  @Test
+  void shouldDeleteHistoryDeletion() {
+    final var resourceKey = 2251799813685385L;
+    final var batchOperationKey = 2251799813685312L;
+
+    writer.delete(resourceKey, batchOperationKey);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.HISTORY_DELETION,
+                    WriteStatementType.DELETE,
+                    "2251799813685312_2251799813685385",
+                    "io.camunda.db.rdbms.sql.HistoryDeletionMapper.delete",
+                    Map.of("resourceKey", resourceKey, "batchOperationKey", batchOperationKey))));
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
@@ -10,9 +10,9 @@ package io.camunda.db.rdbms.write.service;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
@@ -27,8 +27,13 @@ class HistoryDeletionWriterTest {
 
   @Test
   void shouldInsertHistoryDeletion() {
-    final var model = mock(HistoryDeletionDbModel.class);
-    when(model.getId()).thenReturn("2251799813685385");
+    final var model =
+        new HistoryDeletionDbModel.Builder()
+            .resourceKey(2251799813685385L)
+            .resourceType(HistoryDeletionTypeDbModel.PROCESS_INSTANCE)
+            .batchOperationKey(2251799813685312L)
+            .partitionId(1)
+            .build();
 
     writer.create(model);
 
@@ -38,7 +43,7 @@ class HistoryDeletionWriterTest {
                 new QueueItem(
                     ContextType.HISTORY_DELETION,
                     WriteStatementType.INSERT,
-                    "2251799813685385",
+                    model.getId(),
                     "io.camunda.db.rdbms.sql.HistoryDeletionMapper.insert",
                     model)));
   }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -24,6 +24,7 @@ import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
 import io.camunda.db.rdbms.sql.GroupMapper;
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MappingRuleMapper;
@@ -304,6 +305,12 @@ public class MyBatisConfiguration {
   MapperFactoryBean<TableMetricsMapper> tableMetricsMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, TableMetricsMapper.class);
+  }
+
+  @Bean
+  MapperFactoryBean<HistoryDeletionMapper> historyDeletionMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, HistoryDeletionMapper.class);
   }
 
   private <T> MapperFactoryBean<T> createMapperFactoryBean(

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -25,6 +25,7 @@ import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.read.service.FormDbReader;
 import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
 import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
@@ -59,6 +60,7 @@ import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
 import io.camunda.db.rdbms.sql.GroupMapper;
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MappingRuleMapper;
@@ -289,6 +291,12 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public HistoryDeletionDbReader historyDeletionDbReader(
+      HistoryDeletionMapper historyDeletionMapper) {
+    return new HistoryDeletionDbReader(historyDeletionMapper);
+  }
+
+  @Bean
   public RdbmsWriterMetrics rdbmsExporterMetrics(final MeterRegistry meterRegistry) {
     return new RdbmsWriterMetrics(meterRegistry);
   }
@@ -390,7 +398,8 @@ public class RdbmsConfiguration {
       final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader,
       final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsReader,
       final ProcessDefinitionInstanceVersionStatisticsDbReader
-          processDefinitionInstanceVersionStatisticsReader) {
+          processDefinitionInstanceVersionStatisticsReader,
+      final HistoryDeletionDbReader historyDeletionDbReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         auditLogReader,
@@ -424,7 +433,8 @@ public class RdbmsConfiguration {
         processDefinitionMessageSubscriptionStatisticsReader,
         correlatedMessageSubscriptionReader,
         processDefinitionInstanceStatisticsReader,
-        processDefinitionInstanceVersionStatisticsReader);
+        processDefinitionInstanceVersionStatisticsReader,
+        historyDeletionDbReader);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.historydeletion;
+
+import static io.camunda.zeebe.protocol.record.value.HistoryDeletionType.PROCESS_INSTANCE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class HistoryDeletionIT {
+
+  private static final int PARTITION_ID = 0;
+  private static final Long RESOURCE_KEY = 2251799813685312L;
+  private static final Long BATCH_OPERATION_KEY = 2251799813685385L;
+
+  private CamundaRdbmsTestApplication testApplication;
+  private RdbmsWriter rdbmsWriter;
+  private HistoryDeletionDbReader historyDeletionReader;
+  private HistoryDeletionWriter historyDeletionWriter;
+
+  @BeforeEach
+  void setUp() {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    historyDeletionReader = rdbmsService.getHistoryDeletionDbReader();
+    historyDeletionWriter = rdbmsWriter.getHistoryDeletionWriter();
+  }
+
+  @AfterEach
+  void tearDown() {
+    historyDeletionWriter.delete(RESOURCE_KEY, BATCH_OPERATION_KEY);
+    rdbmsWriter.flush();
+  }
+
+  private void writeHistoryDeletion(final HistoryDeletionWriter historyDeletionWriter) {
+    historyDeletionWriter.create(
+        new HistoryDeletionDbModel.Builder()
+            .resourceKey(RESOURCE_KEY)
+            .resourceType(PROCESS_INSTANCE)
+            .batchOperationKey(BATCH_OPERATION_KEY)
+            .partitionId(PARTITION_ID)
+            .build());
+  }
+
+  @TestTemplate
+  public void shouldInsertHistoryDeletion() {
+    // given
+    writeHistoryDeletion(historyDeletionWriter);
+    rdbmsWriter.flush();
+
+    // when
+    final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 1);
+
+    // then
+    assertThat(actual)
+        .containsExactly(
+            new HistoryDeletionDbModel(
+                RESOURCE_KEY, PROCESS_INSTANCE, BATCH_OPERATION_KEY, PARTITION_ID));
+  }
+
+  @TestTemplate
+  public void shouldBeEmpty() {
+    // when
+    final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 1);
+
+    // then
+    assertThat(actual).isEmpty();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -24,6 +24,7 @@ import io.camunda.exporter.rdbms.handlers.FlowNodeExportHandler;
 import io.camunda.exporter.rdbms.handlers.FlowNodeInstanceIncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.FormExportHandler;
 import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
+import io.camunda.exporter.rdbms.handlers.HistoryDeletionDeletedHandler;
 import io.camunda.exporter.rdbms.handlers.IncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.JobExportHandler;
 import io.camunda.exporter.rdbms.handlers.MappingRuleExportHandler;
@@ -235,6 +236,9 @@ public class RdbmsExporterWrapper implements Exporter {
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
         new CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
             rdbmsWriter.getCorrelatedMessageSubscriptionWriter()));
+    builder.withHandler(
+        ValueType.HISTORY_DELETION,
+        new HistoryDeletionDeletedHandler(rdbmsWriter.getHistoryDeletionWriter()));
 
     registerAuditLogHandlers(rdbmsWriter, builder);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/HistoryDeletionDeletedHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/HistoryDeletionDeletedHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public record HistoryDeletionDeletedHandler(HistoryDeletionWriter historyDeletionWriter)
+    implements RdbmsExportHandler<HistoryDeletionRecordValue> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HistoryDeletionDeletedHandler.class);
+
+  @Override
+  public boolean canExport(final Record<HistoryDeletionRecordValue> record) {
+    return HistoryDeletionIntent.DELETED.equals(record.getIntent())
+        && ValueType.HISTORY_DELETION.equals(record.getValueType());
+  }
+
+  @Override
+  public void export(final Record<HistoryDeletionRecordValue> record) {
+    final HistoryDeletionRecordValue value = record.getValue();
+    LOGGER.trace("Export History Deletion Record: {}", value);
+
+    var historyDeletionDbModel =
+        new HistoryDeletionDbModel.Builder()
+            .resourceKey(value.getResourceKey())
+            .batchOperationKey(record.getBatchOperationReference())
+            .resourceType(value.getResourceType())
+            .partitionId(record.getPartitionId())
+            .build();
+    historyDeletionWriter.create(historyDeletionDbModel);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/historydeletion/HistoryDeletionDeletedHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/historydeletion/HistoryDeletionDeletedHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.historydeletion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
+import io.camunda.exporter.rdbms.handlers.HistoryDeletionDeletedHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.ImmutableHistoryDeletionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryDeletionDeletedHandlerTest {
+
+  private static final Integer PARTITION_ID = 1;
+  private static final Long BATCH_OPERATION_KEY = 123L;
+  private static final Long RESOURCE_KEY = 456L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  private HistoryDeletionWriter writer;
+  private HistoryDeletionDeletedHandler handler;
+
+  @Captor private ArgumentCaptor<HistoryDeletionDbModel> historyDeletionCaptor;
+
+  private final Record authorizedRecord =
+      factory.generateRecord(
+          ValueType.HISTORY_DELETION,
+          r ->
+              r.withBatchOperationReference(BATCH_OPERATION_KEY)
+                  .withValue(
+                      ImmutableHistoryDeletionRecordValue.builder()
+                          .withResourceKey(RESOURCE_KEY)
+                          .withResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+                          .build())
+                  .withIntent(HistoryDeletionIntent.DELETED)
+                  .withPartitionId(PARTITION_ID));
+
+  private final Record unauthorizedRecord =
+      factory.generateRecordWithIntent(ValueType.HISTORY_DELETION, HistoryDeletionIntent.DELETE);
+
+  @BeforeEach
+  void setUp() {
+    writer = mock(HistoryDeletionWriter.class);
+    handler = new HistoryDeletionDeletedHandler(writer);
+  }
+
+  @Test
+  void shouldHandleHistoryDeletionDeleted() {
+    assertThat(handler.canExport(authorizedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleHistoryDeletionDeleted() {
+    assertThat(handler.canExport(unauthorizedRecord)).isFalse();
+  }
+
+  @Test
+  void shouldExportHistoryDeletion() {
+    handler.export(authorizedRecord);
+    verify(writer).create(historyDeletionCaptor.capture());
+
+    final HistoryDeletionDbModel capturedModel = historyDeletionCaptor.getValue();
+    assertThat(capturedModel.resourceKey()).isEqualTo(RESOURCE_KEY);
+    assertThat(capturedModel.resourceType()).isEqualTo(HistoryDeletionType.PROCESS_INSTANCE);
+    assertThat(capturedModel.batchOperationKey()).isEqualTo(BATCH_OPERATION_KEY);
+    assertThat(capturedModel.partitionId()).isEqualTo(PARTITION_ID);
+  }
+}


### PR DESCRIPTION
## Description

The `HistoryDeletionIntent.DELETED` event is handled and the process instance to delete is stored in RDBMS.
Also created the get and delete methods

We may need to update these once they’re actually in use. 
e.g. on search add filtering/sorting mechanism, if necessary
I tried to follow the same approach as the ES/OS retrieval and removal.

## Related issues

closes #41529