### PR TITLE
test: e2e for migration of  ai agent capabilities 

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_1.bpmn
@@ -7,8 +7,8 @@
   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
   xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
   targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
-  exporterVersion="eda7bab" modeler:executionPlatform="Camunda Cloud"
-  modeler:executionPlatformVersion="8.8.0">
+  exporterVersion="68c5d80" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -431,6 +431,7 @@
       <bpmn:outgoing>Flow_0vm1c0b</bpmn:outgoing>
       <bpmn:outgoing>Flow_0u3kipb</bpmn:outgoing>
       <bpmn:outgoing>Flow_1krp4hz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u1ir0t</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_0vm1c0b</bpmn:incoming>
@@ -471,6 +472,7 @@
       <bpmn:incoming>Flow_1bo0sui</bpmn:incoming>
       <bpmn:incoming>Flow_0383azr</bpmn:incoming>
       <bpmn:incoming>Flow_0v0pz7s</bpmn:incoming>
+      <bpmn:incoming>Flow_0hblus5</bpmn:incoming>
       <bpmn:outgoing>Flow_1nlysp1</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1bo0sui" sourceRef="Gateway_3" targetRef="Gateway_6" />
@@ -598,6 +600,130 @@
     <bpmn:sequenceFlow id="Flow_1nj16xx" sourceRef="ParallelMultiInstanceAdHocSubProcess"
       targetRef="Gateway_01n2aj8" />
     <bpmn:sequenceFlow id="Flow_1atp6z8" sourceRef="AdHocSubProcess" targetRef="Gateway_01n2aj8" />
+    <bpmn:serviceTask id="AIAgentTask" name="AI agent Task"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input source="AgentTools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResult" target="data.tools.toolCallResults" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.aiagent.v1" />
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06snuuz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fg9wm5</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="Gateway_0ixv76b">
+      <bpmn:incoming>Flow_0u1ir0t</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jxehws</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1xt0clj</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0u1ir0t" sourceRef="Gateway_1" targetRef="Gateway_0ixv76b" />
+    <bpmn:exclusiveGateway id="Gateway_16dc9rt">
+      <bpmn:incoming>Flow_0jxehws</bpmn:incoming>
+      <bpmn:incoming>Flow_15dly8z</bpmn:incoming>
+      <bpmn:outgoing>Flow_06snuuz</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0jxehws" sourceRef="Gateway_0ixv76b" targetRef="Gateway_16dc9rt" />
+    <bpmn:sequenceFlow id="Flow_06snuuz" sourceRef="Gateway_16dc9rt" targetRef="AIAgentTask" />
+    <bpmn:exclusiveGateway id="Gateway_11iaf27" default="Flow_0rxenzq">
+      <bpmn:incoming>Flow_1fg9wm5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ny9jb3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0rxenzq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1fg9wm5" sourceRef="AIAgentTask" targetRef="Gateway_11iaf27" />
+    <bpmn:adHocSubProcess id="AgentTools" name="Agent tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ny9jb3</bpmn:incoming>
+      <bpmn:outgoing>Flow_15dly8z</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeTask" name="Get Date and Time - Task">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_15dly8z" sourceRef="AgentTools" targetRef="Gateway_16dc9rt" />
+    <bpmn:sequenceFlow id="Flow_0ny9jb3" sourceRef="Gateway_11iaf27" targetRef="AgentTools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:adHocSubProcess id="AIAgentsubprocess" name="AI Agent sub process"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults"
+          outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input target="agentContext" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="WAIT_FOR_TOOL_CALL_RESULTS" target="data.events.behavior" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+          <zeebe:input source="=false" target="data.response.includeAgentContext" />
+          <zeebe:output source="=agent" target="agent" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId"
+            value="io.camunda.connectors.agenticai.aiagent.jobworker.v1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xt0clj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nm3vh1</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeSubprocess" name="Get Date and Time - subprocess">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_1xt0clj" sourceRef="Gateway_0ixv76b" targetRef="AIAgentsubprocess" />
+    <bpmn:parallelGateway id="Gateway_1bjd93f">
+      <bpmn:incoming>Flow_1nm3vh1</bpmn:incoming>
+      <bpmn:incoming>Flow_0rxenzq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hblus5</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0hblus5" sourceRef="Gateway_1bjd93f" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_1nm3vh1" sourceRef="AIAgentsubprocess" targetRef="Gateway_1bjd93f" />
+    <bpmn:sequenceFlow id="Flow_0rxenzq" sourceRef="Gateway_11iaf27" targetRef="Gateway_1bjd93f" />
     <bpmn:association id="Association_0xok9ld" associationDirection="One"
       sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
@@ -657,7 +783,7 @@
         <dc:Bounds x="773" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="3202" y="1652" width="36" height="36" />
+        <dc:Bounds x="3962" y="1633" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
@@ -716,55 +842,55 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess"
         isExpanded="true">
-        <dc:Bounds x="2770" y="140" width="350" height="200" />
+        <dc:Bounds x="3530" y="121" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="3032" y="222" width="36" height="36" />
+        <dc:Bounds x="3792" y="203" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="2890" y="200" width="100" height="80" />
+        <dc:Bounds x="3650" y="181" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2810" y="222" width="36" height="36" />
+        <dc:Bounds x="3570" y="203" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2794" y="265" width="70" height="27" />
+          <dc:Bounds x="3554" y="246" width="70" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2846" y="240" />
-        <di:waypoint x="2890" y="240" />
+        <di:waypoint x="3606" y="221" />
+        <di:waypoint x="3650" y="221" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2990" y="240" />
-        <di:waypoint x="3032" y="240" />
+        <di:waypoint x="3750" y="221" />
+        <di:waypoint x="3792" y="221" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess"
         isExpanded="true">
-        <dc:Bounds x="2770" y="390" width="350" height="200" />
+        <dc:Bounds x="3530" y="371" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="3032" y="472" width="36" height="36" />
+        <dc:Bounds x="3792" y="453" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="2890" y="450" width="100" height="80" />
+        <dc:Bounds x="3650" y="431" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2810" y="472" width="36" height="36" />
+        <dc:Bounds x="3570" y="453" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2787" y="515" width="83" height="14" />
+          <dc:Bounds x="3547" y="496" width="83" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2846" y="490" />
-        <di:waypoint x="2890" y="490" />
+        <di:waypoint x="3606" y="471" />
+        <di:waypoint x="3650" y="471" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2990" y="490" />
-        <di:waypoint x="3032" y="490" />
+        <di:waypoint x="3750" y="471" />
+        <di:waypoint x="3792" y="471" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
         <dc:Bounds x="440" y="1212" width="100" height="80" />
@@ -814,42 +940,42 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess"
         isExpanded="true">
-        <dc:Bounds x="2770" y="640" width="350" height="200" />
+        <dc:Bounds x="3530" y="621" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="3062" y="722" width="36" height="36" />
+        <dc:Bounds x="3822" y="703" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2900" y="700" width="100" height="80" />
+        <dc:Bounds x="3660" y="681" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2810" y="722" width="36" height="36" />
+        <dc:Bounds x="3570" y="703" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2786" y="765" width="85" height="14" />
+          <dc:Bounds x="3546" y="746" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="3062" y="792" width="36" height="36" />
+        <dc:Bounds x="3822" y="773" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="2952" y="762" width="36" height="36" />
+        <dc:Bounds x="3712" y="743" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2931" y="805" width="80" height="27" />
+          <dc:Bounds x="3691" y="786" width="80" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2846" y="740" />
-        <di:waypoint x="2900" y="740" />
+        <di:waypoint x="3606" y="721" />
+        <di:waypoint x="3660" y="721" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="3000" y="740" />
-        <di:waypoint x="3062" y="740" />
+        <di:waypoint x="3760" y="721" />
+        <di:waypoint x="3822" y="721" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2970" y="798" />
-        <di:waypoint x="2970" y="810" />
-        <di:waypoint x="3062" y="810" />
+        <di:waypoint x="3730" y="779" />
+        <di:waypoint x="3730" y="791" />
+        <di:waypoint x="3822" y="791" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
         <dc:Bounds x="1212" y="502" width="36" height="36" />
