### PR TITLE
test: migrate decisionInstances.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -8,9 +8,27 @@
 
 import {Page, Locator} from '@playwright/test';
 
+type OptionalFilter =
+  | 'Process Instance Key'
+  | 'Decision Instance Key(s)'
+  | 'Evaluation Date Range';
+
+interface SearchParams {
+  evaluated?: string;
+  failed?: string;
+  [key: string]: string | undefined;
+}
+
 class OperateDecisionsPage {
   private page: Page;
   readonly viewDecisionInstanceLink: (decisionInstanceId: string) => Locator;
+  readonly decisionNameFilter: Locator;
+  readonly decisionVersionFilter: Locator;
+  readonly decisionViewer: Locator;
+  readonly decisionInstanceKeysFilter: Locator;
+  readonly filterRegion: Locator;
+  readonly clearSelectedItemButton: Locator;
+  readonly moreFiltersButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -18,6 +36,22 @@ class OperateDecisionsPage {
       page.getByRole('link', {
         name: `View decision instance ${decisionInstanceId}`,
       });
+
+    this.decisionNameFilter = page.getByRole('combobox', {
+      name: 'Name',
+    });
+    this.decisionVersionFilter = page.getByRole('combobox', {
+      name: 'Version',
+    });
+    this.decisionInstanceKeysFilter = page.getByLabel(
+      /^decision instance key\(s\)$/i,
+    );
+    this.decisionViewer = page.getByTestId('decision-viewer');
+    this.filterRegion = page.getByRole('region', {name: /filter/i});
+    this.clearSelectedItemButton = page.getByRole('button', {
+      name: 'Clear selected item',
+    });
+    this.moreFiltersButton = page.getByRole('button', {name: 'More Filters'});
   }
 
   async clickViewDecisionInstanceLink(
@@ -26,8 +60,49 @@ class OperateDecisionsPage {
     await this.viewDecisionInstanceLink(decisionInstanceId).click();
   }
 
-  async gotoDecisionsPage(): Promise<void> {
-    await this.page.goto('/decisions');
+  async gotoDecisionsPage(options?: {
+    searchParams?: SearchParams;
+  }): Promise<void> {
+    if (!options?.searchParams) {
+      await this.page.goto('/decisions');
+      return;
+    }
+
+    const searchParams = new URLSearchParams();
+    Object.entries(options.searchParams).forEach(([key, value]) => {
+      if (value !== undefined) {
+        searchParams.append(key, value);
+      }
+    });
+
+    await this.page.goto(`/decisions?${searchParams.toString()}`);
+  }
+
+  async selectDecisionName(option: string): Promise<void> {
+    await this.decisionNameFilter.click();
+    await this.filterRegion
+      .getByRole('option', {name: option, exact: true})
+      .click();
+  }
+
+  async selectVersion(option: string): Promise<void> {
+    await this.decisionVersionFilter.click();
+    await this.filterRegion
+      .getByRole('option', {name: option, exact: true})
+      .click();
+  }
+
+  async clearComboBox(): Promise<void> {
+    await this.clearSelectedItemButton.click();
+  }
+
+  async displayOptionalFilter(filterName: OptionalFilter): Promise<void> {
+    await this.moreFiltersButton.click();
+    await this.page
+      .getByRole('menuitem', {
+        name: filterName,
+      })
+      .click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -63,6 +63,10 @@ class OperateProcessesPage {
   readonly resultsCount: Locator;
   readonly scheduledOperationsIcons: Locator;
   processInstanceLinkByKey: (processInstanceKey: string) => Locator;
+  getOperationAndResultsContainer: (
+    operation: string,
+    resultCount?: number,
+  ) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -192,6 +196,15 @@ class OperateProcessesPage {
       page.getByRole('link', {
         name: processInstanceKey,
       });
+    this.getOperationAndResultsContainer = (
+      operation: string,
+      resultCount?: number,
+    ) => {
+      const pattern = resultCount
+        ? new RegExp(`${operation}.*${resultCount} results`)
+        : new RegExp(`${operation}.*\\d+ results`);
+      return page.locator('div').filter({hasText: pattern});
+    };
   }
 
   async filterByProcessName(name: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_1.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_1.dmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Decisions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_0q1ija9" hitPolicy="FIRST">
+      <input id="Input_1" biodi:width="190">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1dpokim">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="Output_1" name="output" typeRef="string">
+        <outputValues id="UnaryTests_15zmna2">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_11sxdbc">
+        <description>Version 1</description>
+        <inputEntry id="UnaryTests_04ikdpm">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0gskvdh">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="Decision_2" name="Decision 2">
+    <informationRequirement id="InformationRequirement_12qlkki">
+      <requiredDecision href="#Decision_1" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1rgra48" hitPolicy="COLLECT">
+      <input id="InputClause_16q7mmf">
+        <inputExpression id="LiteralExpression_02j1kik" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0ct2zzd">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1mncnxr" name="outout" typeRef="string">
+        <outputValues id="UnaryTests_1pzzcto">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_1t96xjw">
+        <description>Version 1</description>
+        <inputEntry id="UnaryTests_1cidmy0">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1rbbzgc">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_0lmkq71" dmnElementRef="Decision_2">
+        <dc:Bounds height="80" width="180" x="410" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0mtid1m" dmnElementRef="InformationRequirement_12qlkki">
+        <di:waypoint x="340" y="140" />
+        <di:waypoint x="390" y="140" />
+        <di:waypoint x="410" y="140" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_2.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decisions_v_2.dmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Decisions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_0q1ija9" hitPolicy="COLLECT">
+      <input id="Input_1" biodi:width="190">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1dpokim">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="Output_1" name="output" typeRef="string">
+        <outputValues id="UnaryTests_15zmna2">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_11sxdbc">
+        <description>Version 2</description>
+        <inputEntry id="UnaryTests_04ikdpm">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0gskvdh">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1waaksc">
+        <inputEntry id="UnaryTests_123ng7i">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0vtifd8">
+          <text>"baz"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="Decision_2" name="Decision 2">
+    <informationRequirement id="InformationRequirement_12qlkki">
+      <requiredDecision href="#Decision_1" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1rgra48" hitPolicy="COLLECT">
+      <input id="InputClause_16q7mmf">
+        <inputExpression id="LiteralExpression_02j1kik" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0ct2zzd">
+          <text>"foo"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1mncnxr" name="output" typeRef="string">
+        <outputValues id="UnaryTests_1pzzcto">
+          <text>"bar"</text>
+        </outputValues>
+      </output>
+      <output id="OutputClause_0kf4cjf" label="output2" name="output2" typeRef="string" />
+      <rule id="DecisionRule_0gmxo7c">
+        <inputEntry id="UnaryTests_1xn32yh">
+          <text>"bar"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_18626pp">
+          <text>"baz"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1hn9h4g">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1t96xjw">
+        <description>Version 2</description>
+        <inputEntry id="UnaryTests_1cidmy0">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1rbbzgc">
+          <text>"bar"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0n7652y">
+          <text>"baz"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_0lmkq71" dmnElementRef="Decision_2">
+        <dc:Bounds height="80" width="180" x="410" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0mtid1m" dmnElementRef="InformationRequirement_12qlkki">
+        <di:waypoint x="340" y="140" />
+        <di:waypoint x="390" y="140" />
+        <di:waypoint x="410" y="140" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {deploy} from 'utils/zeebeClient';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+interface DecisionInfo {
+  key: string;
+  version: string;
+}
+
+let initialData: {
+  decisions: DecisionInfo[];
+};
+
+test.describe('Decision Instances', () => {
+  test.beforeAll(async ({}) => {
+    // Deploy decision versions 1 and 2
+    const decisionV1Response = await deploy(['./resources/decisions_v_1.dmn']);
+    const decisionV2Response = await deploy(['./resources/decisions_v_2.dmn']);
+
+    const decisions: DecisionInfo[] = [];
+
+    // Process decisions from v1
+    decisionV1Response.decisions?.forEach((decision) => {
+      decisions.push({
+        key: decision.decisionDefinitionKey,
+        version: decision.version.toString(),
+      });
+    });
+
+    // Process decisions from v2
+    decisionV2Response.decisions?.forEach((decision) => {
+      decisions.push({
+        key: decision.decisionDefinitionKey,
+        version: decision.version.toString(),
+      });
+    });
+
+    initialData = {decisions};
+
+    await sleep(2000);
+  });
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Switch between Decision versions', async ({
+    operateDecisionsPage,
+    operateHomePage,
+  }) => {
+    const {decisions} = initialData;
+    const [
+      decision1Version1,
+      decision2Version1,
+      decision1Version2,
+      decision2Version2,
+    ] = decisions;
+
+    await test.step('Navigate to Decisions page', async () => {
+      await operateHomePage.clickDecisionsTab();
+    });
+
+    await test.step('Select Decision 1 Version 1', async () => {
+      await operateDecisionsPage.selectDecisionName('Decision 1');
+      await operateDecisionsPage.selectVersion(decision1Version1!.version);
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 1'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Switch to Decision 1 Version 2', async () => {
+      await operateDecisionsPage.selectVersion(decision1Version2!.version);
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 1'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 2'),
+      ).toBeVisible();
+    });
+
+    await test.step('Clear selection and select Decision 2', async () => {
+      await operateDecisionsPage.clearComboBox();
+      await operateDecisionsPage.selectDecisionName('Decision 2');
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 2'),
+      ).toBeVisible();
+    });
+
+    await test.step('Select Decision 2 Version 1', async () => {
+      await operateDecisionsPage.selectVersion(decision2Version1!.version);
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 2'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Switch to Decision 2 Version 2', async () => {
+      await operateDecisionsPage.selectVersion(decision2Version2!.version);
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Decision 2'),
+      ).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionViewer.getByText('Version 2'),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -234,7 +234,9 @@ test.describe('Operations', () => {
 
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText('5 results')).toBeVisible({
+          await expect(
+            operateProcessesPage.getOperationAndResultsContainer('cancel', 5),
+          ).toBeVisible({
             timeout: 30000,
           });
         },


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrated `decisionInstances.spec.ts` from operate component folder to c8-orchestration-cluster-e2e-test-suite following the new architecture patterns.

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20297139894/job/58293542875)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34100
