### PR TITLE
test: properly test REST security

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/SecurityTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/SecurityTest.java
@@ -9,18 +9,17 @@ package io.camunda.zeebe.it.engine.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.Topology;
-import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.configuration.Camunda;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.File;
 import java.net.URL;
 import java.security.cert.CertificateException;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openjdk.jmh.annotations.Timeout;
@@ -31,38 +30,31 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ZeebeIntegration
 public final class SecurityTest {
 
-  @TestZeebe(autoStart = false)
-  private final TestCluster testCluster =
-      TestCluster.builder()
-          .withEmbeddedGateway(false)
-          .withGatewaysCount(1)
-          .withBrokersCount(1)
-          .withPartitionsCount(1)
-          .withReplicationFactor(1)
-          .withGatewayConfig(this::configureGatewayForTls)
-          .build();
-
-  @BeforeEach
-  void setUp() {
-    // When starting a node with SSL enabled, Tomcat will initialize
-    // a static map of cipher aliases in OpenSSLCipherConfigurationParser.
-    // When starting multiple nodes simultaneously, it may fail because
-    // they modify the static map concurrently.
-    // To avoid the concurrent initialization of the static map, the nodes
-    // must be started one by one.
-    final var nodes = testCluster.nodes().values();
-    nodes.forEach(
-        node -> {
-          node.start();
-        });
-    testCluster.awaitCompleteTopology();
-  }
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withAuthorizationsDisabled()
+          .withUnifiedConfig(this::configureClusterForTls);
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void shouldEstablishSecureConnectionWithGrpc(final boolean useRest) {
+  void shouldEstablishSecureConnection(final boolean useRest) {
     // given
     try (final var client = newSecureClient(useRest).build()) {
+
+      // when
+      final var result = client.newTopologyRequest().send().join();
+
+      // then
+      assertThat(result.getBrokers().size()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void shouldAllowToOverrideAuthority() {
+    // given an overridden authority (only works for gRPC)
+    try (final var client = newSecureClient(false).overrideAuthority("localhost").build()) {
 
       // when
       final Topology topology = client.newTopologyRequest().send().join();
@@ -72,58 +64,34 @@ public final class SecurityTest {
     }
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldAllowToOverrideAuthority(final boolean useRest) {
-    // given
-    try (final var client = newSecureClient(useRest).overrideAuthority("localhost").build()) {
-
-      // when
-      final Topology topology = client.newTopologyRequest().useGrpc().send().join();
-
-      // then
-      assertThat(topology.getBrokers().size()).isEqualTo(1);
-    }
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldRejectDifferentAuthority(final boolean useRest) {
-    // given
-    try (final var client = newSecureClient(useRest).overrideAuthority("virtualhost").build()) {
+  @Test
+  void shouldRejectDifferentAuthority() {
+    // given an unknown authority (only works for gRPC)
+    try (final var client = newSecureClient(false).overrideAuthority("virtualhost").build()) {
       // when, then
-      Assertions.assertThatThrownBy(() -> client.newTopologyRequest().useGrpc().send().join())
+      Assertions.assertThatThrownBy(() -> client.newTopologyRequest().send().join())
           .hasRootCauseInstanceOf(CertificateException.class)
           .hasRootCauseMessage("No name matching virtualhost found");
     }
   }
 
   private CamundaClientBuilder newSecureClient(final boolean useRest) {
-    return configureClientForTls(CamundaClient.newClientBuilder())
-        .preferRestOverGrpc(useRest)
-        .grpcAddress(testCluster.anyGateway().grpcAddress())
-        .restAddress(testCluster.anyGateway().restAddress());
+    return configureClientForTls(broker.newClientBuilder()).preferRestOverGrpc(useRest);
   }
 
   private CamundaClientBuilder configureClientForTls(final CamundaClientBuilder clientBuilder) {
     return clientBuilder.caCertificatePath(getResource("security/test-chain.cert.pem").getPath());
   }
 
-  private void configureGatewayForTls(final TestGateway gateway) {
+  private void configureClusterForTls(final Camunda camunda) {
     final String certificatePath = getResource("security/test-chain.cert.pem").getFile();
     final String privateKeyPath = getResource("security/test-server.key.pem").getFile();
 
-    // configure the gRPC server for TLS/SSL
-    final var ssl = gateway.unifiedConfig().getApi().getGrpc().getSsl();
+    // configure the server for TLS/SSL
+    final var ssl = camunda.getApi().getGrpc().getSsl();
     ssl.setEnabled(true);
     ssl.setCertificate(new File(certificatePath));
     ssl.setCertificatePrivateKey(new File(privateKeyPath));
-
-    // configure the REST API server for TLS/SSL
-    gateway
-        .withProperty("server.ssl.enabled", true)
-        .withProperty("server.ssl.certificate", certificatePath)
-        .withProperty("server.ssl.certificate-private-key", privateKeyPath);
   }
 
   private URL getResource(final String name) {


### PR DESCRIPTION
## Description

Ensures we only test things on REST that are available instead of hiding that we always use gRPC.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

n/a
