### PR TITLE
Add scheduled task for history deletion in RDBMS exporter

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import java.time.Duration;
+
+/**
+ * This service is for deleting history on user request. For data retention see {@link
+ * HistoryCleanupService}.
+ */
+public class HistoryDeletionService {
+
+  public HistoryDeletionService() {
+    // TODO add history deletion reader to constructor
+    // TODO add history deletion writer to constructor
+
+  }
+
+  public Duration deleteHistory(final int partitionId) {
+    System.out.println("DELETE HISTORY FOR PARTITION " + partitionId);
+    return Duration.ofSeconds(1);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -7,22 +7,31 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This service is for deleting history on user request. For data retention see {@link
  * HistoryCleanupService}.
  */
 public class HistoryDeletionService {
+  private static final Logger LOG = LoggerFactory.getLogger(HistoryDeletionService.class);
 
-  public HistoryDeletionService() {
-    // TODO add history deletion reader to constructor
-    // TODO add history deletion writer to constructor
+  private final RdbmsWriters rdbmsWriters;
+  private final HistoryDeletionDbReader historyDeletionDbReader;
 
+  public HistoryDeletionService(
+      final RdbmsWriters rdbmsWriters, final HistoryDeletionDbReader historyDeletionDbReader) {
+    this.rdbmsWriters = rdbmsWriters;
+    this.historyDeletionDbReader = historyDeletionDbReader;
   }
 
   public Duration deleteHistory(final int partitionId) {
-    System.out.println("DELETE HISTORY FOR PARTITION " + partitionId);
+    final var batch = historyDeletionDbReader.getNextBatch(partitionId, 100);
+    LOG.trace("Deleting historic data for entities: {}", batch);
     return Duration.ofSeconds(1);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HistoryDeletionServiceTest {
+
+  private HistoryDeletionService historyDeletionService;
+  private RdbmsWriters rdbmsWritersMock;
+  private HistoryDeletionDbReader historyDeletionDbReaderMock;
+
+  @BeforeEach
+  void setUp() {
+    rdbmsWritersMock = mock(RdbmsWriters.class);
+    historyDeletionDbReaderMock = mock(HistoryDeletionDbReader.class);
+    historyDeletionService =
+        new HistoryDeletionService(rdbmsWritersMock, historyDeletionDbReaderMock);
+  }
+
+  @Test
+  void shouldGetNextBatchOfResourcesToDelete() {
+    // given
+    final var partitionId = 1;
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(historyDeletionDbReaderMock).getNextBatch(partitionId, 100);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
+import io.camunda.db.rdbms.write.service.HistoryDeletionService;
 import io.camunda.exporter.rdbms.RdbmsExporter.Builder;
 import io.camunda.exporter.rdbms.cache.RdbmsBatchOperationCacheLoader;
 import io.camunda.exporter.rdbms.cache.RdbmsDecisionRequirementsCacheLoader;
@@ -138,6 +139,8 @@ public class RdbmsExporterWrapper implements Exporter {
 
     final var historyCleanupService = new HistoryCleanupService(rdbmsWriterConfig, rdbmsWriters);
     builder.historyCleanupService(historyCleanupService);
+    final var historyDeletionService = new HistoryDeletionService();
+    builder.historyDeletionService(historyDeletionService);
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);
     createBatchOperationHandlers(rdbmsWriters, builder, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -139,7 +139,8 @@ public class RdbmsExporterWrapper implements Exporter {
 
     final var historyCleanupService = new HistoryCleanupService(rdbmsWriterConfig, rdbmsWriters);
     builder.historyCleanupService(historyCleanupService);
-    final var historyDeletionService = new HistoryDeletionService();
+    final var historyDeletionService =
+        new HistoryDeletionService(rdbmsWriters, rdbmsService.getHistoryDeletionDbReader());
     builder.historyDeletionService(historyDeletionService);
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a scheduled task which retrieves the data from the `HISTORY_DELETION` table periodically. The deletion of data itself is out of scope for this PR. So essentially, this does absolutely nothing right now 😄 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41530 
