### PR TITLE
Store batch operation actor info in rdbms

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -869,4 +869,11 @@
 
   </changeSet>
 
+  <changeSet id="add_actor_columns_to_batch_operations" author="camunda">
+    <addColumn tableName="${prefix}BATCH_OPERATION">
+      <column name="ACTOR_TYPE" type="VARCHAR(50)"/>
+      <column name="ACTOR_ID" type="VARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
@@ -20,6 +20,8 @@ public class BatchOperationEntityMapper {
         dbModel.operationType(),
         dbModel.startDate(),
         dbModel.endDate(),
+        dbModel.actorType(),
+        dbModel.actorId(),
         dbModel.operationsTotalCount(),
         dbModel.operationsFailedCount(),
         dbModel.operationsCompletedCount(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -14,7 +14,9 @@ public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEnt
   STATE("state"),
   OPERATION_TYPE("operationType"),
   START_DATE("startDate"),
-  END_DATE("endDate");
+  END_DATE("endDate"),
+  ACTOR_TYPE("actorType"),
+  ACTOR_ID("actorId");
 
   private final String property;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.domain;
 
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.util.ObjectBuilder;
@@ -22,6 +23,21 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
   private BatchOperationType operationType;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
+
+  /**
+   * The type of the actor that performed the operation, (USER or CLIENT).
+   *
+   * @since 8.9.0
+   */
+  private final BatchOperationActorType actorType;
+
+  /**
+   * The id of the actor that performed the operation.
+   *
+   * @since 8.9.0
+   */
+  private final String actorId;
+
   private Integer operationsTotalCount;
   private Integer operationsFailedCount;
   private Integer operationsCompletedCount;
@@ -33,6 +49,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
       final BatchOperationType operationType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
+      final BatchOperationActorType actorType,
+      final String actorId,
       final Integer operationsTotalCount,
       final Integer operationsFailedCount,
       final Integer operationsCompletedCount) {
@@ -41,6 +59,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
     this.operationType = operationType;
     this.startDate = startDate;
     this.endDate = endDate;
+    this.actorType = actorType;
+    this.actorId = actorId;
     this.operationsTotalCount = operationsTotalCount;
     this.operationsFailedCount = operationsFailedCount;
     this.operationsCompletedCount = operationsCompletedCount;
@@ -52,6 +72,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
       final BatchOperationType operationType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
+      final BatchOperationActorType actorType,
+      final String actorId,
       final Integer operationsTotalCount,
       final Integer operationsFailedCount,
       final Integer operationsCompletedCount,
@@ -61,6 +83,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
     this.operationType = operationType;
     this.startDate = startDate;
     this.endDate = endDate;
+    this.actorType = actorType;
+    this.actorId = actorId;
     this.operationsTotalCount = operationsTotalCount;
     this.operationsFailedCount = operationsFailedCount;
     this.operationsCompletedCount = operationsCompletedCount;
@@ -116,6 +140,14 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
     this.endDate = endDate;
   }
 
+  public BatchOperationActorType actorType() {
+    return actorType;
+  }
+
+  public String actorId() {
+    return actorId;
+  }
+
   public Integer operationsTotalCount() {
     return operationsTotalCount;
   }
@@ -155,6 +187,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
         .operationType(operationType)
         .startDate(startDate)
         .endDate(endDate)
+        .actorType(actorType)
+        .actorId(actorId)
         .operationsTotalCount(operationsTotalCount)
         .operationsFailedCount(operationsFailedCount)
         .operationsCompletedCount(operationsCompletedCount)
@@ -167,6 +201,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
     private BatchOperationType operationType;
     private OffsetDateTime startDate;
     private OffsetDateTime endDate;
+    private BatchOperationActorType actorType;
+    private String actorId;
     private Integer operationsTotalCount = 0;
     private Integer operationsFailedCount = 0;
     private Integer operationsCompletedCount = 0;
@@ -204,6 +240,16 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
       return this;
     }
 
