### PR TITLE
Decision requirements search API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/isMammal_.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/isMammal_.dmn
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="dmnIsMammal" name="IsMammal" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="8f56dcb" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <decision id="MammalLikeBody" name="Mammal Like Body">
+    <informationRequirement id="InformationRequirement_0nunx5r">
+      <requiredInput href="#hasHairOrFur" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_0gnz4gt">
+      <requiredInput href="#warmBlooded" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_17u0un2">
+      <input id="Input_1" label="Hair or Fur">
+        <inputExpression id="InputExpression_1" typeRef="boolean">
+          <text>hasHairOrFur</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_1887ac3" label="Warm blooded">
+        <inputExpression id="LiteralExpression_07xyhv2" typeRef="boolean">
+          <text>warmBlooded</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="MammalLikeBody" name="bodyMammalScore" typeRef="string">
+        <outputValues id="UnaryTests_0k6apo7">
+          <text>"Strong","Weak"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0m3xh93">
+        <inputEntry id="UnaryTests_1it6e8x">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qhze7d">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1mds7fa">
+          <text>"Strong"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01sxitb">
+        <inputEntry id="UnaryTests_0ipor9x">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yfkinj">
+          <text>false</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1jbibw4">
+          <text>"Weak"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0tfgmfq">
+        <inputEntry id="UnaryTests_0lnh0o5">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jyjyf3">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1npv8fc">
+          <text>"Weak"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_07oevd0">
+        <inputEntry id="UnaryTests_0s5bnw9">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_135yods">
+          <text>false</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mdaz3y">
+          <text>"Weak"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <inputData id="hasHairOrFur" name="has Hair or Fur?" />
+  <inputData id="warmBlooded" name="Warm blooded?" />
+  <inputData id="givesMilk" name="Gives Milk?" />
+  <decision id="MammalLikeNursing" name="Mammal Like Nursing">
+    <informationRequirement id="InformationRequirement_1xns7gk">
+      <requiredInput href="#warmBlooded" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_0opmwlp">
+      <requiredInput href="#givesMilk" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_00ci0tm">
+      <input id="InputClause_1vsrodn" label="Gives Milk">
+        <inputExpression id="LiteralExpression_12x6r76" typeRef="boolean">
+          <text>givesMilk</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_1qtrnli" label="Warm Blooded">
+        <inputExpression id="LiteralExpression_0xb0rtm" typeRef="boolean">
+          <text>warmBlooded</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0l08s83" label="MammalLikeNursing" name="nursingMammalScore" typeRef="string" />
+      <rule id="DecisionRule_17la9c6">
+        <inputEntry id="UnaryTests_0054yic">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11ys4p1">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ey0ut6">
+          <text>"Strong"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0qtsnun">
+        <inputEntry id="UnaryTests_1eyppco">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lcwspw">
+          <text>false</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_149ihkv">
+          <text>"Weak"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="IsMammal" name="Is Mammal?">
+    <informationRequirement id="InformationRequirement_0l5ozl4">
+      <requiredDecision href="#MammalLikeBody" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_0gz9b7p">
+      <requiredDecision href="#MammalLikeNursing" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1lzdl5n">
+      <input id="InputClause_1j5pmm4" label="Mammal Body" biodi:width="192">
+        <inputExpression id="LiteralExpression_0qru4yz" typeRef="string">
+          <text>MammalLikeBody</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1hrmcxh">
+          <text>"Strong","Weak"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_09ebm3u" label="Mammal Nursing">
+        <inputExpression id="LiteralExpression_1bheaqq" typeRef="string">
+          <text>MammalLikeNursing</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1bm8gun">
+          <text>"Strong","Weak"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1q8krr2" label="is Mammal" name="isMammal" typeRef="boolean" />
+      <rule id="DecisionRule_0yetjp4">
+        <inputEntry id="UnaryTests_0naicf5">
+          <text>"Strong"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r6o9ie">
+          <text>"Strong"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_18htrc2">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0hj737y">
+        <inputEntry id="UnaryTests_0jya7hh">
+          <text>"Strong"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ftsuis">
+          <text>"Weak"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1k7tjun">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0jvbhgs">
+        <inputEntry id="UnaryTests_1b38vc1">
+          <text>"Weak"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x46t59">
+          <text>"Strong"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01hnj8x">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_13zesya">
+        <inputEntry id="UnaryTests_05k9nfz">
+          <text>"Weak"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w3e82i">
+          <text>"Weak"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_09u6id8">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="MammalLikeBody">
+        <dc:Bounds height="80" width="180" x="260" y="240" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_15yddzc" dmnElementRef="hasHairOrFur">
+        <dc:Bounds height="45" width="125" x="158" y="408" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_0h4r1ln" dmnElementRef="warmBlooded">
+        <dc:Bounds height="45" width="125" x="397" y="408" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_03yqp9q" dmnElementRef="givesMilk">
+        <dc:Bounds height="45" width="125" x="658" y="409" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_05u2tpo" dmnElementRef="MammalLikeNursing">
+        <dc:Bounds height="80" width="180" x="560" y="240" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_03mxsik" dmnElementRef="IsMammal">
+        <dc:Bounds height="80" width="180" x="420" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0kby9sd" dmnElementRef="InformationRequirement_0nunx5r">
+        <di:waypoint x="221" y="408" />
+        <di:waypoint x="320" y="340" />
+        <di:waypoint x="320" y="320" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_1mulfen" dmnElementRef="InformationRequirement_0gnz4gt">
+        <di:waypoint x="460" y="408" />
+        <di:waypoint x="380" y="340" />
+        <di:waypoint x="380" y="320" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_056rnaf" dmnElementRef="InformationRequirement_1xns7gk">
+        <di:waypoint x="460" y="408" />
+        <di:waypoint x="620" y="340" />
+        <di:waypoint x="620" y="320" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_17it6js" dmnElementRef="InformationRequirement_0opmwlp">
+        <di:waypoint x="721" y="409" />
+        <di:waypoint x="680" y="340" />
+        <di:waypoint x="680" y="320" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_1tncn7n" dmnElementRef="InformationRequirement_0l5ozl4">
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="480" y="180" />
+        <di:waypoint x="480" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_00xf1zw" dmnElementRef="InformationRequirement_0gz9b7p">
+        <di:waypoint x="650" y="240" />
+        <di:waypoint x="540" y="180" />
+        <di:waypoint x="540" y="160" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
@@ -14,7 +14,6 @@ import {
   assertBadRequest,
   assertStatusCode,
   assertEqualsForKeys,
-  assertRequiredFields,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
@@ -17,7 +17,7 @@ import {
   assertRequiredFields,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import {deployMammalDecisionAndStoreResponse} from '@requestHelpers';
+import {deployMammalDecisionAndStoreResponse, deployTwoSimpleDecisionsAndStoreResponse} from '@requestHelpers';
 import {DecisionRequirementsDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import {validateResponse} from '../../../../json-body-assertions';
 import { decisionRequirementRequiredFields } from 'utils/beans/requestBeans';
@@ -32,9 +32,10 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
     await deployMammalDecisionAndStoreResponse(
       decisionRequirements,
     );
+    await deployTwoSimpleDecisionsAndStoreResponse(decisionRequirements);
   });
 
-  test('Search decision requirements - 1 result - success', async ({request}) => {
+  test('Search decision requirements - multiple results - success', async ({request}) => {
     await expect(async () => {
       const res = await request.post(
         buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT, {}),
@@ -55,19 +56,19 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
       );
 
       const body = await res.json();
-      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      expect(body.items.length).toBeGreaterThanOrEqual(3);
       expect(Array.isArray(body.items)).toBe(true);
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search decision requirements by decisionRequirementsName success', async ({request}) => {
-    const decisionRequirementToSearch = decisionRequirements[0];
+  test('Search decision requirements by version success', async ({request}) => {
+    const decisionRequirementToSearch = decisionRequirements[1];
     await expect(async () => {
       const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),
         data: {
           filter: {
-            decisionRequirementsName: decisionRequirementToSearch.decisionRequirementsName,
+            version: decisionRequirementToSearch.version,
           },
         },
       });
@@ -84,10 +85,99 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
       );
 
       const body = await res.json();
-      assertRequiredFields(body, ['items', 'page']);
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision requirements by decisionRequirementsName and version success', async ({request}) => {
+    const decisionRequirementToSearch = decisionRequirements[0];
+    await expect(async () => {
+      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            decisionRequirementsName: decisionRequirementToSearch.decisionRequirementsName,
+            version: decisionRequirementToSearch.version,
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+
+      await validateResponse(
+        {
+        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
       expect(body.items.length).toEqual(1);
       expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
       assertEqualsForKeys(decisionRequirementToSearch, body.items[0], decisionRequirementRequiredFields);
     }).toPass(defaultAssertionOptions);
   });
+
+  test('Search decision requirements - unauthorized request', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+        });
+
+        await assertUnauthorizedRequest(res);
+     }).toPass(defaultAssertionOptions);
+   });
+
+   test('Search decision requirements - empty result', async ({request}) => {
+    const someNotExistingDecisionRequirementsName = 'someRandomDecisionRequirementsName';
+    await expect(async () => {
+      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+          data: {
+            filter: {
+              decisionRequirementsName: someNotExistingDecisionRequirementsName,
+            },
+          },
+      });
+
+      await assertStatusCode(res, 200);
+
+      await validateResponse(
+        {
+        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      expect(body.items.length).toEqual(0);
+      expect(body.page.totalItems).toEqual(0);
+     }).toPass(defaultAssertionOptions);
+   });
+
+   test('Search decision requirements - invalid filter', async ({request}) => {
+    const someRandomFilterValue = 'meow';
+    await expect(async () => {
+      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+          data: {
+            filter: {
+              randomNotExistingFieldName: someRandomFilterValue,
+            },
+          },
+      });
+
+      await assertBadRequest(
+        res,
+        'Request property [filter.randomNotExistingFieldName] cannot be parsed',
+      );
+     }).toPass(defaultAssertionOptions);
+   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
@@ -17,25 +17,27 @@ import {
   assertRequiredFields,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import {deployMammalDecisionAndStoreResponse, deployTwoSimpleDecisionsAndStoreResponse} from '@requestHelpers';
+import {
+  deployMammalDecisionAndStoreResponse,
+  deployTwoSimpleDecisionsAndStoreResponse,
+} from '@requestHelpers';
 import {DecisionRequirementsDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import {validateResponse} from '../../../../json-body-assertions';
-import { decisionRequirementRequiredFields } from 'utils/beans/requestBeans';
+import {decisionRequirementRequiredFields} from 'utils/beans/requestBeans';
 
 const DECISION_REQUIREMENTS_SEARCH_ENDPOINT = '/decision-requirements/search';
 
-/* eslint-disable playwright/expect-expect */
 test.describe.parallel('Search Decision Requirements API Tests', () => {
   let decisionRequirements: DecisionRequirementsDeployment[] = [];
 
   test.beforeAll(async () => {
-    await deployMammalDecisionAndStoreResponse(
-      decisionRequirements,
-    );
+    await deployMammalDecisionAndStoreResponse(decisionRequirements);
     await deployTwoSimpleDecisionsAndStoreResponse(decisionRequirements);
   });
 
-  test('Search decision requirements - multiple results - success', async ({request}) => {
+  test('Search decision requirements - multiple results - success', async ({
+    request,
+  }) => {
     await expect(async () => {
       const res = await request.post(
         buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT, {}),
@@ -48,9 +50,9 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
       await assertStatusCode(res, 200);
       await validateResponse(
         {
-        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
+          path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
         },
         res,
       );
@@ -64,22 +66,25 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
   test('Search decision requirements by version success', async ({request}) => {
     const decisionRequirementToSearch = decisionRequirements[1];
     await expect(async () => {
-      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
-        headers: jsonHeaders(),
-        data: {
-          filter: {
-            version: decisionRequirementToSearch.version,
+      const res = await request.post(
+        buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              version: decisionRequirementToSearch.version,
+            },
           },
         },
-      });
+      );
 
       await assertStatusCode(res, 200);
 
       await validateResponse(
         {
-        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
+          path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
         },
         res,
       );
@@ -89,26 +94,32 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search decision requirements by decisionRequirementsName and version success', async ({request}) => {
+  test('Search decision requirements by decisionRequirementsName and version success', async ({
+    request,
+  }) => {
     const decisionRequirementToSearch = decisionRequirements[0];
     await expect(async () => {
-      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
-        headers: jsonHeaders(),
-        data: {
-          filter: {
-            decisionRequirementsName: decisionRequirementToSearch.decisionRequirementsName,
-            version: decisionRequirementToSearch.version,
+      const res = await request.post(
+        buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              decisionRequirementsName:
+                decisionRequirementToSearch.decisionRequirementsName,
+              version: decisionRequirementToSearch.version,
+            },
           },
         },
-      });
+      );
 
       await assertStatusCode(res, 200);
 
       await validateResponse(
         {
-        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
+          path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
         },
         res,
       );
@@ -116,42 +127,55 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
       const body = await res.json();
       expect(body.items.length).toEqual(1);
       expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-      assertEqualsForKeys(decisionRequirementToSearch, body.items[0], decisionRequirementRequiredFields);
+      assertEqualsForKeys(
+        decisionRequirementToSearch,
+        body.items[0],
+        decisionRequirementRequiredFields,
+      );
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search decision requirements - unauthorized request', async ({request}) => {
+  test('Search decision requirements - unauthorized request', async ({
+    request,
+  }) => {
     await expect(async () => {
-        const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
+      const res = await request.post(
+        buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT),
+        {
           headers: {
             'Content-Type': 'application/json',
           },
           data: {},
-        });
+        },
+      );
 
-        await assertUnauthorizedRequest(res);
-     }).toPass(defaultAssertionOptions);
-   });
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
 
-   test('Search decision requirements - empty result', async ({request}) => {
-    const someNotExistingDecisionRequirementsName = 'someRandomDecisionRequirementsName';
+  test('Search decision requirements - empty result', async ({request}) => {
+    const someNotExistingDecisionRequirementsName =
+      'someRandomDecisionRequirementsName';
     await expect(async () => {
-      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
-        headers: jsonHeaders(),
+      const res = await request.post(
+        buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
           data: {
             filter: {
               decisionRequirementsName: someNotExistingDecisionRequirementsName,
             },
           },
-      });
+        },
+      );
 
       await assertStatusCode(res, 200);
 
       await validateResponse(
         {
-        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
+          path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
         },
         res,
       );
@@ -159,25 +183,28 @@ test.describe.parallel('Search Decision Requirements API Tests', () => {
       const body = await res.json();
       expect(body.items.length).toEqual(0);
       expect(body.page.totalItems).toEqual(0);
-     }).toPass(defaultAssertionOptions);
-   });
+    }).toPass(defaultAssertionOptions);
+  });
 
-   test('Search decision requirements - invalid filter', async ({request}) => {
+  test('Search decision requirements - invalid filter', async ({request}) => {
     const someRandomFilterValue = 'meow';
     await expect(async () => {
-      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
-        headers: jsonHeaders(),
+      const res = await request.post(
+        buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
           data: {
             filter: {
               randomNotExistingFieldName: someRandomFilterValue,
             },
           },
-      });
+        },
+      );
 
       await assertBadRequest(
         res,
         'Request property [filter.randomNotExistingFieldName] cannot be parsed',
       );
-     }).toPass(defaultAssertionOptions);
-   });
+    }).toPass(defaultAssertionOptions);
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-requirements/decision-requirements-search-api.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertStatusCode,
+  assertEqualsForKeys,
+  assertRequiredFields,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {deployMammalDecisionAndStoreResponse} from '@requestHelpers';
+import {DecisionRequirementsDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
+import {validateResponse} from '../../../../json-body-assertions';
+import { decisionRequirementRequiredFields } from 'utils/beans/requestBeans';
+
+const DECISION_REQUIREMENTS_SEARCH_ENDPOINT = '/decision-requirements/search';
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Search Decision Requirements API Tests', () => {
+  let decisionRequirements: DecisionRequirementsDeployment[] = [];
+
+  test.beforeAll(async () => {
+    await deployMammalDecisionAndStoreResponse(
+      decisionRequirements,
+    );
+  });
+
+  test('Search decision requirements - 1 result - success', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      expect(Array.isArray(body.items)).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision requirements by decisionRequirementsName success', async ({request}) => {
+    const decisionRequirementToSearch = decisionRequirements[0];
+    await expect(async () => {
+      const res = await request.post(buildUrl(DECISION_REQUIREMENTS_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            decisionRequirementsName: decisionRequirementToSearch.decisionRequirementsName,
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+
+      await validateResponse(
+        {
+        path: DECISION_REQUIREMENTS_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      assertRequiredFields(body, ['items', 'page']);
+      expect(body.items.length).toEqual(1);
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      assertEqualsForKeys(decisionRequirementToSearch, body.items[0], decisionRequirementRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -123,6 +123,14 @@ export const decisionDefinitionRequiredFields: string[] = [
   'decisionDefinitionKey',
   'decisionRequirementsKey',
 ];
+export const decisionRequirementRequiredFields: string[] = [
+    'decisionRequirementsId',
+    'version',
+    'decisionRequirementsName',
+    'tenantId',
+    'decisionRequirementsKey',
+    'resourceName',
+];
 export const evaluateDecisionRequiredFields: string[] = [
   'decisionDefinitionId',
   'decisionDefinitionName',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -124,12 +124,12 @@ export const decisionDefinitionRequiredFields: string[] = [
   'decisionRequirementsKey',
 ];
 export const decisionRequirementRequiredFields: string[] = [
-    'decisionRequirementsId',
-    'version',
-    'decisionRequirementsName',
-    'tenantId',
-    'decisionRequirementsKey',
-    'resourceName',
+  'decisionRequirementsId',
+  'version',
+  'decisionRequirementsName',
+  'tenantId',
+  'decisionRequirementsKey',
+  'resourceName',
 ];
 export const evaluateDecisionRequiredFields: string[] = [
   'decisionDefinitionId',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-requirement-requestHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-requirement-requestHelper.ts
@@ -12,7 +12,7 @@ import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
 import {decisionDefinitionRequiredFields} from '../beans/requestBeans';
 import {validateResponse} from '../../json-body-assertions';
 import {deploy} from '../zeebeClient';
-import { DecisionDeployment, DecisionRequirementsDeployment } from '@camunda8/sdk/dist/c8/lib/C8Dto';
+import {DecisionRequirementsDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import { defaultAssertionOptions } from 'utils/constants';
 
 export async function deployMammalDecisionAndStoreResponse(
@@ -21,4 +21,12 @@ export async function deployMammalDecisionAndStoreResponse(
   const response = await deploy(['./resources/isMammal_.dmn',]);
   expect(response.decisionRequirements.length).toBe(1);
   decisionRequirements.push(response.decisionRequirements[0] as DecisionRequirementsDeployment);
+}
+
+export async function deployTwoSimpleDecisionsAndStoreResponse(decisionRequirements: DecisionRequirementsDeployment[]){
+  const response = await deploy(['./resources/simpleDecisionTable1.dmn','./resources/simpleDecisionTable2.dmn']);
+  expect(response.decisionRequirements.length).toBe(2);
+  for (const decisionRequirementElement of response.decisionRequirements) {
+    decisionRequirements.push(decisionRequirementElement as DecisionRequirementsDeployment);
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-requirement-requestHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-requirement-requestHelper.ts
@@ -6,27 +6,31 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Serializable} from 'playwright-core/types/structs';
-import {APIRequestContext, expect} from '@playwright/test';
-import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
-import {decisionDefinitionRequiredFields} from '../beans/requestBeans';
-import {validateResponse} from '../../json-body-assertions';
+import {expect} from '@playwright/test';
 import {deploy} from '../zeebeClient';
 import {DecisionRequirementsDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
-import { defaultAssertionOptions } from 'utils/constants';
 
 export async function deployMammalDecisionAndStoreResponse(
   decisionRequirements: DecisionRequirementsDeployment[],
 ) {
-  const response = await deploy(['./resources/isMammal_.dmn',]);
+  const response = await deploy(['./resources/isMammal_.dmn']);
   expect(response.decisionRequirements.length).toBe(1);
-  decisionRequirements.push(response.decisionRequirements[0] as DecisionRequirementsDeployment);
+  decisionRequirements.push(
+    response.decisionRequirements[0] as DecisionRequirementsDeployment,
+  );
 }
 
-export async function deployTwoSimpleDecisionsAndStoreResponse(decisionRequirements: DecisionRequirementsDeployment[]){
-  const response = await deploy(['./resources/simpleDecisionTable1.dmn','./resources/simpleDecisionTable2.dmn']);
+export async function deployTwoSimpleDecisionsAndStoreResponse(
+  decisionRequirements: DecisionRequirementsDeployment[],
+) {
+  const response = await deploy([
+    './resources/simpleDecisionTable1.dmn',
+    './resources/simpleDecisionTable2.dmn',
+  ]);
   expect(response.decisionRequirements.length).toBe(2);
   for (const decisionRequirementElement of response.decisionRequirements) {
-    decisionRequirements.push(decisionRequirementElement as DecisionRequirementsDeployment);
+    decisionRequirements.push(
+      decisionRequirementElement as DecisionRequirementsDeployment,
+    );
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-requirement-requestHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-requirement-requestHelper.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Serializable} from 'playwright-core/types/structs';
+import {APIRequestContext, expect} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {decisionDefinitionRequiredFields} from '../beans/requestBeans';
+import {validateResponse} from '../../json-body-assertions';
+import {deploy} from '../zeebeClient';
+import { DecisionDeployment, DecisionRequirementsDeployment } from '@camunda8/sdk/dist/c8/lib/C8Dto';
+import { defaultAssertionOptions } from 'utils/constants';
+
+export async function deployMammalDecisionAndStoreResponse(
+  decisionRequirements: DecisionRequirementsDeployment[],
+) {
+  const response = await deploy(['./resources/isMammal_.dmn',]);
+  expect(response.decisionRequirements.length).toBe(1);
+  decisionRequirements.push(response.decisionRequirements[0] as DecisionRequirementsDeployment);
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -47,3 +47,4 @@ export {createSingleIncidentProcessInstance} from './incident-requestHelpers';
 export {createTwoIncidentsInOneProcess} from './incident-requestHelpers';
 export {createIncidentsInTwoProcesses} from './incident-requestHelpers';
 export {createTwoDifferentIncidentsInOneProcess} from './incident-requestHelpers';
+export {deployMammalDecisionAndStoreResponse} from './decision-requirement-requestHelper';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -47,4 +47,7 @@ export {createSingleIncidentProcessInstance} from './incident-requestHelpers';
 export {createTwoIncidentsInOneProcess} from './incident-requestHelpers';
 export {createIncidentsInTwoProcesses} from './incident-requestHelpers';
 export {createTwoDifferentIncidentsInOneProcess} from './incident-requestHelpers';
-export {deployMammalDecisionAndStoreResponse, deployTwoSimpleDecisionsAndStoreResponse} from './decision-requirement-requestHelper';
+export {
+  deployMammalDecisionAndStoreResponse,
+  deployTwoSimpleDecisionsAndStoreResponse,
+} from './decision-requirement-requestHelper';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -47,4 +47,4 @@ export {createSingleIncidentProcessInstance} from './incident-requestHelpers';
 export {createTwoIncidentsInOneProcess} from './incident-requestHelpers';
 export {createIncidentsInTwoProcesses} from './incident-requestHelpers';
 export {createTwoDifferentIncidentsInOneProcess} from './incident-requestHelpers';
-export {deployMammalDecisionAndStoreResponse} from './decision-requirement-requestHelper';
+export {deployMammalDecisionAndStoreResponse, deployTwoSimpleDecisionsAndStoreResponse} from './decision-requirement-requestHelper';


### PR DESCRIPTION
## Description

This PR covers [Decision requirements search API](https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/specifications/search-decision-requirements/)  happy path:

- Search decision requirements by decisionRequirementsName and version success
- Search decision requirements - multiple results - success
- Search decision requirements - empty result
- Search decision requirements by version success

and unhappy path:

- Search decision requirements - invalid filter (bad request)
- Search decision requirements - unauthorized request

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
related #37204

## On demand workflow
[was successful](https://github.com/camunda/camunda/actions/runs/20296843148)
