### PR TITLE
fix: ensure wnameless json base + flattener dependencies in sync

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -724,6 +724,12 @@
       <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.liquibase</groupId>
+          <artifactId>liquibase-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -319,7 +319,6 @@
     <dependency>
       <groupId>com.github.wnameless.json</groupId>
       <artifactId>json-flattener</artifactId>
-      <version>0.18.0</version>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2201,7 +2201,13 @@
       <dependency>
         <groupId>com.github.wnameless.json</groupId>
         <artifactId>json-base</artifactId>
-        <version>2.5.1</version>
+        <version>3.0.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.wnameless.json</groupId>
+        <artifactId>json-flattener</artifactId>
+        <version>0.18.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -67,6 +67,8 @@
     <version.identity>8.9.0-alpha2</version.identity>
     <version.instancio>5.5.1</version.instancio>
     <version.jackson>2.19.2</version.jackson>
+    <version.json-base>3.0.0</version.json-base>
+    <version.json-flattener>0.18.0</version.json-flattener>
     <version.junit>5.13.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.1</version.log4j>
@@ -2201,13 +2203,13 @@
       <dependency>
         <groupId>com.github.wnameless.json</groupId>
         <artifactId>json-base</artifactId>
-        <version>3.0.0</version>
+        <version>${version.json-base}</version>
       </dependency>
 
       <dependency>
         <groupId>com.github.wnameless.json</groupId>
         <artifactId>json-flattener</artifactId>
-        <version>0.18.0</version>
+        <version>${version.json-flattener}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
plus have them both have versions in dependencyManagement so we can maintain dependency convergence more easily.