+    public Builder actorType(final BatchOperationActorType actorType) {
+      this.actorType = actorType;
+      return this;
+    }
+
+    public Builder actorId(final String actorId) {
+      this.actorId = actorId;
+      return this;
+    }
+
     public Builder operationsTotalCount(final Integer operationsTotalCount) {
       this.operationsTotalCount = operationsTotalCount;
       return this;
@@ -232,6 +278,8 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
           operationType,
           startDate,
           endDate,
+          actorType,
+          actorId,
           operationsTotalCount,
           operationsFailedCount,
           operationsCompletedCount,

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -14,6 +14,9 @@
       <arg column="OPERATION_TYPE" javaType="io.camunda.search.entities.BatchOperationType"/>
       <arg column="START_DATE" javaType="java.time.OffsetDateTime"/>
       <arg column="END_DATE" javaType="java.time.OffsetDateTime"/>
+      <arg column="ACTOR_TYPE"
+        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationActorType"/>
+      <arg column="ACTOR_ID" javaType="java.lang.String"/>
       <arg column="OPERATIONS_TOTAL_COUNT" javaType="int"/>
       <arg column="OPERATIONS_FAILED_COUNT" javaType="int"/>
       <arg column="OPERATIONS_COMPLETED_COUNT" javaType="int"/>
@@ -46,6 +49,8 @@
     OPERATION_TYPE,
     START_DATE,
     END_DATE,
+    ACTOR_TYPE,
+    ACTOR_ID,
     OPERATIONS_TOTAL_COUNT,
     OPERATIONS_FAILED_COUNT,
     OPERATIONS_COMPLETED_COUNT)
@@ -54,6 +59,8 @@
     #{operationType},
     #{startDate, jdbcType=TIMESTAMP},
     #{endDate, jdbcType=TIMESTAMP},
+    #{actorType},
+    #{actorId},
     #{operationsTotalCount},
     #{operationsFailedCount},
     #{operationsCompletedCount})
@@ -246,6 +253,8 @@
     bof.OPERATION_TYPE,
     bof.START_DATE,
     bof.END_DATE,
+    bof.ACTOR_TYPE,
+    bof.ACTOR_ID,
     bof.OPERATIONS_TOTAL_COUNT,
     bof.OPERATIONS_FAILED_COUNT,
     bof.OPERATIONS_COMPLETED_COUNT,
@@ -260,6 +269,8 @@
     bo.OPERATION_TYPE,
     bo.START_DATE,
     bo.END_DATE,
+    bo.ACTOR_TYPE,
+    bo.ACTOR_ID,
     bo.OPERATIONS_TOTAL_COUNT,
     bo.OPERATIONS_FAILED_COUNT,
     bo.OPERATIONS_COMPLETED_COUNT

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -316,6 +316,18 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
+    <if test="filter.actorTypeOperations != null and !filter.actorTypeOperations.isEmpty()">
+      <foreach collection="filter.actorTypeOperations" item="operation">
+        AND ACTOR_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.actorIdOperations != null and !filter.actorIdOperations.isEmpty()">
+      <foreach collection="filter.actorIdOperations" item="operation">
+        AND ACTOR_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
   </sql>
 
   <select id="countItems" resultType="java.lang.Long">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