@@ -966,49 +1092,49 @@
         <dc:Bounds x="1675" y="1557" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1j4ljfk_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2585" y="1645" width="50" height="50" />
+        <dc:Bounds x="3345" y="1626" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess"
         isExpanded="true">
-        <dc:Bounds x="2770" y="894" width="350" height="200" />
+        <dc:Bounds x="3530" y="875" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="3062" y="976" width="36" height="36" />
+        <dc:Bounds x="3822" y="957" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2900" y="954" width="100" height="80" />
+        <dc:Bounds x="3660" y="935" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2810" y="976" width="36" height="36" />
+        <dc:Bounds x="3570" y="957" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2792" y="1019" width="76" height="27" />
+          <dc:Bounds x="3552" y="1000" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0vd8mzp_di" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2846" y="994" />
-        <di:waypoint x="2900" y="994" />
+        <di:waypoint x="3606" y="975" />
+        <di:waypoint x="3660" y="975" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="3000" y="994" />
-        <di:waypoint x="3062" y="994" />
+        <di:waypoint x="3760" y="975" />
+        <di:waypoint x="3822" y="975" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1dvyj5q_di" bpmnElement="EscalationThrowEvent">
         <dc:Bounds x="1102" y="1352" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2440" y="280" width="100" height="80" />
+        <dc:Bounds x="3200" y="261" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2502" y="182" width="36" height="36" />
+        <dc:Bounds x="3262" y="163" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2485" y="225" width="71" height="27" />
+          <dc:Bounds x="3245" y="206" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="2320" y="160" width="100" height="80" />
+        <dc:Bounds x="3080" y="141" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0le8k76_di" bpmnElement="AdHocSubProcess" isExpanded="true">
@@ -1041,12 +1167,44 @@
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1wuhuhy_di" bpmnElement="Gateway_01n2aj8">
-        <dc:Bounds x="2415" y="1557" width="50" height="50" />
+        <dc:Bounds x="2365" y="1557" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1amzseu_di" bpmnElement="AIAgentTask">
+        <dc:Bounds x="2670" y="370" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tc4lou_di" bpmnElement="Gateway_0ixv76b">
+        <dc:Bounds x="2495" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_16dc9rt_di" bpmnElement="Gateway_16dc9rt" isMarkerVisible="true">
+        <dc:Bounds x="2575" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_11iaf27_di" bpmnElement="Gateway_11iaf27" isMarkerVisible="true">
+        <dc:Bounds x="2835" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0f0guw8" bpmnElement="AgentTools" isExpanded="true">
+        <dc:Bounds x="2570" y="520" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01wf4eo_di" bpmnElement="GetDateAndTimeTask">
+        <dc:Bounds x="2680" y="585" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1gu98u1" bpmnElement="AIAgentsubprocess" isExpanded="true">
+        <dc:Bounds x="2580" y="834" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0z8j6cn" bpmnElement="GetDateAndTimeSubprocess">
+        <dc:Bounds x="2690" y="899" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09pxz1z" bpmnElement="Gateway_1bjd93f">
+        <dc:Bounds x="3035" y="1557" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="2372" y="222" width="36" height="36" />
+        <dc:Bounds x="3132" y="203" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2352" y="265" width="76" height="27" />
+          <dc:Bounds x="3112" y="246" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
@@ -1309,8 +1467,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dzoyo4_di" bpmnElement="Flow_1dzoyo4">
         <di:waypoint x="1700" y="1607" />
-        <di:waypoint x="1700" y="1670" />
-        <di:waypoint x="2585" y="1670" />
+        <di:waypoint x="1700" y="1651" />
+        <di:waypoint x="3345" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01ogvlh_di" bpmnElement="Flow_01ogvlh">
         <di:waypoint x="1495" y="200" />
@@ -1343,13 +1501,13 @@
         <di:waypoint x="1700" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nlysp1_di" bpmnElement="Flow_1nlysp1">
-        <di:waypoint x="2635" y="1670" />
-        <di:waypoint x="3202" y="1670" />
+        <di:waypoint x="3395" y="1651" />
+        <di:waypoint x="3962" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bo0sui_di" bpmnElement="Flow_1bo0sui">
         <di:waypoint x="970" y="1607" />
-        <di:waypoint x="970" y="1670" />
-        <di:waypoint x="2585" y="1670" />
+        <di:waypoint x="970" y="1651" />
+        <di:waypoint x="3345" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xejz9b_di" bpmnElement="Flow_0xejz9b">
         <di:waypoint x="1380" y="1488" />
@@ -1362,17 +1520,17 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0u3kipb_di" bpmnElement="Flow_0u3kipb">
         <di:waypoint x="355" y="110" />
-        <di:waypoint x="2370" y="110" />
-        <di:waypoint x="2370" y="160" />
+        <di:waypoint x="3130" y="110" />
+        <di:waypoint x="3130" y="141" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0383azr_di" bpmnElement="Flow_0383azr">
-        <di:waypoint x="2538" y="200" />
-        <di:waypoint x="2610" y="200" />
-        <di:waypoint x="2610" y="1645" />
+        <di:waypoint x="3298" y="181" />
+        <di:waypoint x="3370" y="181" />
+        <di:waypoint x="3370" y="1626" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2420" y="200" />
-        <di:waypoint x="2502" y="200" />
+        <di:waypoint x="3180" y="181" />
+        <di:waypoint x="3262" y="181" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1krp4hz_di" bpmnElement="Flow_1krp4hz">
         <di:waypoint x="355" y="110" />
@@ -1395,29 +1553,75 @@
         <di:waypoint x="1940" y="1150" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v0pz7s_di" bpmnElement="Flow_0v0pz7s">
-        <di:waypoint x="2440" y="1607" />
-        <di:waypoint x="2440" y="1670" />
-        <di:waypoint x="2585" y="1670" />
+        <di:waypoint x="2390" y="1607" />
+        <di:waypoint x="2390" y="1651" />
+        <di:waypoint x="3345" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ektns0_di" bpmnElement="Flow_1ektns0">
         <di:waypoint x="2290" y="1150" />
-        <di:waypoint x="2440" y="1150" />
-        <di:waypoint x="2440" y="1557" />
+        <di:waypoint x="2390" y="1150" />
+        <di:waypoint x="2390" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nj16xx_di" bpmnElement="Flow_1nj16xx">
         <di:waypoint x="2290" y="815" />
-        <di:waypoint x="2440" y="815" />
-        <di:waypoint x="2440" y="1557" />
+        <di:waypoint x="2390" y="815" />
+        <di:waypoint x="2390" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1atp6z8_di" bpmnElement="Flow_1atp6z8">
         <di:waypoint x="2290" y="490" />
-        <di:waypoint x="2440" y="490" />
-        <di:waypoint x="2440" y="1557" />
+        <di:waypoint x="2390" y="490" />
+        <di:waypoint x="2390" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u1ir0t_di" bpmnElement="Flow_0u1ir0t">
+        <di:waypoint x="355" y="110" />
+        <di:waypoint x="2520" y="110" />
+        <di:waypoint x="2520" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jxehws_di" bpmnElement="Flow_0jxehws">
+        <di:waypoint x="2520" y="225" />
+        <di:waypoint x="2520" y="410" />
+        <di:waypoint x="2575" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06snuuz_di" bpmnElement="Flow_06snuuz">
+        <di:waypoint x="2625" y="410" />
+        <di:waypoint x="2670" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fg9wm5_di" bpmnElement="Flow_1fg9wm5">
+        <di:waypoint x="2770" y="410" />
+        <di:waypoint x="2835" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15dly8z_di" bpmnElement="Flow_15dly8z">
+        <di:waypoint x="2600" y="520" />
+        <di:waypoint x="2600" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ny9jb3_di" bpmnElement="Flow_0ny9jb3">
+        <di:waypoint x="2860" y="435" />
+        <di:waypoint x="2860" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xt0clj_di" bpmnElement="Flow_1xt0clj">
+        <di:waypoint x="2520" y="225" />
+        <di:waypoint x="2520" y="934" />
+        <di:waypoint x="2580" y="934" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hblus5_di" bpmnElement="Flow_0hblus5">
+        <di:waypoint x="3060" y="1607" />
+        <di:waypoint x="3060" y="1651" />
+        <di:waypoint x="3345" y="1651" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nm3vh1_di" bpmnElement="Flow_1nm3vh1">
+        <di:waypoint x="2930" y="934" />
+        <di:waypoint x="3060" y="934" />
+        <di:waypoint x="3060" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rxenzq_di" bpmnElement="Flow_0rxenzq">
+        <di:waypoint x="2885" y="410" />
+        <di:waypoint x="3060" y="410" />
+        <di:waypoint x="3060" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="2390" y="258" />
-        <di:waypoint x="2390" y="320" />
-        <di:waypoint x="2440" y="320" />
+        <di:waypoint x="3150" y="239" />
+        <di:waypoint x="3150" y="301" />
+        <di:waypoint x="3200" y="301" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_2.bpmn
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="0782300" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+  exporterVersion="68c5d80" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -21,7 +30,8 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment"
+      targetRef="ExclusiveGateway_1qqmrb8" />
     <bpmn:serviceTask id="requestForPayment" name="Request for payment">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
