### PR TITLE
fix: use threadsafe map for lastScheduledPositions

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
@@ -17,6 +17,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
@@ -34,7 +35,8 @@ public class ImportPositionHolder {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportPositionHolder.class);
 
   // this is the in-memory only storage
-  private final Map<String, ImportPositionEntity> lastScheduledPositions = new HashMap<>();
+  private final Map<String, ImportPositionEntity> lastScheduledPositions =
+      new ConcurrentHashMap<>();
 
   private final Map<String, ImportPositionEntity> pendingImportPositionUpdates = new HashMap<>();
   private final Map<String, ImportPositionEntity> pendingPostImportPositionUpdates =


### PR DESCRIPTION
As `HashMap` is not threadsafe and `lastScheduledPositions` was being read and written to from more than one thread.

This could produce weird behaviour (previously put values disappearing etc).  Potentially this could lead to issues with the importer not running for a specific record type + partition (or not doing so consistently).

Refs: #42554