@@ -32,6 +32,8 @@ class BatchOperationEntityMapperTest {
             .operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .startDate(OffsetDateTime.parse("2024-07-01T10:00:00Z"))
             .endDate(null)
+            .actorType(null)
+            .actorId(null)
             .operationsTotalCount(10)
             .operationsFailedCount(2)
             .operationsCompletedCount(8)
@@ -46,6 +48,8 @@ class BatchOperationEntityMapperTest {
     assertThat(entity.operationType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(entity.startDate()).isEqualTo(OffsetDateTime.parse("2024-07-01T10:00:00Z"));
     assertThat(entity.endDate()).isNull();
+    assertThat(entity.actorType()).isNull();
+    assertThat(entity.actorId()).isNull();
     assertThat(entity.operationsTotalCount()).isEqualTo(10);
     assertThat(entity.operationsFailedCount()).isEqualTo(2);
     assertThat(entity.operationsCompletedCount()).isEqualTo(8);
@@ -55,6 +59,21 @@ class BatchOperationEntityMapperTest {
     assertThat(errorEntity.partitionId()).isEqualTo(1);
     assertThat(errorEntity.type()).isEqualTo("ERROR_TYPE");
     assertThat(errorEntity.message()).isEqualTo("stacktrace");
+  }
+
+  @Test
+  void shouldMapDbModelToEntityWithActor() {
+    final var dbModel =
+        new BatchOperationDbModel.Builder()
+            .actorType(io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType.USER)
+            .actorId("user-123")
+            .build();
+
+    final var entity = BatchOperationEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.actorType())
+        .isEqualTo(io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType.USER);
+    assertThat(entity.actorId()).isEqualTo("user-123");
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
@@ -72,6 +73,11 @@ public class SearchColumnTest {
                       BatchOperationType.MIGRATE_PROCESS_INSTANCE),
                   Tuple.of(
                       BatchOperationType.MIGRATE_PROCESS_INSTANCE, "MIGRATE_PROCESS_INSTANCE"))),
+          Map.entry(
+              BatchOperationActorType.class,
+              List.of(
+                  Tuple.of(BatchOperationActorType.USER, BatchOperationActorType.USER),
+                  Tuple.of(BatchOperationActorType.USER, "USER"))),
           Map.entry(
               ProcessInstanceState.class,
               List.of(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel.Builder;
 import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
@@ -38,6 +39,8 @@ public final class BatchOperationFixtures {
             .operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .startDate(OffsetDateTime.now())
             .endDate(OffsetDateTime.now().plusSeconds(1))
+            .actorType(randomEnum(BatchOperationActorType.class))
+            .actorId("actor-" + key)
             .operationsTotalCount(0)
             .operationsFailedCount(0)
             .operationsCompletedCount(0);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.entity;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
@@ -49,6 +50,10 @@ public class BatchOperationEntityTransformer
         BatchOperationType.valueOf(source.getType().name()),
         source.getStartDate(),
         source.getEndDate(),
+        source.getActorType() != null
+            ? BatchOperationActorType.valueOf(source.getActorType().name())
+            : null,
+        source.getActorId(),
         source.getOperationsTotalCount(),
         source.getOperationsFailedCount(),
         source.getOperationsCompletedCount(),
@@ -71,6 +76,10 @@ public class BatchOperationEntityTransformer
         source.getType() != null ? BatchOperationType.valueOf(source.getType().name()) : null,
         source.getStartDate(),
         source.getEndDate(),
+        source.getActorType() != null
+            ? BatchOperationActorType.valueOf(source.getActorType().name())
+            : null,
+        source.getActorId(),
         source.getOperationsTotalCount(),
         0,
         source.getOperationsFinishedCount(),

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -21,6 +21,18 @@ public record BatchOperationEntity(
     BatchOperationType operationType,
     OffsetDateTime startDate,
     OffsetDateTime endDate,
+    /**
+     * The type of the actor who started the batch operation (USER or CLIENT).
+     *
+     * @since 8.9.0
+     */
+    BatchOperationActorType actorType,
+    /**
+     * The id of the actor who started the batch operation.
+     *
+     * @since 8.9.0
+     */
+    String actorId,
     Integer operationsTotalCount,
     Integer operationsFailedCount,
     Integer operationsCompletedCount,
@@ -76,5 +88,10 @@ public record BatchOperationEntity(
     SKIPPED,
     CANCELED,
     FAILED
+  }
+
+  public enum BatchOperationActorType {
+    USER,
+    CLIENT
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
@@ -20,7 +20,9 @@ import java.util.Objects;
 public record BatchOperationFilter(
     List<Operation<String>> batchOperationKeyOperations,
     List<Operation<String>> operationTypeOperations,
-    List<Operation<String>> stateOperations)
+    List<Operation<String>> stateOperations,
+    List<Operation<String>> actorTypeOperations,
+    List<Operation<String>> actorIdOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationFilter> {
@@ -28,6 +30,8 @@ public record BatchOperationFilter(
     private List<Operation<String>> batchOperationKeyOperations;
     private List<Operation<String>> operationTypeOperations;
     private List<Operation<String>> stateOperations;
+    private List<Operation<String>> actorTypeOperations;
+    private List<Operation<String>> actorIdOperations;
 
     public Builder batchOperationKeyOperations(final List<Operation<String>> operations) {
       batchOperationKeyOperations = addValuesToList(batchOperationKeyOperations, operations);
@@ -89,12 +93,54 @@ public record BatchOperationFilter(
       return stateOperations(collectValues(operation, operations));
     }
 
+    public Builder actorTypeOperations(final List<Operation<String>> operations) {
+      actorTypeOperations = addValuesToList(actorTypeOperations, operations);
+      return this;
+    }
+
+    public Builder actorTypes(final String value, final String... values) {
+      return actorTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceActorTypeOperations(final List<Operation<String>> operations) {
+      actorTypeOperations = new ArrayList<>(operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder actorTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return actorTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder actorIdOperations(final List<Operation<String>> operations) {
+      actorIdOperations = addValuesToList(actorIdOperations, operations);
+      return this;
+    }
+
+    public Builder actorIds(final String value, final String... values) {
+      return actorIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceActorIdOperations(final List<Operation<String>> operations) {
+      actorIdOperations = new ArrayList<>(operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder actorIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return actorIdOperations(collectValues(operation, operations));
+    }
+
     @Override
     public BatchOperationFilter build() {
       return new BatchOperationFilter(
           Objects.requireNonNullElse(batchOperationKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(operationTypeOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(stateOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(actorTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(actorIdOperations, Collections.emptyList()));
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -10,8 +10,10 @@ package io.camunda.exporter.rdbms.handlers.batchoperation;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo.AuditLogActor;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -19,6 +21,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.util.DateUtil;
+import io.camunda.zeebe.util.SemanticVersion;
 
 /**
  * Exports a batch operation creation record to the database. Where the creation in the db just
@@ -29,6 +32,7 @@ public class BatchOperationCreatedExportHandler
 
   private final BatchOperationWriter batchOperationWriter;
   private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
+  private final ActorInfoExtractor actorInfoExtractor = new ActorInfoExtractor();
 
   public BatchOperationCreatedExportHandler(
       final BatchOperationWriter batchOperationWriter,
@@ -55,12 +59,50 @@ public class BatchOperationCreatedExportHandler
 
   private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {
     final var value = record.getValue();
+    final var actorInfo = actorInfoExtractor.extract(record);
     final String batchOperationKey = String.valueOf(record.getKey());
     return new BatchOperationDbModel.Builder()
         .batchOperationKey(batchOperationKey)
         .state(BatchOperationState.ACTIVE)
         .operationType(BatchOperationType.valueOf(value.getBatchOperationType().name()))
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+        .actorType(actorInfo.type())
+        .actorId(actorInfo.id())
         .build();
+  }
+
+  private record ActorInfo(BatchOperationActorType type, String id) {
+    static final ActorInfo NULL_VALUES = new ActorInfo(null, null);
+  }
+
+  private static final class ActorInfoExtractor {
+
+    private static final SemanticVersion VERSION_8_9_0 = new SemanticVersion(8, 9, 0, null, null);
+
+    /**
+     * Extracts the actor information from the record's authorizations based on the broker version.
+     * Actor info is only provided for broker versions 8.9.0 and above. If the actor info is not
+     * available, null values are provided.
+     */
+    private ActorInfo extract(final Record<BatchOperationCreationRecordValue> record) {
+      final var semanticVersion = SemanticVersion.parse(record.getBrokerVersion()).orElse(null);
+      if (semanticVersion == null || semanticVersion.compareTo(VERSION_8_9_0) < 0) {
+        // actor info should only be set for versions 8.9.0 and above
+        return ActorInfo.NULL_VALUES;
+      }
+
+      final AuditLogActor auditLogActor = AuditLogActor.of(record);
+      if (auditLogActor == null) {
+        return ActorInfo.NULL_VALUES;
+      }
+
+      final var actorType =
+          switch (auditLogActor.actorType()) {
+            case USER -> BatchOperationActorType.USER;
+            case CLIENT -> BatchOperationActorType.CLIENT;
+            case null -> null;
+          };
+      return new ActorInfo(actorType, auditLogActor.actorId());
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationActorType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
@@ -321,6 +322,8 @@ class BatchOperationControllerTest extends RestControllerTest {
         BatchOperationType.CANCEL_PROCESS_INSTANCE,
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
+        BatchOperationActorType.USER,
+        "frodo.baggins",
         10,
         0,
         10,
@@ -339,6 +342,8 @@ class BatchOperationControllerTest extends RestControllerTest {
         BatchOperationType.CANCEL_PROCESS_INSTANCE,
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
+        BatchOperationActorType.USER,
+        "frodo.baggins",
         operationsTotalCount,
         operationsFailedCount,
         operationsCompletedCount,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds actor type and id for batch operations to RDBMS, similar to ES/OS.

I've tried to keep this changeset as small as possible, but it wasn't possible to only focus the changes on storing the data in RDBMS - changes to the queries were required by failing tests.

So this also enables querying the stored data from RDBMS, including filtering. Note that this PR does not change the gateway yet so the searching/querying isn't in use yet.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42066 
