### PR TITLE
feat: Update exporter to support migration from Job-based User Task

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -126,6 +126,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
 
     assignUser(userTaskProperties, userTaskRecord);
 
+    job.setIsJobToUserTaskMigration(true);
     // Cancel previous job worker job
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -629,6 +629,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -736,6 +737,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -848,6 +850,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -942,6 +945,7 @@ public class MigrateUserTaskTest {
         .addMappingInstruction("A", "B")
         .migrate();
 
+    // then
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -958,6 +962,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -1067,6 +1072,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -187,6 +187,21 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     }
     if (entity.getState() != null) {
       updateFields.put(TaskTemplate.STATE, entity.getState());
+      // Add update fields for migrated user tasks
+      if (entity.getState() == TaskState.CREATED) {
+        if (entity.getImplementation() != null) {
+          updateFields.put(TaskTemplate.IMPLEMENTATION, entity.getImplementation());
+        }
+        if (entity.getPriority() != null) {
+          updateFields.put(TaskTemplate.PRIORITY, entity.getPriority());
+        }
+        if (entity.getFormId() != null) {
+          updateFields.put(TaskTemplate.FORM_ID, entity.getFormId());
+        }
+        if (entity.getFormKey() != null) {
+          updateFields.put(TaskTemplate.FORM_KEY, entity.getFormKey());
+        }
+      }
     }
     if (entity.getFlowNodeBpmnId() != null) {
       updateFields.put(TaskTemplate.FLOW_NODE_BPMN_ID, entity.getFlowNodeBpmnId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -86,7 +86,8 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
   @Override
   public boolean handlesRecord(final Record<JobRecordValue> record) {
     return SUPPORTED_INTENTS.contains(record.getIntent())
-        && record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE);
+        && record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE)
+        && !record.getValue().isJobToUserTaskMigration();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -1073,6 +1073,90 @@ public class UserTaskHandlerTest {
             indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
+  @Test
+  void flushedCreateEntityShouldContainUserTaskMigrationUpdates() {
+    // given
+    final long processInstanceKey = 123;
+    final long flowNodeInstanceKey = 456;
+    final long recordKey = 110;
+    final String formId = "my-form-id";
+    final String formKey = "my-form-key";
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 100);
+    final var dateTime = OffsetDateTime.now();
+    final UserTaskRecordValue taskRecordValue =
+        ImmutableUserTaskRecordValue.builder()
+            .withChangedAttributes(
+                List.of(
+                    "priority",
+                    "dueDate",
+                    "followUpDate",
+                    "candidateUsersList",
+                    "candidateGroupsList"))
+            .withProcessInstanceKey(processInstanceKey)
+            .withPriority(99)
+            .withDueDate(dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+            .withFollowUpDate(dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+            .withCandidateUsersList(Arrays.asList("user1", "user2"))
+            .withCandidateGroupsList(Arrays.asList("group1", "group2"))
+            .withElementInstanceKey(flowNodeInstanceKey)
+            .build();
+
+    final Record<UserTaskRecordValue> taskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATED)
+                    .withValue(taskRecordValue)
+                    .withKey(recordKey)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity =
+        underTest
+            .createNewEntity(String.valueOf(recordKey))
+            .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
+            .setFormId(formId)
+            .setFormKey(formKey);
+    underTest.updateEntity(taskRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
+    expectedUpdates.put(TaskTemplate.FOLLOW_UP_DATE, taskEntity.getFollowUpDate());
+    expectedUpdates.put(TaskTemplate.DUE_DATE, taskEntity.getDueDate());
+    expectedUpdates.put(TaskTemplate.CANDIDATE_USERS, taskEntity.getCandidateUsers());
+    expectedUpdates.put(TaskTemplate.CANDIDATE_GROUPS, taskEntity.getCandidateGroups());
+    expectedUpdates.put(
+        TaskTemplate.CHANGED_ATTRIBUTES,
+        List.of(
+            "priority", "dueDate", "followUpDate", "candidateUsersList", "candidateGroupsList"));
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(TaskTemplate.IMPLEMENTATION, taskEntity.getImplementation());
+    expectedUpdates.put(TaskTemplate.FORM_ID, taskEntity.getFormId());
+    expectedUpdates.put(TaskTemplate.FORM_KEY, taskEntity.getFormKey());
+
+    // then
+    assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
+    assertThat(taskEntity.getDueDate()).isEqualTo(taskRecordValue.getDueDate());
+    assertThat(taskEntity.getFollowUpDate()).isEqualTo(taskRecordValue.getFollowUpDate());
+    assertThat(taskEntity.getFormId()).isEqualTo(formId);
+    assertThat(taskEntity.getFormKey()).isEqualTo(formKey);
+    assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
+    assertThat(Arrays.stream(taskEntity.getCandidateGroups()).toList())
+        .isEqualTo(taskRecordValue.getCandidateGroupsList());
+    assertThat(Arrays.stream(taskEntity.getCandidateUsers()).toList())
+        .isEqualTo(taskRecordValue.getCandidateUsersList());
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            String.valueOf(recordKey),
+            taskEntity,
+            expectedUpdates,
+            String.valueOf(processInstanceKey));
+  }
+
   @ParameterizedTest
   @EnumSource(value = UserTaskIntent.class)
   void flushedEntityShouldContainPartialStates(final UserTaskIntent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -86,6 +86,7 @@ public class UserTaskJobBasedHandlerTest {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(false)
             .build();
 
     SUPPORTED_INTENTS.forEach(
@@ -95,6 +96,26 @@ public class UserTaskJobBasedHandlerTest {
                   ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
           // when - then
           assertThat(underTest.handlesRecord(jobRecord)).isTrue();
+        });
+  }
+
+  @Test
+  void shouldNotHandleUserTaskMigrationRecord() {
+    // given
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    SUPPORTED_INTENTS.forEach(
+        intent -> {
+          final Record<JobRecordValue> jobRecord =
+              factory.generateRecord(
+                  ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
+          // when - then
+          assertThat(underTest.handlesRecord(jobRecord)).isFalse();
         });
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -104,6 +104,9 @@
                 "tags": {
                   "type": "keyword"
                 },
+                "jobToUserTaskMigration": {
+                  "type": "boolean"
+                },
                 "result": {
                   "properties": {
                     "type": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -85,6 +85,9 @@
             "tags": {
               "type": "keyword"
             },
+            "jobToUserTaskMigration": {
+              "type": "boolean"
+            },
             "result": {
               "properties": {
                 "type": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -104,6 +104,9 @@
                 "tags": {
                   "type": "keyword"
                 },
+                "jobToUserTaskMigration": {
+                  "type": "boolean"
+                },
                 "result": {
                   "properties": {
                     "type": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -85,6 +85,9 @@
             "tags": {
               "type": "keyword"
             },
+            "jobToUserTaskMigration": {
+              "type": "boolean"
+            },
             "result": {
               "properties": {
                 "type": {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -72,6 +73,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue CHANGED_ATTRIBUTES_KEY = new StringValue("changedAttributes");
   private static final StringValue RESULT_KEY = new StringValue("result");
   private static final StringValue TAGS = new StringValue("tags");
+  private static final StringValue IS_JOB_TO_USERTASK_MIGRATION_KEY =
+      new StringValue("isUserTaskMigration");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
 
@@ -115,9 +118,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ObjectProperty<JobResult> resultProp =
       new ObjectProperty<>(RESULT_KEY, new JobResult());
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>(TAGS, StringValue::new);
+  private final BooleanProperty isJobToUserTaskMigrationProp =
+      new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
 
   public JobRecord() {
-    super(23);
+    super(24);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -140,7 +145,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tenantIdProp)
         .declareProperty(changedAttributesProp)
         .declareProperty(resultProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(isJobToUserTaskMigrationProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -166,6 +172,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     tenantIdProp.setValue(record.getTenantId());
     setChangedAttributes(record.getChangedAttributes());
     resultProp.getValue().wrap(record.getResult());
+    isJobToUserTaskMigrationProp.setValue(record.isJobToUserTaskMigration());
 
     setTags(record.getTags());
   }
@@ -333,6 +340,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  @Override
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
+  }
+
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -426,6 +438,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {
     jobListenerEventTypeProp.setValue(jobListenerEventType);
+    return this;
+  }
+
+  public JobRecord setIsJobToUserTaskMigration(final boolean isJobToUserTaskMigration) {
+    isJobToUserTaskMigrationProp.setValue(isJobToUserTaskMigration);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -812,7 +812,8 @@ final class JsonSerializableToJsonTest {
                   .setElementInstanceKey(activityInstanceKey)
                   .setChangedAttributes(changedAttributes)
                   .setResult(result)
-                  .setTags(Set.of("tag1", "tag2"));
+                  .setTags(Set.of("tag1", "tag2"))
+                  .setIsJobToUserTaskMigration(true);
 
               return record;
             },
@@ -851,6 +852,7 @@ final class JsonSerializableToJsonTest {
                       "tenantId": "<default>",
                       "changedAttributes": ["bar", "foo"],
                       "tags": ["tag1", "tag2"],
+                      "jobToUserTaskMigration": true,
                       "result": {
                         "type": "USER_TASK",
                         "denied": true,
@@ -997,7 +999,8 @@ final class JsonSerializableToJsonTest {
                       .setElementInstanceKey(activityInstanceKey)
                       .setChangedAttributes(changedAttributes)
                       .setResult(result)
-                      .setTags(Set.of("tag1", "tag2"));
+                      .setTags(Set.of("tag1", "tag2"))
+                      .setIsJobToUserTaskMigration(true);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -1029,6 +1032,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": 14,
                   "tenantId": "<default>",
                   "tags": ["tag1", "tag2"],
+                  "jobToUserTaskMigration": true,
                   "changedAttributes": ["bar", "foo"],
                   "result": {
                     "type": "AD_HOC_SUB_PROCESS",
@@ -1102,6 +1106,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": -1,
                   "tenantId": "<default>",
                   "tags": [],
+                  "jobToUserTaskMigration": false,
                   "changedAttributes": [],
                   "result": {
                     "type": "USER_TASK",
@@ -1160,6 +1165,7 @@ final class JsonSerializableToJsonTest {
                   "customHeaders": {},
                   "tenantId": "<default>",
                   "tags": [],
+                  "jobToUserTaskMigration": false,
                   "changedAttributes": [],
                   "result": {
                     "type": "USER_TASK",

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -72,6 +73,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue CHANGED_ATTRIBUTES_KEY = new StringValue("changedAttributes");
   private static final StringValue RESULT_KEY = new StringValue("result");
   private static final StringValue TAGS = new StringValue("tags");
+  private static final StringValue IS_JOB_TO_USERTASK_MIGRATION_KEY =
+      new StringValue("isUserTaskMigration");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
 
@@ -115,9 +118,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ObjectProperty<JobResult> resultProp =
       new ObjectProperty<>(RESULT_KEY, new JobResult());
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>(TAGS, StringValue::new);
+  private final BooleanProperty isJobToUserTaskMigrationProp =
+      new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
 
   public JobRecord() {
-    super(23);
+    super(24);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -140,7 +145,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tenantIdProp)
         .declareProperty(changedAttributesProp)
         .declareProperty(resultProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(isJobToUserTaskMigrationProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -166,6 +172,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     tenantIdProp.setValue(record.getTenantId());
     setChangedAttributes(record.getChangedAttributes());
     resultProp.getValue().wrap(record.getResult());
+    isJobToUserTaskMigrationProp.setValue(record.isJobToUserTaskMigration());
 
     setTags(record.getTags());
   }
@@ -333,6 +340,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  @Override
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
+  }
+
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -426,6 +438,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {
     jobListenerEventTypeProp.setValue(jobListenerEventType);
+    return this;
+  }
+
+  public JobRecord setIsJobToUserTaskMigration(final boolean isJobToUserTaskMigration) {
+    isJobToUserTaskMigrationProp.setValue(isJobToUserTaskMigration);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -136,6 +136,11 @@ public interface JobRecordValue
    */
   Set<String> getTags();
 
+  /**
+   * @return true if the job is part of a user task migration
+   */
+  boolean isJobToUserTaskMigration();
+
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableJobResultValue.Builder.class)
   interface JobResultValue {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Implement migration handler for user task PIM
- introduce `isUserTaskMigration` flag for JobRecord to identify usertask related job cancellations in the exporter
- modified `UserTaskHandler` to overwrite old user task entries
- modified `UserTaskJobBasedHandler` to ignore updates from the migration job cancellation to prevent overwriting new Camunda user task entities (that have the same key) with the job cancellation data
- updated the JobRecord.golden file since I do set a default value for the new field

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/29269