@@ -29,11 +39,14 @@
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid"
+      sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment"
+      targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8"
+      targetRef="shipArticles">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="shipArticles" name="Ship Articles">
@@ -43,7 +56,8 @@
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Activity_0ae6k1y" />
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles"
+      targetRef="Activity_0ae6k1y" />
     <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="Gateway_3" />
     <bpmn:serviceTask id="Activity_0ae6k1y" name="Notify Customer">
       <bpmn:extensionElements>
@@ -95,7 +109,8 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting"
+      cancelActivity="false" attachedToRef="TaskC">
       <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_1xpzcw8" />
     </bpmn:boundaryEvent>
@@ -131,7 +146,8 @@
       <bpmn:outgoing>Flow_0hx3trf</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0hx3trf" sourceRef="TaskD" targetRef="Gateway_3" />
-    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting"
+      cancelActivity="false" attachedToRef="TaskD">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
@@ -167,7 +183,8 @@
     <bpmn:sequenceFlow id="Flow_0qh5pp6" sourceRef="TaskA" targetRef="Gateway_3" />
     <bpmn:sequenceFlow id="Flow_13205bp" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch" />
     <bpmn:sequenceFlow id="Flow_0lwoyt0" sourceRef="MessageIntermediateCatch" targetRef="Gateway_3" />
-    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
       </bpmn:endEvent>
@@ -180,12 +197,14 @@
       </bpmn:serviceTask>
       <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
         <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_0cooija" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx"
+          messageRef="Message_0cooija" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE" targetRef="Event_13rtwuo" />
       <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE" />
     </bpmn:subProcess>
-    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
       </bpmn:endEvent>
@@ -205,7 +224,8 @@
       <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF" targetRef="Event_0lk89tk" />
       <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF" />
     </bpmn:subProcess>
-    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_19ff1sq">
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task"
+      messageRef="Message_19ff1sq">
       <bpmn:incoming>Flow_10qe08j</bpmn:incoming>
       <bpmn:outgoing>Flow_170beuy</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -268,13 +288,18 @@
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:outgoing>Flow_0brqydf</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway" targetRef="Gateway_1cs756a">
+    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway"
+      targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway" targetRef="TimerIntermediateCatchB" />
-    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway" targetRef="MessageIntermediateCatchB" />
-    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB" targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway"
+      targetRef="TimerIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway"
+      targetRef="MessageIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
       <bpmn:incoming>Flow_0mmpytv</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
@@ -285,8 +310,10 @@
       <bpmn:outgoing>Flow_1yhf88z</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_18ev63b" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch" />
-    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process" triggeredByEvent="true">
+    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow"
+      targetRef="SignalIntermediateCatch" />
+    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
       </bpmn:endEvent>
@@ -304,7 +331,8 @@
       <bpmn:endEvent id="Event_049m1di">
         <bpmn:incoming>Flow_0bfr615</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event" attachedToRef="TaskH">
+      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event"
+        attachedToRef="TaskH">
         <bpmn:outgoing>Flow_0bfr615</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_0o1z67o" signalRef="Signal_18ev63b" />
       </bpmn:boundaryEvent>
@@ -322,7 +350,8 @@
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_04fbdug</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process"
+        triggeredByEvent="true">
         <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
           <bpmn:outgoing>Flow_1nc8qvq</bpmn:outgoing>
           <bpmn:errorEventDefinition id="ErrorEventDefinition_1jxc702" errorRef="Error_0guddpc" />
@@ -340,7 +369,8 @@
         <bpmn:sequenceFlow id="Flow_1nc8qvq" sourceRef="ErrorStartEvent" targetRef="TaskG" />
         <bpmn:sequenceFlow id="Flow_1n6hwxq" sourceRef="TaskG" targetRef="Event_12yeu6m" />
       </bpmn:subProcess>
-      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
+      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent"
+        targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
     <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
       <bpmn:incoming>Flow_0s7xnsc</bpmn:incoming>
@@ -380,7 +410,8 @@
       <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
         <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
         <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_0aipw8x" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il"
+          escalationRef="Escalation_0aipw8x" />
       </bpmn:intermediateThrowEvent>
       <bpmn:startEvent id="Event_1vxuw3v">
         <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
@@ -396,9 +427,11 @@
       <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
       <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
     </bpmn:subProcess>
-    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event" attachedToRef="EscalationSubProcess">
+    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event"
+      attachedToRef="EscalationSubProcess">
       <bpmn:outgoing>Flow_1pu67u8</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_1d2ue2p" sourceRef="Gateway_1" targetRef="Gateway_2" />
     <bpmn:parallelGateway id="Gateway_1">
@@ -407,6 +440,7 @@
       <bpmn:outgoing>Flow_00b9dxt</bpmn:outgoing>
       <bpmn:outgoing>Flow_0yepp52</bpmn:outgoing>
       <bpmn:outgoing>Flow_12u9pvx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ikvzw8</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_00b9dxt</bpmn:incoming>
@@ -447,10 +481,12 @@
       <bpmn:incoming>Flow_1xou7mm</bpmn:incoming>
       <bpmn:incoming>Flow_19y2492</bpmn:incoming>
       <bpmn:incoming>Flow_01xs1ek</bpmn:incoming>
-      <bpmn:incoming>Flow_1yfpso7</bpmn:incoming>
+      <bpmn:incoming>Flow_1ki1oct</bpmn:incoming>
+      <bpmn:incoming>Flow_13karsw</bpmn:incoming>
       <bpmn:outgoing>Flow_0whnivt</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_1cmlzk4">
         <bpmn:incoming>Flow_0of03mm</bpmn:incoming>
       </bpmn:endEvent>
@@ -461,19 +497,24 @@
         <bpmn:incoming>Flow_0vd8mzp</bpmn:incoming>
         <bpmn:outgoing>Flow_0of03mm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event" isInterrupting="false">
+      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event"
+        isInterrupting="false">
         <bpmn:outgoing>Flow_0vd8mzp</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s" escalationRef="Escalation_0aipw8x" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s"
+          escalationRef="Escalation_0aipw8x" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_0of03mm" sourceRef="EscalationEventTask" targetRef="Event_1cmlzk4" />
-      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent" targetRef="EscalationEventTask" />
+      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent"
+        targetRef="EscalationEventTask" />
     </bpmn:subProcess>
     <bpmn:intermediateThrowEvent id="EscalationThrowEvent">
       <bpmn:incoming>Flow_1fmviig</bpmn:incoming>
       <bpmn:outgoing>Flow_0yr2bpp</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:sequenceFlow id="Flow_0yr2bpp" sourceRef="EscalationThrowEvent" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0yr2bpp" sourceRef="EscalationThrowEvent"
+      targetRef="EscalationSubProcess" />
     <bpmn:intermediateThrowEvent id="CompensationThrowEvent" name="Compensation throw event">
       <bpmn:incoming>Flow_0ejrzsk</bpmn:incoming>
       <bpmn:outgoing>Flow_01xs1ek</bpmn:outgoing>
