### PR TITLE
fix: NPE when migrating call activities with missing called element incident

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -547,6 +547,9 @@ public class ProcessInstanceMigrationMigrateProcessor
    */
   private void migrateCalledSubProcessElements(final long calledChildInstanceKey) {
     final var calledInstance = elementInstanceState.getInstance(calledChildInstanceKey);
+    if (calledInstance == null) {
+      return;
+    }
     final var elementInstances = new ArrayDeque<>(List.of(calledInstance));
     while (!elementInstances.isEmpty()) {
       final var instance = elementInstances.poll();
@@ -586,11 +589,13 @@ public class ProcessInstanceMigrationMigrateProcessor
         instance.getKey(), ProcessInstanceIntent.ANCESTOR_MIGRATED, elementInstanceRecord);
 
     if (elementInstanceRecord.getBpmnElementType() == BpmnElementType.CALL_ACTIVITY) {
-      // found more call activities? add the called child instance to the queue to continue going
-      // deeper the tree
+      // found more call activities? add the called child instance to the queue if present
+      // to continue going deeper the tree
       final ElementInstance calledInstance =
           elementInstanceState.getInstance(instance.getCalledChildInstanceKey());
-      elementInstances.add(calledInstance);
+      if (calledInstance != null) {
+        elementInstances.add(calledInstance);
+      }
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -9,13 +9,16 @@ package io.camunda.zeebe.engine.processing.processinstance.migration;
 
 import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static io.camunda.zeebe.protocol.record.value.ErrorType.CALLED_ELEMENT_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
@@ -601,5 +604,210 @@ public class MigrateCallActivityTest {
         .hasOnlyProcessDefinitionPath(
             parentProcessDefinitionKey, targetProcessDefinitionKey, level2ChildProcessDefinitionKey)
         .hasOnlyCallingElementPath(0, 1);
+  }
+
+  @Test
+  public void shouldMigrateCallActivityWithIncident() {
+    // given
+    final String processId = helper.getBpmnProcessId() + "_source";
+    final String targetProcessId = helper.getBpmnProcessId() + "_target";
+    final String nonExistentProcessId = helper.getBpmnProcessId() + "_nonexistent";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .callActivity("callActivity1", c -> c.zeebeProcessId(nonExistentProcessId))
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .callActivity("callActivity2", c -> c.zeebeProcessId(nonExistentProcessId))
+                    .endEvent("end")
+                    .done())
+            .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    assertThat(RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst().getValue())
+        .describedAs("Expect that incident exists on call activity 1")
+        .hasElementId("callActivity1")
+        .describedAs("Expect that incident error type is CALLED_ELEMENT_ERROR")
+        .hasErrorType(CALLED_ELEMENT_ERROR);
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("callActivity1", "callActivity2")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed to target")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that process bpmn process id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that process version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.CALL_ACTIVITY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that call activity process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that call activity bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("callActivity2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(RecordingExporter.incidentRecords(IncidentIntent.MIGRATED).getFirst().getValue())
+        .describedAs("Expect that incident migrated and exists on call activity 2")
+        .hasElementId("callActivity2")
+        .describedAs("Expect that incident error type is CALLED_ELEMENT_ERROR")
+        .hasErrorType(CALLED_ELEMENT_ERROR);
+
+    assertThat(
+            RecordingExporter.processInstanceMigrationRecords(
+                    ProcessInstanceMigrationIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .describedAs("Expect that process instance is migrated")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldMigrateSubsequentCallActivitiesWithIncident() {
+    // given
+    final String processId = helper.getBpmnProcessId() + "_source";
+    final String targetProcessId = helper.getBpmnProcessId() + "_target";
+    final String level1ChildProcessId = helper.getBpmnProcessId() + "_child1";
+    final String level2ChildProcessId = helper.getBpmnProcessId() + "_child2";
+    final String nonExistentProcessId = helper.getBpmnProcessId() + "_nonexistent";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .callActivity("callActivity1", c -> c.zeebeProcessId(level1ChildProcessId))
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(level1ChildProcessId)
+                    .startEvent("start")
+                    .callActivity("None", c -> c.zeebeProcessId(nonExistentProcessId))
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .callActivity("callActivity2", c -> c.zeebeProcessId(level2ChildProcessId))
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(level2ChildProcessId)
+                    .startEvent("start")
+                    .callActivity("None", c -> c.zeebeProcessId(nonExistentProcessId))
+                    .endEvent("end")
+                    .done())
+            .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    final long childProcessInstanceKey = childProcessInstance.getKey();
+
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withElementId("None")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that incident exists on child call activity 'None'")
+        .hasElementId("None")
+        .describedAs("Expect that incident error type is CALLED_ELEMENT_ERROR")
+        .hasErrorType(CALLED_ELEMENT_ERROR);
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("callActivity1", "callActivity2")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that parent process definition key is changed to target")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that parent process bpmn process id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that parent process version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.CALL_ACTIVITY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that call activity process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that call activity bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("callActivity2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ANCESTOR_MIGRATED)
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .describedAs("Expect that ANCESTOR_MIGRATED event exists for the child process")
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ANCESTOR_MIGRATED)
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .withElementType(BpmnElementType.CALL_ACTIVITY)
+                .exists())
+        .describedAs("Expect that ANCESTOR_MIGRATED event exists for the child call activity")
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.processInstanceMigrationRecords(
+                    ProcessInstanceMigrationIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .describedAs("Expect that process instance is migrated")
+        .isTrue();
   }
 }


### PR DESCRIPTION
## Description
Fix NPE when migrating call activities with incident `CALLED_ELEMENT_ERROR` -- called element process id not deployed
Based on discussion [here](https://camunda.slack.com/archives/C08MRKHJ0CD/p1764595924546799)

2 cases covered:
- 1 PI with 1 Call Activity - Incident work/migrated if Called element process id not deployed yet 
  -  ✅ IncidentIntent.MIGRATED
- 1 PI with 2 Subsequent child Call Activities - Incident exists on last child
  -  ✅ ProcessInstanceIntent.ANCESTOR_MIGRATED
  - Incident not migrated since it is not a direct migration, it is an ancestor one

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41846
