### PR TITLE
[Backport stable/8.8] fix: describe current processing state without race condition

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -163,6 +163,7 @@ public final class ProcessingStateMachine {
   private final ScheduledCommandCache scheduledCommandCache;
   private volatile ErrorHandlingPhase errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
   private final ControllableStreamClock clock;
+  private String currentStateDescription = "idle";
 
   public ProcessingStateMachine(
       final StreamProcessorContext context,
@@ -200,14 +201,7 @@ public final class ProcessingStateMachine {
   }
 
   String describeCurrentState() {
-    if (errorHandlingPhase != ErrorHandlingPhase.NO_ERROR) {
-      return String.format(
-          "in error handling phase %s for '%s %s'", errorHandlingPhase, currentRecord, metadata);
-    } else if (inProcessing) {
-      return String.format("processing '%s %s'", currentRecord, metadata);
-    } else {
-      return String.format("finished processing '%s %s'", currentRecord, metadata);
-    }
+    return currentStateDescription;
   }
 
   private void skipRecord() {
@@ -218,6 +212,7 @@ public final class ProcessingStateMachine {
   }
 
   void markProcessingCompleted() {
+    currentStateDescription = String.format("finished processing '%s %s'", currentRecord, metadata);
     inProcessing = false;
     if (onErrorRetries > 0) {
       onErrorRetries = 0;
@@ -273,6 +268,7 @@ public final class ProcessingStateMachine {
 
     metadata.reset();
     loggedEvent.readMetadata(metadata);
+    currentStateDescription = String.format("processing '%s %s'", currentRecord, metadata);
 
     try {
       // Here we need to get the current time, since we want to calculate
@@ -796,6 +792,12 @@ public final class ProcessingStateMachine {
   }
 
   private void updateErrorHandlingPhase(final ErrorHandlingPhase errorHandlingPhase) {
+    if (errorHandlingPhase != ErrorHandlingPhase.NO_ERROR) {
+      currentStateDescription =
+          String.format(
+              "in error handling phase %s for '%s %s'",
+              errorHandlingPhase, currentRecord, metadata);
+    }
     this.errorHandlingPhase = errorHandlingPhase;
     processingMetrics.errorHandlingPhase(errorHandlingPhase);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -86,6 +86,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   private final ReplayMetrics replayMetrics;
   private final List<RecordProcessor> recordProcessors;
   private final int partitionId;
+  private String currentStateDescription = "idle";
 
   public ReplayStateMachine(
       final List<RecordProcessor> recordProcessors,
@@ -184,6 +185,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
         onRecordsReplayed();
 
       } else {
+        currentStateDescription = "awaiting record to replay";
         currentState = State.AWAIT_RECORD;
       }
 
@@ -228,6 +230,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
       LOG.trace("Replaying event {}: {}", currentTypedEvent.getPosition(), currentTypedEvent);
+      currentStateDescription = "replaying event %s".formatted(typedEvent);
 
       final var processor =
           recordProcessors.stream()
@@ -324,10 +327,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   }
 
   String describeCurrentState() {
-    return switch (currentState) {
-      case AWAIT_RECORD -> "awaiting record to replay";
-      case REPLAY_EVENT -> "replaying event %s".formatted(typedEvent);
-    };
+    return currentStateDescription;
   }
 
   public void close() {


### PR DESCRIPTION
# Description
Backport of #42728 to `stable/8.8`.

relates to 