### PR TITLE
Migrate dashboard.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
@@ -1186,7 +1186,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
       "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1258,7 +1257,6 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -1464,7 +1462,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2250,7 +2247,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2312,7 +2308,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3931,7 +3926,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
       "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3973,7 +3967,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4686,7 +4679,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -11,39 +11,113 @@ import {Page, Locator} from '@playwright/test';
 export class OperateDashboardPage {
   private page: Page;
   readonly metricPanel: Locator;
-  readonly incidentInstancesBadge: Locator;
-  readonly activeInstancesBadge: Locator;
   readonly totalInstancesLink: Locator;
   readonly activeInstancesLink: Locator;
   readonly incidentInstancesLink: Locator;
   readonly instancesByProcess: Locator;
   readonly incidentsByError: Locator;
+  readonly instancesByProcessItem: (index: number) => Locator;
+  readonly incidentsByErrorItem: (index: number) => Locator;
+  readonly activeInstancesBadge: Locator;
+  readonly incidentInstancesBadge: Locator;
+  readonly processInstancesHeading: (
+    count: string | number,
+    isPlural?: boolean,
+  ) => Locator;
+  readonly incidentLinkByType: (type: string | RegExp) => Locator;
+  readonly viewInstanceLink: () => Locator;
+  readonly expandRowButton: () => Locator;
+  readonly incidentBadgeFromItem: (item: Locator) => Locator;
+  readonly activeBadgeFromItem: (item: Locator) => Locator;
+  readonly expandRowButtonFromItem: (item: Locator) => Locator;
+  readonly firstLinkFromItem: (item: Locator) => Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.metricPanel = page.getByTestId('metric-panel');
-    this.incidentInstancesBadge = page
-      .getByTestId('incident-instances-badge')
-      .first();
-    this.activeInstancesBadge = page
-      .getByTestId('active-instances-badge')
-      .first();
     this.totalInstancesLink = page.getByTestId('total-instances-link');
     this.activeInstancesLink = page.getByTestId('active-instances-link');
     this.incidentInstancesLink = page.getByTestId('incident-instances-link');
     this.instancesByProcess = page.getByTestId('instances-by-process');
     this.incidentsByError = page.getByTestId('incident-byError');
+
+    this.instancesByProcessItem = (index: number) =>
+      page.getByTestId(`instances-by-process-${index}`);
+
+    this.incidentsByErrorItem = (index: number) =>
+      page.getByTestId(`incident-byError-${index}`);
+
+    this.activeInstancesBadge = page
+      .getByTestId('active-instances-badge')
+      .nth(0);
+
+    this.incidentInstancesBadge = page
+      .getByTestId('incident-instances-badge')
+      .nth(0);
+
+    this.processInstancesHeading = (count, isPlural = true) =>
+      page.getByRole('heading', {
+        name: `Process Instances - ${count} result${isPlural ? 's' : ''}`,
+      });
+
+    this.incidentLinkByType = (type) =>
+      page.getByRole('link', {
+        name: type,
+      });
+
+    this.viewInstanceLink = () =>
+      page.getByRole('link', {
+        name: /view instance/i,
+      });
+
+    this.expandRowButton = () =>
+      page.getByRole('button', {
+        name: 'Expand current row',
+      });
+
+    this.incidentBadgeFromItem = (item) =>
+      item.getByTestId('incident-instances-badge');
+
+    this.activeBadgeFromItem = (item) =>
+      item.getByTestId('active-instances-badge');
+
+    this.expandRowButtonFromItem = (item) =>
+      item.getByRole('button', {
+        name: 'Expand current row',
+      });
+
+    this.firstLinkFromItem = (item) => item.getByRole('link').nth(0);
   }
 
   async gotoDashboardPage(options?: Parameters<Page['goto']>[1]) {
     await this.page.goto('/operate', options);
   }
 
