### PR TITLE
[Backport stable/8.8] fix: add port validation to c8run

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -52,6 +52,13 @@ func validateKeystore(settings types.C8RunSettings, parentDir string) error {
 	return nil
 }
 
+func validatePort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("--port must be between 1 and 65535 (got %d)", port)
+	}
+	return nil
+}
+
 func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	err := os.Chdir(composeExtractedFolder)
 	if err != nil {
@@ -147,6 +154,13 @@ func getBaseCommandSettings(baseCommand string) (types.C8RunSettings, error) {
 		if !flagPassed(startFlagSet, "startup-url") {
 			settings.StartupUrl = createOperateUrl(&settings)
 		}
+<<<<<<< HEAD
+=======
+		startupURLProvided = flagPassed(startFlagSet, "startup-url")
+		if err := validatePort(settings.Port); err != nil {
+			return settings, startupURLProvided, err
+		}
+>>>>>>> e3ee4aab (fix: add port validation)
 	case "stop":
 		err := stopFlagSet.Parse(os.Args[2:])
 		if err != nil {

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -117,3 +117,74 @@ func TestCamundaCmdPassword(t *testing.T) {
 	}
 	assert.Contains(t, javaOptsEnvVar, "-Dcamunda.security.initialization.users[0].password=changeme")
 }
+<<<<<<< HEAD
+=======
+
+func TestApplySecondaryStorageDefaultsDisablesElasticsearchForRdbms(t *testing.T) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "configuration")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+	config := `
+camunda:
+  data:
+    secondary-storage:
+      type: rdbms
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "application.yaml"), []byte(config), 0o644))
+
+	settings := types.C8RunSettings{DisableElasticsearch: false}
+	applySecondaryStorageDefaults(tempDir, &settings)
+
+	assert.Equal(t, "rdbms", settings.SecondaryStorageType)
+	assert.True(t, settings.DisableElasticsearch)
+}
+
+func TestApplySecondaryStorageDefaultsKeepsFlagWhenElasticsearchRequested(t *testing.T) {
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "configuration")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+	config := `
+camunda:
+  data:
+    secondary-storage:
+      type: elasticsearch
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "application.yaml"), []byte(config), 0o644))
+
+	settings := types.C8RunSettings{DisableElasticsearch: false}
+	applySecondaryStorageDefaults(tempDir, &settings)
+
+	assert.Equal(t, "elasticsearch", settings.SecondaryStorageType)
+	assert.False(t, settings.DisableElasticsearch)
+}
+
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    int
+		wantErr bool
+	}{
+		{name: "valid lower bound", port: 1},
+		{name: "valid upper bound", port: 65535},
+		{name: "zero", port: 0, wantErr: true},
+		{name: "negative", port: -1, wantErr: true},
+		{name: "too large", port: 70000, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePort(tt.port)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+>>>>>>> e3ee4aab (fix: add port validation)


### PR DESCRIPTION
# Description
Backport of #42312 to `stable/8.8`.

relates to #26287