### PR TITLE
fix: reinstate fetching from userinfo during authentication flows

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -745,9 +745,10 @@ public class WebSecurityConfig {
     @Bean
     public OidcUserService oidcUserService() {
       final var userService = new OidcUserService();
-      // disable fetching user info from the IdP, as we never use it, and this can cause rate
-      // limiting issues with some IdPs
-      userService.setRetrieveUserInfo(ignored -> false);
+      // We need to consume the userinfo endpoint to support retrieving additional information about
+      // the principal (e.g., email, groups, etc.) in case the access token does not contain them
+      // Remove when https://github.com/camunda/camunda/issues/42751 is completed
+      userService.setRetrieveUserInfo(ignored -> true);
       return userService;
     }
 


### PR DESCRIPTION
## Description

There is a customer need to rely on data taken from the userinfo endpoint. This PR visibly reinstates this functionality that was removed in https://github.com/camunda/camunda/commit/68f978dc716e3f91f314d8c7751e34d4eb67294d

## Related issues

closes #42745