-  getInstancesByProcessItem(index: number): Locator {
-    return this.page.getByTestId(`instances-by-process-${index}`);
+  async clickActiveInstancesLink(): Promise<void> {
+    await this.activeInstancesLink.click();
   }
 
-  getIncidentsByErrorItem(index: number): Locator {
-    return this.page.getByTestId(`incident-byError-${index}`);
+  async clickIncidentInstancesLink(): Promise<void> {
+    await this.incidentInstancesLink.click();
+  }
+
+  async clickIncidentByType(type: string | RegExp): Promise<void> {
+    await this.incidentLinkByType(type).click();
+  }
+
+  async clickViewInstanceLink(): Promise<void> {
+    await this.viewInstanceLink().click();
+  }
+
+  async clickItem(item: Locator): Promise<void> {
+    await item.click();
+  }
+
+  async expandItem(item: Locator): Promise<void> {
+    await this.expandRowButtonFromItem(item).click();
+  }
+
+  async clickFirstLinkInItem(item: Locator): Promise<void> {
+    await this.firstLinkFromItem(item).click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -11,13 +11,39 @@ import {Page, Locator} from '@playwright/test';
 export class OperateDashboardPage {
   private page: Page;
   readonly metricPanel: Locator;
+  readonly incidentInstancesBadge: Locator;
+  readonly activeInstancesBadge: Locator;
+  readonly totalInstancesLink: Locator;
+  readonly activeInstancesLink: Locator;
+  readonly incidentInstancesLink: Locator;
+  readonly instancesByProcess: Locator;
+  readonly incidentsByError: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.metricPanel = page.getByTestId('metric-panel');
+    this.incidentInstancesBadge = page
+      .getByTestId('incident-instances-badge')
+      .first();
+    this.activeInstancesBadge = page
+      .getByTestId('active-instances-badge')
+      .first();
+    this.totalInstancesLink = page.getByTestId('total-instances-link');
+    this.activeInstancesLink = page.getByTestId('active-instances-link');
+    this.incidentInstancesLink = page.getByTestId('incident-instances-link');
+    this.instancesByProcess = page.getByTestId('instances-by-process');
+    this.incidentsByError = page.getByTestId('incident-byError');
   }
 
   async gotoDashboardPage(options?: Parameters<Page['goto']>[1]) {
     await this.page.goto('/operate', options);
+  }
+
+  getInstancesByProcessItem(index: number): Locator {
+    return this.page.getByTestId(`instances-by-process-${index}`);
+  }
+
+  getIncidentsByErrorItem(index: number): Locator {
+    return this.page.getByTestId(`incident-byError-${index}`);
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -22,7 +22,7 @@ class OperateHomePage {
   constructor(page: Page) {
     this.page = page;
     this.operateBanner = page.getByRole('link', {name: 'Camunda logo Operate'});
-    this.processesTab = page.getByRole('link', {name: 'Processes'});
+    this.processesTab = page.getByRole('link', {name: 'Processes'}).first();
     this.decisionsTab = page.getByRole('link', {name: 'Decisions'});
     this.informationDialog = page.getByRole('button', {
       name: 'Close this dialog',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -70,6 +70,7 @@ class OperateProcessInstancePage {
   readonly addVariableModificationButton: Locator;
   readonly modalDialog: Locator;
   readonly noVariablesText: Locator;
+  readonly variableCellByName: (name: string | RegExp) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -175,6 +176,9 @@ class OperateProcessInstancePage {
     });
     this.modalDialog = page.getByRole('dialog');
     this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
+
+    this.variableCellByName = (name) =>
+      this.variablesList.getByRole('cell', {name});
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/incidentGeneratorProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/incidentGeneratorProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0lj6gqo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="incidentGeneratorProcess" name="Incident Generator Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_13hjtls</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_13hjtls" sourceRef="StartEvent_1" targetRef="IncidentGenerator" />
+    <bpmn:endEvent id="Event_11zx0y4">
+      <bpmn:incoming>Flow_1nrs4lg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1nrs4lg" sourceRef="IncidentGenerator" targetRef="Event_11zx0y4" />
+    <bpmn:serviceTask id="IncidentGenerator" name="Incident Generator">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="incidentGenerator" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13hjtls</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nrs4lg</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="incidentGeneratorProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11zx0y4_di" bpmnElement="Event_11zx0y4">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05iptua_di" bpmnElement="IncidentGenerator">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13hjtls_di" bpmnElement="Flow_13hjtls">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nrs4lg_di" bpmnElement="Flow_1nrs4lg">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_1.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="onlyIncidentsProcess" name="Only Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="onlyIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_2.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="onlyIncidentsProcess" name="Only Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_01kuijd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_1ker6z2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="alwaysFails2" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_01kuijd</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1ker6z2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_01kuijd" sourceRef="alwaysFails" targetRef="alwaysFails2" />
+    <bpmn:sequenceFlow id="SequenceFlow_1ker6z2" sourceRef="alwaysFails2" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="onlyIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0s7aueh_di" bpmnElement="alwaysFails2">
+        <dc:Bounds x="600" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_01kuijd_di" bpmnElement="SequenceFlow_01kuijd">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="600" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ker6z2_di" bpmnElement="SequenceFlow_1ker6z2">
+        <di:waypoint x="700" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcess_processes.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcess_processes.bpmn
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+  <bpmn:process id="orderProcessProcessesTest" name="Order process processes test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Order received">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
+    <bpmn:serviceTask id="checkPayment" name="Check payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="checkPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="shipArticles" name="Ship Articles">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="shipArticles" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="EndEvent_042s0oc" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
+      <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:serviceTask id="requestForPayment" name="Request for payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="requestPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessProcessesTest">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="156" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+        <dc:Bounds x="300" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
+        <dc:Bounds x="633" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="792" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="469" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="460" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="444" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="138" />
+        <di:waypoint x="300" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
+        <di:waypoint x="733" y="138" />
+        <di:waypoint x="792" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
+        <di:waypoint x="400" y="138" />
+        <di:waypoint x="469" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="54.5" y="227" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
+        <di:waypoint x="494" y="163" />
+        <di:waypoint x="494" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="188" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
+        <di:waypoint x="444" y="300" />
+        <di:waypoint x="350" y="300" />
+        <di:waypoint x="350" y="178" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="389" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
+        <di:waypoint x="519" y="138" />
+        <di:waypoint x="633" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="566" y="117" width="21" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutIncidentsProcess_v_2.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="withoutIncidentsProcess" name="Without Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverFails" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_0g2buaw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverFails" name="Never fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0v10lat</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="neverFails2" name="Never fails again">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverFails2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0v10lat</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0g2buaw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0v10lat" sourceRef="neverFails" targetRef="neverFails2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0g2buaw" sourceRef="neverFails2" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="withoutIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="374" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverFails">
+        <dc:Bounds x="374" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1j8pmi5_di" bpmnElement="neverFails2">
+        <dc:Bounds x="602" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0v10lat_di" bpmnElement="SequenceFlow_0v10lat">
+        <di:waypoint x="474" y="120" />
+        <di:waypoint x="602" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g2buaw_di" bpmnElement="SequenceFlow_0g2buaw">
+        <di:waypoint x="702" y="120" />
+        <di:waypoint x="867" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_1.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="noInstancesProcess" name="Without Instances Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverExecuted" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverExecuted" targetRef="end" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverExecuted" name="Never executed">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverExecuted" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="noInstancesProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="602" y="120" />
+        <di:waypoint x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverExecuted">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/withoutInstancesProcess_v_2.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="noInstancesProcess" name="Without Instances Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="neverExecuted" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="neverExecuted" targetRef="neverExecuted2" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1uidxur</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="neverExecuted" name="Never executed">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverExecuted" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="neverExecuted2" name="Never executed again">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="neverExecuted2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1uidxur</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1uidxur" sourceRef="neverExecuted2" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="noInstancesProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="363" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="463" y="120" />
+        <di:waypoint x="606" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="neverExecuted">
+        <dc:Bounds x="363" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1j5fcpc_di" bpmnElement="neverExecuted2">
+        <dc:Bounds x="606" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1uidxur_di" bpmnElement="SequenceFlow_1uidxur">
+        <di:waypoint x="706" y="120" />
+        <di:waypoint x="867" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {
+  deploy,
+  createInstances,
+  createSingleInstance,
+  createWorker,
+} from 'utils/zeebeClient';
+import {waitForProcessInstances} from 'utils/incidentsHelper';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {sleep} from 'utils/sleep';
+
+// Set secure connection to false for this test only
+
+let instanceIds: string[] = [];
+
+test.beforeAll(async ({request}) => {
+  test.setTimeout(180000); // 3 minutes timeout
+
+  // Deploy processes
+  await deploy([
+    './resources/withoutInstancesProcess_v_1.bpmn',
+    './resources/withoutIncidentsProcess_v_1.bpmn',
+    './resources/onlyIncidentsProcess_v_1.bpmn',
+    './resources/orderProcess_v_1.bpmn',
+    './resources/processWithAnIncident.bpmn',
+    './resources/incidentGeneratorProcess.bpmn',
+  ]);
+
+  await deploy([
+    './resources/withoutInstancesProcess_v_2.bpmn',
+    './resources/withoutIncidentsProcess_v_2.bpmn',
+    './resources/onlyIncidentsProcess_v_2.bpmn',
+  ]);
+
+  // Create worker for incident generation (replicating dashboard.mocks.ts)
+  createWorker('incidentGenerator', true, {}, (job) => {
+    const BASE_ERROR_MESSAGE =
+      'This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
+
+    if (job.variables.incidentType === 'Incident Type A') {
+      return job.fail(`${BASE_ERROR_MESSAGE} Type A`);
+    } else {
+      return job.fail(`${BASE_ERROR_MESSAGE} Type B`);
+    }
+  });
+
+  // Create instances exactly like dashboard.mocks.ts
+  const instancesList = await Promise.all([
+    createInstances('withoutIncidentsProcess', 1, 4),
+    createInstances('withoutIncidentsProcess', 2, 8),
+    createInstances('onlyIncidentsProcess', 1, 10),
+    createInstances('onlyIncidentsProcess', 2, 5),
+    createInstances('orderProcess', 1, 10),
+    createSingleInstance('processWithAnIncident', 1),
+    createSingleInstance('incidentGeneratorProcess', 1, {
+      incidentType: 'Incident Type A',
+    }),
+    createSingleInstance('incidentGeneratorProcess', 1, {
+      incidentType: 'Incident Type B',
+    }),
+  ]);
+
+  const allInstances = instancesList.flatMap((instances) => instances);
+  instanceIds = allInstances.map((instance) => instance.processInstanceKey);
+
+  // Wait for instances to be created (40 total: 4+8+10+5+10+1+1+1 = 40)
+  await waitForProcessInstances(request, instanceIds, 40);
+
+  // Additional sleep to ensure incidents are generated and UI is updated
+  console.log('Waiting for incidents to be created...');
+  await sleep(10000);
+
+  // Log to see if incidents were created
+  console.log('Total instances created:', instanceIds.length);
+});
+
+test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+  await navigateToApp(page, 'operate');
+  await loginPage.login('demo', 'demo');
+  await expect(operateHomePage.operateBanner).toBeVisible();
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Dashboard', () => {
+  test('Statistics', async ({operateDashboardPage}) => {
+    const incidentInstancesCount = Number(
+      await operateDashboardPage.incidentInstancesBadge.innerText(),
+    );
+
+    const activeProcessInstancesCount = Number(
+      await operateDashboardPage.activeInstancesBadge.innerText(),
+    );
+
+    const totalInstancesCount = operateDashboardPage.totalInstancesLink;
+
+    await expect(totalInstancesCount).toHaveText(
+      `${
+        incidentInstancesCount + activeProcessInstancesCount
+      } Running Process Instances in total`,
+    );
+  });
+
+  test('Navigation to Processes View', async ({operateDashboardPage, page}) => {
+    const activeProcessInstancesCount = await page
+      .getByTestId('active-instances-badge')
+      .nth(0)
+      .innerText();
+
+    const instancesWithIncidentCount = await page
+      .getByTestId('incident-instances-badge')
+      .nth(0)
+      .innerText();
+
+    await operateDashboardPage.activeInstancesLink.click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: `Process Instances - ${activeProcessInstancesCount} result${
+          Number(activeProcessInstancesCount) > 1 ? 's' : ''
+        }`,
+      }),
+    ).toBeVisible();
+
+    await operateDashboardPage.gotoDashboardPage();
+
+    await operateDashboardPage.incidentInstancesLink.click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: `Process Instances - ${instancesWithIncidentCount} result${
+          Number(instancesWithIncidentCount) > 1 ? 's' : ''
+        }`,
+      }),
+    ).toBeVisible();
+  });
+
+  test('Navigate to processes view (same truncated error message)', async ({
+    page,
+    operateDashboardPage,
+    operateProcessInstancePage,
+  }) => {
+    // Select incident type a from the incidents list
+    await page
+      .getByRole('link', {
+        name: /type a/i,
+      })
+      .click();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Process Instances - 1 result',
+      }),
+    ).toBeVisible();
+
+    await page
+      .getByRole('link', {
+        name: /view instance/i,
+      })
+      .click();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('cell', {
+        name: /incident type a/i,
+      }),
+    ).toBeVisible();
+
+    await operateDashboardPage.gotoDashboardPage();
+
+    // Select incident type b from the incidents list
+    await page
+      .getByRole('link', {
+        name: /type b/i,
+      })
+      .click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Process Instances - 1 result',
+      }),
+    ).toBeVisible();
+
+    await page
+      .getByRole('link', {
+        name: /view instance/i,
+      })
+      .click();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('cell', {
+        name: /incident type b/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test('Select process instances by name', async ({
+    page,
+    operateDashboardPage,
+  }) => {
+    await expect(operateDashboardPage.instancesByProcess).toBeVisible();
+
+    const firstInstanceByProcess =
+      operateDashboardPage.getInstancesByProcessItem(0);
+
+    const incidentCount = Number(
+      await firstInstanceByProcess
+        .getByTestId('incident-instances-badge')
+        .innerText(),
+    );
+    const runningInstanceCount = Number(
+      await firstInstanceByProcess
+        .getByTestId('active-instances-badge')
+        .innerText(),
+    );
+
+    const totalInstanceCount = incidentCount + runningInstanceCount;
+
+    await firstInstanceByProcess.click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: `Process Instances - ${totalInstanceCount} result${
+          Number(totalInstanceCount) > 1 ? 's' : ''
+        }`,
+      }),
+    ).toBeVisible();
+  });
+
+  test('Select process instances by error message', async ({
+    page,
+    operateDashboardPage,
+  }) => {
+    await expect(operateDashboardPage.incidentsByError).toBeVisible();
+
+    const firstInstanceByError =
+      operateDashboardPage.getIncidentsByErrorItem(0);
+
+    const incidentCount = Number(
+      await firstInstanceByError
+        .getByTestId('incident-instances-badge')
+        .innerText(),
+    );
+
+    await firstInstanceByError.click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: `Process Instances - ${incidentCount} result${
+          Number(incidentCount) > 1 ? 's' : ''
+        }`,
+      }),
+    ).toBeVisible();
+  });
+
+  test('Select process instances by error message (expanded)', async ({
+    page,
+    operateDashboardPage,
+  }) => {
+    await expect(operateDashboardPage.incidentsByError).toBeVisible();
+
+    const firstInstanceByError =
+      operateDashboardPage.getIncidentsByErrorItem(0);
+
+    const incidentCount = Number(
+      await firstInstanceByError
+        .getByTestId('incident-instances-badge')
+        .innerText(),
+    );
+
+    await firstInstanceByError
+      .getByRole('button', {
+        name: 'Expand current row',
+      })
+      .click();
+
+    await firstInstanceByError.getByRole('link').nth(0).click();
+
+    await expect(
+      page.getByRole('heading', {
+        name: `Process Instances - ${incidentCount} result${
+          Number(incidentCount) > 1 ? 's' : ''
+        }`,
+      }),
+    ).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -21,9 +21,8 @@ import {captureScreenshot, captureFailureVideo} from '@setup';
 let instanceIds: string[] = [];
 
 test.beforeAll(async ({request}) => {
-  test.setTimeout(180000); // 3 minutes timeout
+  test.setTimeout(180000);
 
-  // Deploy processes
   await deploy([
     './resources/withoutInstancesProcess_v_1.bpmn',
     './resources/withoutIncidentsProcess_v_1.bpmn',
@@ -39,7 +38,6 @@ test.beforeAll(async ({request}) => {
     './resources/onlyIncidentsProcess_v_2.bpmn',
   ]);
 
-  // Create worker for incident generation (replicating dashboard.mocks.ts)
   createWorker('incidentGenerator', true, {}, (job) => {
     const BASE_ERROR_MESSAGE =
       'This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
@@ -51,7 +49,6 @@ test.beforeAll(async ({request}) => {
     }
   });
 
-  // Create instances exactly like dashboard.mocks.ts
   const instancesList = await Promise.all([
     createInstances('withoutIncidentsProcess', 1, 4),
     createInstances('withoutIncidentsProcess', 2, 8),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -28,14 +28,14 @@ let instanceToCancel: ProcessInstance;
 let deployedProcess: DeployedProcess | undefined;
 
 test.beforeAll(async () => {
-  await deploy(['./resources/orderProcess_v_1.bpmn']);
+  await deploy(['./resources/orderProcess_processes.bpmn']);
   deployedProcess = {
     version: 1,
-    bpmnProcessId: 'orderProcess',
+    bpmnProcessId: 'orderProcessProcessesTest',
   };
 
   const instanceWithoutAnIncidentResponse = await createSingleInstance(
-    'orderProcess',
+    'orderProcessProcessesTest',
     1,
   );
   instanceWithoutAnIncident = {
@@ -156,7 +156,9 @@ test.describe('Processes', () => {
         instanceWithoutAnIncident.processInstanceKey,
       );
 
-      await operateFiltersPanelPage.selectProcess('Order process');
+      await operateFiltersPanelPage.selectProcess(
+        'Order process processes test',
+      );
       await waitForAssertion({
         assertion: async () => {
           await expect
@@ -167,7 +169,9 @@ test.describe('Processes', () => {
         },
         onFailure: async () => {
           await page.reload();
-          await operateFiltersPanelPage.selectProcess('Order process');
+          await operateFiltersPanelPage.selectProcess(
+            'Order process processes test',
+          );
         },
       });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/incidentsHelper.ts
@@ -90,35 +90,3 @@ export async function waitForProcessInstances(
 
   await sleep(2000);
 }
-
-export async function waitForIncidentsToBeResolved(
-  request: APIRequestContext,
-  processInstanceKey: string,
-  timeout = 120000,
-): Promise<void> {
-  const requestHeaders = getAuthHeaders();
-
-  await expect
-    .poll(
-      async () => {
-        const response = await request.post('/v1/incidents/search', {
-          ...requestHeaders,
-          data: {
-            filter: {
-              processInstanceKey: parseInt(processInstanceKey),
-            },
-          },
-        });
-        const incidents: {items: [{state: string}]; total: number} =
-          await response.json();
-        return (
-          incidents.total > 0 &&
-          incidents.items.filter(({state}) => state === 'PENDING').length === 0
-        );
-      },
-      {timeout},
-    )
-    .toBeTruthy();
-
-  await sleep(2000);
-}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -20,7 +20,8 @@ const c8 = new Camunda8({
   CAMUNDA_BASIC_AUTH_USERNAME: process.env.CAMUNDA_BASIC_AUTH_USERNAME,
   CAMUNDA_BASIC_AUTH_PASSWORD: process.env.CAMUNDA_BASIC_AUTH_PASSWORD,
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
-  ZEEBE_GRPC_ADDRESS: process.env.ZEEBE_GRPC_ADDRESS,
+  ZEEBE_GRPC_ADDRESS:
+    process.env.ZEEBE_GRPC_ADDRESS || 'grpc://localhost:26500',
 });
 
 function generateManyVariables(): Record<string, string> {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrates `dashboard.spec.ts` from the Operate component folder to the c8-orchestration-cluster-e2e-test-suite following POM patterns.

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20307266914)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34096
