### PR TITLE
ci: add descriptive labels to Slack E2E test notifications (#42855)

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -150,6 +150,7 @@ jobs:
           INCLUDE_SLACK_REPORTER: true
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           VERSION: ${{ matrix.branch }}
+          API_TESTS_ONLY: true
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "false"
         run: |
           if [[ "${{ matrix.branch }}" == "stable/8.6" || "${{ matrix.branch }}" == "stable/8.7" ]]; then

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -24,7 +24,8 @@ function getTestTypeLabel(): string {
   if (isApiTestsOnly) {
     return `Nightly API Test Results for Mono Repo - ${process.env.VERSION}`;
   }
-  return `Nightly Test Results for Mono Repo - ${process.env.VERSION}`;
+  const tasklistMode = isV2ModeEnabled ? 'V2' : 'V1';
+  return `Nightly Test Results for Mono Repo - ${process.env.VERSION} (Tasklist ${tasklistMode})`;
 }
 
 


### PR DESCRIPTION
Fixes #42855

This change ensures Slack notifications for E2E test results clearly distinguish between different test types:
- API tests
- V1 Tasklist tests  
- V2 Tasklist tests

**Changes:**
- Added `API_TESTS_ONLY` env var to API tests job
- Updated `getTestTypeLabel()` function to include Tasklist mode (V1/V2) in notification labels

**Before:**
All tests showed: `Nightly Test Results for Mono Repo - main`

**After:**
- API tests: `Nightly API Test Results for Mono Repo - main`
- V1 tests: `Nightly Test Results for Mono Repo - main (Tasklist V1)`
- V2 tests: `Nightly Test Results for Mono Repo - main (Tasklist V2)`