### PR TITLE
fix: key overflow script was not working for 8.7

### DIFF
--- a/debug-cli/scripts/overwrite-key/README.md
+++ b/debug-cli/scripts/overwrite-key/README.md
@@ -276,7 +276,7 @@ If failed, check logs:
 kubectl logs job/key-recovery-job -n $NAMESPACE
 ```
 
-If the recovery job did not succeeded the best way to understand and fix the problem is to create another job YAML that
+If the recovery job did not succeed, the best way to understand and fix the problem is to create another job YAML that
 mounts all the PVCs as the recovery job, but without actually running the job.
 If you change the container to run this command, it will stay up until it's killed manually.
 

--- a/debug-cli/scripts/overwrite-key/README.md
+++ b/debug-cli/scripts/overwrite-key/README.md
@@ -276,6 +276,27 @@ If failed, check logs:
 kubectl logs job/key-recovery-job -n $NAMESPACE
 ```
 
+If the recovery job did not succeeded the best way to understand and fix the problem is to create another job YAML that
+mounts all the PVCs as the recovery job, but without actually running the job.
+If you change the container to run this command, it will stay up until it's killed manually.
+
+```yaml
+containers:
+  - name: recovery
+    image: gcr.io/zeebe-io/zeebe:cs-key-recovery-87-9e55dd4
+    command:
+      - /bin/bash
+      - -c
+    args:
+      - "trap : TERM INT; sleep infinity & wait"
+```
+
+This will allow you to exec into the pod and access the shell (change `$pod_name` accordingly):
+
+```bash
+kubectl exec $pod_name -it -- bash
+```
+
 ### 9. Clean Up Recovery Job
 
 ```bash

--- a/debug-cli/scripts/overwrite-key/recovery-script.sh
+++ b/debug-cli/scripts/overwrite-key/recovery-script.sh
@@ -166,7 +166,7 @@ echo ""
 echo "[4/5] Updating key values using cdbg on leader broker ${LEADER_BROKER}..."
 
 # Build the cdbg command
-CDBG_CMD="/usr/local/camunda/bin/cdbg state update-key"
+CDBG_CMD="cdbg state update-key"
 CDBG_CMD="${CDBG_CMD} --root ${LEADER_PATH}"
 CDBG_CMD="${CDBG_CMD} --runtime ${RUNTIME_PATH}"
 CDBG_CMD="${CDBG_CMD} --snapshot ${SELECTED_SNAPSHOT}"

--- a/debug-cli/scripts/overwrite-key/recovery-script.sh
+++ b/debug-cli/scripts/overwrite-key/recovery-script.sh
@@ -185,14 +185,6 @@ echo ""
 echo "Key update completed successfully!"
 echo ""
 
-# Delete the original snapshot since cdbg created a new one
-echo "Removing original snapshot: ${SELECTED_SNAPSHOT}"
-rm -rf "${LEADER_PATH}/snapshots/${SELECTED_SNAPSHOT}"
-# Also remove the checksum file if it exists
-[ -f "${LEADER_PATH}/snapshots/${SELECTED_SNAPSHOT}.checksum" ] && rm -f "${LEADER_PATH}/snapshots/${SELECTED_SNAPSHOT}.checksum"
-echo "Original snapshot removed"
-echo ""
-
 echo "Updated snapshot location: ${LEADER_PATH}/snapshots/"
 ls -la "${LEADER_PATH}/snapshots/"
 echo ""


### PR DESCRIPTION
## Description

Fixed a couple of problems in the script that made running the job impossible for 8.7:
- `/usr/local/camunda/bin/cdbg` does not exists, as it's `/usr/local/zeebe/bin`
  - however, `cdbg` is in th `PATH` so it's not required.
- the original snapshot should not be deleted:  before 8.8 snapshots did not contain a checksum, so the snapshot created by `cdbg` has the same name as the original. This was noted in the [backport](https://github.com/camunda/camunda/pull/42671#issuecomment-3660375977) but I didn't realize it would create this issue.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
- [ ] I will manually backport one commit to main (using `cdbg` directly)