@@ -487,10 +528,12 @@
       <bpmn:outgoing>Flow_0ejrzsk</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:task id="UndoTask" name="Undo" isForCompensation="true" />
-    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event" attachedToRef="CompensationTask">
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event"
+      attachedToRef="CompensationTask">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a309d0" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
+    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask"
+      targetRef="CompensationThrowEvent" />
     <bpmn:sequenceFlow id="Flow_0yepp52" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:sequenceFlow id="Flow_01xs1ek" sourceRef="CompensationThrowEvent" targetRef="Gateway_6" />
     <bpmn:adHocSubProcess id="AdHocSubProcess" name="Ad hoc sub process">
@@ -505,7 +548,8 @@
         </bpmn:extensionElements>
       </bpmn:serviceTask>
     </bpmn:adHocSubProcess>
-    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess" name="Parallel multi instance Ad hoc sub process">
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess"
+      name="Parallel multi instance Ad hoc sub process">
       <bpmn:extensionElements>
         <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ&#34;]" />
       </bpmn:extensionElements>
@@ -522,7 +566,8 @@
         </bpmn:extensionElements>
       </bpmn:serviceTask>
     </bpmn:adHocSubProcess>
-    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess" name="Sequential multi instance Ad hoc sub process">
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess"
+      name="Sequential multi instance Ad hoc sub process">
       <bpmn:extensionElements>
         <zeebe:adHoc activeElementsCollection="=[&#34;TaskK&#34;]" />
       </bpmn:extensionElements>
@@ -549,17 +594,146 @@
       <bpmn:incoming>Flow_0dx8hzz</bpmn:incoming>
       <bpmn:incoming>Flow_1fuizf1</bpmn:incoming>
       <bpmn:incoming>Flow_07bkx0g</bpmn:incoming>
-      <bpmn:outgoing>Flow_1yfpso7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ki1oct</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_12u9pvx" sourceRef="Gateway_1" targetRef="Gateway_14pehud" />
     <bpmn:sequenceFlow id="Flow_0v443hz" sourceRef="Gateway_14pehud" targetRef="AdHocSubProcess" />
-    <bpmn:sequenceFlow id="Flow_0x38e96" sourceRef="Gateway_14pehud" targetRef="ParallelMultiInstanceAdHocSubProcess" />
-    <bpmn:sequenceFlow id="Flow_14ntaal" sourceRef="Gateway_14pehud" targetRef="SequentialMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0x38e96" sourceRef="Gateway_14pehud"
+      targetRef="ParallelMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_14ntaal" sourceRef="Gateway_14pehud"
+      targetRef="SequentialMultiInstanceAdHocSubProcess" />
     <bpmn:sequenceFlow id="Flow_0dx8hzz" sourceRef="AdHocSubProcess" targetRef="Gateway_00j3vbq" />
-    <bpmn:sequenceFlow id="Flow_1fuizf1" sourceRef="SequentialMultiInstanceAdHocSubProcess" targetRef="Gateway_00j3vbq" />
-    <bpmn:sequenceFlow id="Flow_07bkx0g" sourceRef="ParallelMultiInstanceAdHocSubProcess" targetRef="Gateway_00j3vbq" />
-    <bpmn:sequenceFlow id="Flow_1yfpso7" sourceRef="Gateway_00j3vbq" targetRef="Gateway_6" />
-    <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
+    <bpmn:sequenceFlow id="Flow_1fuizf1" sourceRef="SequentialMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_07bkx0g" sourceRef="ParallelMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_1ki1oct" sourceRef="Gateway_00j3vbq" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_1hhnvkz">
+      <bpmn:incoming>Flow_0ikvzw8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vdvtnf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1oinugz</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0ikvzw8" sourceRef="Gateway_1" targetRef="Gateway_1hhnvkz" />
+    <bpmn:adHocSubProcess id="AgentTools" name="Agent tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1r65qfr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z5salg</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeTask" name="Get Date and Time - Task">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:exclusiveGateway id="Gateway_1dx8l94">
+      <bpmn:incoming>Flow_1oinugz</bpmn:incoming>
+      <bpmn:incoming>Flow_0z5salg</bpmn:incoming>
+      <bpmn:outgoing>Flow_07tfzl7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0ssa7n0" default="Flow_14vcfav">
+      <bpmn:incoming>Flow_0jzt8hh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1r65qfr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14vcfav</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:adHocSubProcess id="AIAgentsubprocess" name="AI Agent sub process"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults"
+          outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input target="agentContext" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="WAIT_FOR_TOOL_CALL_RESULTS" target="data.events.behavior" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+          <zeebe:input source="=false" target="data.response.includeAgentContext" />
+          <zeebe:output source="=agent" target="agent" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId"
+            value="io.camunda.connectors.agenticai.aiagent.jobworker.v1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0vdvtnf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1plh702</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeSubprocess" name="Get Date and Time - subprocess">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0vdvtnf" sourceRef="Gateway_1hhnvkz" targetRef="AIAgentsubprocess" />
+    <bpmn:sequenceFlow id="Flow_1oinugz" sourceRef="Gateway_1hhnvkz" targetRef="Gateway_1dx8l94" />
+    <bpmn:sequenceFlow id="Flow_07tfzl7" sourceRef="Gateway_1dx8l94" targetRef="AIAgentTask" />
+    <bpmn:sequenceFlow id="Flow_0jzt8hh" sourceRef="AIAgentTask" targetRef="Gateway_0ssa7n0" />
+    <bpmn:sequenceFlow id="Flow_0z5salg" sourceRef="AgentTools" targetRef="Gateway_1dx8l94" />
+    <bpmn:sequenceFlow id="Flow_1r65qfr" sourceRef="Gateway_0ssa7n0" targetRef="AgentTools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:parallelGateway id="Gateway_0zcqny6">
+      <bpmn:incoming>Flow_1plh702</bpmn:incoming>
+      <bpmn:incoming>Flow_14vcfav</bpmn:incoming>
+      <bpmn:outgoing>Flow_13karsw</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1plh702" sourceRef="AIAgentsubprocess" targetRef="Gateway_0zcqny6" />
+    <bpmn:sequenceFlow id="Flow_13karsw" sourceRef="Gateway_0zcqny6" targetRef="Gateway_6" />
+    <bpmn:serviceTask id="AIAgentTask" name="AI agent Task"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input source="AgentTools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResult" target="data.tools.toolCallResults" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.aiagent.v1" />
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07tfzl7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jzt8hh</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_14vcfav" sourceRef="Gateway_0ssa7n0" targetRef="Gateway_0zcqny6" />
+    <bpmn:association id="Association_0xok9ld" associationDirection="One"
+      sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -622,12 +796,13 @@
         <dc:Bounds x="400" y="178" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2784" y="1680" width="36" height="36" />
+        <dc:Bounds x="3842" y="1662" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
+        isMarkerVisible="true">
         <dc:Bounds x="569" y="193" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="559" y="169" width="69" height="14" />
@@ -684,61 +859,57 @@
           <dc:Bounds x="718" y="804" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1e1imfy_di" bpmnElement="Gateway_14pehud">
-        <dc:Bounds x="1925" y="193" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0vr8496_di" bpmnElement="Gateway_00j3vbq">
-        <dc:Bounds x="2425" y="1523" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2662" y="178" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="210" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2924" y="260" width="36" height="36" />
+        <dc:Bounds x="3977" y="292" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="2782" y="238" width="100" height="80" />
+        <dc:Bounds x="3835" y="270" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2702" y="260" width="36" height="36" />
+        <dc:Bounds x="3755" y="292" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2686" y="303" width="70" height="27" />
+          <dc:Bounds x="3739" y="335" width="70" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2882" y="278" />
-        <di:waypoint x="2924" y="278" />
+        <di:waypoint x="3935" y="310" />
+        <di:waypoint x="3977" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2738" y="278" />
-        <di:waypoint x="2782" y="278" />
+        <di:waypoint x="3791" y="310" />
+        <di:waypoint x="3835" y="310" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2662" y="428" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="460" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2924" y="510" width="36" height="36" />
+        <dc:Bounds x="3977" y="542" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="2782" y="488" width="100" height="80" />
+        <dc:Bounds x="3835" y="520" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2702" y="510" width="36" height="36" />
+        <dc:Bounds x="3755" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2679" y="553" width="83" height="14" />
+          <dc:Bounds x="3732" y="585" width="83" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2882" y="528" />
-        <di:waypoint x="2924" y="528" />
+        <di:waypoint x="3935" y="560" />
+        <di:waypoint x="3977" y="560" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2738" y="528" />
-        <di:waypoint x="2782" y="528" />
+        <di:waypoint x="3791" y="560" />
+        <di:waypoint x="3835" y="560" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
         <dc:Bounds x="400" y="1230" width="100" height="80" />
