### PR TITLE
Extract topology functions to service layer

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -62,6 +62,7 @@ import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.SignalServices;
 import io.camunda.service.TenantServices;
+import io.camunda.service.TopologyServices;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserTaskServices;
@@ -575,6 +576,20 @@ public class CamundaServicesConfiguration {
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new ConditionalServices(
+        brokerClient,
+        securityContextProvider,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Bean
+  public TopologyServices topologyServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new TopologyServices(
         brokerClient,
         securityContextProvider,
         null,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerNoAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerNoAuthIT.java
@@ -27,7 +27,7 @@ public class GlobalErrorControllerNoAuthIT {
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker().withAuthorizationsDisabled().withAuthenticatedAccess();
+      new TestStandaloneBroker().withAuthorizationsDisabled();
 
   @Test
   void shouldPass() throws URISyntaxException {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -28,6 +28,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
     <dependency>

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.atomix.utils.net.Address;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.TopologyServices.Topology.Builder;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import io.camunda.zeebe.util.VersionUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class TopologyServices extends ApiServices<TopologyServices> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TopologyServices.class);
+
+  public TopologyServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final CamundaAuthentication authentication,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Override
+  public TopologyServices withAuthentication(final CamundaAuthentication authentication) {
+    return new TopologyServices(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public CompletableFuture<ClusterStatus> getStatus() {
+    try {
+      if (!hasAPartitionWithAHealthyLeader()) {
+        return CompletableFuture.completedFuture(ClusterStatus.UNHEALTHY);
+      }
+
+      return CompletableFuture.completedFuture(ClusterStatus.HEALTHY);
+    } catch (final Exception ex) {
+      return CompletableFuture.failedFuture(ErrorMapper.mapError(ex));
+    }
+  }
+
+  private boolean hasAPartitionWithAHealthyLeader() {
+    final var topology = brokerClient.getTopologyManager().getTopology();
+    final var partitions = topology.getPartitions();
+
+    return partitions.stream()
+        .anyMatch(
+            partition -> {
+              final var leader = topology.getLeaderForPartition(partition);
+              return topology.getPartitionHealth(leader, partition)
+                  == PartitionHealthStatus.HEALTHY;
+            });
+  }
+
+  public CompletableFuture<Topology> getTopology() {
+    try {
+      final var topology = Topology.Builder.create();
+      final var clusterState = brokerClient.getTopologyManager().getTopology();
+
+      final var gatewayVersion = VersionUtil.getVersion();
+      if (gatewayVersion != null && !gatewayVersion.isBlank()) {
+        topology.gatewayVersion(gatewayVersion);
+      }
+
+      if (clusterState != null) {
+        topology
+            .clusterId(clusterState.getClusterId())
+            .clusterSize(clusterState.getClusterSize())
+            .partitionsCount(clusterState.getPartitionsCount())
+            .replicationFactor(clusterState.getReplicationFactor())
+            .lastCompletedChangeId(clusterState.getLastCompletedChangeId());
+
+        clusterState
+            .getBrokers()
+            .forEach(
+                brokerId -> {
+                  final var broker = Broker.Builder.create();
+                  addBrokerInfo(broker, brokerId, clusterState);
+                  addPartitionInfoToBrokerInfo(broker, brokerId, clusterState);
+
+                  topology.addBroker(broker.build());
+                });
+      }
+
+      return CompletableFuture.completedFuture(topology.build());
+    } catch (final Exception ex) {
+      return CompletableFuture.failedFuture(ErrorMapper.mapError(ex));
+    }
+  }
+
+  private void addBrokerInfo(
+      final Broker.Builder broker, final Integer brokerId, final BrokerClusterState topology) {
+    final var brokerAddress = topology.getBrokerAddress(brokerId);
+    final var address = Address.from(brokerAddress);
+
+    broker
+        .nodeId(brokerId)
+        .host(address.host())
+        .port(address.port())
+        .version(topology.getBrokerVersion(brokerId));
+  }
+
+  private void addPartitionInfoToBrokerInfo(
+      final Broker.Builder broker, final Integer brokerId, final BrokerClusterState topology) {
+    topology
+        .getPartitions()
+        .forEach(
+            partitionId -> {
+              final var partition = Partition.Builder.create();
+
+              partition.partitionId(partitionId);
+              final var isRoleSet = setRole(brokerId, partitionId, topology, partition);
+              if (!isRoleSet) {
+                return;
+              }
+
+              final var status = topology.getPartitionHealth(brokerId, partitionId);
+              switch (status) {
+                case HEALTHY -> partition.health(Health.HEALTHY);
+                case UNHEALTHY -> partition.health(Health.UNHEALTHY);
+                case DEAD -> partition.health(Health.DEAD);
+                default ->
+                    LOGGER.debug("Unsupported partition broker health status '{}'", status.name());
+              }
+              broker.addPartition(partition.build());
+            });
+  }
+
+  private boolean setRole(
+      final Integer brokerId,
+      final Integer partitionId,
+      final BrokerClusterState topology,
+      final Partition.Builder partition) {
+    final var partitionLeader = topology.getLeaderForPartition(partitionId);
+    final var partitionFollowers = topology.getFollowersForPartition(partitionId);
+    final var partitionInactives = topology.getInactiveNodesForPartition(partitionId);
+
+    if (partitionLeader == brokerId) {
+      partition.role(Role.LEADER);
+    } else if (partitionFollowers != null && partitionFollowers.contains(brokerId)) {
+      partition.role(Role.FOLLOWER);
+    } else if (partitionInactives != null && partitionInactives.contains(brokerId)) {
+      partition.role(Role.INACTIVE);
+    } else {
+      return false;
+    }
+
+    return true;
+  }
+
+  public record Topology(
+      List<Broker> brokers,
+      String clusterId,
+      Integer clusterSize,
+      Integer partitionsCount,
+      Integer replicationFactor,
+      String gatewayVersion,
+      Long lastCompletedChangeId) {
+
+    static class Builder {
+      List<Broker> brokers = new ArrayList<>();
+      String clusterId;
+      Integer clusterSize;
+      Integer partitionsCount;
+      Integer replicationFactor;
+      String gatewayVersion;
+      Long lastCompletedChangeId;
+
+      public static Builder create() {
+        return new Builder();
+      }
+
+      public Builder addBroker(final Broker broker) {
+        brokers.add(broker);
+        return this;
+      }
+
+      public Builder clusterId(final String clusterId) {
+        this.clusterId = clusterId;
+        return this;
+      }
+
+      public Builder clusterSize(final Integer clusterSize) {
+        this.clusterSize = clusterSize;
+        return this;
+      }
+
+      public Builder partitionsCount(final Integer partitionsCount) {
+        this.partitionsCount = partitionsCount;
+        return this;
+      }
+
+      public Builder replicationFactor(final Integer replicationFactor) {
+        this.replicationFactor = replicationFactor;
+        return this;
+      }
+
+      public Builder gatewayVersion(final String gatewayVersion) {
+        this.gatewayVersion = gatewayVersion;
+        return this;
+      }
+
+      public Builder lastCompletedChangeId(final long lastCompletedChangeId) {
+        this.lastCompletedChangeId = lastCompletedChangeId;
+        return this;
+      }
+
+      public Topology build() {
+        return new Topology(
+            brokers,
+            clusterId,
+            clusterSize,
+            partitionsCount,
+            replicationFactor,
+            gatewayVersion,
+            lastCompletedChangeId);
+      }
+    }
+  }
+
+  public record Broker(
+      Integer nodeId, String host, Integer port, List<Partition> partitions, String version) {
+
+    static class Builder {
+      Integer nodeId;
+      String host;
+      Integer port;
+      List<Partition> partitions = new ArrayList<>();
+      String version;
+
+      public static Builder create() {
+        return new Builder();
+      }
+
+      public Builder nodeId(final Integer nodeId) {
+        this.nodeId = nodeId;
+        return this;
+      }
+
+      public Builder host(final String host) {
+        this.host = host;
+        return this;
+      }
+
+      public Builder port(final Integer port) {
+        this.port = port;
+        return this;
+      }
+
+      public Builder addPartition(final Partition partition) {
+        partitions.add(partition);
+        return this;
+      }
+
+      public Builder version(final String version) {
+        this.version = version;
+        return this;
+      }
+
+      public Broker build() {
+        return new Broker(nodeId, host, port, partitions, version);
+      }
+    }
+  }
+
+  public record Partition(Integer partitionId, Role role, Health health) {
+    static class Builder {
+      Integer partitionId;
+      Role role;
+      Health health;
+
+      public static Builder create() {
+        return new Builder();
+      }
+
+      public Builder partitionId(final Integer partitionId) {
+        this.partitionId = partitionId;
+        return this;
+      }
+
+      public Builder role(final Role role) {
+        this.role = role;
+        return this;
+      }
+
+      public Builder health(final Health health) {
+        this.health = health;
+        return this;
+      }
+
+      public Partition build() {
+        return new Partition(partitionId, role, health);
+      }
+    }
+  }
+
+  /** Describes the Raft role of the broker for a given partition. */
+  public enum Role {
+    LEADER,
+    FOLLOWER,
+    INACTIVE
+  }
+
+  /** Describes the current health of the partition. */
+  public enum Health {
+    HEALTHY,
+    UNHEALTHY,
+    DEAD
+  }
+
+  public enum ClusterStatus {
+    HEALTHY,
+    UNHEALTHY
+  }
+}

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -65,6 +65,11 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
 
   private boolean hasAPartitionWithAHealthyLeader() {
     final var topology = brokerClient.getTopologyManager().getTopology();
+
+    if (topology == null) {
+      return false;
+    }
+
     final var partitions = topology.getPartitions();
 
     return partitions.stream()

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -9,6 +9,7 @@ package io.camunda.service;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.service.TopologyServices.Broker;
@@ -133,6 +134,22 @@ public class TopologyServiceTest {
     verify(brokerClient).getTopologyManager();
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
+  }
+
+  @Test
+  void shouldReturnUnhealthyWhenNoTopologyExist() {
+    // given
+    when(topologyManager.getTopology()).thenReturn(null);
+
+    // when
+    final var status = services.getStatus().join();
+
+    // then
+    Assertions.assertThat(status).isEqualTo(ClusterStatus.UNHEALTHY);
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verifyNoInteractions(clusterState);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.TopologyServices.Broker;
+import io.camunda.service.TopologyServices.ClusterStatus;
+import io.camunda.service.TopologyServices.Health;
+import io.camunda.service.TopologyServices.Partition;
+import io.camunda.service.TopologyServices.Role;
+import io.camunda.service.TopologyServices.Topology;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import io.camunda.zeebe.util.VersionUtil;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+
+public class TopologyServiceTest {
+
+  private BrokerClient brokerClient;
+  private BrokerClusterState clusterState;
+  private TopologyServices services;
+  private BrokerTopologyManager topologyManager;
+
+  @BeforeEach
+  public void before() {
+    brokerClient = mock(BrokerClient.class);
+    clusterState = mock(BrokerClusterState.class);
+    topologyManager = mock(BrokerTopologyManager.class);
+    when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+    when(topologyManager.getTopology()).thenReturn(clusterState);
+    services =
+        new TopologyServices(
+            brokerClient,
+            mock(SecurityContextProvider.class),
+            null,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+  }
+
+  @Test
+  void shouldReturnHealthyWhenAtLeastOnePartitionHasHealthyLeader() {
+    // given
+    final int partitionId1 = 1;
+    final int partitionId2 = 2;
+    final int leaderId1 = 1;
+    final int leaderId2 = 2;
+
+    when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
+
+    // when
+    final var status = services.getStatus().join();
+
+    // then
+    Assertions.assertThat(status).isEqualTo(ClusterStatus.HEALTHY);
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+    verify(clusterState).getLeaderForPartition(partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = PartitionHealthStatus.class,
+      names = {"HEALTHY"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void shouldReturnUnhealthyWhenNoPartitionHasHealthyLeader(
+      final PartitionHealthStatus unhealthyStatus) {
+    // given
+    final int partitionId1 = 1;
+    final int partitionId2 = 2;
+    final int leaderId1 = 1;
+    final int leaderId2 = 2;
+
+    when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1)).thenReturn(unhealthyStatus);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2)).thenReturn(unhealthyStatus);
+
+    // when
+    final var status = services.getStatus().join();
+
+    // then
+    Assertions.assertThat(status).isEqualTo(ClusterStatus.UNHEALTHY);
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+    verify(clusterState).getLeaderForPartition(partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getLeaderForPartition(partitionId2);
+    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
+  }
+
+  @Test
+  void shouldReturnUnhealthyWhenNoPartitionsExist() {
+    // given
+    when(clusterState.getPartitions()).thenReturn(List.of());
+
+    // when
+    final var status = services.getStatus().join();
+
+    // then
+    Assertions.assertThat(status).isEqualTo(ClusterStatus.UNHEALTHY);
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+  }
+
+  @Test
+  void shouldHandleMixedPartitionHealthStatuses() {
+    // given
+    final int partitionId1 = 1;
+    final int partitionId2 = 2;
+    final int partitionId3 = 3;
+    final int leaderId1 = 1;
+    final int leaderId2 = 2;
+    final int leaderId3 = 3;
+
+    when(clusterState.getPartitions())
+        .thenReturn(List.of(partitionId1, partitionId2, partitionId3));
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getLeaderForPartition(partitionId3)).thenReturn(leaderId3);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
+        .thenReturn(PartitionHealthStatus.DEAD);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(clusterState.getPartitionHealth(leaderId3, partitionId3))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+
+    // when
+    final var status = services.getStatus().join();
+
+    // then
+    Assertions.assertThat(status).isEqualTo(ClusterStatus.HEALTHY);
+
+    verify(brokerClient).getTopologyManager();
+    verify(topologyManager).getTopology();
+    verify(clusterState).getPartitions();
+    verify(clusterState).getLeaderForPartition(partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getLeaderForPartition(partitionId2);
+    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
+    verify(clusterState).getLeaderForPartition(partitionId3);
+    verify(clusterState).getPartitionHealth(leaderId3, partitionId3);
+  }
+
+  @Test
+  public void shouldGetTopology() {
+    // given
+    final var version = VersionUtil.getVersion();
+    final var clusterId = "cluster-id";
+
+    when(topologyManager.getTopology()).thenReturn(new TestBrokerClusterState(version, clusterId));
+
+    final var expectedTopology =
+        new Topology(
+            List.of(
+                new Broker(
+                    0,
+                    "localhost",
+                    26501,
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY)),
+                    version),
+                new Broker(
+                    1,
+                    "localhost",
+                    26502,
+                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY)),
+                    version),
+                new Broker(
+                    2,
+                    "localhost",
+                    26503,
+                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
+                    version)),
+            "cluster-id",
+            3,
+            1,
+            3,
+            version,
+            1L);
+
+    // when
+    final var topology = services.getTopology().join();
+
+    // then
+    Assertions.assertThat(topology).isEqualTo(expectedTopology);
+  }
+
+  @Test
+  void shouldReturnEmptyTopology() {
+    // given
+    final var version = VersionUtil.getVersion();
+    final var expectedTopology = new Topology(List.of(), null, null, null, null, version, null);
+    Mockito.when(topologyManager.getTopology()).thenReturn(null);
+
+    // when
+    final var topology = services.getTopology().join();
+
+    // then
+    Assertions.assertThat(topology).isEqualTo(expectedTopology);
+  }
+
+  /**
+   * Topology stub which returns a static topology with 3 brokers, 1 partition, replication factor
+   * 3, where 0 is the leader (healthy), 1 is the follower (healthy), and 2 is inactive (unhealthy).
+   */
+  private record TestBrokerClusterState(String version, String clusterId)
+      implements BrokerClusterState {
+
+    @Override
+    public boolean isInitialized() {
+      return true;
+    }
+
+    @Override
+    public int getClusterSize() {
+      return 3;
+    }
+
+    @Override
+    public int getPartitionsCount() {
+      return 1;
+    }
+
+    @Override
+    public int getReplicationFactor() {
+      return 3;
+    }
+
+    @Override
+    public int getLeaderForPartition(final int partition) {
+      return 0;
+    }
+
+    @Override
+    public Set<Integer> getFollowersForPartition(final int partition) {
+      return Set.of(1);
+    }
+
+    @Override
+    public Set<Integer> getInactiveNodesForPartition(final int partition) {
+      return Set.of(2);
+    }
+
+    @Override
+    public int getRandomBroker() {
+      return ThreadLocalRandom.current().nextInt(0, 3);
+    }
+
+    @Override
+    public List<Integer> getPartitions() {
+      return List.of(1);
+    }
+
+    @Override
+    public List<Integer> getBrokers() {
+      return List.of(0, 1, 2);
+    }
+
+    @Override
+    public String getBrokerAddress(final int brokerId) {
+      return "localhost:" + (26501 + brokerId);
+    }
+
+    @Override
+    public String getBrokerVersion(final int brokerId) {
+      return version;
+    }
+
+    @Override
+    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+      if (partition != 1) {
+        return PartitionHealthStatus.NULL_VAL;
+      }
+
+      return switch (brokerId) {
+        case 0, 1 -> PartitionHealthStatus.HEALTHY;
+        case 2 -> PartitionHealthStatus.UNHEALTHY;
+        default -> PartitionHealthStatus.NULL_VAL;
+      };
+    }
+
+    @Override
+    public long getLastCompletedChangeId() {
+      return 1;
+    }
+
+    @Override
+    public String getClusterId() {
+      return clusterId;
+    }
+  }
+}

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -69,11 +69,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-atomix-utils</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker-client</artifactId>
     </dependency>
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -7,122 +7,36 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.atomix.utils.net.Address;
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.gateway.protocol.rest.BrokerInfo;
-import io.camunda.zeebe.gateway.protocol.rest.Partition;
-import io.camunda.zeebe.gateway.protocol.rest.Partition.HealthEnum;
-import io.camunda.zeebe.gateway.protocol.rest.Partition.RoleEnum;
-import io.camunda.zeebe.gateway.protocol.rest.TopologyResponse;
-import io.camunda.zeebe.gateway.rest.Loggers;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.TopologyServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
-import io.camunda.zeebe.gateway.rest.util.KeyUtil;
-import io.camunda.zeebe.util.VersionUtil;
-import java.util.Set;
+import io.camunda.zeebe.gateway.rest.mapper.RequestMapper;
+import io.camunda.zeebe.gateway.rest.mapper.ResponseMapper;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
 @RequestMapping(path = {"/v1", "/v2"})
 public final class TopologyController {
 
-  private final BrokerClient client;
+  private final TopologyServices topologyServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public TopologyController(final BrokerClient client) {
-    this.client = client;
+  public TopologyController(
+      final TopologyServices topologyServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.topologyServices = topologyServices;
+    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaGetMapping(path = "/topology")
-  public TopologyResponse get() {
-
-    final var response = new TopologyResponse();
-    final BrokerClusterState topology = client.getTopologyManager().getTopology();
-
-    final String gatewayVersion = VersionUtil.getVersion();
-    if (gatewayVersion != null && !gatewayVersion.isBlank()) {
-      response.gatewayVersion(gatewayVersion);
-    }
-
-    if (topology != null) {
-      response
-          .clusterId(topology.getClusterId())
-          .clusterSize(topology.getClusterSize())
-          .partitionsCount(topology.getPartitionsCount())
-          .replicationFactor(topology.getReplicationFactor())
-          .lastCompletedChangeId(KeyUtil.keyToString(topology.getLastCompletedChangeId()));
-
-      topology
-          .getBrokers()
-          .forEach(
-              brokerId -> {
-                final BrokerInfo brokerInfo = new BrokerInfo();
-                addBrokerInfo(brokerInfo, brokerId, topology);
-                addPartitionInfoToBrokerInfo(brokerInfo, brokerId, topology);
-
-                response.addBrokersItem(brokerInfo);
-              });
-    }
-
-    return response;
-  }
-
-  private void addBrokerInfo(
-      final BrokerInfo brokerInfo, final Integer brokerId, final BrokerClusterState topology) {
-    final String brokerAddress = topology.getBrokerAddress(brokerId);
-    final Address address = Address.from(brokerAddress);
-
-    brokerInfo.setNodeId(brokerId);
-    brokerInfo.setHost(address.host());
-    brokerInfo.setPort(address.port());
-    brokerInfo.setVersion(topology.getBrokerVersion(brokerId));
-  }
-
-  private void addPartitionInfoToBrokerInfo(
-      final BrokerInfo brokerInfo, final Integer brokerId, final BrokerClusterState topology) {
-    topology
-        .getPartitions()
-        .forEach(
-            partitionId -> {
-              final Partition partition = new Partition();
-
-              partition.setPartitionId(partitionId);
-              final var isRoleSet = setRole(brokerId, partitionId, topology, partition);
-              if (!isRoleSet) {
-                return;
-              }
-
-              final var status = topology.getPartitionHealth(brokerId, partitionId);
-              switch (status) {
-                case HEALTHY -> partition.setHealth(HealthEnum.HEALTHY);
-                case UNHEALTHY -> partition.setHealth(HealthEnum.UNHEALTHY);
-                case DEAD -> partition.setHealth(HealthEnum.DEAD);
-                default ->
-                    Loggers.REST_LOGGER.debug(
-                        "Unsupported partition broker health status '{}'", status.name());
-              }
-              brokerInfo.addPartitionsItem(partition);
-            });
-  }
-
-  private boolean setRole(
-      final Integer brokerId,
-      final Integer partitionId,
-      final BrokerClusterState topology,
-      final Partition partition) {
-    final int partitionLeader = topology.getLeaderForPartition(partitionId);
-    final Set<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final Set<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
-
-    if (partitionLeader == brokerId) {
-      partition.setRole(RoleEnum.LEADER);
-    } else if (partitionFollowers != null && partitionFollowers.contains(brokerId)) {
-      partition.setRole(RoleEnum.FOLLOWER);
-    } else if (partitionInactives != null && partitionInactives.contains(brokerId)) {
-      partition.setRole(RoleEnum.INACTIVE);
-    } else {
-      return false;
-    }
-
-    return true;
+  public CompletableFuture<ResponseEntity<Object>> getTopology() {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            topologyServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .getTopology(),
+        ResponseMapper::toTopologyResponse);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayDisabledTest.java
@@ -44,6 +44,6 @@ public class RestApiBrokerGatewayDisabledTest extends RestApiConfigurationTest {
         .expectStatus()
         .isNotFound();
 
-    verifyNoInteractions(topologyManager);
+    verifyNoInteractions(topologyServices);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.rest.configuration;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -17,11 +16,11 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.service.TopologyServices;
+import io.camunda.service.TopologyServices.Topology;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -30,21 +29,21 @@ abstract class RestApiConfigurationTest extends RestControllerTest {
   static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/process-instances/search";
   static final String TOPOLOGY_URL = "/v2/topology";
 
-  @MockitoBean ProcessInstanceServices processInstanceServices;
   @MockitoBean MultiTenancyConfiguration multiTenancyConfiguration;
-  @MockitoBean BrokerClient brokerClient;
-  @MockitoBean BrokerTopologyManager topologyManager;
-  @MockitoBean ClusterConfiguration clusterConfiguration;
+  @MockitoBean ProcessInstanceServices processInstanceServices;
+  @MockitoBean TopologyServices topologyServices;
 
   @BeforeEach
   void setupServices() {
     when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
         .thenReturn(processInstanceServices);
-    when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
     when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
         .thenReturn(new Builder<ProcessInstanceEntity>().build());
-    when(topologyManager.getTopology()).thenReturn(mock(BrokerClusterState.class));
-    when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
-    when(clusterConfiguration.clusterId()).thenReturn(java.util.Optional.of("cluster-id"));
+    when(topologyServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(topologyServices);
+    when(topologyServices.getTopology())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new Topology(List.of(), "cluster-id", null, null, null, null, null)));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
@@ -56,6 +56,6 @@ public class RestApiDefaultConfigurationTest extends RestApiConfigurationTest {
         .expectStatus()
         .isOk();
 
-    verify(topologyManager).getTopology();
+    verify(topologyServices).getTopology();
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledTest.java
@@ -44,6 +44,6 @@ public class RestApiDisabledTest extends RestApiConfigurationTest {
         .expectStatus()
         .isNotFound();
 
-    verifyNoInteractions(topologyManager);
+    verifyNoInteractions(topologyServices);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -7,16 +7,21 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.TopologyServices;
+import io.camunda.service.TopologyServices.Broker;
+import io.camunda.service.TopologyServices.Health;
+import io.camunda.service.TopologyServices.Partition;
+import io.camunda.service.TopologyServices.Role;
+import io.camunda.service.TopologyServices.Topology;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
-import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,12 +34,15 @@ import org.springframework.test.json.JsonCompareMode;
 @WebMvcTest(TopologyController.class)
 public class TopologyControllerTest extends RestControllerTest {
 
-  @MockitoBean BrokerClient brokerClient;
-  @MockitoBean BrokerTopologyManager topologyManager;
+  @MockitoBean TopologyServices topologyServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
 
   @BeforeEach
   void setUp() {
-    Mockito.when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(topologyServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(topologyServices);
   }
 
   @ParameterizedTest
@@ -96,10 +104,36 @@ public class TopologyControllerTest extends RestControllerTest {
         }
         """
             .formatted(version, version, version, version);
-    final var brokerClusterState = new TestBrokerClusterState(version, clusterId);
-    final ClusterConfiguration clusterConfiguration = Mockito.mock(ClusterConfiguration.class);
-    Mockito.when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
-    Mockito.when(topologyManager.getTopology()).thenReturn(brokerClusterState);
+
+    final var topology =
+        new Topology(
+            List.of(
+                new Broker(
+                    0,
+                    "localhost",
+                    26501,
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY)),
+                    version),
+                new Broker(
+                    1,
+                    "localhost",
+                    26502,
+                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY)),
+                    version),
+                new Broker(
+                    2,
+                    "localhost",
+                    26503,
+                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
+                    version)),
+            "cluster-id",
+            3,
+            1,
+            3,
+            version,
+            1L);
+    Mockito.when(topologyServices.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(topology));
 
     // when / then
     webClient
@@ -128,7 +162,10 @@ public class TopologyControllerTest extends RestControllerTest {
         }
         """
             .formatted(version);
-    Mockito.when(topologyManager.getTopology()).thenReturn(null);
+    Mockito.when(topologyServices.getTopology())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new Topology(List.of(), null, null, null, null, version, null)));
 
     // when / then
     webClient
@@ -142,96 +179,5 @@ public class TopologyControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
-  }
-
-  /**
-   * Topology stub which returns a static topology with 3 brokers, 1 partition, replication factor
-   * 3, where 0 is the leader (healthy), 1 is the follower (healthy), and 2 is inactive (unhealthy).
-   */
-  private record TestBrokerClusterState(String version, String clusterId)
-      implements BrokerClusterState {
-
-    @Override
-    public boolean isInitialized() {
-      return true;
-    }
-
-    @Override
-    public int getClusterSize() {
-      return 3;
-    }
-
-    @Override
-    public int getPartitionsCount() {
-      return 1;
-    }
-
-    @Override
-    public int getReplicationFactor() {
-      return 3;
-    }
-
-    @Override
-    public int getLeaderForPartition(final int partition) {
-      return 0;
-    }
-
-    @Override
-    public Set<Integer> getFollowersForPartition(final int partition) {
-      return Set.of(1);
-    }
-
-    @Override
-    public Set<Integer> getInactiveNodesForPartition(final int partition) {
-      return Set.of(2);
-    }
-
-    @Override
-    public int getRandomBroker() {
-      return ThreadLocalRandom.current().nextInt(0, 3);
-    }
-
-    @Override
-    public List<Integer> getPartitions() {
-      return List.of(1);
-    }
-
-    @Override
-    public List<Integer> getBrokers() {
-      return List.of(0, 1, 2);
-    }
-
-    @Override
-    public String getBrokerAddress(final int brokerId) {
-      return "localhost:" + (26501 + brokerId);
-    }
-
-    @Override
-    public String getBrokerVersion(final int brokerId) {
-      return version;
-    }
-
-    @Override
-    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
-      if (partition != 1) {
-        return PartitionHealthStatus.NULL_VAL;
-      }
-
-      return switch (brokerId) {
-        case 0, 1 -> PartitionHealthStatus.HEALTHY;
-        case 2 -> PartitionHealthStatus.UNHEALTHY;
-        default -> PartitionHealthStatus.NULL_VAL;
-      };
-    }
-
-    @Override
-    public long getLastCompletedChangeId() {
-      return 1;
-    }
-
-    @Override
-    public String getClusterId() {
-      return clusterId;
-    }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterStatusTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterStatusTest.java
@@ -36,7 +36,7 @@ public class ClusterStatusTest {
       TestCluster.builder()
           .withEmbeddedGateway(false)
           .withGatewaysCount(1)
-          .withGatewayConfig(gateway -> gateway.withCreateSchema(false))
+          .withGatewayConfig(gateway -> gateway.withCreateSchema(false).withUnauthenticatedAccess())
           .withBrokersCount(3)
           .withBrokerConfig(node -> node.withCreateSchema(false))
           .withPartitionsCount(3)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyClusterTest.java
@@ -39,7 +39,7 @@ public final class TopologyClusterTest {
       TestCluster.builder()
           .withEmbeddedGateway(false)
           .withGatewaysCount(1)
-          .withGatewayConfig(gateway -> gateway.withCreateSchema(false))
+          .withGatewayConfig(gateway -> gateway.withCreateSchema(false).withUnauthenticatedAccess())
           .withBrokersCount(3)
           .withBrokerConfig(node -> node.withCreateSchema(false))
           .withPartitionsCount(3)


### PR DESCRIPTION
## Description

* Moves the functionality implemented in the StatusController and TopologyController to a TopologyServices class.
* This makes the functionality reusable for other gateways and allows to align the controllers with other REST controllers.
* Uses the TopologyServices in the TopologyController and StatusController to align them with other REST controllers.
* Verifies the topology functionality still works as expected.
* The REST controller tests adjust to mocking the service layer instead of implementation details.
* The former tests to ensure broker client and topology manager move to a new service layer test for topology services.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

n/a
