### PR TITLE
RocksDB: Add AUTO memory allocation strategy.

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -68,9 +68,10 @@ public class RocksDb {
    * Configures the memory allocation strategy by RocksDB. If set to 'PARTITION', the total memory
    * allocated to RocksDB will be the number of partitions times the configured memory limit. If the
    * value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
-   * memory limit.
+   * memory limit. If set to 'AUTO', Zeebe will allocate the remaining memory available to RocksDB
+   * after accounting for other components, such as the JVM heap and other native memory consumers.
    */
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.AUTO;
 
   /**
    * Configures how many files are kept open by RocksDB, per default it is unlimited (-1). This is a

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -7,14 +7,20 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
+import com.sun.management.OperatingSystemMXBean;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RocksDbSharedCache {
   public static final long MINIMUM_PARTITION_MEMORY_LIMIT = 32 * 1024 * 1024L;
+  private static final double MAX_ROCKSDB_MEMORY_FRACTION = 0.5;
+  private static final double ROCKSDB_OVERHEAD_FACTOR = 0.15;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 
@@ -36,13 +42,73 @@ public class RocksDbSharedCache {
 
     return switch (rocksdbCfg.getMemoryAllocationStrategy()) {
       case BROKER -> rocksdbCfg.getMemoryLimit().toBytes();
+      case AUTO -> getAvailableMemoryCapacity();
       // in case of PARTITION or null, we allocate per partition
       default -> rocksdbCfg.getMemoryLimit().toBytes() * partitionsCount;
     };
   }
 
+  static long getAvailableMemoryCapacity() {
+    final long totalMemorySize =
+        ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
+    final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+
+    // This is the largest size the JVM Heap is allowed to grow to. -XX:MaxRAMPercentage.
+    final long maxHeapBytes = memoryBean.getHeapMemoryUsage().getMax();
+    // Get Maximum Non-Heap Size, -XX:MaxMetaspaceSize
+    long maxNonHeapBytes = memoryBean.getNonHeapMemoryUsage().getMax();
+    // both return -1 if not defined.
+
+    // if not set, assume default to 25% of total memory
+    if (maxNonHeapBytes < 0) {
+      maxNonHeapBytes = Math.round(0.25 * totalMemorySize);
+      LOGGER.info(
+          "Warning: Non-Heap limit is not set. Using a assumption of 25% of "
+              + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
+              + "Consider setting -XX:MaxMetaspaceSize explicitly.",
+          maxNonHeapBytes);
+    }
+    // -XX:MaxRAMPercentage is almost always set, but in case it is removed.
+    if (maxHeapBytes < 0) {
+      final long assumedHeap = Math.round(0.25 * totalMemorySize);
+      LOGGER.info(
+          "Warning: Heap limit is not set. Using a assumption of 25% of "
+              + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
+              + "Consider setting -XX:MaxRAMPercentage explicitly.",
+          assumedHeap);
+    }
+
+    // Estimate Total JVM Memory Usage (Heap + Non-Heap)
+    final long maxJvmInternalBytes = maxHeapBytes + maxNonHeapBytes;
+
+    final long availableOffHeapBudget = totalMemorySize - maxJvmInternalBytes;
+
+    // We set the cache capacity to a percentage of the remaining budget and
+    // reserve space for native overheads.
+    return (long) (availableOffHeapBudget * (1.0 - ROCKSDB_OVERHEAD_FACTOR));
+  }
+
   public static void validateRocksDbMemory(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
     final long blockCacheBytes = getBlockCacheBytes(rocksdbCfg, partitionsCount);
+    final long totalMemorySize =
+        ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
+    // Heap by default is 25% of the RAM, and off-heap (unless configured otherwise) is the same.
+    // So 50% of your RAM goes to the JVM, for both heap and off-heap (aka direct) memory.
+    // Leaving 50% of RAM for OS page cache and other processes.
+
+    final long maxRocksDbMem = (long) (totalMemorySize * MAX_ROCKSDB_MEMORY_FRACTION);
+
+    if (blockCacheBytes > maxRocksDbMem
+        && rocksdbCfg.getMemoryAllocationStrategy() != MemoryAllocationStrategy.AUTO) {
+      // this check does not apply for AUTO strategy as it is calculated
+      // based on available memory
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected the allocated memory for RocksDB to be below or "
+                  + "equal %.2f %% of ram memory, but was %.2f %%.",
+              MAX_ROCKSDB_MEMORY_FRACTION * 100,
+              ((double) blockCacheBytes / totalMemorySize * 100)));
+    }
 
     if (blockCacheBytes / partitionsCount < MINIMUM_PARTITION_MEMORY_LIMIT) {
       throw new IllegalArgumentException(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.partitioning;
 import com.sun.management.OperatingSystemMXBean;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
-import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -19,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 public class RocksDbSharedCache {
   public static final long MINIMUM_PARTITION_MEMORY_LIMIT = 32 * 1024 * 1024L;
-  private static final double MAX_ROCKSDB_MEMORY_FRACTION = 0.5;
   private static final double ROCKSDB_OVERHEAD_FACTOR = 0.15;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
@@ -54,7 +52,7 @@ public class RocksDbSharedCache {
     final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
 
     // This is the largest size the JVM Heap is allowed to grow to. -XX:MaxRAMPercentage.
-    final long maxHeapBytes = memoryBean.getHeapMemoryUsage().getMax();
+    long maxHeapBytes = memoryBean.getHeapMemoryUsage().getMax();
     // Get Maximum Non-Heap Size, -XX:MaxMetaspaceSize
     long maxNonHeapBytes = memoryBean.getNonHeapMemoryUsage().getMax();
     // both return -1 if not defined.
@@ -63,19 +61,19 @@ public class RocksDbSharedCache {
     if (maxNonHeapBytes < 0) {
       maxNonHeapBytes = Math.round(0.25 * totalMemorySize);
       LOGGER.info(
-          "Warning: Non-Heap limit is not set. Using a assumption of 25% of "
+          "Warning: Non-Heap limit is not set. Using an assumption of 25% of "
               + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
               + "Consider setting -XX:MaxMetaspaceSize explicitly.",
           maxNonHeapBytes);
     }
     // -XX:MaxRAMPercentage is almost always set, but in case it is removed.
     if (maxHeapBytes < 0) {
-      final long assumedHeap = Math.round(0.25 * totalMemorySize);
+      maxHeapBytes = Math.round(0.25 * totalMemorySize);
       LOGGER.info(
-          "Warning: Heap limit is not set. Using a assumption of 25% of "
+          "Warning: Heap limit is not set. Using an assumption of 25% of "
               + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
               + "Consider setting -XX:MaxRAMPercentage explicitly.",
-          assumedHeap);
+          maxHeapBytes);
     }
 
     // Estimate Total JVM Memory Usage (Heap + Non-Heap)
@@ -90,25 +88,6 @@ public class RocksDbSharedCache {
 
   public static void validateRocksDbMemory(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
     final long blockCacheBytes = getBlockCacheBytes(rocksdbCfg, partitionsCount);
-    final long totalMemorySize =
-        ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
-    // Heap by default is 25% of the RAM, and off-heap (unless configured otherwise) is the same.
-    // So 50% of your RAM goes to the JVM, for both heap and off-heap (aka direct) memory.
-    // Leaving 50% of RAM for OS page cache and other processes.
-
-    final long maxRocksDbMem = (long) (totalMemorySize * MAX_ROCKSDB_MEMORY_FRACTION);
-
-    if (blockCacheBytes > maxRocksDbMem
-        && rocksdbCfg.getMemoryAllocationStrategy() != MemoryAllocationStrategy.AUTO) {
-      // this check does not apply for AUTO strategy as it is calculated
-      // based on available memory
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected the allocated memory for RocksDB to be below or "
-                  + "equal %.2f %% of ram memory, but was %.2f %%.",
-              MAX_ROCKSDB_MEMORY_FRACTION * 100,
-              ((double) blockCacheBytes / totalMemorySize * 100)));
-    }
 
     if (blockCacheBytes / partitionsCount < MINIMUM_PARTITION_MEMORY_LIMIT) {
       throw new IllegalArgumentException(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -29,7 +29,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.AUTO;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -34,13 +34,34 @@ class RocksDbSharedCacheTest {
         .setMemoryAllocationStrategy(MemoryAllocationStrategy.PARTITION);
   }
 
-  private static MockedStatic<ManagementFactory> mockTotalMemorySize(final long memorySize) {
+  /**
+   * Mocks both ManagementFactory.getOperatingSystemMXBean() and getMemoryMXBean() to control total
+   * memory, heap max, and non-heap max for testing memory allocation strategies. Returns a
+   * MockedStatic for use in try-with-resources.
+   */
+  private static MockedStatic<ManagementFactory> mockMemoryEnvironment(
+      final long totalMemorySize, final long heapMax, final long nonHeapMax) {
     final MockedStatic<ManagementFactory> managementFactoryMock =
         Mockito.mockStatic(ManagementFactory.class);
     final var osBean = Mockito.mock(com.sun.management.OperatingSystemMXBean.class);
+    final var memoryBean = Mockito.mock(java.lang.management.MemoryMXBean.class);
+    final var heapUsage = Mockito.mock(java.lang.management.MemoryUsage.class);
+    final var nonHeapUsage = Mockito.mock(java.lang.management.MemoryUsage.class);
+
     managementFactoryMock.when(ManagementFactory::getOperatingSystemMXBean).thenReturn(osBean);
-    Mockito.when(osBean.getTotalMemorySize()).thenReturn(memorySize);
+    managementFactoryMock.when(ManagementFactory::getMemoryMXBean).thenReturn(memoryBean);
+    Mockito.when(osBean.getTotalMemorySize()).thenReturn(totalMemorySize);
+    Mockito.when(memoryBean.getHeapMemoryUsage()).thenReturn(heapUsage);
+    Mockito.when(memoryBean.getNonHeapMemoryUsage()).thenReturn(nonHeapUsage);
+    Mockito.when(heapUsage.getMax()).thenReturn(heapMax);
+    Mockito.when(nonHeapUsage.getMax()).thenReturn(nonHeapMax);
+
     return managementFactoryMock;
+  }
+
+  /** Overload for cases where only totalMemorySize is relevant. */
+  private static MockedStatic<ManagementFactory> mockMemoryEnvironment(final long totalMemorySize) {
+    return mockMemoryEnvironment(totalMemorySize, 0, 0);
   }
 
   @Test
@@ -53,7 +74,7 @@ class RocksDbSharedCacheTest {
         .setMemoryLimit(DataSize.ofBytes(MINIMUM_PARTITION_MEMORY_LIMIT / 2)); // 16MB
 
     // then it should throw since the memory per partition is too small
-    try (final var managementFactoryMock = mockTotalMemorySize(256L * 1024 * 1024)) { // 256MB
+    try (final var managementFactoryMock = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB
       final var throwable =
           catchThrowable(
               () -> {
@@ -84,7 +105,7 @@ class RocksDbSharedCacheTest {
 
     // should still be valid even with 2 partitions since we allocate per broker, we will only
     // allocate 128mb
-    try (final var managementFactoryMock = mockTotalMemorySize(256L * 1024 * 1024)) { // 256MB
+    try (final var managementFactoryMock = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB
       assertThatCode(
               () -> {
                 RocksDbSharedCache.validateRocksDbMemory(
@@ -96,13 +117,71 @@ class RocksDbSharedCacheTest {
     final int morePartitionsCount = 4;
     // should still be valid even with 4 partitions since we allocate per
     // broker, we will only allocate 128mb
-    try (final var managementFactoryMock = mockTotalMemorySize(256L * 1024 * 1024)) { // 256MB
+    try (final var managementFactoryMock = mockMemoryEnvironment(256L * 1024 * 1024)) { // 256MB
       assertThatCode(
               () -> {
                 RocksDbSharedCache.validateRocksDbMemory(
                     brokerCfg.getExperimental().getRocksdb(), morePartitionsCount);
               })
           .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  void shouldAllocateMemoryAutomatically() {
+    // when
+    brokerCfg
+        .getExperimental()
+        .getRocksdb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.AUTO);
+    final int partitionsCount = 1;
+
+    // we have broker with 512mb of ram, where:
+    // - max heap is 128mb
+    // - max non-heap is 128mb
+    // so available memory is 512 - 128 - 128 = 256mb with a
+    // ROCKSDB_OVERHEAD_FACTOR of 0.15 we can allocate 217.6mb to rocksdb
+    try (final var managementFactoryMock =
+        mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
+      assertThatCode(
+              () -> {
+                RocksDbSharedCache.validateRocksDbMemory(
+                    brokerCfg.getExperimental().getRocksdb(), partitionsCount);
+              })
+          .doesNotThrowAnyException();
+    }
+
+    final int morePartitionsCount = 7;
+    // should not be valid with 7 partitions since 217.6 / 7 = 31.08mb < 32mb
+    try (final var managementFactoryMock =
+        mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
+      final var throwable =
+          catchThrowable(
+              () -> {
+                RocksDbSharedCache.validateRocksDbMemory(
+                    brokerCfg.getExperimental().getRocksdb(), morePartitionsCount);
+              });
+
+      assertThat(throwable)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(
+              "Expected the allocated memory for RocksDB per partition to be at least %s bytes, but was %s bytes.",
+              MINIMUM_PARTITION_MEMORY_LIMIT, 32_595_733); // 217.6mb / 7 partitions
+    }
+  }
+
+  @Test
+  void shouldReturnExpectedAvailableMemoryCapacityWhenNonHeapNotSet() {
+    // 512MB total, 128MB heap, -1 non-heap triggers fallback
+    try (final var managementFactoryMock =
+        mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, -1)) {
+      final long available = RocksDbSharedCache.getAvailableMemoryCapacity();
+      // 25% of 512MB = 128MB fallback for non-heap
+      final long expectedNonHeap = 128L * 1024 * 1024;
+      final long expectedAvailable =
+          (long) (((512L * 1024 * 1024) - (128L * 1024 * 1024) - expectedNonHeap) * (1.0 - 0.15));
+      // Assert
+      assertThat(available).isEqualTo(expectedAvailable);
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -285,37 +285,4 @@ public final class RocksdbCfgTest {
     // then
     assertThat(rocksdb.isDisableWal()).isTrue();
   }
-
-  @Test
-  public void shouldUseDefaultMemoryAllocationStrategy() {
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
-    final var rocksdb = cfg.getExperimental().getRocksdb();
-
-    // then
-    assertThat(rocksdb.getMemoryAllocationStrategy().name()).isEqualTo("AUTO");
-  }
-
-  @Test
-  public void shouldSetMemoryAllocationStrategyViaConfig() {
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
-    final var rocksdb = cfg.getExperimental().getRocksdb();
-
-    // then
-    assertThat(rocksdb.getMemoryAllocationStrategy().name()).isEqualTo("BROKER");
-  }
-
-  @Test
-  public void shouldSetMemoryAllocationStrategyViaEnvironmentVariable() {
-    // given
-    environment.put("zeebe.broker.experimental.rocksdb.memoryAllocationStrategy", "PARTITION");
-
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
-    final var rocksdb = cfg.getExperimental().getRocksdb();
-
-    // then
-    assertThat(rocksdb.getMemoryAllocationStrategy().name()).isEqualTo("PARTITION");
-  }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -285,4 +285,37 @@ public final class RocksdbCfgTest {
     // then
     assertThat(rocksdb.isDisableWal()).isTrue();
   }
+
+  @Test
+  public void shouldUseDefaultMemoryAllocationStrategy() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMemoryAllocationStrategy().name()).isEqualTo("AUTO");
+  }
+
+  @Test
+  public void shouldSetMemoryAllocationStrategyViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMemoryAllocationStrategy().name()).isEqualTo("BROKER");
+  }
+
+  @Test
+  public void shouldSetMemoryAllocationStrategyViaEnvironmentVariable() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.memoryAllocationStrategy", "PARTITION");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMemoryAllocationStrategy().name()).isEqualTo("PARTITION");
+  }
 }

--- a/zeebe/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -7,6 +7,7 @@ zeebe:
           write_buffer_size: 67108864
         enableStatistics: true
         memoryLimit: 32MB
+        memoryAllocationStrategy: "BROKER"
         maxOpenFiles: 3
         maxWriteBufferNumber: 3
         minWriteBufferNumberToMerge: 3

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -250,5 +250,10 @@
       <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-db</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -35,6 +35,7 @@ import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.broker.NodeIdProviderConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
@@ -474,6 +475,13 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         .getDisk()
         .getFreeSpace()
         .setReplication(DataSize.ofMegabytes(64));
+
+    // set default default size for rocks db
+    unifiedConfig
+        .getData()
+        .getPrimaryStorage()
+        .getRocksDb()
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.BROKER);
 
     // Set processing defaults - enable consistency checks
     unifiedConfig.getProcessing().setEnablePreconditionsCheck(true);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -43,7 +43,7 @@ public final class RocksDbConfiguration {
 
   public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
   public static final MemoryAllocationStrategy DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY =
-      MemoryAllocationStrategy.PARTITION;
+      MemoryAllocationStrategy.AUTO;
   private Properties columnFamilyOptions = new Properties();
   private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
   private long memoryLimit = DEFAULT_MEMORY_LIMIT;
@@ -171,6 +171,7 @@ public final class RocksDbConfiguration {
 
   public enum MemoryAllocationStrategy {
     PARTITION,
-    BROKER
+    BROKER,
+    AUTO
   }
 }


### PR DESCRIPTION
## Description


This PR introduces `AUTO` memory allocation strategy:

- checks for the total RAM memory available in the container.
- Checks for the largest size the JVM Heap is allowed to grow to which is configured using -XX:MaxRAMPercentage.
- Checks for the maximum Non-Heap Size, which is configured using -XX:MaxMetaspaceSize. This is currently not configured by default in our JAVA_TOOL_OPTIONS. Perhaps we could also confiure this.
- If either the MaxRAMPercentage or MaxMetaspaceSize are not configured, we assume that these will use up to 25% of ram each.
- For RocksDB cache we will allocate ( 1 - `ROCKSDB_OVERHEAD_FACTOR` ) * free space. This will give us some memory margin for any other possible overhead used in rocksDB.

As a starting point we are using `ROCKSDB_OVERHEAD_FACTOR` = 0.15, which means that we will allocate to rocks DB cache 85% of the ram memory not used by either JVM and non heap memory. 

Additionally this PR also makes the `AUTO` strategy the default one.

`ZeebeRocksDbFactory` has the same exact configuration values allocated to each instance as long as  the porportional cache size per partition is the same. For example a cluster with 3 partitions,  where we have 1GB allocated to rocksDB per broker, will have the same rocksDB option configurations indenpently if we are using whichever allocation strategy.

**This PR needs to be backported manually to 8.8, since we dont intend to have AUTO as default in 8.8.**

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/42276