@@ -754,7 +925,8 @@
       <bpmndi:BPMNShape id="Activity_1f4kynw_di" bpmnElement="SendTask">
         <dc:Bounds x="400" y="1590" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway"
+        isMarkerVisible="true">
         <dc:Bounds x="1355" y="193" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1357" y="251" width="47" height="27" />
@@ -796,43 +968,44 @@
           <dc:Bounds x="1536" y="553" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2662" y="678" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="710" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2954" y="760" width="36" height="36" />
+        <dc:Bounds x="4007" y="792" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2792" y="738" width="100" height="80" />
+        <dc:Bounds x="3845" y="770" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2702" y="760" width="36" height="36" />
+        <dc:Bounds x="3755" y="792" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2678" y="803" width="85" height="14" />
+          <dc:Bounds x="3731" y="835" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2954" y="830" width="36" height="36" />
+        <dc:Bounds x="4007" y="862" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="2844" y="800" width="36" height="36" />
+        <dc:Bounds x="3897" y="832" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2823" y="843" width="80" height="27" />
+          <dc:Bounds x="3876" y="875" width="80" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2892" y="778" />
-        <di:waypoint x="2954" y="778" />
+        <di:waypoint x="3945" y="810" />
+        <di:waypoint x="4007" y="810" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2738" y="778" />
-        <di:waypoint x="2792" y="778" />
+        <di:waypoint x="3791" y="810" />
+        <di:waypoint x="3845" y="810" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2862" y="836" />
-        <di:waypoint x="2862" y="848" />
-        <di:waypoint x="2954" y="848" />
+        <di:waypoint x="3915" y="868" />
+        <di:waypoint x="3915" y="880" />
+        <di:waypoint x="4007" y="880" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1280" y="618" width="423" height="350" />
@@ -873,7 +1046,8 @@
         <di:waypoint x="1393" y="678" />
         <di:waypoint x="1570" y="678" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1405" y="1028" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -895,7 +1069,8 @@
         <di:waypoint x="1633" y="1128" />
         <di:waypoint x="1685" y="1128" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1405" y="1288" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -934,48 +1109,49 @@
         <dc:Bounds x="1805" y="1523" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_10o6pf2_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2637" y="1673" width="50" height="50" />
+        <dc:Bounds x="3695" y="1655" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2662" y="928" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="960" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2954" y="1010" width="36" height="36" />
+        <dc:Bounds x="4007" y="1042" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2792" y="988" width="100" height="80" />
+        <dc:Bounds x="3845" y="1020" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2702" y="1010" width="36" height="36" />
+        <dc:Bounds x="3755" y="1042" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2684" y="1053" width="76" height="27" />
+          <dc:Bounds x="3737" y="1085" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2892" y="1028" />
-        <di:waypoint x="2954" y="1028" />
+        <di:waypoint x="3945" y="1060" />
+        <di:waypoint x="4007" y="1060" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vd8mzp_di" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2738" y="1028" />
-        <di:waypoint x="2792" y="1028" />
+        <di:waypoint x="3791" y="1060" />
+        <di:waypoint x="3845" y="1060" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
         <dc:Bounds x="1222" y="1370" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2444" y="160" width="36" height="36" />
+        <dc:Bounds x="3497" y="192" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2427" y="203" width="71" height="27" />
+          <dc:Bounds x="3480" y="235" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="2262" y="138" width="100" height="80" />
+        <dc:Bounds x="3315" y="170" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2382" y="258" width="100" height="80" />
+        <dc:Bounds x="3435" y="290" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_17mq8ma_di" bpmnElement="AdHocSubProcess" isExpanded="true">
@@ -986,7 +1162,8 @@
         <dc:Bounds x="2160" y="480" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_18hzbbj" bpmnElement="ParallelMultiInstanceAdHocSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="BPMNShape_18hzbbj" bpmnElement="ParallelMultiInstanceAdHocSubProcess"
+        isExpanded="true">
         <dc:Bounds x="2040" y="810" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -994,7 +1171,8 @@
         <dc:Bounds x="2160" y="862" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_02upd8b" bpmnElement="SequentialMultiInstanceAdHocSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="BPMNShape_02upd8b" bpmnElement="SequentialMultiInstanceAdHocSubProcess"
+        isExpanded="true">
         <dc:Bounds x="2040" y="1140" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -1002,10 +1180,48 @@
         <dc:Bounds x="2160" y="1192" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1e1imfy_di" bpmnElement="Gateway_14pehud">
+        <dc:Bounds x="1925" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0vr8496_di" bpmnElement="Gateway_00j3vbq">
+        <dc:Bounds x="2515" y="1523" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1islyat_di" bpmnElement="Gateway_1hhnvkz">
+        <dc:Bounds x="2805" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1e3en9c" bpmnElement="AgentTools" isExpanded="true">
+        <dc:Bounds x="2930" y="618" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ibwe9p_di" bpmnElement="GetDateAndTimeTask">
+        <dc:Bounds x="3050" y="670" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1dx8l94_di" bpmnElement="Gateway_1dx8l94" isMarkerVisible="true">
+        <dc:Bounds x="2935" y="503" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1e0mmf0" bpmnElement="Gateway_0ssa7n0" isMarkerVisible="true">
+        <dc:Bounds x="3175" y="503" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11d96my" bpmnElement="AIAgentsubprocess" isExpanded="true">
+        <dc:Bounds x="2940" y="1028" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wafzqh_di" bpmnElement="GetDateAndTimeSubprocess">
+        <dc:Bounds x="3060" y="1080" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1iui2ch" bpmnElement="Gateway_0zcqny6">
+        <dc:Bounds x="3340" y="1523" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xk2tk4_di" bpmnElement="AIAgentTask">
+        <dc:Bounds x="3030" y="488" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="2314" y="200" width="36" height="36" />
+        <dc:Bounds x="3367" y="232" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2294" y="243" width="76" height="27" />
+          <dc:Bounds x="3347" y="275" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
@@ -1122,8 +1338,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xou7mm_di" bpmnElement="Flow_1xou7mm">
         <di:waypoint x="1000" y="1655" />
-        <di:waypoint x="1000" y="1698" />
-        <di:waypoint x="2637" y="1698" />
+        <di:waypoint x="1000" y="1680" />
+        <di:waypoint x="3695" y="1680" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vp8yz2_di" bpmnElement="Flow_0vp8yz2">
         <di:waypoint x="500" y="779" />
@@ -1311,37 +1527,32 @@
         <di:waypoint x="1830" y="1523" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0whnivt_di" bpmnElement="Flow_0whnivt">
-        <di:waypoint x="2687" y="1698" />
-        <di:waypoint x="2784" y="1698" />
+        <di:waypoint x="3745" y="1680" />
+        <di:waypoint x="3842" y="1680" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19y2492_di" bpmnElement="Flow_19y2492">
         <di:waypoint x="1830" y="1573" />
-        <di:waypoint x="1830" y="1698" />
-        <di:waypoint x="2637" y="1698" />
+        <di:waypoint x="1830" y="1680" />
+        <di:waypoint x="3695" y="1680" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yr2bpp_di" bpmnElement="Flow_0yr2bpp">
         <di:waypoint x="1258" y="1388" />
         <di:waypoint x="1405" y="1388" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2362" y="178" />
