### PR TITLE
feat: use membership status to filter out member if not reachable

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/ClusterMembershipEventListener.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/ClusterMembershipEventListener.java
@@ -16,7 +16,11 @@
  */
 package io.atomix.cluster;
 
+import io.atomix.cluster.protocol.GroupMembershipEventListener.GroupMembershipState;
 import io.atomix.utils.event.EventListener;
 
 /** Entity capable of receiving device cluster-related events. */
-public interface ClusterMembershipEventListener extends EventListener<ClusterMembershipEvent> {}
+public interface ClusterMembershipEventListener extends EventListener<ClusterMembershipEvent> {
+
+  default void onState(final GroupMembershipState state) {}
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -35,6 +35,10 @@ public class Member extends Node {
   private final Properties properties;
   private final long nodeVersion;
 
+  public Member(final Member member) {
+    this(member.config());
+  }
+
   public Member(final MemberConfig config) {
     super(config);
     id = config.getId();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -30,6 +30,7 @@ import io.atomix.cluster.discovery.NodeDiscoveryEvent;
 import io.atomix.cluster.discovery.NodeDiscoveryEventListener;
 import io.atomix.cluster.discovery.NodeDiscoveryService;
 import io.atomix.cluster.impl.AddressSerializer;
+import io.atomix.cluster.protocol.GroupMembershipEventListener.GroupMembershipState;
 import io.atomix.utils.Version;
 import io.atomix.utils.event.AbstractListenerManager;
 import io.atomix.utils.net.Address;
@@ -216,6 +217,14 @@ public class SwimMembershipProtocol
       LOGGER.info("Stopped");
     }
     return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public void addListener(final GroupMembershipEventListener listener) {
+    listener.onState(
+        new GroupMembershipState(
+            members.values().stream().map(Member::id).collect(Collectors.toSet())));
+    super.addListener(listener);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -229,6 +229,9 @@ public final class RaftClusterContext
   public Set<RaftMember> getVotingMembers() {
     return remoteActiveMembers.stream()
         .map(RaftMemberContext::getMember)
+        .filter(
+            member ->
+                groupMembershipState.map(s -> s.members().contains(member.memberId())).orElse(true))
         .collect(Collectors.toSet());
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -251,6 +251,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     this.partitionConfig = partitionConfig;
     cluster = new RaftClusterContext(localMemberId, this);
+    membershipService.addListener(cluster);
 
     replicationMetrics = new RaftReplicationMetrics(name, meterRegistry);
     replicationMetrics.setAppendIndex(raftLog.getLastIndex());
@@ -865,6 +866,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         term,
         raftLog.getCommitIndex(),
         raftLog.getLastIndex());
+    membershipService.removeListener(cluster);
     raftRoleMetrics.becomingInactive();
     started = false;
     // Unregister protocol listeners.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -125,8 +125,6 @@ public final class FollowerRole extends ActiveRole {
       return;
     }
 
-    log.info("Sending poll requests to all active members: {}", votingMembers);
-
     final var quorum =
         raft.getCluster()
             .getVoteQuorum(
@@ -141,6 +139,7 @@ public final class FollowerRole extends ActiveRole {
                     electionTimer.reset();
                   }
                 });
+    log.info("Sending poll requests to all active members: {}", quorum.participants());
 
     // First, load the last log entry to get its term. We load the entry
     // by its index since the index is required by the protocol.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
@@ -9,6 +9,8 @@ package io.atomix.raft.utils;
 
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.function.Consumer;
 
 public class JointConsensusVoteQuorum implements VoteQuorum {
@@ -59,6 +61,13 @@ public class JointConsensusVoteQuorum implements VoteQuorum {
       completed = true;
       callback.accept(false);
     }
+  }
+
+  @Override
+  public Collection<MemberId> participants() {
+    final var set = new HashSet<>((oldQuorum).participants());
+    set.addAll(newQuorum.participants());
+    return Collections.unmodifiableSet(set);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -32,6 +32,11 @@ public class SimpleVoteQuorum implements VoteQuorum {
   }
 
   @Override
+  public Collection<MemberId> participants() {
+    return members;
+  }
+
+  @Override
   public void succeed(final MemberId member) {
     if (members.remove(member)) {
       succeeded++;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -8,8 +8,11 @@
 package io.atomix.raft.utils;
 
 import io.atomix.cluster.MemberId;
+import java.util.Collection;
 
 public interface VoteQuorum {
+
+  Collection<MemberId> participants();
 
   void succeed(MemberId member);
 


### PR DESCRIPTION
## Description
PR resulting from the today's mob session.

The approach is simple:
- `RaftClusterContext`subscribes to the `ClusterMembershipService` (unsubscribe when stopped)
- A set of members is sent when a listener is added
- When there's a cluster membership event it updates the state
- the quorum is created by filtering out voting members which are not part active (currently)

Not sure if this is entirely the right approach, so asking for a quick feedback rather than a full review
/cc @panagiotisgts @rodrigo-camunda 
Co-Authored-By: panosg@pm.me
Co-Authored-By: rodrigo.lopes@camunda.com
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #9648
