### PR TITLE
feat: add missing UC properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -48,7 +48,8 @@ public class Cluster implements Cloneable {
           "clusterSize", "zeebe.broker.cluster.clusterSize",
           "messageCompression", "zeebe.broker.cluster.messageCompression",
           "clusterName", "zeebe.broker.cluster.clusterName",
-          "initialContactPoints", "zeebe.broker.cluster.initialContactPoints");
+          "initialContactPoints", "zeebe.broker.cluster.initialContactPoints",
+          "clusterId", "zeebe.broker.cluster.clusterId");
 
   static {
     LEGACY_INITIAL_CONTACT_POINTS_PROPERTY =
@@ -100,6 +101,12 @@ public class Cluster implements Cloneable {
 
   /** Set the name of the cluster */
   private String name = DEFAULT_CLUSTER_NAME;
+
+  /**
+   * Set the cluster id of the cluster. This setting is used to identify the cluster and should be
+   * unique across clusters. If not configured, the cluster ID will be set with a new random UUID.
+   */
+  private String clusterId;
 
   /** Configuration for the Raft protocol in the cluster. */
   @NestedConfigurationProperty private Raft raft = new Raft();
@@ -238,6 +245,19 @@ public class Cluster implements Cloneable {
 
   public void setName(final String name) {
     this.name = name;
+  }
+
+  public String getClusterId() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".cluster-id",
+        clusterId,
+        String.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("clusterId")));
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
   }
 
   public Raft getRaft() {

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -14,11 +14,23 @@ public class Engine {
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
 
+  /** Configuration properties for the engine's batch operation settings. */
+  @NestedConfigurationProperty
+  private EngineBatchOperation batchOperations = new EngineBatchOperation();
+
   public Distribution getDistribution() {
     return distribution;
   }
 
   public void setDistribution(final Distribution distribution) {
     this.distribution = distribution;
+  }
+
+  public EngineBatchOperation getBatchOperations() {
+    return batchOperations;
+  }
+
+  public void setBatchOperations(final EngineBatchOperation batchOperations) {
+    this.batchOperations = batchOperations;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import java.time.Duration;
+import java.util.Set;
+
+public class EngineBatchOperation {
+
+  private static final String PREFIX = "camunda.processing.engine.batch-operations";
+
+  private static final Set<String> LEGACY_SCHEDULER_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.schedulerInterval");
+
+  /**
+   * The interval at which the batch operation scheduler runs. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
+   */
+  private Duration schedulerInterval =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL;
+
+  public Duration getSchedulerInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".scheduler-interval",
+        schedulerInterval,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SCHEDULER_INTERVAL_PROPERTIES);
+  }
+
+  public void setSchedulerInterval(final Duration schedulerInterval) {
+    this.schedulerInterval = schedulerInterval;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -199,6 +199,7 @@ public class BrokerBasedPropertiesOverride {
 
   private void populateFromEngine(final BrokerBasedProperties override) {
     populateFromDistribution(override);
+    populateFromBatchOperations(override);
   }
 
   private void populateFromDistribution(final BrokerBasedProperties override) {
@@ -208,6 +209,16 @@ public class BrokerBasedPropertiesOverride {
     final var distributionCfg = override.getExperimental().getEngine().getDistribution();
     distributionCfg.setMaxBackoffDuration(distribution.getMaxBackoffDuration());
     distributionCfg.setRedistributionInterval(distribution.getRedistributionInterval());
+  }
+
+  private void populateFromBatchOperations(final BrokerBasedProperties override) {
+    final var engineBatchOperation =
+        unifiedConfiguration.getCamunda().getProcessing().getEngine().getBatchOperations();
+    override
+        .getExperimental()
+        .getEngine()
+        .getBatchOperations()
+        .setSchedulerInterval(engineBatchOperation.getSchedulerInterval());
   }
 
   private void populateFromFlowControl(final BrokerBasedProperties override) {
@@ -370,6 +381,7 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setReplicationFactor(cluster.getReplicationFactor());
     override.getCluster().setClusterSize(cluster.getSize());
     override.getCluster().setClusterName(cluster.getName());
+    override.getCluster().setClusterId(cluster.getClusterId());
 
     populateFromMembership(override);
     populateFromRaftProperties(override);

--- a/configuration/src/test/java/io/camunda/configuration/ClusterBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterBrokerPropertiesTest.java
@@ -52,7 +52,8 @@ public class ClusterBrokerPropertiesTest {
         "camunda.cluster.size=10",
         "camunda.cluster.compression-algorithm=gzip",
         "camunda.cluster.name=zeebeClusterNew",
-        "camunda.cluster.initial-contact-points=1new,2new"
+        "camunda.cluster.initial-contact-points=1new,2new",
+        "camunda.cluster.cluster-id=clusterIdNew"
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -70,7 +71,8 @@ public class ClusterBrokerPropertiesTest {
           .returns(10, ClusterCfg::getClusterSize)
           .returns(CompressionAlgorithm.GZIP, ClusterCfg::getMessageCompression)
           .returns("zeebeClusterNew", ClusterCfg::getClusterName)
-          .returns(List.of("1new", "2new"), ClusterCfg::getInitialContactPoints);
+          .returns(List.of("1new", "2new"), ClusterCfg::getInitialContactPoints)
+          .returns("clusterIdNew", ClusterCfg::getClusterId);
     }
   }
 
@@ -106,7 +108,8 @@ public class ClusterBrokerPropertiesTest {
         "zeebe.broker.cluster.clusterSize=12",
         "zeebe.broker.cluster.messageCompression=gzip",
         "zeebe.broker.cluster.clusterName=zeebeClusterLegacyBroker",
-        "zeebe.broker.cluster.initialContactPoints=1LegacyBroker,2LegacyBroker"
+        "zeebe.broker.cluster.initialContactPoints=1LegacyBroker,2LegacyBroker",
+        "zeebe.broker.cluster.clusterId=clusterIdLegacyBroker"
       })
   class WithOnlyBrokerLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -124,7 +127,8 @@ public class ClusterBrokerPropertiesTest {
           .returns(12, ClusterCfg::getClusterSize)
           .returns(CompressionAlgorithm.GZIP, ClusterCfg::getMessageCompression)
           .returns("zeebeClusterLegacyBroker", ClusterCfg::getClusterName)
-          .returns(List.of("1LegacyBroker", "2LegacyBroker"), ClusterCfg::getInitialContactPoints);
+          .returns(List.of("1LegacyBroker", "2LegacyBroker"), ClusterCfg::getInitialContactPoints)
+          .returns("clusterIdLegacyBroker", ClusterCfg::getClusterId);
     }
   }
 
@@ -139,6 +143,7 @@ public class ClusterBrokerPropertiesTest {
         "camunda.cluster.compression-algorithm=gzip",
         "camunda.cluster.name=zeebeClusterNew",
         "camunda.cluster.initial-contact-points=1new,2new",
+        "camunda.cluster.cluster-id=clusterIdNew",
         // legacy gateway
         "zeebe.gateway.cluster.messageCompression=snappy",
         "zeebe.gateway.cluster.clusterName=zeebeClusterLegacyGateway",
@@ -150,7 +155,8 @@ public class ClusterBrokerPropertiesTest {
         "zeebe.broker.cluster.clusterSize=99",
         "zeebe.broker.cluster.messageCompression=snappy",
         "zeebe.broker.cluster.clusterName=zeebeClusterLegacyBroker",
-        "zeebe.broker.cluster.initialContactPoints=1LegacyBroker,2LegacyBroker"
+        "zeebe.broker.cluster.initialContactPoints=1LegacyBroker,2LegacyBroker",
+        "zeebe.broker.cluster.clusterId=clusterIdLegacyBroker"
       })
   class WithNewAndLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -168,7 +174,8 @@ public class ClusterBrokerPropertiesTest {
           .returns(15, ClusterCfg::getClusterSize)
           .returns(CompressionAlgorithm.GZIP, ClusterCfg::getMessageCompression)
           .returns("zeebeClusterNew", ClusterCfg::getClusterName)
-          .returns(List.of("1new", "2new"), ClusterCfg::getInitialContactPoints);
+          .returns(List.of("1new", "2new"), ClusterCfg::getInitialContactPoints)
+          .returns("clusterIdNew", ClusterCfg::getClusterId);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/EngineBatchOperationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineBatchOperationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.BatchOperationCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class EngineBatchOperationTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.batch-operations.scheduler-interval=15s",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBatchOperation() {
+      assertThat(brokerCfg.getExperimental().getEngine().getBatchOperations())
+          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.batchOperations.schedulerInterval=15s",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBatchOperationFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getBatchOperations())
+          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.batch-operations.scheduler-interval=15s",
+        // legacy
+        "zeebe.broker.experimental.engine.batchOperations.schedulerInterval=150s",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBatchOperationFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getBatchOperations())
+          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementIT.java
@@ -48,10 +48,12 @@ public class BatchOperationLifecycleManagementIT {
   private static final TestStandaloneApplication<?> APPLICATION =
       new TestStandaloneBroker()
           .withUnauthenticatedAccess()
-          // set schedulerInterval via properties because it is not yet supported in unified config
-          .withProperty(
-              "zeebe.broker.experimental.engine.batchOperations.schedulerInterval",
-              Duration.ofDays(1));
+          .withUnifiedConfig(
+              cfg ->
+                  cfg.getProcessing()
+                      .getEngine()
+                      .getBatchOperations()
+                      .setSchedulerInterval(Duration.ofDays(1)));
 
   String testScopeId;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -27,8 +27,7 @@ final class ClusterEndpointResponseIT {
   static void initTestStandaloneBroker() {
     broker =
         new TestStandaloneBroker()
-            // set clusterId via properties because it is not yet supported in unified config
-            .withProperty("zeebe.broker.cluster.clusterId", "cluster-id");
+            .withUnifiedConfig(cfg -> cfg.getCluster().setClusterId("cluster-id"));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.cluster in unified config.

The legacy properties are:
zeebe.broker.cluster.clusterId
zeebe.broker.experimental.engine.batchOperations.schedulerInterval

The new properties are:
camunda.cluster.cluster-id
camunda.processing.engine.batch-operations.scheduler-interval

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code
## Related issues

related to #34912