-        <di:waypoint x="2444" y="178" />
+        <di:waypoint x="3415" y="210" />
+        <di:waypoint x="3497" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yepp52_di" bpmnElement="Flow_0yepp52">
         <di:waypoint x="335" y="110" />
-        <di:waypoint x="2312" y="110" />
-        <di:waypoint x="2312" y="138" />
+        <di:waypoint x="3365" y="110" />
+        <di:waypoint x="3365" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01xs1ek_di" bpmnElement="Flow_01xs1ek">
-        <di:waypoint x="2480" y="178" />
-        <di:waypoint x="2552" y="178" />
-        <di:waypoint x="2552" y="1698" />
-        <di:waypoint x="2637" y="1698" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="2332" y="236" />
-        <di:waypoint x="2332" y="298" />
-        <di:waypoint x="2382" y="298" />
+        <di:waypoint x="3533" y="210" />
+        <di:waypoint x="3610" y="210" />
+        <di:waypoint x="3610" y="1680" />
+        <di:waypoint x="3695" y="1680" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_12u9pvx_di" bpmnElement="Flow_12u9pvx">
         <di:waypoint x="335" y="110" />
@@ -1365,23 +1576,76 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0dx8hzz_di" bpmnElement="Flow_0dx8hzz">
         <di:waypoint x="2390" y="528" />
-        <di:waypoint x="2450" y="528" />
-        <di:waypoint x="2450" y="1523" />
+        <di:waypoint x="2540" y="528" />
+        <di:waypoint x="2540" y="1523" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1fuizf1_di" bpmnElement="Flow_1fuizf1">
         <di:waypoint x="2390" y="1240" />
-        <di:waypoint x="2450" y="1240" />
-        <di:waypoint x="2450" y="1523" />
+        <di:waypoint x="2540" y="1240" />
+        <di:waypoint x="2540" y="1523" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07bkx0g_di" bpmnElement="Flow_07bkx0g">
         <di:waypoint x="2390" y="910" />
-        <di:waypoint x="2450" y="910" />
-        <di:waypoint x="2450" y="1523" />
+        <di:waypoint x="2540" y="910" />
+        <di:waypoint x="2540" y="1523" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1yfpso7_di" bpmnElement="Flow_1yfpso7">
-        <di:waypoint x="2450" y="1573" />
-        <di:waypoint x="2450" y="1698" />
-        <di:waypoint x="2637" y="1698" />
+      <bpmndi:BPMNEdge id="Flow_1ki1oct_di" bpmnElement="Flow_1ki1oct">
+        <di:waypoint x="2540" y="1573" />
+        <di:waypoint x="2540" y="1680" />
+        <di:waypoint x="3695" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ikvzw8_di" bpmnElement="Flow_0ikvzw8">
+        <di:waypoint x="335" y="110" />
+        <di:waypoint x="2830" y="110" />
+        <di:waypoint x="2830" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vdvtnf_di" bpmnElement="Flow_0vdvtnf">
+        <di:waypoint x="2855" y="218" />
+        <di:waypoint x="2880" y="218" />
+        <di:waypoint x="2880" y="1128" />
+        <di:waypoint x="2940" y="1128" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oinugz_di" bpmnElement="Flow_1oinugz">
+        <di:waypoint x="2855" y="218" />
+        <di:waypoint x="2880" y="220" />
+        <di:waypoint x="2880" y="530" />
+        <di:waypoint x="2936" y="529" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07tfzl7_di" bpmnElement="Flow_07tfzl7">
+        <di:waypoint x="2985" y="528" />
+        <di:waypoint x="3030" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jzt8hh_di" bpmnElement="Flow_0jzt8hh">
+        <di:waypoint x="3130" y="528" />
+        <di:waypoint x="3175" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z5salg_di" bpmnElement="Flow_0z5salg">
+        <di:waypoint x="2960" y="618" />
+        <di:waypoint x="2960" y="553" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1r65qfr_di" bpmnElement="Flow_1r65qfr">
+        <di:waypoint x="3200" y="553" />
+        <di:waypoint x="3200" y="618" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1plh702_di" bpmnElement="Flow_1plh702">
+        <di:waypoint x="3290" y="1128" />
+        <di:waypoint x="3365" y="1128" />
+        <di:waypoint x="3365" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13karsw_di" bpmnElement="Flow_13karsw">
+        <di:waypoint x="3365" y="1573" />
+        <di:waypoint x="3365" y="1680" />
+        <di:waypoint x="3695" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14vcfav_di" bpmnElement="Flow_14vcfav">
+        <di:waypoint x="3225" y="528" />
+        <di:waypoint x="3365" y="528" />
+        <di:waypoint x="3365" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="3385" y="268" />
+        <di:waypoint x="3385" y="330" />
+        <di:waypoint x="3435" y="330" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_3.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_3.bpmn
@@ -7,7 +7,7 @@
   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
   xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
   targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
-  exporterVersion="eda7bab" modeler:executionPlatform="Camunda Cloud"
+  exporterVersion="68c5d80" modeler:executionPlatform="Camunda Cloud"
   modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
@@ -450,6 +450,7 @@
       <bpmn:outgoing>Flow_1rs7xob</bpmn:outgoing>
       <bpmn:outgoing>Flow_1hxtfne</bpmn:outgoing>
       <bpmn:outgoing>Flow_013v9pn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1tp7z6r</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_1rs7xob</bpmn:incoming>
@@ -490,6 +491,7 @@
       <bpmn:incoming>Flow_1c49dph</bpmn:incoming>
       <bpmn:incoming>Flow_0f4n4wb</bpmn:incoming>
       <bpmn:incoming>Flow_0xe17zu</bpmn:incoming>
+      <bpmn:incoming>Flow_0ni9op7</bpmn:incoming>
       <bpmn:outgoing>Flow_1tyhemw</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1c49dph" sourceRef="Gateway_5" targetRef="Gateway_6" />
@@ -616,6 +618,130 @@
     <bpmn:sequenceFlow id="Flow_1v1ohc8" sourceRef="Gateway_1wrnxon"
       targetRef="SequentialMultiInstanceAdHocSubProcess2" />
     <bpmn:sequenceFlow id="Flow_0xe17zu" sourceRef="Gateway_1azg5ns" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_0fnm4hh">
+      <bpmn:incoming>Flow_1tp7z6r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jrw5g8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0x7mnk9</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:adHocSubProcess id="AgentTools2" name="Agent tools 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1yc0op3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mekit0</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeTask2" name="Get Date and Time - Task 2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="AIAgentsubprocess2" name="AI Agent sub process 2"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults"
+          outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input target="agentContext" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="WAIT_FOR_TOOL_CALL_RESULTS" target="data.events.behavior" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+          <zeebe:input source="=false" target="data.response.includeAgentContext" />
+          <zeebe:output source="=agent" target="agent" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId"
+            value="io.camunda.connectors.agenticai.aiagent.jobworker.v1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0x7mnk9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0l97oqw</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeSubprocess2" name="Get Date and Time - subprocess 2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:exclusiveGateway id="Gateway_1qy5kyn">
+      <bpmn:incoming>Flow_0mekit0</bpmn:incoming>
+      <bpmn:incoming>Flow_1jrw5g8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1je2j55</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0lovonw" default="Flow_0yyosmm">
+      <bpmn:incoming>Flow_0h1700r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yc0op3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0yyosmm</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0h1700r" sourceRef="AIAgentTask2" targetRef="Gateway_0lovonw" />
+    <bpmn:sequenceFlow id="Flow_1je2j55" sourceRef="Gateway_1qy5kyn" targetRef="AIAgentTask2" />
+    <bpmn:serviceTask id="AIAgentTask2" name="AI agent Task 2"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input source="AgentTools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResult" target="data.tools.toolCallResults" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.aiagent.v1" />
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1je2j55</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h1700r</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0mekit0" sourceRef="AgentTools2" targetRef="Gateway_1qy5kyn" />
+    <bpmn:sequenceFlow id="Flow_1yc0op3" sourceRef="Gateway_0lovonw" targetRef="AgentTools2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:parallelGateway id="Gateway_0znmhei">
+      <bpmn:incoming>Flow_0yyosmm</bpmn:incoming>
+      <bpmn:incoming>Flow_0l97oqw</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ni9op7</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0yyosmm" sourceRef="Gateway_0lovonw" targetRef="Gateway_0znmhei" />
+    <bpmn:sequenceFlow id="Flow_0ni9op7" sourceRef="Gateway_0znmhei" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_1jrw5g8" sourceRef="Gateway_0fnm4hh" targetRef="Gateway_1qy5kyn" />
+    <bpmn:sequenceFlow id="Flow_1tp7z6r" sourceRef="Gateway_1" targetRef="Gateway_0fnm4hh" />
+    <bpmn:sequenceFlow id="Flow_0x7mnk9" sourceRef="Gateway_0fnm4hh" targetRef="AIAgentsubprocess2" />
+    <bpmn:sequenceFlow id="Flow_0l97oqw" sourceRef="AIAgentsubprocess2" targetRef="Gateway_0znmhei" />
     <bpmn:association id="Association_0xok9ld" associationDirection="One"
       sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
