### PR TITLE
[Backport stable/8.7] fix: describe current processing state without race condition

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -86,6 +86,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   private final ReplayMetrics replayMetrics;
   private final List<RecordProcessor> recordProcessors;
   private final int partitionId;
+  private String currentStateDescription = "idle";
 
   public ReplayStateMachine(
       final List<RecordProcessor> recordProcessors,
@@ -184,6 +185,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
         onRecordsReplayed();
 
       } else {
+        currentStateDescription = "awaiting record to replay";
         currentState = State.AWAIT_RECORD;
       }
 
@@ -228,6 +230,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
       LOG.trace("Replaying event {}: {}", currentTypedEvent.getPosition(), currentTypedEvent);
+      currentStateDescription = "replaying event %s".formatted(typedEvent);
 
       final var processor =
           recordProcessors.stream()
@@ -324,10 +327,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   }
 
   String describeCurrentState() {
-    return switch (currentState) {
-      case AWAIT_RECORD -> "awaiting record to replay";
-      case REPLAY_EVENT -> "replaying event %s".formatted(typedEvent);
-    };
+    return currentStateDescription;
   }
 
   public void close() {


### PR DESCRIPTION
# Description
Backport of #42728 to `stable/8.7`.

relates to 