### PR TITLE
[Backport stable/8.7] fix: add port validation to c8run

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -64,6 +64,13 @@ func validateKeystore(settings types.C8RunSettings, parentDir string) error {
 	return nil
 }
 
+func validatePort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("--port must be between 1 and 65535 (got %d)", port)
+	}
+	return nil
+}
+
 func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	err := os.Chdir(composeExtractedFolder)
 	if err != nil {
@@ -155,6 +162,13 @@ func getBaseCommandSettings(baseCommand string) (types.C8RunSettings, error) {
 		if err != nil {
 			return settings, fmt.Errorf("error parsing start argument: %w", err)
 		}
+<<<<<<< HEAD
+=======
+		startupURLProvided = flagPassed(startFlagSet, "startup-url")
+		if err := validatePort(settings.Port); err != nil {
+			return settings, startupURLProvided, err
+		}
+>>>>>>> e3ee4aab (fix: add port validation)
 	case "stop":
 		err := stopFlagSet.Parse(os.Args[2:])
 		if err != nil {

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -78,3 +78,29 @@ func TestCamundaCmdDifferentPort(t *testing.T) {
 	assert.Contains(t, javaOptsEnvVar, "-Dserver.port=8087")
 
 }
+
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    int
+		wantErr bool
+	}{
+		{name: "valid lower bound", port: 1},
+		{name: "valid upper bound", port: 65535},
+		{name: "zero", port: 0, wantErr: true},
+		{name: "negative", port: -1, wantErr: true},
+		{name: "too large", port: 70000, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePort(tt.port)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
Backport of #42312 to `stable/8.7`.

relates to #26287