### PR TITLE
feat: migrate v2 processes diagram-panel to query hooks

### DIFF
--- a/operate/client/src/App/Processes/CopiableProcessID.tsx
+++ b/operate/client/src/App/Processes/CopiableProcessID.tsx
@@ -6,22 +6,21 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type ProcessDto} from 'modules/api/processes/fetchGroupedProcesses';
 import {CopiableContent} from 'modules/components/PanelHeader/CopiableContent';
 
 type Props = {
-  bpmnProcessId?: ProcessDto['bpmnProcessId'];
+  processDefinitionId?: string;
 };
 
-const CopiableProcessID: React.FC<Props> = ({bpmnProcessId}) => {
-  if (bpmnProcessId === undefined) {
+const CopiableProcessID: React.FC<Props> = ({processDefinitionId}) => {
+  if (processDefinitionId === undefined) {
     return null;
   }
 
   return (
     <CopiableContent
       copyButtonDescription="Process ID / Click to copy"
-      content={bpmnProcessId}
+      content={processDefinitionId}
     />
   );
 };

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
@@ -66,7 +66,7 @@ const DiagramHeader: React.FC<DiagramHeaderProps> = observer(
             <Description>
               <DescriptionTitle>Process ID</DescriptionTitle>
               <DescriptionData>
-                <CopiableProcessID bpmnProcessId={bpmnProcessId} />
+                <CopiableProcessID processDefinitionId={bpmnProcessId} />
               </DescriptionData>
             </Description>
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.test.tsx
@@ -16,10 +16,8 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
-import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
-import {mockProcessDefinitions, mockProcessInstances} from 'modules/testUtils';
+import {mockProcessInstances} from 'modules/testUtils';
 
 vi.mock('modules/utils/bpmn');
 vi.mock('modules/hooks/useCallbackPrompt', () => {
@@ -38,7 +36,6 @@ function getWrapper(initialPath: string = Paths.processes()) {
       return () => {
         processInstancesStore.reset();
         processInstancesSelectionStore.reset();
-        processesStore.reset();
         batchModificationStore.reset();
       };
     }, []);
@@ -61,9 +58,6 @@ function getWrapper(initialPath: string = Paths.processes()) {
 describe('<InstancesTable />', () => {
   beforeEach(() => {
     mockFetchProcessInstances().withSuccess(mockProcessInstances);
-    mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
-
-    processesStore.fetchProcesses();
   });
 
   it.each(['all', undefined])(

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -23,7 +23,6 @@ import {
   processInstancesStore,
 } from 'modules/stores/processInstances';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {processesStore} from 'modules/stores/processes/processes.list';
 
 import {batchModificationStore} from 'modules/stores/batchModification';
 
@@ -46,9 +45,9 @@ const InstancesTable: React.FC = observer(() => {
   /**
    * Is true if at least one process instances from the store has a version tag.
    */
-  const hasVersionTags = processInstances.some(({processId}) => {
-    return processesStore.getVersionTag(processId);
-  });
+  const hasVersionTags = processInstances.some(
+    ({processVersionTag}) => !!processVersionTag,
+  );
 
   const filters = useFilters();
   const location = useLocation();
@@ -153,8 +152,6 @@ const InstancesTable: React.FC = observer(() => {
           processInstancesStore.fetchNextInstances();
         }}
         rows={processInstances.map((instance) => {
-          const versionTag = processesStore.getVersionTag(instance.processId);
-
           return {
             id: instance.id,
             processName: (
@@ -190,7 +187,7 @@ const InstancesTable: React.FC = observer(() => {
               </Link>
             ),
             processVersion: instance.processVersion,
-            versionTag: versionTag ?? '--',
+            versionTag: instance.processVersionTag ?? '--',
             tenant: isTenantColumnVisible ? instance.tenantId : undefined,
             startDate: formatDate(instance.startDate),
             endDate: formatDate(instance.endDate),

--- a/operate/client/src/App/Processes/ListView/v2/DiagramPanel/BatchModificationNotification/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/DiagramPanel/BatchModificationNotification/index.test.tsx
@@ -19,11 +19,6 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {mockProcessXML} from 'modules/testUtils';
 
 vi.mock('modules/hooks/useProcessInstanceStatisticsFilters');
-vi.mock('modules/stores/processes/processes.list', () => ({
-  processesStore: {
-    getProcessIdByLocation: () => '123',
-  },
-}));
 
 const notificationText1 =
   'Please select where you want to move the selected instances on the diagram.';

--- a/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.test.tsx
@@ -13,19 +13,17 @@ import {
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {
-  mockProcessDefinitions,
   mockProcessStatisticsV2 as mockProcessStatistics,
-  mockProcessInstances,
   mockMultipleStatesStatistics,
   mockProcessXML,
   mockProcessInstancesV2,
+  searchResult,
+  createProcessDefinition,
 } from 'modules/testUtils';
 import {DiagramPanel} from './index';
-import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
 import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {useEffect} from 'react';
 import {Paths} from 'modules/Routes';
 import {batchModificationStore} from 'modules/stores/batchModification';
@@ -41,12 +39,13 @@ vi.mock('modules/bpmn-js/utils/isProcessEndEvent', () => ({
   isProcessOrSubProcessEndEvent: vi.fn(() => true),
 }));
 
-function getWrapper(initialPath: string = Paths.dashboard()) {
+function getWrapper(queryParams?: Record<string, string>) {
+  const initialPath = `${Paths.processes()}?${new URLSearchParams(queryParams).toString()}`;
+
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
     useEffect(() => {
       processInstancesSelectionStore.init();
       return () => {
-        processesStore.reset();
         batchModificationStore.reset();
         processInstancesSelectionStore.reset();
       };
@@ -78,26 +77,27 @@ function getWrapper(initialPath: string = Paths.dashboard()) {
 
 describe('DiagramPanel', () => {
   beforeEach(() => {
-    mockFetchProcessInstances().withSuccess(mockProcessInstances);
-    mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
     mockFetchProcessDefinitionXml().withSuccess('');
     mockSearchProcessInstances().withSuccess(mockProcessInstancesV2);
-
-    processesStore.fetchProcesses();
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({
+          name: 'Big variable process',
+          processDefinitionId: 'bigVarProcess',
+          version: 1,
+          versionTag: 'MyVersionTag',
+          processDefinitionKey: '123',
+        }),
+      ]),
+    );
   });
 
   it('should render header', async () => {
-    const queryString = '?process=bigVarProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-    vi.stubGlobal('prompt', vi.fn());
+    const queryParams = {process: 'bigVarProcess', version: '1'};
 
     const {user} = render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByText('Big variable process')).toBeInTheDocument();
@@ -117,17 +117,11 @@ describe('DiagramPanel', () => {
   });
 
   it('should show the loading indicator, when diagram is loading', async () => {
-    const queryString = '?process=bigVarProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
+    const queryParams = {process: 'bigVarProcess', version: '1'};
     mockFetchProcessInstancesStatistics().withDelay(mockProcessStatistics);
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(screen.getByTestId('diagram-spinner')).toBeInTheDocument();
@@ -154,15 +148,10 @@ describe('DiagramPanel', () => {
   });
 
   it('should show a message when no process version is selected', async () => {
-    const queryString = '?process=bigVarProcess&version=all';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {process: 'bigVarProcess', version: 'all'};
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(
@@ -178,15 +167,19 @@ describe('DiagramPanel', () => {
   });
 
   it('should display bpmnProcessId as process name in the message when no process version is selected', async () => {
-    const queryString = '?process=eventBasedGatewayProcess&version=all';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {process: 'eventBasedGatewayProcess', version: 'all'};
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({
+          processDefinitionId: 'eventBasedGatewayProcess',
+          name: undefined,
+          processDefinitionKey: '123',
+        }),
+      ]),
+    );
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(
@@ -197,40 +190,32 @@ describe('DiagramPanel', () => {
   });
 
   it('should show an error message', async () => {
-    const consoleErrorMock = vi
-      .spyOn(global.console, 'error')
-      .mockImplementation(() => {});
+    const queryParams = {process: 'bigVarProcess', version: '1'};
 
     mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
     mockFetchProcessDefinitionXml().withServerError();
+    mockFetchProcessDefinitionXml().withServerError();
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(),
+      wrapper: getWrapper(queryParams),
     });
 
+    expect(await screen.findByText('Big variable process')).toBeInTheDocument();
     expect(
       await screen.findByText('Data could not be fetched'),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/There is no Process selected/),
     ).not.toBeInTheDocument();
-
-    consoleErrorMock.mockRestore();
   });
 
   it('should render statistics', async () => {
-    const queryString = '?process=bigVarProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
+    const queryParams = {process: 'bigVarProcess', version: '1'};
     mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
     mockFetchProcessDefinitionXml().withSuccess('');
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
@@ -238,12 +223,7 @@ describe('DiagramPanel', () => {
   });
 
   it('should not fetch batch modification data outside batch modification mode', async () => {
-    const queryString = '?process=bigVarProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {process: 'bigVarProcess', version: '1'};
 
     const mockProcessInstancesStatisticsResolver = vi.fn();
     mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics, {
@@ -252,7 +232,7 @@ describe('DiagramPanel', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
 
     const {user} = render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     // Expect fetching initial statistics
@@ -303,18 +283,13 @@ describe('DiagramPanel', () => {
   });
 
   it('should still render diagram when useProcessInstancesOverlayData fails', async () => {
-    const queryString = '?process=bigVarProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {process: 'bigVarProcess', version: '1'};
 
     mockFetchProcessInstancesStatistics().withServerError();
     mockFetchProcessDefinitionXml().withSuccess('');
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
@@ -322,18 +297,13 @@ describe('DiagramPanel', () => {
   });
 
   it('should still render diagram when useBatchModificationOverlayData fails', async () => {
-    const queryString = '?process=bigVarProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {process: 'bigVarProcess', version: '1'};
 
     mockFetchProcessDefinitionXml().withSuccess('');
     mockFetchProcessInstancesStatistics().withServerError();
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
@@ -341,13 +311,12 @@ describe('DiagramPanel', () => {
   });
 
   it('should display statistics when active and incidents are selected in the filter', async () => {
-    const queryString =
-      '?process=bigVarProcess&version=1&active=true&incidents=true';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {
+      process: 'bigVarProcess',
+      version: '1',
+      active: 'true',
+      incidents: 'true',
+    };
 
     mockFetchProcessInstancesStatistics().withSuccess(
       mockMultipleStatesStatistics,
@@ -355,7 +324,7 @@ describe('DiagramPanel', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
@@ -368,13 +337,12 @@ describe('DiagramPanel', () => {
   });
 
   it('should display statistics when completed and canceled are selected in the filter', async () => {
-    const queryString =
-      '?process=bigVarProcess&version=1&completed=true&canceled=true';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {
+      process: 'bigVarProcess',
+      version: '1',
+      completed: 'true',
+      canceled: 'true',
+    };
 
     mockFetchProcessInstancesStatistics().withSuccess(
       mockMultipleStatesStatistics,
@@ -382,7 +350,7 @@ describe('DiagramPanel', () => {
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
@@ -397,13 +365,14 @@ describe('DiagramPanel', () => {
   });
 
   it('should display statistics when all states are selected', async () => {
-    const queryString =
-      '?process=bigVarProcess&version=1&active=true&incidents=true&completed=true&canceled=true';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
+    const queryParams = {
+      process: 'bigVarProcess',
+      version: '1',
+      active: 'true',
+      incidents: 'true',
+      completed: 'true',
+      canceled: 'true',
+    };
 
     mockFetchProcessInstancesStatistics().withSuccess(
       mockMultipleStatesStatistics,
@@ -411,7 +380,7 @@ describe('DiagramPanel', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
 
     render(<DiagramPanel />, {
-      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
+      wrapper: getWrapper(queryParams),
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();

--- a/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/DiagramPanel/index.tsx
@@ -6,11 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useLocation, useNavigate, type Location} from 'react-router-dom';
+import {useSearchParams} from 'react-router-dom';
 import {observer} from 'mobx-react';
-import {deleteSearchParams} from 'modules/utils/filter';
-import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {Section} from '../../DiagramPanel/styled';
 import {DiagramShell} from 'modules/components/DiagramShell';
 import {Diagram} from 'modules/components/Diagram';
@@ -23,7 +20,6 @@ import {BatchModificationNotification} from './BatchModificationNotification';
 import {DiagramHeader} from './DiagramHeader';
 import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesStatistics/useOverlayData';
 import {useBatchModificationOverlayData} from 'modules/queries/processInstancesStatistics/useBatchModificationOverlayData';
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
 import {
   getFlowNode,
@@ -31,6 +27,11 @@ import {
 } from 'modules/utils/flowNodes';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import type {FlowNodeState} from 'modules/types/operate';
+import {parseProcessInstancesFilter} from 'modules/utils/filter/v2/processInstancesSearch';
+import {
+  getProcessDefinitionName,
+  useProcessDefinitionSelection,
+} from 'modules/hooks/processDefinitions';
 
 const OVERLAY_TYPE_BATCH_MODIFICATIONS_BADGE = 'batchModificationsBadge';
 
@@ -39,29 +40,24 @@ type ModificationBadgePayload = {
   cancelledTokenCount: number;
 };
 
-function setSearchParam(
-  location: Location,
-  [key, value]: [key: string, value: string],
-) {
-  const params = new URLSearchParams(location.search);
-
-  params.set(key, value);
-
-  return {
-    ...location,
-    search: params.toString(),
-  };
-}
-
 const DiagramPanel: React.FC = observer(() => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const {version, flowNodeId} = getProcessInstanceFilters(location.search);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const {flowNodeId} = parseProcessInstancesFilter(searchParams);
 
-  const isVersionSelected = version !== undefined && version !== 'all';
-
-  const processDetails = processesStore.getSelectedProcessDetails();
-  const {processName} = processDetails;
+  const {
+    data: definitionSelection = {kind: 'no-match'},
+    isLoading: isDefinitionSelectionLoading,
+    isEnabled: isDefinitionSelectionEnabled,
+    isError: isDefinitionSelectionError,
+  } = useProcessDefinitionSelection();
+  const selectedDefinitionKey =
+    definitionSelection.kind === 'single-version'
+      ? definitionSelection.definition.processDefinitionKey
+      : undefined;
+  const selectedDefinitionName =
+    definitionSelection.kind !== 'no-match'
+      ? getProcessDefinitionName(definitionSelection.definition)
+      : 'Process';
 
   const statisticsOverlays = diagramOverlaysStore.state.overlays.filter(
     ({type}) => type.match(/^statistics/) !== null,
@@ -72,17 +68,14 @@ const DiagramPanel: React.FC = observer(() => {
       ({type}) => type === OVERLAY_TYPE_BATCH_MODIFICATIONS_BADGE,
     );
 
-  const processId = processesStore.getProcessIdByLocation(location);
-
-  const {selectedTargetElementId} = batchModificationStore.state;
-
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-  const processDefinitionXML = useListViewXml({
-    processDefinitionKey,
+  const {
+    data: processDefinitionXML,
+    isFetching: isXmlFetching,
+    isError: isXmlError,
+  } = useListViewXml({
+    processDefinitionKey: selectedDefinitionKey,
   });
-
-  const xml = processDefinitionXML?.data?.xml;
-  const selectableIds = processDefinitionXML?.data?.selectableFlowNodes.map(
+  const selectableIds = processDefinitionXML?.selectableFlowNodes.map(
     (flowNode) => flowNode.id,
   );
 
@@ -90,16 +83,17 @@ const DiagramPanel: React.FC = observer(() => {
 
   const {data: processInstanceOverlayData} = useProcessInstancesOverlayData(
     {},
-    processId,
+    selectedDefinitionKey,
   );
 
+  const {selectedTargetElementId} = batchModificationStore.state;
   const {data: batchOverlayData} = useBatchModificationOverlayData(
     {},
     {
       sourceFlowNodeId: flowNodeId,
       targetFlowNodeId: selectedTargetElementId ?? undefined,
     },
-    processId,
+    selectedDefinitionKey,
     batchModificationStore.state.isEnabled,
   );
 
@@ -116,37 +110,29 @@ const DiagramPanel: React.FC = observer(() => {
     'statistics-incidents',
   );
 
-  const isDiagramLoading =
-    processDefinitionXML?.isFetching ||
-    !processesStore.isInitialLoadComplete ||
-    (processesStore.state.status === 'fetching' &&
-      location.state?.refreshContent);
-
   const getStatus = () => {
-    if (isDiagramLoading) {
-      return 'loading';
+    switch (true) {
+      case isXmlFetching || isDefinitionSelectionLoading:
+        return 'loading';
+      case isXmlError || isDefinitionSelectionError:
+        return 'error';
+      case !isDefinitionSelectionEnabled ||
+        definitionSelection.kind !== 'single-version':
+        return 'empty';
+      default:
+        return 'content';
     }
-    if (processDefinitionXML?.isError) {
-      return 'error';
-    }
-    if (!isVersionSelected) {
-      return 'empty';
-    }
-    return 'content';
   };
 
   return (
     <Section aria-label="Diagram Panel">
-      <DiagramHeader
-        processDetails={processDetails}
-        processDefinitionKey={processDefinitionKey}
-      />
+      <DiagramHeader processDefinitionSelection={definitionSelection} />
       <DiagramShell
         status={getStatus()}
         emptyMessage={
-          version === 'all'
+          definitionSelection.kind === 'all-versions'
             ? {
-                message: `There is more than one Version selected for Process "${processName}"`,
+                message: `There is more than one Version selected for Process "${selectedDefinitionName}"`,
                 additionalInfo: 'To see a Diagram, select a single Version',
               }
             : {
@@ -156,10 +142,10 @@ const DiagramPanel: React.FC = observer(() => {
               }
         }
       >
-        {xml !== undefined && (
+        {processDefinitionXML?.xml !== undefined && (
           <Diagram
-            xml={xml}
-            processDefinitionKey={processDefinitionKey}
+            xml={processDefinitionXML.xml}
+            processDefinitionKey={selectedDefinitionKey}
             {...(batchModificationStore.state.isEnabled
               ? // Props for batch modification mode
                 {
@@ -188,8 +174,7 @@ const DiagramPanel: React.FC = observer(() => {
                       isMoveModificationTarget(
                         getFlowNode({
                           businessObjects:
-                            processDefinitionXML.data?.diagramModel
-                              .elementsById,
+                            processDefinitionXML?.diagramModel.elementsById,
                           flowNodeId: selectedFlowNodeId,
                         }),
                       ),
@@ -200,11 +185,15 @@ const DiagramPanel: React.FC = observer(() => {
                   selectedFlowNodeIds: flowNodeId ? [flowNodeId] : undefined,
                   onFlowNodeSelection: (flowNodeId) => {
                     if (flowNodeId === null || flowNodeId === undefined) {
-                      navigate(deleteSearchParams(location, ['flowNodeId']));
+                      setSearchParams((p) => {
+                        p.delete('flowNodeId');
+                        return p;
+                      });
                     } else {
-                      navigate(
-                        setSearchParam(location, ['flowNodeId', flowNodeId]),
-                      );
+                      setSearchParams((p) => {
+                        p.set('flowNodeId', flowNodeId);
+                        return p;
+                      });
                     }
                   },
                   overlaysData: [

--- a/operate/client/src/App/Processes/ListView/v2/Filters/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/Filters/index.tsx
@@ -47,12 +47,7 @@ import {
   splitDefinitionIdentifier,
 } from 'modules/hooks/processDefinitions';
 
-interface FilterValues extends ProcessInstancesFilter {
-  variableName?: string;
-  variableValues?: string;
-}
-
-const initialValues: FilterValues = {
+const initialValues: ProcessInstancesFilter = {
   active: true,
   incidents: true,
 };
@@ -62,7 +57,7 @@ const Filters: React.FC = observer(() => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [visibleFilters, setVisibleFilters] = useState<OptionalFilter[]>([]);
-  const filterValues: FilterValues = parseProcessInstancesFilter(searchParams);
+  const filterValues = parseProcessInstancesFilter(searchParams);
   const variable = variableFilterStore.variable;
   if (variable) {
     filterValues.variableName = variable.name;

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.test.tsx
@@ -15,9 +15,6 @@ import {useEffect} from 'react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {processesStore} from 'modules/stores/processes/processes.list';
-import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
-import {mockProcessDefinitions} from 'modules/testUtils';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 
 vi.mock('modules/utils/bpmn');
@@ -54,7 +51,7 @@ function getWrapper(initialPath: string = Paths.processes()) {
     useEffect(() => {
       return () => {
         processInstancesSelectionStore.reset();
-        processesStore.reset();
+
         batchModificationStore.reset();
       };
     }, []);
@@ -75,11 +72,6 @@ function getWrapper(initialPath: string = Paths.processes()) {
 }
 
 describe('<InstancesTable />', () => {
-  beforeEach(() => {
-    mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
-    processesStore.fetchProcesses();
-  });
-
   it.each(['all', undefined])(
     'should show tenant column when multi tenancy is enabled and tenant filter is %p',
     async (tenant) => {

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
@@ -17,9 +17,6 @@ import {tracking} from 'modules/tracking';
 import {Link} from 'modules/components/Link';
 import {useFilters} from 'modules/hooks/useFilters';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
-
-/** Stores */
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {Toolbar} from './Toolbar';
 import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
@@ -45,9 +42,9 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
     onVerticalScrollStartReach,
     onVerticalScrollEndReach,
   }) => {
-    const hasVersionTags = processInstances.some(({processDefinitionKey}) => {
-      return processesStore.getVersionTag(processDefinitionKey);
-    });
+    const hasVersionTags = processInstances.some(
+      ({processDefinitionVersionTag}) => !!processDefinitionVersionTag,
+    );
 
     const filters = useFilters();
     const location = useLocation();
@@ -108,9 +105,6 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
           onVerticalScrollStartReach={onVerticalScrollStartReach}
           onVerticalScrollEndReach={onVerticalScrollEndReach}
           rows={processInstances.map((instance) => {
-            const versionTag = processesStore.getVersionTag(
-              instance.processDefinitionKey,
-            );
             const instanceState: InstanceEntityState = instance.hasIncident
               ? 'INCIDENT'
               : instance.state;
@@ -144,7 +138,7 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
                 </Link>
               ),
               processVersion: instance.processDefinitionVersion,
-              versionTag: versionTag ?? '--',
+              versionTag: instance.processDefinitionVersionTag ?? '--',
               tenant: isTenantColumnVisible ? instance.tenantId : undefined,
               startDate: formatDate(instance.startDate),
               endDate: formatDate(instance.endDate ?? null),

--- a/operate/client/src/App/Processes/ListView/v2/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/ProcessOperations/index.tsx
@@ -23,13 +23,13 @@ import {observer} from 'mobx-react';
 import {useRunningInstancesCount} from 'modules/queries/processInstance/useRunningInstancesCount';
 
 type Props = {
-  processDefinitionId: string;
+  processDefinitionKey: string;
   processName: string;
-  processVersion: string;
+  processVersion: number;
 };
 
 const ProcessOperations: React.FC<Props> = observer(
-  ({processDefinitionId, processName, processVersion}) => {
+  ({processDefinitionKey, processName, processVersion}) => {
     const [isDeleteModalVisible, setIsDeleteModalVisible] =
       useState<boolean>(false);
 
@@ -40,7 +40,7 @@ const ProcessOperations: React.FC<Props> = observer(
       isPending,
       isError,
     } = useRunningInstancesCount({
-      processDefinitionKey: processDefinitionId,
+      processDefinitionKey: processDefinitionKey,
     });
 
     return (
@@ -67,7 +67,7 @@ const ProcessOperations: React.FC<Props> = observer(
                 tracking.track({
                   eventName: 'definition-deletion-button',
                   resource: 'process',
-                  version: processVersion,
+                  version: processVersion.toString(),
                 });
 
                 setIsDeleteModalVisible(true);
@@ -133,11 +133,11 @@ const ProcessOperations: React.FC<Props> = observer(
             tracking.track({
               eventName: 'definition-deletion-confirmation',
               resource: 'process',
-              version: processVersion,
+              version: processVersion.toString(),
             });
 
             operationsStore.applyDeleteProcessDefinitionOperation({
-              processDefinitionId,
+              processDefinitionId: processDefinitionKey,
               onSuccess: () => {
                 setIsOperationRunning(false);
                 panelStatesStore.expandOperationsPanel();

--- a/operate/client/src/App/Processes/ListView/v2/tests/processOperations.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/tests/processOperations.test.tsx
@@ -14,6 +14,8 @@ import {
   mockProcessXML,
   createUser,
   mockProcessInstancesV2,
+  searchResult,
+  createProcessDefinition,
 } from 'modules/testUtils';
 import {mockQueryBatchOperations} from 'modules/mocks/api/v2/batchOperations/queryBatchOperations';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -26,6 +28,16 @@ describe('<ListView /> - operations', () => {
   beforeEach(() => {
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({
+          processDefinitionId: 'demoProcess',
+          processDefinitionKey: 'demoProcess1',
+          name: 'New demo process',
+          version: 1,
+        }),
+      ]),
+    );
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     mockQueryBatchOperations().withSuccess({
@@ -53,11 +65,6 @@ describe('<ListView /> - operations', () => {
 
     const queryString =
       '?active=true&incidents=true&process=demoProcess&version=1';
-
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
 
     render(<ListView />, {
       wrapper: createWrapper(`/processes${queryString}`),
@@ -120,11 +127,6 @@ describe('<ListView /> - operations', () => {
 
     const queryString = '?active=true&incidents=true&process=demoProcess';
 
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
     render(<ListView />, {
       wrapper: createWrapper(`/processes${queryString}`),
     });
@@ -152,11 +154,6 @@ describe('<ListView /> - operations', () => {
 
     const queryString = '?process=demoProcess&version=1';
 
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
     render(<ListView />, {
       wrapper: createWrapper(`/processes${queryString}`),
     });
@@ -179,11 +176,6 @@ describe('<ListView /> - operations', () => {
 
     const queryString = '?process=demoProcess&version=1';
 
-    vi.stubGlobal('location', {
-      ...window.location,
-      search: queryString,
-    });
-
     vi.stubGlobal('clientConfig', {
       resourcePermissionsEnabled: true,
     });
@@ -192,6 +184,9 @@ describe('<ListView /> - operations', () => {
       wrapper: createWrapper(`/processes${queryString}`),
     });
 
+    expect(
+      await screen.findByRole('heading', {name: 'New demo process'}),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', {
         name: /delete process definition/i,

--- a/operate/client/src/modules/stores/processes/processes.list.ts
+++ b/operate/client/src/modules/stores/processes/processes.list.ts
@@ -6,37 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {computed, makeObservable} from 'mobx';
 import {ProcessesBase} from './processes.base';
-import type {ProcessVersionDto} from 'modules/api/processes/fetchGroupedProcesses';
 
 class Processes extends ProcessesBase {
   constructor() {
     super();
-    makeObservable(this, {
-      processVersions: computed,
-    });
-  }
-
-  /**
-   * flat list of all process versions
-   */
-  get processVersions() {
-    return this.filteredProcesses.reduce<ProcessVersionDto[]>(
-      (processVersions, process) => {
-        return [
-          ...processVersions,
-          ...process.processes.map((processDefinition) => processDefinition),
-        ];
-      },
-      [],
-    );
-  }
-
-  getVersionTag(processId: string) {
-    return this.processVersions.find(({id}) => {
-      return id === processId;
-    })?.versionTag;
   }
 }
 

--- a/operate/client/src/modules/types/operate.ts
+++ b/operate/client/src/modules/types/operate.ts
@@ -55,6 +55,7 @@ interface ProcessInstanceEntity {
   processId: string;
   processName: string;
   processVersion: number;
+  processVersionTag?: string | null;
   startDate: string;
   endDate: null | string;
   state: InstanceEntityState;

--- a/operate/client/src/modules/utils/filter/decisionsFilter.ts
+++ b/operate/client/src/modules/utils/filter/decisionsFilter.ts
@@ -100,7 +100,10 @@ function mapDecisionDefinitionVersionFilter(
   filter: DecisionsFilter,
 ): DecisionInstancesSearchFilter['decisionDefinitionVersion'] {
   if (filter.version && filter.version !== 'all') {
-    return parseInt(filter.version);
+    const version = parseInt(filter.version, 10);
+    if (!isNaN(version)) {
+      return version;
+    }
   }
 }
 

--- a/operate/client/src/modules/utils/filter/v2/processDefinitionsSearchFilter.test.ts
+++ b/operate/client/src/modules/utils/filter/v2/processDefinitionsSearchFilter.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {parseProcessDefinitionsSearchFilter} from './processDefinitionsSearchFilter';
+
+describe('parseProcessDefinitionsSearchFilter', () => {
+  it('should parse process definitions search filter from search params', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('process', 'testProcess');
+    searchParams.append('version', '3');
+    searchParams.append('tenant', 'tenant-A');
+
+    const filter = parseProcessDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({
+      processDefinitionId: 'testProcess',
+      version: 3,
+      tenantId: 'tenant-A',
+    });
+  });
+
+  it('should return empty filters when no relevant param is set', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('someParam', 'someValue');
+
+    const filter = parseProcessDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({});
+  });
+
+  it('should not include a version in the filter when its value is all', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('process', 'testProcess');
+    searchParams.append('version', 'all');
+
+    const filter = parseProcessDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({
+      processDefinitionId: 'testProcess',
+    });
+  });
+
+  it('should not include a tenantId in the filter when its value is all', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('process', 'testProcess');
+    searchParams.append('tenant', 'all');
+
+    const filter = parseProcessDefinitionsSearchFilter(searchParams);
+
+    expect(filter).toEqual({
+      processDefinitionId: 'testProcess',
+    });
+  });
+});

--- a/operate/client/src/modules/utils/filter/v2/processDefinitionsSearchFilter.ts
+++ b/operate/client/src/modules/utils/filter/v2/processDefinitionsSearchFilter.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {QueryProcessDefinitionsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {
+  parseProcessInstancesFilter,
+  type ProcessInstancesFilter,
+} from './processInstancesSearch';
+
+type ProcessDefinitionsSearchFilter = NonNullable<
+  QueryProcessDefinitionsRequestBody['filter']
+>;
+
+/**
+ * Parses filter arguments for a process-definitions search from the given {@linkcode URLSearchParams}.
+ */
+function parseProcessDefinitionsSearchFilter(
+  search: URLSearchParams,
+): ProcessDefinitionsSearchFilter {
+  const filter = parseProcessInstancesFilter(search);
+
+  return {
+    processDefinitionId: filter.process,
+    tenantId: filter.tenant === 'all' ? undefined : filter.tenant,
+    version: mapProcessDefinitionVersion(filter),
+  };
+}
+
+function mapProcessDefinitionVersion(
+  filter: ProcessInstancesFilter,
+): ProcessDefinitionsSearchFilter['version'] {
+  if (filter.version && filter.version !== 'all') {
+    const version = parseInt(filter.version, 10);
+    if (!isNaN(version)) {
+      return version;
+    }
+  }
+}
+
+export {parseProcessDefinitionsSearchFilter};


### PR DESCRIPTION
## Description

This PR is the first batch of removing the `processes.list` store:

- Removed `getVersionTag(...)` usage in the instance table v1 and v2.
- Removed store usage in the v2 diagram panel (same pattern as the decisions diagram panel)
  - This could also be copied to the v1 diagram panel, but I avoided it for now as the v1 panel will be removed anyway.

> [!NOTE]
> If you want to test it locally, you have to start Operate against RDBMS to see the v2 Processes ListView code. Alternatively, you can change [this condition](https://github.com/camunda/camunda/blob/main/operate/client/src/App/Processes/index.tsx#L33-L34) temporarily.

## Related issues

relates #42481