@@ -684,12 +810,6 @@
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment2">
         <dc:Bounds x="360" y="168" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="3072" y="1651" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="270" width="90" height="12" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
         isMarkerVisible="true">
@@ -760,58 +880,12 @@
           <dc:Bounds x="745" y="795" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2"
-        isExpanded="true">
-        <dc:Bounds x="2900" y="419" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="3162" y="501" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
-        <dc:Bounds x="3020" y="479" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2940" y="501" width="36" height="36" />
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="3822" y="1651" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2917" y="544" width="83" height="27" />
+          <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="3120" y="519" />
-        <di:waypoint x="3162" y="519" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2976" y="519" />
-        <di:waypoint x="3020" y="519" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2"
-        isExpanded="true">
-        <dc:Bounds x="2900" y="169" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="3162" y="251" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
-        <dc:Bounds x="3020" y="229" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2940" y="251" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2924" y="294" width="70" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="3120" y="269" />
-        <di:waypoint x="3162" y="269" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2976" y="269" />
-        <di:waypoint x="3020" y="269" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask2">
         <dc:Bounds x="360" y="1220" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -870,45 +944,42 @@
           <dc:Bounds x="1608" y="563" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2"
-        isExpanded="true">
-        <dc:Bounds x="2900" y="669" width="350" height="200" />
+      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="3525" y="1644" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="3402" y="179" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3387" y="222" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
+        <dc:Bounds x="3220" y="157" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="3192" y="751" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
+        <dc:Bounds x="3340" y="277" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="3030" y="729" width="100" height="80" />
+      <bpmndi:BPMNShape id="Gateway_0rftrqi_di" bpmnElement="Gateway_1azg5ns">
+        <dc:Bounds x="2615" y="1565" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2940" y="751" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2916" y="794" width="85" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="BPMNShape_04ytft3" bpmnElement="Gateway_0fnm4hh">
+        <dc:Bounds x="2735" y="183" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="3192" y="821" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_1qy5kyn_di" bpmnElement="Gateway_1qy5kyn" isMarkerVisible="true">
+        <dc:Bounds x="2975" y="365" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
-        <dc:Bounds x="3082" y="791" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3063" y="834" width="80" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Gateway_0lovonw_di" bpmnElement="Gateway_0lovonw" isMarkerVisible="true">
+        <dc:Bounds x="3220" y="365" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="3130" y="769" />
-        <di:waypoint x="3192" y="769" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2976" y="769" />
-        <di:waypoint x="3030" y="769" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="3100" y="827" />
-        <di:waypoint x="3100" y="839" />
-        <di:waypoint x="3192" y="839" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_08j9cnb_di" bpmnElement="AIAgentTask2">
+        <dc:Bounds x="3065" y="350" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0w6sekb" bpmnElement="Gateway_0znmhei">
+        <dc:Bounds x="3365" y="1565" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1402" y="628" width="423" height="350" />
         <bpmndi:BPMNLabel />
@@ -1010,51 +1081,8 @@
       <bpmndi:BPMNShape id="Gateway_06z2xtb_di" bpmnElement="Gateway_5">
         <dc:Bounds x="1905" y="1565" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2775" y="1644" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0bwi9k5" bpmnElement="EscalationEventSubProcess"
-        isExpanded="true">
-        <dc:Bounds x="2900" y="919" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="3192" y="1001" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="3030" y="979" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2940" y="1001" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2920" y="1044" width="76" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="3130" y="1019" />
-        <di:waypoint x="3192" y="1019" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_095dl4e" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2976" y="1019" />
-        <di:waypoint x="3030" y="1019" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
         <dc:Bounds x="1342" y="1330" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2652" y="179" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2637" y="222" width="71" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="2470" y="157" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2590" y="277" width="100" height="80" />
-        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1jfa5hv_di" bpmnElement="AdHocSubProcess2" isExpanded="true">
         <dc:Bounds x="2190" y="507" width="350" height="200" />
@@ -1085,14 +1113,143 @@
       <bpmndi:BPMNShape id="Gateway_0fi1sa1_di" bpmnElement="Gateway_1wrnxon">
         <dc:Bounds x="2065" y="183" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0rftrqi_di" bpmnElement="Gateway_1azg5ns">
-        <dc:Bounds x="2615" y="1565" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="419" width="350" height="200" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="2522" y="219" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="3912" y="501" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
+        <dc:Bounds x="3770" y="479" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="3690" y="501" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2502" y="262" width="76" height="27" />
+          <dc:Bounds x="3667" y="544" width="83" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="3870" y="519" />
+        <di:waypoint x="3912" y="519" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="3726" y="519" />
+        <di:waypoint x="3770" y="519" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="169" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="3912" y="251" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
+        <dc:Bounds x="3770" y="229" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="3690" y="251" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3674" y="294" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="3870" y="269" />
+        <di:waypoint x="3912" y="269" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="3726" y="269" />
+        <di:waypoint x="3770" y="269" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="669" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="3942" y="751" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="3780" y="729" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="3690" y="751" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3666" y="794" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="3942" y="821" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
+        <dc:Bounds x="3832" y="791" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3813" y="834" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="3880" y="769" />
+        <di:waypoint x="3942" y="769" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="3726" y="769" />
+        <di:waypoint x="3780" y="769" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="3850" y="827" />
+        <di:waypoint x="3850" y="839" />
+        <di:waypoint x="3942" y="839" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_0bwi9k5" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="919" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
+        <dc:Bounds x="3942" y="1001" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
+        <dc:Bounds x="3780" y="979" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
+        <dc:Bounds x="3690" y="1001" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3670" y="1044" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
+        <di:waypoint x="3880" y="1019" />
+        <di:waypoint x="3942" y="1019" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_095dl4e" bpmnElement="Flow_0vd8mzp">
+        <di:waypoint x="3726" y="1019" />
+        <di:waypoint x="3780" y="1019" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="3290" y="255" />
+        <di:waypoint x="3290" y="317" />
+        <di:waypoint x="3340" y="317" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_14cq402" bpmnElement="AgentTools2" isExpanded="true">
+        <dc:Bounds x="2940" y="507" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08u4hm8_di" bpmnElement="GetDateAndTimeTask2">
+        <dc:Bounds x="3050" y="570" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1us6dd1" bpmnElement="AIAgentsubprocess2" isExpanded="true">
+        <dc:Bounds x="2940" y="800" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1er4p8u_di" bpmnElement="GetDateAndTimeSubprocess2">
+        <dc:Bounds x="3060" y="863" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
         <dc:Bounds x="1575" y="1430" width="36" height="36" />
@@ -1122,6 +1279,12 @@
         <dc:Bounds x="412" y="629" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="358" y="656" width="65" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="3272" y="219" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3252" y="262" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1223,7 +1386,7 @@
       <bpmndi:BPMNEdge id="Flow_1ibxab9_di" bpmnElement="Flow_1ibxab9">
         <di:waypoint x="1130" y="1615" />
         <di:waypoint x="1130" y="1669" />
-        <di:waypoint x="2775" y="1669" />
+        <di:waypoint x="3525" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lyxcbw_di" bpmnElement="Flow_0lyxcbw">
         <di:waypoint x="460" y="769" />
