### PR TITLE
fix: add openapi yaml file to the camunda distribution

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -850,6 +850,32 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-openapi-yaml</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <outputDirectory>${project.build.directory}/camunda-zeebe/config/openapi/v2</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto/v2</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>**/*.yaml</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/OpenApiYamlLoader.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/OpenApiYamlLoader.java
@@ -12,6 +12,7 @@ import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.slf4j.Logger;
@@ -21,15 +22,23 @@ import org.springframework.core.io.ClassPathResource;
 /** Utility class for loading OpenAPI specifications from YAML files. */
 public final class OpenApiYamlLoader {
 
+  /** Default location of the OpenAPI spec in the distribution. */
+  public static final String DEFAULT_SPEC_PATH = "config/openapi/v2/rest-api.yaml";
+
+  /** Default classpath location used during local development/testing. */
+  static final String DEFAULT_CLASSPATH_SPEC_PATH = "v2/rest-api.yaml";
+
   private static final Logger LOG = LoggerFactory.getLogger(OpenApiYamlLoader.class);
 
   // Prevent instantiation
   private OpenApiYamlLoader() {}
 
   /**
-   * Loads an OpenAPI specification from a YAML file located in the classpath.
+   * Loads an OpenAPI specification from a YAML file.
    *
-   * @param yamlPath the path to the YAML file relative to the classpath
+   * <p>The file can be either on the filesystem (absolute or relative path), or on the classpath.
+   *
+   * @param yamlPath the path to the YAML file, either as a filesystem path or classpath resource
    * @return the parsed OpenAPI specification
    * @throws OpenApiLoadingException if the YAML file cannot be loaded or parsed
    */
@@ -62,36 +71,28 @@ public final class OpenApiYamlLoader {
    * @throws OpenApiLoadingException if the YAML file cannot be loaded or parsed
    */
   public static void customizeOpenApiFromYaml(final OpenAPI targetOpenApi, final String yamlPath) {
-    try {
-      final OpenAPI yamlOpenApi = loadOpenApiFromYaml(yamlPath);
+    final OpenAPI yamlOpenApi = loadOpenApiFromYaml(yamlPath);
 
-      if (yamlOpenApi.getTags() != null) {
-        targetOpenApi.setTags(yamlOpenApi.getTags());
-      }
-
-      if (yamlOpenApi.getPaths() != null) {
-        final var v2Paths = new io.swagger.v3.oas.models.Paths();
-        yamlOpenApi
-            .getPaths()
-            .forEach(
-                (pathKey, pathItem) -> {
-                  v2Paths.addPathItem("/v2" + pathKey, pathItem);
-                });
-        targetOpenApi.setPaths(v2Paths);
-      }
-
-      if (yamlOpenApi.getComponents() != null) {
-        targetOpenApi.setComponents(yamlOpenApi.getComponents());
-      }
-
-      LOG.debug("Successfully customized OpenAPI specification from: {}", yamlPath);
-    } catch (final OpenApiLoadingException e) {
-      LOG.warn(
-          "Could not load OpenAPI from {}, using controller-based organization: {}",
-          yamlPath,
-          e.getMessage());
-      throw e;
+    if (yamlOpenApi.getTags() != null) {
+      targetOpenApi.setTags(yamlOpenApi.getTags());
     }
+
+    if (yamlOpenApi.getPaths() != null) {
+      final var v2Paths = new io.swagger.v3.oas.models.Paths();
+      yamlOpenApi
+          .getPaths()
+          .forEach(
+              (pathKey, pathItem) -> {
+                v2Paths.addPathItem("/v2" + pathKey, pathItem);
+              });
+      targetOpenApi.setPaths(v2Paths);
+    }
+
+    if (yamlOpenApi.getComponents() != null) {
+      targetOpenApi.setComponents(yamlOpenApi.getComponents());
+    }
+
+    LOG.debug("Successfully customized OpenAPI specification from: {}", yamlPath);
   }
 
   private static SwaggerParseResult loadYamlContent(final String yamlPath) throws IOException {
@@ -99,21 +100,31 @@ public final class OpenApiYamlLoader {
     options.setResolve(true);
     options.setResolveFully(true);
 
-    final Path absolutePath = Path.of(yamlPath);
-
-    if (absolutePath.isAbsolute() && Files.exists(absolutePath)) {
-      // Load from absolute file path - convert to file:// URL
-      LOG.debug("Loading OpenAPI from absolute path: {}", yamlPath);
-      final String fileUrl = absolutePath.toUri().toString();
+    final Path filePath = Path.of(yamlPath);
+    if (Files.exists(filePath) && Files.isRegularFile(filePath)) {
+      // Load from file path (absolute or relative) - convert to file:// URL
+      LOG.debug("Loading OpenAPI from file path: {}", yamlPath);
+      final String fileUrl = filePath.toUri().toString();
       return new OpenAPIV3Parser().readLocation(fileUrl, null, options);
     }
-    // Load from classpath - need to resolve references using classpath resources
+    // Load from classpath
     LOG.debug("Loading OpenAPI from classpath: {}", yamlPath);
-    final ClassPathResource resource = new ClassPathResource(yamlPath);
 
-    // Get the URL of the resource to use as base for reference resolution
-    final String resourceUrl = resource.getURL().toString();
-    return new OpenAPIV3Parser().readLocation(resourceUrl, null, options);
+    final URL resourceUrl;
+    try {
+      resourceUrl = new ClassPathResource(yamlPath).getURL();
+    } catch (final IOException e) {
+      if (DEFAULT_SPEC_PATH.equals(yamlPath)) {
+        LOG.debug(
+            "OpenAPI spec not found at '{}', falling back to classpath '{}'",
+            DEFAULT_SPEC_PATH,
+            DEFAULT_CLASSPATH_SPEC_PATH);
+        return loadYamlContent(DEFAULT_CLASSPATH_SPEC_PATH);
+      }
+      throw e;
+    }
+
+    return new OpenAPIV3Parser().readLocation(resourceUrl.toString(), null, options);
   }
 
   /** Custom exception for OpenAPI loading failures. */


### PR DESCRIPTION
## Description

Put v2/rest-api.yaml + siblings on the filesystem in the assembled distribution (or Docker image) and load via an absolute path.
