### PR TITLE
[Backport stable/8.6] refactor: remove obsolete inputs from load test workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -61,16 +61,6 @@ on:
         type: string
         default: ""
         required: false
-      cluster:
-        description: 'Specifies which cluster to deploy the load test on'
-        default: 'zeebe-cluster'
-        type: string
-        required: false
-      cluster-region:
-        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
-        default: europe-west1-b
-        type: string
-        required: false
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         type: string
@@ -269,8 +259,8 @@ jobs:
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.5
         with:
-          cluster_name: ${{ inputs.cluster }}
-          location: ${{ inputs.cluster-region }}
+          cluster_name: zeebe-cluster
+          location: europe-west1-b
       - name: Create namespace if not exists
         run: |
           if ! kubectl get namespace ${{ inputs.name }} >/dev/null 2>&1; then
@@ -362,8 +352,8 @@ jobs:
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.5
         with:
-          cluster_name: ${{ inputs.cluster }}
-          location: ${{ inputs.cluster-region }}
+          cluster_name: zeebe-cluster
+          location: europe-west1-b
       - name: Add Load test Helm repo
         run: |
           helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -27,14 +27,6 @@ on:
         type: string
         default: ""
         required: false
-      cluster:
-        description: 'Specifies which cluster to deploy the load test on'
-        default: 'zeebe-cluster'
-        required: false
-      cluster-region:
-        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
-        default: europe-west1-b
-        required: false
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -17,8 +17,6 @@ jobs:
     secrets: inherit
     with:
       name: ${{github.event.pull_request.head.ref}}-benchmark
-      cluster: zeebe-cluster
-      cluster-region: europe-west1-b
       ref: ${{ github.event.pull_request.head.ref }}
 
   delete-benchmark:

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -24,8 +24,6 @@ jobs:
     secrets: inherit
     with:
       name: release-rolling
-      cluster: zeebe-cluster
-      cluster-region: europe-west1-b
       ref: refs/tags/${{ needs.fetch-release.outputs.release-tag }}
       load-test-load: >
         --set starter.rate=5


### PR DESCRIPTION
# Description
Backport of #42575 to `stable/8.6`.

relates to camunda/camunda#41839 #41839