### PR TITLE
test: mock requestAnimationFrame and cancelAnimationFrame for tests

### DIFF
--- a/tasklist/client/src/setupTests.ts
+++ b/tasklist/client/src/setupTests.ts
@@ -52,6 +52,12 @@ beforeEach(() => {
 
   vi.stubGlobal('Notification', {permission: 'denied'});
   vi.stubGlobal('ResizeObserver', ResizeObserverPolyfill);
+  vi.stubGlobal('requestAnimationFrame', (fn: FrameRequestCallback) => {
+    return setTimeout(() => fn(Date.now()), 1) as unknown as number;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    clearTimeout(id);
+  });
 });
 
 beforeAll(() => {


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

There is an issue affecting the Tasklist tests. The error `ReferenceError: cancelAnimationFrame is not defined` continues to appear in Tasklist frontend unit test runs.



See slack incident for more info:
https://camunda.slack.com/archives/C0A2MVBESM7


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