@@ -1400,32 +1563,19 @@
         <di:waypoint x="1593" y="1590" />
         <di:waypoint x="1905" y="1590" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tyhemw_di" bpmnElement="Flow_1tyhemw">
-        <di:waypoint x="2825" y="1669" />
-        <di:waypoint x="3072" y="1669" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1c49dph_di" bpmnElement="Flow_1c49dph">
         <di:waypoint x="1930" y="1615" />
         <di:waypoint x="1930" y="1669" />
-        <di:waypoint x="2775" y="1669" />
+        <di:waypoint x="3525" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bhp20l_di" bpmnElement="Flow_0bhp20l">
         <di:waypoint x="1378" y="1348" />
         <di:waypoint x="1412" y="1348" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2570" y="197" />
-        <di:waypoint x="2652" y="197" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hxtfne_di" bpmnElement="Flow_1hxtfne">
         <di:waypoint x="315" y="110" />
-        <di:waypoint x="2520" y="110" />
-        <di:waypoint x="2520" y="157" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0f4n4wb_di" bpmnElement="Flow_0f4n4wb">
-        <di:waypoint x="2688" y="197" />
-        <di:waypoint x="2800" y="197" />
-        <di:waypoint x="2800" y="1644" />
+        <di:waypoint x="3270" y="110" />
+        <di:waypoint x="3270" y="157" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19ud3sr_di" bpmnElement="Flow_19ud3sr">
         <di:waypoint x="2540" y="1210" />
@@ -1462,15 +1612,69 @@
         <di:waypoint x="2090" y="1210" />
         <di:waypoint x="2190" y="1210" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tyhemw_di" bpmnElement="Flow_1tyhemw">
+        <di:waypoint x="3575" y="1669" />
+        <di:waypoint x="3822" y="1669" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f4n4wb_di" bpmnElement="Flow_0f4n4wb">
+        <di:waypoint x="3438" y="197" />
+        <di:waypoint x="3550" y="197" />
+        <di:waypoint x="3550" y="1644" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xe17zu_di" bpmnElement="Flow_0xe17zu">
         <di:waypoint x="2640" y="1615" />
         <di:waypoint x="2640" y="1669" />
-        <di:waypoint x="2775" y="1669" />
+        <di:waypoint x="3525" y="1669" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="2540" y="255" />
-        <di:waypoint x="2540" y="317" />
-        <di:waypoint x="2590" y="317" />
+      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
+        <di:waypoint x="3320" y="197" />
+        <di:waypoint x="3402" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1je2j55_di" bpmnElement="Flow_1je2j55">
+        <di:waypoint x="3025" y="390" />
+        <di:waypoint x="3065" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h1700r_di" bpmnElement="Flow_0h1700r">
+        <di:waypoint x="3165" y="390" />
+        <di:waypoint x="3220" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mekit0_di" bpmnElement="Flow_0mekit0">
+        <di:waypoint x="3000" y="507" />
+        <di:waypoint x="3000" y="415" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yc0op3_di" bpmnElement="Flow_1yc0op3">
+        <di:waypoint x="3245" y="415" />
+        <di:waypoint x="3245" y="507" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yyosmm_di" bpmnElement="Flow_0yyosmm">
+        <di:waypoint x="3270" y="390" />
+        <di:waypoint x="3390" y="390" />
+        <di:waypoint x="3390" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ni9op7_di" bpmnElement="Flow_0ni9op7">
+        <di:waypoint x="3390" y="1615" />
+        <di:waypoint x="3390" y="1669" />
+        <di:waypoint x="3525" y="1669" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jrw5g8_di" bpmnElement="Flow_1jrw5g8">
+        <di:waypoint x="2760" y="233" />
+        <di:waypoint x="2760" y="390" />
+        <di:waypoint x="2975" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tp7z6r_di" bpmnElement="Flow_1tp7z6r">
+        <di:waypoint x="315" y="110" />
+        <di:waypoint x="2760" y="110" />
+        <di:waypoint x="2760" y="183" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x7mnk9_di" bpmnElement="Flow_0x7mnk9">
+        <di:waypoint x="2760" y="233" />
+        <di:waypoint x="2760" y="900" />
+        <di:waypoint x="2940" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0l97oqw_di" bpmnElement="Flow_0l97oqw">
+        <di:waypoint x="3290" y="900" />
+        <di:waypoint x="3390" y="900" />
+        <di:waypoint x="3390" y="1565" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -261,6 +261,18 @@ test.describe.serial('Process Instance Migration', () => {
           targetValue: 'SequentialMultiInstanceAdHocSubProcess',
         },
         {label: 'target element for task k', targetValue: 'TaskK'},
+        {
+          label: 'target element for ai agent task',
+          targetValue: 'AIAgentTask',
+        },
+        {
+          label: 'target element for agent tools',
+          targetValue: 'AgentTools',
+        },
+        {
+          label: 'target element for ai agent sub process',
+          targetValue: 'AIAgentsubprocess',
+        },
       ]);
 
       await operateProcessMigrationModePage.completeProcessInstanceMigration();
@@ -371,6 +383,46 @@ test.describe.serial('Process Instance Migration', () => {
         );
 
         await expect(page.getByText('6 results')).toBeVisible({timeout: 90000});
+      });
+    }
+  });
+
+  test('Migrated ai agent task and ad hoc sub processes', async ({
+    page,
+    operateFiltersPanelPage,
+    operateProcessesPage,
+    operateOperationPanelPage,
+  }) => {
+    const targetBpmnProcessId = testProcesses.processV2.bpmnProcessId;
+    const targetVersion = testProcesses.processV2.version.toString();
+
+    await test.step('Navigate to processes and expand operations panel', async () => {
+      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(targetVersion);
+
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
+        timeout: 30000,
+      });
+
+      await operateOperationPanelPage.expandOperationIdField();
+    });
+
+    const tasksToVerify = ['AIAgentTask', 'AIAgentsubprocess'];
+    for (const taskId of tasksToVerify) {
+      await test.step(`Get migration operation ID and verify ${taskId} instances`, async () => {
+        const operationId =
+          await operateOperationPanelPage.getMigrationOperationId();
+
+        await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
+        await operateFiltersPanelPage.selectVersion(targetVersion);
+
+        await page.goto(
+          `operate/processes?active=true&incidents=true&process=${targetBpmnProcessId}&version=${targetVersion}&operationId=${operationId}&flowNodeId=${taskId}`,
+        );
+
+        await expect(page.getByText('6 results')).toBeVisible({
+          timeout: 90000,
+        });
       });
     }
   });
@@ -542,6 +594,18 @@ test.describe.serial('Process Instance Migration', () => {
       await operateProcessMigrationModePage.mapFlowNode(
         'Sequential multi instance Ad hoc sub process',
         'Sequential multi instance Ad hoc sub process 2',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'AI agent Task',
+        'AI agent Task 2',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'Agent tools',
+        'Agent tools 2',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'AI Agent sub process',
+        'AI Agent sub process 2',
       );
     });
 


### PR DESCRIPTION
This pull request significantly enhances the `orderProcessMigration_v_1.bpmn` process by introducing AI agent integration and related orchestration logic. The main changes add new service and ad-hoc subprocess tasks for AI agents, update process flows to support tool invocation, and adjust diagram layout to accommodate the expanded process.

**AI Agent Integration and Orchestration:**

* Added a new `AIAgentTask` (`bpmn:serviceTask`) configured to use the AgenticAI connector with detailed input/output mappings, system/user prompts, and tool integration, enabling the process to call an AI agent for customer requests.
* Introduced an ad-hoc subprocess `AgentTools` that provides a script task for getting the current date and time, allowing the AI agent to invoke this tool as part of its reasoning.
* Added a new ad-hoc subprocess `AIAgentsubprocess` using the AgenticAI job worker connector, with similar configuration and tool call orchestration, further supporting complex agent-driven flows.

This changes were added in order to test the migration of this components from 8.9 onward.


CI on demand run: https://github.com/camunda/camunda/actions/runs/20269837749


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
