### PR TITLE
feat: add more metrics for history cleanup

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
@@ -99,7 +99,7 @@ public class RdbmsWriterMetrics {
         .minimumExpectedValue(Duration.ofMillis(10));
   }
 
-  public void recordHistoryCleanupBulkSize(final int bulkSize, final String entityName) {
+  public void recordHistoryCleanupEntities(final int bulkSize, final String entityName) {
     DistributionSummary.builder(meterName("historyCleanup.bulk.size"))
         .description("Exporter bulk size")
         .tag("entity", entityName)
@@ -108,6 +108,12 @@ public class RdbmsWriterMetrics {
             100_000)
         .register(meterRegistry)
         .record(bulkSize);
+
+    Counter.builder(meterName("historyCleanup.deletedEntities"))
+        .tags("entity", entityName)
+        .description("Number of removed rows of the given entity")
+        .register(meterRegistry)
+        .increment(bulkSize);
   }
 
   public void recordFailedFlush() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -238,7 +238,7 @@ public class HistoryCleanupService {
     LOG.debug("Deleted {}history records: {}", cleanupType, numDeletedRecords);
     for (final var entry : numDeletedRecords.entrySet()) {
       LOG.debug("    Deleted {}s: {}", entry.getKey(), entry.getValue());
-      metrics.recordHistoryCleanupBulkSize(entry.getValue(), entry.getKey());
+      metrics.recordHistoryCleanupEntities(entry.getValue(), entry.getKey());
     }
 
     LOG.debug(

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -121,6 +121,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 36,
   "links": [],
   "panels": [
     {
@@ -184,7 +185,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   }
                 ]
               }
@@ -229,7 +231,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -293,7 +295,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -328,7 +331,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -397,7 +400,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -429,7 +433,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -474,7 +478,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -514,7 +519,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -580,7 +585,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -613,18 +619,20 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
+              "editorMode": "code",
               "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"skipped|processed\"}[$__rate_interval])) by (pod, partition, processor)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{pod}}-{{partition}}-{{processor}}-processed",
+              "range": true,
               "refId": "A"
             },
             {
@@ -690,7 +698,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -723,7 +732,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -791,7 +800,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -807,7 +817,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 88
+            "y": 12
           },
           "id": 62,
           "options": {
@@ -823,7 +833,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -864,7 +874,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   },
                   {
                     "color": "#EAB839",
@@ -884,7 +895,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 88
+            "y": 12
           },
           "id": 232,
           "options": {
@@ -905,7 +916,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -973,7 +984,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -989,7 +1001,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 88
+            "y": 12
           },
           "id": 74,
           "options": {
@@ -1005,7 +1017,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1047,7 +1059,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1063,7 +1076,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 90
+            "y": 14
           },
           "id": 118,
           "maxDataPoints": 100,
@@ -1084,7 +1097,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1126,7 +1139,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1142,7 +1156,7 @@
             "h": 2,
             "w": 5,
             "x": 8,
-            "y": 92
+            "y": 16
           },
           "id": 117,
           "maxDataPoints": 100,
@@ -1163,7 +1177,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1205,7 +1219,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1221,7 +1236,7 @@
             "h": 2,
             "w": 4,
             "x": 13,
-            "y": 92
+            "y": 16
           },
           "id": 655,
           "maxDataPoints": 100,
@@ -1242,7 +1257,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1311,7 +1326,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1327,7 +1343,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 94
+            "y": 18
           },
           "id": 39,
           "options": {
@@ -1343,7 +1359,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1407,7 +1423,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1423,7 +1440,7 @@
             "h": 6,
             "w": 5,
             "x": 8,
-            "y": 94
+            "y": 18
           },
           "id": 190,
           "options": {
@@ -1452,7 +1469,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1494,7 +1511,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "#EAB839",
@@ -1514,7 +1532,7 @@
             "h": 6,
             "w": 4,
             "x": 13,
-            "y": 94
+            "y": 18
           },
           "id": 612,
           "options": {
@@ -1532,7 +1550,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1600,7 +1618,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1659,7 +1678,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 94
+            "y": 18
           },
           "id": 33,
           "options": {
@@ -1675,7 +1694,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1778,7 +1797,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 100
+            "y": 24
           },
           "id": 622,
           "maxPerRow": 3,
@@ -1850,6 +1869,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -1881,7 +1901,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": 0
                   },
                   {
                     "color": "orange",
@@ -1901,7 +1922,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 3102
+            "y": 126
           },
           "id": 272,
           "options": {
@@ -1912,11 +1933,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -1957,7 +1979,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3109
+            "y": 223
           },
           "id": 418,
           "options": {
@@ -1994,7 +2016,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2030,6 +2052,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2060,7 +2083,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2075,7 +2099,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3109
+            "y": 223
           },
           "id": 421,
           "options": {
@@ -2086,11 +2110,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2129,6 +2154,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2159,7 +2185,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2174,7 +2201,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3943
+            "y": 231
           },
           "id": 192,
           "options": {
@@ -2185,11 +2212,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2223,6 +2251,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 70,
                 "hideFrom": {
                   "legend": false,
@@ -2276,7 +2305,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               }
@@ -2287,7 +2317,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3943
+            "y": 231
           },
           "id": 602,
           "options": {
@@ -2301,11 +2331,12 @@
             "rowHeight": 0.9,
             "showValue": "auto",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.1.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2364,6 +2395,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2394,7 +2426,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2409,7 +2442,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 3999
+            "y": 239
           },
           "id": 194,
           "options": {
@@ -2420,11 +2453,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2466,7 +2500,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2541,7 +2576,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 3999
+            "y": 239
           },
           "id": 199,
           "options": {
@@ -2556,7 +2591,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2605,7 +2640,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2680,7 +2716,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 3999
+            "y": 239
           },
           "id": 196,
           "options": {
@@ -2695,7 +2731,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2744,7 +2780,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2819,7 +2856,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 3999
+            "y": 239
           },
           "id": 200,
           "options": {
@@ -2834,7 +2871,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -2883,7 +2920,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2958,7 +2996,7 @@
             "h": 8,
             "w": 5,
             "x": 12,
-            "y": 4003
+            "y": 243
           },
           "id": 198,
           "options": {
@@ -2973,7 +3011,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3022,7 +3060,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3097,7 +3136,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 4003
+            "y": 243
           },
           "id": 268,
           "options": {
@@ -3112,7 +3151,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3156,6 +3195,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3186,7 +3226,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3201,7 +3242,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 4005
+            "y": 245
           },
           "id": 189,
           "options": {
@@ -3212,11 +3253,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3260,7 +3302,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3335,7 +3378,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 4005
+            "y": 245
           },
           "id": 201,
           "options": {
@@ -3350,7 +3393,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3432,7 +3475,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   }
                 ]
               }
@@ -3458,7 +3502,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 4011
+            "y": 251
           },
           "id": 604,
           "interval": "1s",
@@ -3477,7 +3521,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3561,7 +3605,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   }
                 ]
               }
@@ -3587,7 +3632,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4011
+            "y": 251
           },
           "id": 605,
           "interval": "1s",
@@ -3606,7 +3651,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3662,6 +3707,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3692,7 +3738,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3707,7 +3754,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 4017
+            "y": 257
           },
           "id": 543,
           "options": {
@@ -3718,11 +3765,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3751,11 +3799,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3786,7 +3836,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3801,7 +3852,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4023
+            "y": 263
           },
           "id": 561,
           "options": {
@@ -3812,11 +3863,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3849,11 +3901,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3884,7 +3938,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3899,7 +3954,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4023
+            "y": 263
           },
           "id": 594,
           "options": {
@@ -3910,10 +3965,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -3968,7 +4025,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4004,7 +4062,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 3103
+            "y": 127
           },
           "id": 12,
           "options": {
@@ -4019,7 +4077,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4068,7 +4126,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4104,7 +4163,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 3103
+            "y": 127
           },
           "id": 13,
           "options": {
@@ -4119,7 +4178,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4162,6 +4221,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4193,7 +4253,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4209,7 +4270,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3108
+            "y": 222
           },
           "id": 2,
           "options": {
@@ -4220,11 +4281,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4268,6 +4330,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4300,7 +4363,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4316,7 +4380,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3108
+            "y": 222
           },
           "id": 3,
           "options": {
@@ -4327,11 +4391,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4375,6 +4440,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4407,7 +4473,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4423,7 +4490,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 3114
+            "y": 228
           },
           "id": 4,
           "options": {
@@ -4434,11 +4501,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4473,6 +4541,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4505,7 +4574,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4521,7 +4591,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 3114
+            "y": 228
           },
           "id": 266,
           "options": {
@@ -4532,11 +4602,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4572,6 +4643,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4604,7 +4676,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4620,7 +4693,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 3114
+            "y": 228
           },
           "id": 267,
           "options": {
@@ -4631,11 +4704,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4672,6 +4746,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4703,7 +4778,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4719,7 +4795,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 3946
+            "y": 234
           },
           "id": 290,
           "options": {
@@ -4730,11 +4806,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4768,6 +4845,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4799,7 +4877,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4815,7 +4894,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 3946
+            "y": 234
           },
           "id": 291,
           "options": {
@@ -4826,11 +4905,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4864,6 +4944,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4895,7 +4976,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4911,7 +4993,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 3946
+            "y": 234
           },
           "id": 288,
           "options": {
@@ -4922,11 +5004,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4960,6 +5043,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4991,7 +5075,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5007,7 +5092,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 3946
+            "y": 234
           },
           "id": 289,
           "options": {
@@ -5018,11 +5103,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5101,7 +5187,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5117,7 +5204,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4018
+            "y": 128
           },
           "id": 102,
           "options": {
@@ -5128,11 +5215,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5173,7 +5261,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4018
+            "y": 128
           },
           "id": 112,
           "options": {
@@ -5214,7 +5302,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5295,7 +5383,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5311,7 +5400,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4026
+            "y": 226
           },
           "id": 105,
           "options": {
@@ -5322,11 +5411,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5366,7 +5456,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4026
+            "y": 226
           },
           "id": 106,
           "options": {
@@ -5407,7 +5497,7 @@
               "unit": "decmbytes"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5472,7 +5562,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5488,7 +5579,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4061
+            "y": 234
           },
           "id": 182,
           "options": {
@@ -5499,11 +5590,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5551,6 +5643,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -5582,7 +5675,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5641,7 +5735,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3105
+            "y": 129
           },
           "id": 261,
           "options": {
@@ -5657,11 +5751,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5725,6 +5820,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -5756,7 +5852,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5815,7 +5912,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3105
+            "y": 129
           },
           "id": 659,
           "options": {
@@ -5831,11 +5928,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5889,6 +5987,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5920,7 +6019,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5936,7 +6036,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3114
+            "y": 138
           },
           "id": 98,
           "options": {
@@ -5952,11 +6052,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6032,6 +6133,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -6063,7 +6165,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6079,7 +6182,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3114
+            "y": 138
           },
           "id": 35,
           "options": {
@@ -6090,11 +6193,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6142,6 +6246,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6172,7 +6277,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -6184,7 +6290,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3948
+            "y": 203
           },
           "id": 579,
           "options": {
@@ -6195,10 +6301,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6233,6 +6341,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6263,7 +6372,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -6275,7 +6385,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3948
+            "y": 203
           },
           "id": 580,
           "options": {
@@ -6286,10 +6396,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6324,6 +6436,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -6354,7 +6467,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6370,7 +6484,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4004
+            "y": 211
           },
           "id": 285,
           "options": {
@@ -6381,11 +6495,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6433,6 +6548,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -6463,7 +6579,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6479,7 +6596,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4004
+            "y": 211
           },
           "id": 286,
           "options": {
@@ -6490,11 +6607,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6557,6 +6675,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6587,7 +6706,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6603,7 +6723,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3106
+            "y": 358
           },
           "id": 614,
           "options": {
@@ -6619,11 +6739,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6658,6 +6779,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -6689,7 +6811,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6705,7 +6828,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3115
+            "y": 367
           },
           "id": 64,
           "options": {
@@ -6721,11 +6844,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6761,6 +6885,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -6792,7 +6917,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6808,7 +6934,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3115
+            "y": 367
           },
           "id": 294,
           "options": {
@@ -6819,11 +6945,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6942,7 +7069,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6958,7 +7086,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 4089
+            "y": 359
           },
           "id": 260,
           "options": {
@@ -6969,11 +7097,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7035,7 +7164,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7050,7 +7180,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4094
+            "y": 364
           },
           "id": 379,
           "options": {
@@ -7061,11 +7191,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7130,7 +7261,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7145,7 +7277,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4094
+            "y": 364
           },
           "id": 381,
           "options": {
@@ -7156,11 +7288,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7226,7 +7359,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7266,7 +7400,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4102
+            "y": 372
           },
           "id": 37,
           "options": {
@@ -7277,11 +7411,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7358,7 +7493,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7374,7 +7510,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4102
+            "y": 372
           },
           "id": 40,
           "options": {
@@ -7385,11 +7521,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7456,7 +7593,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7472,7 +7610,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4110
+            "y": 380
           },
           "id": 122,
           "options": {
@@ -7483,11 +7621,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7555,7 +7694,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7571,7 +7711,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4110
+            "y": 380
           },
           "id": 124,
           "options": {
@@ -7582,11 +7722,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7669,7 +7810,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4118
+            "y": 388
           },
           "id": 126,
           "options": {
@@ -7767,7 +7908,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4118
+            "y": 388
           },
           "id": 127,
           "options": {
@@ -7839,7 +7980,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4127
+            "y": 360
           },
           "id": 339,
           "options": {
@@ -7880,7 +8021,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -7937,7 +8078,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4127
+            "y": 360
           },
           "id": 341,
           "options": {
@@ -7978,7 +8119,7 @@
               "unit": "deckbytes"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -8058,7 +8199,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8074,7 +8216,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 4135
+            "y": 368
           },
           "id": 343,
           "options": {
@@ -8085,11 +8227,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -8182,7 +8325,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8198,7 +8342,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 4135
+            "y": 368
           },
           "id": 345,
           "options": {
@@ -8209,11 +8353,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -8305,7 +8450,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8320,7 +8466,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4145
+            "y": 378
           },
           "id": 347,
           "options": {
@@ -8331,11 +8477,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -8400,7 +8547,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8415,7 +8563,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4145
+            "y": 378
           },
           "id": 349,
           "options": {
@@ -8426,11 +8574,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -8510,7 +8659,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4153
+            "y": 386
           },
           "id": 353,
           "options": {
@@ -8606,7 +8755,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4153
+            "y": 386
           },
           "id": 351,
           "options": {
@@ -8676,7 +8825,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 361
           },
           "id": 692,
           "options": {
@@ -8714,7 +8863,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "adhocFilters": [],
@@ -8782,7 +8931,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8798,7 +8948,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 361
           },
           "id": 693,
           "options": {
@@ -8817,7 +8967,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "adhocFilters": [],
@@ -8890,7 +9040,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 369
           },
           "id": 132,
           "options": {
@@ -8931,7 +9081,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -9016,7 +9166,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9032,7 +9183,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 369
           },
           "id": 222,
           "options": {
@@ -9048,7 +9199,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -9130,7 +9281,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 377
           },
           "id": 133,
           "options": {
@@ -9171,7 +9322,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -9230,7 +9381,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 377
           },
           "id": 135,
           "options": {
@@ -9271,7 +9422,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -9329,7 +9480,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 385
           },
           "id": 28,
           "options": {
@@ -9454,7 +9605,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 392
           },
           "id": 593,
           "options": {
@@ -9544,7 +9695,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 402
           },
           "id": 233,
           "options": {
@@ -9629,7 +9780,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 402
           },
           "id": 269,
           "options": {
@@ -9713,7 +9864,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 409
           },
           "id": 690,
           "options": {
@@ -9799,7 +9950,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 409
           },
           "id": 691,
           "options": {
@@ -9885,7 +10036,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 416
           },
           "id": 420,
           "options": {
@@ -9967,7 +10118,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 416
           },
           "id": 419,
           "options": {
@@ -10088,7 +10239,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 423
           },
           "id": 310,
           "options": {
@@ -10218,7 +10369,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 423
           },
           "id": 311,
           "options": {
@@ -10307,7 +10458,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 430
           },
           "id": 235,
           "options": {
@@ -10390,7 +10541,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 430
           },
           "id": 234,
           "options": {
@@ -10480,6 +10631,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -10511,7 +10663,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10527,7 +10680,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 5245
+            "y": 362
           },
           "id": 26,
           "options": {
@@ -10538,11 +10691,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -10576,6 +10730,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -10607,7 +10762,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10623,7 +10779,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 5245
+            "y": 362
           },
           "id": 27,
           "options": {
@@ -10634,11 +10790,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -10690,7 +10847,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 5252
+            "y": 369
           },
           "id": 22,
           "options": {
@@ -10731,7 +10888,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -10784,7 +10941,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 5252
+            "y": 369
           },
           "id": 23,
           "options": {
@@ -10825,7 +10982,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -10878,7 +11035,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 5252
+            "y": 369
           },
           "id": 24,
           "options": {
@@ -10919,7 +11076,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -10987,7 +11144,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5246
+            "y": 135
           },
           "id": 164,
           "options": {
@@ -11028,7 +11185,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11073,6 +11230,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11106,7 +11264,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11143,7 +11302,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5254
+            "y": 200
           },
           "id": 166,
           "options": {
@@ -11154,11 +11313,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11191,6 +11351,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11224,7 +11385,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11261,7 +11423,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5254
+            "y": 200
           },
           "id": 168,
           "options": {
@@ -11272,11 +11434,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11323,6 +11486,7 @@
                 "axisLabel": "Requests",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11354,7 +11518,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11411,7 +11576,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 5247
+            "y": 136
           },
           "id": 278,
           "options": {
@@ -11422,11 +11587,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11462,6 +11628,7 @@
                 "axisLabel": "Install Requests",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11493,7 +11660,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11550,7 +11718,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 5247
+            "y": 136
           },
           "id": 283,
           "options": {
@@ -11561,11 +11729,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11599,6 +11768,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11630,7 +11800,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11646,7 +11817,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 5254
+            "y": 200
           },
           "id": 373,
           "options": {
@@ -11657,11 +11828,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11696,6 +11868,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11727,7 +11900,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11743,7 +11917,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 5262
+            "y": 208
           },
           "id": 363,
           "options": {
@@ -11754,11 +11928,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11793,6 +11968,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11824,7 +12000,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11840,7 +12017,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 5262
+            "y": 208
           },
           "id": 406,
           "options": {
@@ -11851,11 +12028,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11890,6 +12068,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -11921,7 +12100,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11937,7 +12117,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 5269
+            "y": 215
           },
           "id": 79,
           "options": {
@@ -11948,11 +12128,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -11987,6 +12168,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -12018,7 +12200,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -12034,7 +12217,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 5269
+            "y": 215
           },
           "id": 114,
           "options": {
@@ -12045,11 +12228,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12088,7 +12272,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 5276
+            "y": 222
           },
           "id": 86,
           "options": {
@@ -12129,7 +12313,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12163,6 +12347,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -12193,7 +12378,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -12209,7 +12395,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 5276
+            "y": 222
           },
           "id": 305,
           "options": {
@@ -12220,11 +12406,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12274,7 +12461,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5283
+            "y": 229
           },
           "id": 70,
           "options": {
@@ -12315,7 +12502,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12350,6 +12537,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -12381,7 +12569,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -12418,7 +12607,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5283
+            "y": 229
           },
           "id": 72,
           "options": {
@@ -12430,11 +12619,12 @@
               "width": 100
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12464,6 +12654,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 70,
                 "hideFrom": {
                   "legend": false,
@@ -12506,7 +12697,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   }
                 ]
               }
@@ -12517,7 +12709,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5291
+            "y": 237
           },
           "id": 432,
           "interval": "1s",
@@ -12532,11 +12724,12 @@
             "rowHeight": 0.9,
             "showValue": "auto",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12588,6 +12781,7 @@
                 "axisLabel": "Role (3 = Leader)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -12622,7 +12816,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -12659,7 +12854,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5291
+            "y": 237
           },
           "id": 95,
           "interval": "1s",
@@ -12674,11 +12869,12 @@
               "width": 300
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -12778,7 +12974,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 5299
+            "y": 245
           },
           "id": 205,
           "options": {
@@ -12905,7 +13101,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 5364
+            "y": 250
           },
           "id": 209,
           "options": {
@@ -12957,71 +13153,6 @@
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
           },
-          "description": "The number of records a follower is lagging behind for a given partition (p) and follower (f)",
-          "fieldConfig": {
-            "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 1000
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 12,
-            "x": 12,
-            "y": 5419
-          },
-          "id": 396,
-          "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "last"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto",
-            "text": {}
-          },
-          "pluginVersion": "10.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "sum(atomix_non_replicated_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (partition, follower)",
-              "interval": "",
-              "legendFormat": "p{{partition}} f{{follower}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Non replicated records",
-          "type": "gauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$DS_PROMETHEUS"
-          },
           "description": "The number of locally appended but non committed records on the leader per partition (p)",
           "fieldConfig": {
             "defaults": {
@@ -13030,7 +13161,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -13045,7 +13177,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 5429
+            "y": 255
           },
           "id": 215,
           "options": {
@@ -13064,7 +13196,7 @@
             "sizing": "auto",
             "text": {}
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13080,6 +13212,72 @@
             }
           ],
           "title": "Non committed records",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "The number of records a follower is lagging behind for a given partition (p) and follower (f)",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 255
+          },
+          "id": 396,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(atomix_non_replicated_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (partition, follower)",
+              "interval": "",
+              "legendFormat": "p{{partition}} f{{follower}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Non replicated records",
           "type": "gauge"
         }
       ],
@@ -13120,7 +13318,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3507
+            "y": 137
           },
           "id": 78,
           "options": {
@@ -13161,7 +13359,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13196,6 +13394,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13227,7 +13426,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -13243,7 +13443,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4018
+            "y": 200
           },
           "id": 180,
           "options": {
@@ -13254,11 +13454,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13292,6 +13493,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13323,7 +13525,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -13339,7 +13542,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 4026
+            "y": 208
           },
           "id": 368,
           "options": {
@@ -13350,11 +13553,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13389,6 +13593,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13420,7 +13625,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -13436,7 +13642,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4026
+            "y": 208
           },
           "id": 411,
           "options": {
@@ -13447,11 +13653,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13486,6 +13693,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13516,7 +13724,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -13532,7 +13741,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 4033
+            "y": 215
           },
           "id": 300,
           "options": {
@@ -13543,11 +13752,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13603,7 +13813,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4033
+            "y": 215
           },
           "id": 89,
           "options": {
@@ -13644,7 +13854,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13687,7 +13897,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 4040
+            "y": 222
           },
           "id": 401,
           "options": {
@@ -13728,7 +13938,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13764,6 +13974,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13794,7 +14005,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -13810,7 +14022,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4040
+            "y": 222
           },
           "id": 416,
           "options": {
@@ -13821,11 +14033,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13903,7 +14116,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 4047
+            "y": 229
           },
           "id": 386,
           "options": {
@@ -13944,7 +14157,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -13986,7 +14199,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4047
+            "y": 229
           },
           "id": 81,
           "options": {
@@ -14028,7 +14241,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14071,7 +14284,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 4053
+            "y": 235
           },
           "id": 426,
           "options": {
@@ -14112,7 +14325,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14147,6 +14360,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -14177,7 +14391,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -14193,7 +14408,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4053
+            "y": 235
           },
           "id": 427,
           "options": {
@@ -14204,11 +14419,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14253,6 +14469,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -14300,7 +14517,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 4060
+            "y": 242
           },
           "id": 304,
           "options": {
@@ -14372,7 +14589,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4060
+            "y": 242
           },
           "id": 391,
           "options": {
@@ -14456,7 +14673,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 4066
+            "y": 248
           },
           "id": 687,
           "options": {
@@ -14497,7 +14714,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14519,91 +14736,6 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Overall latency distribution to seek to an index",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 4066
-          },
-          "id": 559,
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": false
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "mode": "single",
-              "showColorScale": false,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "10.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "sum(increase(atomix_journal_seek_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_journal_seek_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
-              "format": "heatmap",
-              "intervalFactor": 1,
-              "legendFormat": "{{le}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Segment Seek Latency",
-          "type": "heatmap"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "description": "Number of times journal seek was executed. This included both seek to an index and seek to asqn.",
           "fieldConfig": {
             "defaults": {
@@ -14617,6 +14749,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14647,7 +14780,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -14659,7 +14793,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4066
+            "y": 248
           },
           "id": 560,
           "options": {
@@ -14670,11 +14804,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14724,6 +14859,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -14756,7 +14892,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -14768,7 +14905,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 4019
+            "y": 138
           },
           "id": 356,
           "options": {
@@ -14780,11 +14917,12 @@
               "width": 250
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14829,7 +14967,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4025
+            "y": 201
           },
           "id": 357,
           "options": {
@@ -14869,7 +15007,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14914,7 +15052,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4025
+            "y": 201
           },
           "id": 358,
           "options": {
@@ -14955,7 +15093,7 @@
               "unit": "kbytes"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -14993,6 +15131,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -15025,7 +15164,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -15037,7 +15177,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 4033
+            "y": 209
           },
           "id": 586,
           "options": {
@@ -15048,11 +15188,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15090,6 +15231,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -15122,7 +15264,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -15134,7 +15277,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 4033
+            "y": 209
           },
           "id": 589,
           "options": {
@@ -15145,11 +15288,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15187,6 +15331,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -15219,7 +15364,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -15231,7 +15377,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 4033
+            "y": 209
           },
           "id": 590,
           "options": {
@@ -15242,11 +15388,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15283,6 +15430,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15313,7 +15461,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -15328,7 +15477,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4042
+            "y": 218
           },
           "id": 606,
           "options": {
@@ -15339,11 +15488,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15382,6 +15532,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15412,7 +15563,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -15427,7 +15579,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4042
+            "y": 218
           },
           "id": 607,
           "options": {
@@ -15438,11 +15590,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15495,6 +15648,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15525,7 +15679,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               }
@@ -15536,7 +15691,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4050
+            "y": 226
           },
           "id": 608,
           "options": {
@@ -15547,11 +15702,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15587,6 +15743,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15617,7 +15774,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               }
@@ -15628,7 +15786,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4050
+            "y": 226
           },
           "id": 609,
           "options": {
@@ -15639,11 +15797,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15679,6 +15838,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15709,7 +15869,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -15724,7 +15885,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4058
+            "y": 234
           },
           "id": 610,
           "options": {
@@ -15735,11 +15896,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15789,6 +15951,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15819,7 +15982,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -15834,7 +15998,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4058
+            "y": 234
           },
           "id": 611,
           "options": {
@@ -15845,11 +16009,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15896,7 +16061,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 4066
+            "y": 242
           },
           "id": 588,
           "options": {
@@ -15914,11 +16079,12 @@
               "values": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -15967,7 +16133,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 4066
+            "y": 242
           },
           "id": 591,
           "options": {
@@ -15985,11 +16151,12 @@
               "values": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16039,7 +16206,7 @@
             "h": 9,
             "w": 5,
             "x": 12,
-            "y": 4066
+            "y": 242
           },
           "id": 592,
           "options": {
@@ -16057,11 +16224,12 @@
               "values": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16097,7 +16265,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "#EAB839",
@@ -16117,7 +16286,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 4066
+            "y": 242
           },
           "id": 613,
           "options": {
@@ -16135,7 +16304,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16186,6 +16355,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 2,
                 "gradientMode": "none",
@@ -16218,7 +16388,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16234,7 +16405,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 4022
+            "y": 139
           },
           "id": 154,
           "options": {
@@ -16245,11 +16416,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16284,6 +16456,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16315,7 +16488,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16331,7 +16505,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4022
+            "y": 139
           },
           "id": 144,
           "options": {
@@ -16342,11 +16516,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16380,6 +16555,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16411,7 +16587,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16427,7 +16604,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4028
+            "y": 202
           },
           "id": 142,
           "options": {
@@ -16438,11 +16615,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16476,6 +16654,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16508,7 +16687,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16524,7 +16704,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 4034
+            "y": 208
           },
           "id": 151,
           "options": {
@@ -16535,11 +16715,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16573,6 +16754,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16605,7 +16787,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16621,7 +16804,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4034
+            "y": 208
           },
           "id": 152,
           "options": {
@@ -16632,11 +16815,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16670,6 +16854,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16702,7 +16887,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16718,7 +16904,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4040
+            "y": 214
           },
           "id": 150,
           "options": {
@@ -16729,11 +16915,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16767,6 +16954,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16799,7 +16987,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16815,7 +17004,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 4046
+            "y": 220
           },
           "id": 147,
           "options": {
@@ -16826,11 +17015,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16864,6 +17054,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16896,7 +17087,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -16912,7 +17104,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4046
+            "y": 220
           },
           "id": 149,
           "options": {
@@ -16923,11 +17115,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -16961,6 +17154,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -16992,7 +17186,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17008,7 +17203,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4053
+            "y": 227
           },
           "id": 148,
           "options": {
@@ -17019,11 +17214,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17057,6 +17253,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17088,7 +17285,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17104,7 +17302,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4059
+            "y": 233
           },
           "id": 155,
           "options": {
@@ -17115,11 +17313,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17153,6 +17352,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17184,7 +17384,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17200,7 +17401,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4059
+            "y": 233
           },
           "id": 156,
           "options": {
@@ -17211,11 +17412,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17249,6 +17451,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -17279,7 +17482,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17294,7 +17498,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 4067
+            "y": 241
           },
           "id": 158,
           "options": {
@@ -17305,11 +17509,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "6.7.1",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17344,6 +17549,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17375,7 +17581,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17391,7 +17598,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 4067
+            "y": 241
           },
           "id": 157,
           "options": {
@@ -17402,11 +17609,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17440,6 +17648,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17471,7 +17680,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17487,7 +17697,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4067
+            "y": 241
           },
           "id": 146,
           "options": {
@@ -17498,11 +17708,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17536,6 +17747,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17567,7 +17779,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17583,7 +17796,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 4073
+            "y": 247
           },
           "id": 159,
           "options": {
@@ -17594,11 +17807,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17632,6 +17846,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17663,7 +17878,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17679,7 +17895,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 4073
+            "y": 247
           },
           "id": 160,
           "options": {
@@ -17690,11 +17906,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17728,6 +17945,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -17760,7 +17978,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17776,7 +17995,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 4073
+            "y": 247
           },
           "id": 153,
           "options": {
@@ -17787,11 +18006,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17825,6 +18045,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -17859,7 +18080,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17875,7 +18097,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 4080
+            "y": 254
           },
           "id": 603,
           "options": {
@@ -17886,10 +18108,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -17940,7 +18164,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -17955,7 +18180,7 @@
             "h": 8,
             "w": 4,
             "x": 0,
-            "y": 3116
+            "y": 140
           },
           "id": 675,
           "options": {
@@ -17973,7 +18198,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18019,7 +18244,7 @@
             "h": 8,
             "w": 10,
             "x": 4,
-            "y": 3116
+            "y": 140
           },
           "id": 676,
           "options": {
@@ -18046,7 +18271,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18092,7 +18317,7 @@
             "h": 8,
             "w": 10,
             "x": 14,
-            "y": 3116
+            "y": 140
           },
           "id": 677,
           "options": {
@@ -18119,7 +18344,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18189,7 +18414,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -18204,7 +18430,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3854
+            "y": 205
           },
           "id": 667,
           "options": {
@@ -18220,7 +18446,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18289,7 +18515,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -18304,7 +18531,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3854
+            "y": 205
           },
           "id": 683,
           "options": {
@@ -18320,7 +18547,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18361,7 +18588,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3862
+            "y": 213
           },
           "id": 670,
           "options": {
@@ -18399,7 +18626,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18446,7 +18673,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3862
+            "y": 213
           },
           "id": 673,
           "options": {
@@ -18484,7 +18711,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18526,7 +18753,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3870
+            "y": 221
           },
           "id": 669,
           "maxDataPoints": 494,
@@ -18568,7 +18795,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18639,7 +18866,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -18654,7 +18882,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3870
+            "y": 221
           },
           "id": 674,
           "options": {
@@ -18670,7 +18898,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18717,7 +18945,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3878
+            "y": 229
           },
           "id": 678,
           "options": {
@@ -18755,7 +18983,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18801,7 +19029,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3878
+            "y": 229
           },
           "id": 668,
           "options": {
@@ -18838,7 +19066,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18887,7 +19115,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3886
+            "y": 237
           },
           "id": 672,
           "options": {
@@ -18925,7 +19153,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -18992,7 +19220,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -19007,7 +19236,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3886
+            "y": 237
           },
           "id": 665,
           "options": {
@@ -19023,7 +19252,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.0.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -19082,7 +19311,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 4201
+            "y": 141
           },
           "id": 20,
           "options": {
@@ -19123,7 +19352,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -19159,6 +19388,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -19190,7 +19420,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -19206,7 +19437,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 4201
+            "y": 141
           },
           "id": 255,
           "options": {
@@ -19217,11 +19448,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -19262,7 +19494,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 4211
+            "y": 208
           },
           "id": 21,
           "options": {
@@ -19303,7 +19535,7 @@
               "unit": "short"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -19338,6 +19570,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -19369,7 +19602,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -19385,7 +19619,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 4211
+            "y": 208
           },
           "id": 185,
           "options": {
@@ -19396,11 +19630,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -19435,6 +19670,7 @@
                 "axisLabel": "Disk Usage %",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -19467,7 +19703,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": 0
                   },
                   {
                     "color": "rgba(216, 200, 27, 0.27)",
@@ -19487,7 +19724,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 4221
+            "y": 218
           },
           "id": 52,
           "options": {
@@ -19503,11 +19740,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -19562,7 +19800,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 3118
+            "y": 142
           },
           "id": 616,
           "options": {
@@ -19657,7 +19895,7 @@
             "h": 9,
             "w": 3,
             "x": 10,
-            "y": 3118
+            "y": 142
           },
           "id": 617,
           "options": {
@@ -19763,7 +20001,7 @@
             "h": 9,
             "w": 11,
             "x": 13,
-            "y": 3118
+            "y": 142
           },
           "id": 621,
           "options": {
@@ -19822,7 +20060,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 3152
+            "y": 208
           },
           "id": 618,
           "options": {
@@ -19948,7 +20186,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 3157
+            "y": 213
           },
           "id": 628,
           "options": {
@@ -20063,7 +20301,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 3157
+            "y": 213
           },
           "id": 623,
           "options": {
@@ -20122,7 +20360,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 3164
+            "y": 220
           },
           "id": 626,
           "options": {
@@ -20266,7 +20504,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 3164
+            "y": 220
           },
           "id": 627,
           "options": {
@@ -20381,7 +20619,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 3170
+            "y": 226
           },
           "id": 643,
           "options": {
@@ -20457,7 +20695,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 3179
+            "y": 235
           },
           "id": 647,
           "options": {
@@ -20541,7 +20779,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 3187
+            "y": 243
           },
           "id": 646,
           "options": {
@@ -20640,7 +20878,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 3187
+            "y": 243
           },
           "id": 645,
           "options": {
@@ -20723,7 +20961,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 3187
+            "y": 243
           },
           "id": 658,
           "options": {
@@ -20819,7 +21057,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 3119
+            "y": 53
           },
           "id": 630,
           "options": {
@@ -20906,7 +21144,7 @@
             "h": 9,
             "w": 11,
             "x": 10,
-            "y": 3119
+            "y": 53
           },
           "id": 636,
           "options": {
@@ -21002,7 +21240,7 @@
             "h": 9,
             "w": 3,
             "x": 21,
-            "y": 3119
+            "y": 53
           },
           "id": 634,
           "options": {
@@ -21081,7 +21319,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 3128
+            "y": 62
           },
           "id": 633,
           "options": {
@@ -21167,7 +21405,7 @@
             "h": 8,
             "w": 11,
             "x": 10,
-            "y": 3128
+            "y": 62
           },
           "id": 688,
           "options": {
@@ -21315,7 +21553,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 3136
+            "y": 70
           },
           "id": 684,
           "options": {
@@ -21500,7 +21738,8 @@
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "short"
             },
             "overrides": []
           },
@@ -21508,7 +21747,7 @@
             "h": 8,
             "w": 8,
             "x": 10,
-            "y": 3136
+            "y": 70
           },
           "id": 685,
           "options": {
@@ -21595,7 +21834,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 3136
+            "y": 70
           },
           "id": 686,
           "options": {
@@ -21626,7 +21865,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_rdbms_table_row_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+              "expr": "max by (table) (zeebe_rdbms_table_row_count{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
               "format": "table",
               "instant": true,
               "interval": "30s",
@@ -21654,6 +21893,296 @@
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Number of deleted rows per entity in each cleanup run",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 78
+          },
+          "id": 694,
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "short"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_rdbms_exporter_historyCleanup_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "History cleanup bulk sizes",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The interval between history cleanup runs.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "displayName": "History cleanup interval",
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 78
+          },
+          "id": 696,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "avg(zeebe_rdbms_exporter_historyCleanup_backoffDuration{cluster=~\"$cluster\", namespace=~\"$namespace\", partitionId=~\"$partition\"})",
+              "format": "time_series",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{table}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "History cleanup interval",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Number of deleted rows during history cleanup",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 14,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 78
+          },
+          "id": 697,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(zeebe_rdbms_exporter_historyCleanup_deletedEntities_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (entity)",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{entity}}",
+              "range": true,
+              "refId": "Execution Queue Memory Size",
+              "useBackend": false
+            }
+          ],
+          "title": "History cleanup - deleted rows per entity",
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -21721,7 +22250,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3144
+            "y": 86
           },
           "id": 689,
           "options": {
@@ -21740,6 +22269,10 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "disableTextWrap": false,
               "editorMode": "builder",
               "expr": "rate(zeebe_rdbms_exporter_queue_memory_bytes_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_queue_memory_bytes_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
@@ -21749,11 +22282,7 @@
               "legendFormat": "__auto",
               "range": true,
               "refId": "Execution Queue Memory Size",
-              "useBackend": false,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              }
+              "useBackend": false
             }
           ],
           "title": "RDBMS Execution Queue Memory Size",
@@ -21807,7 +22336,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 4644
+            "y": 834
           },
           "id": 170,
           "maxPerRow": 6,
@@ -21875,7 +22404,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -21891,7 +22421,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 4656
+            "y": 846
           },
           "id": 174,
           "options": {
@@ -21919,7 +22449,7 @@
             "text": {},
             "valueMode": "color"
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -21951,7 +22481,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -21967,7 +22498,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 4656
+            "y": 846
           },
           "id": 265,
           "options": {
@@ -21995,7 +22526,7 @@
             "text": {},
             "valueMode": "color"
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22047,7 +22578,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5253
+            "y": 835
           },
           "id": 329,
           "options": {
@@ -22055,6 +22586,7 @@
             "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -22067,7 +22599,7 @@
             "textMode": "value_and_name",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22101,7 +22633,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -22113,7 +22646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5253
+            "y": 835
           },
           "id": 319,
           "options": {
@@ -22121,6 +22654,7 @@
             "graphMode": "area",
             "justifyMode": "center",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
               "calcs": [
                 "max"
@@ -22133,7 +22667,7 @@
             "textMode": "value_and_name",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22173,7 +22707,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5261
+            "y": 849
           },
           "id": 323,
           "maxDataPoints": 25,
@@ -22215,7 +22749,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22248,7 +22782,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -22264,7 +22799,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5261
+            "y": 849
           },
           "id": 325,
           "options": {
@@ -22272,6 +22807,7 @@
             "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -22284,7 +22820,7 @@
             "textMode": "value_and_name",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22319,6 +22855,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -22350,7 +22887,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -22362,7 +22900,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5269
+            "y": 857
           },
           "id": 313,
           "options": {
@@ -22373,11 +22911,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22410,7 +22949,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               }
@@ -22421,7 +22961,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5269
+            "y": 857
           },
           "id": 321,
           "options": {
@@ -22429,6 +22969,7 @@
             "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
               "calcs": [
                 "max"
@@ -22441,7 +22982,7 @@
             "textMode": "value_and_name",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22517,7 +23058,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5277
+            "y": 865
           },
           "id": 335,
           "options": {
@@ -22575,7 +23116,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5277
+            "y": 865
           },
           "id": 317,
           "options": {
@@ -22637,7 +23178,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5285
+            "y": 873
           },
           "id": 327,
           "options": {
@@ -22712,7 +23253,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4206
+            "y": 836
           },
           "id": 538,
           "options": {
@@ -22753,7 +23294,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22797,7 +23338,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4206
+            "y": 836
           },
           "id": 540,
           "options": {
@@ -22838,7 +23379,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22875,6 +23416,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -22906,7 +23448,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -22922,7 +23465,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4214
+            "y": 850
           },
           "id": 444,
           "options": {
@@ -22933,11 +23476,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -22986,6 +23530,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -23016,7 +23561,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23032,7 +23578,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4214
+            "y": 850
           },
           "id": 446,
           "options": {
@@ -23043,11 +23589,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23096,6 +23643,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -23126,7 +23674,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23141,7 +23690,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4222
+            "y": 858
           },
           "id": 440,
           "options": {
@@ -23152,11 +23701,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23191,6 +23741,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -23221,7 +23772,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23236,7 +23788,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4222
+            "y": 858
           },
           "id": 442,
           "options": {
@@ -23247,11 +23799,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23307,7 +23860,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4207
+            "y": 837
           },
           "id": 547,
           "options": {
@@ -23348,7 +23901,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23385,6 +23938,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -23415,7 +23969,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23430,7 +23985,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4207
+            "y": 837
           },
           "id": 549,
           "options": {
@@ -23441,10 +23996,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23495,6 +24052,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -23526,7 +24084,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23542,7 +24101,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 4208
+            "y": 838
           },
           "id": 562,
           "options": {
@@ -23553,11 +24112,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23594,6 +24154,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -23625,7 +24186,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23641,7 +24203,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 4208
+            "y": 838
           },
           "id": 563,
           "options": {
@@ -23652,11 +24214,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23693,6 +24256,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -23724,7 +24288,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23740,7 +24305,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 4208
+            "y": 838
           },
           "id": 564,
           "options": {
@@ -23751,11 +24316,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23814,6 +24380,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -23845,7 +24412,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23861,7 +24429,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 4209
+            "y": 839
           },
           "id": 566,
           "options": {
@@ -23872,11 +24440,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -23912,6 +24481,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -23943,7 +24513,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -23959,7 +24530,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 4209
+            "y": 839
           },
           "id": 567,
           "options": {
@@ -23970,11 +24541,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24010,6 +24582,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -24041,7 +24614,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24057,7 +24631,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 4209
+            "y": 839
           },
           "id": 568,
           "options": {
@@ -24068,11 +24642,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24122,6 +24697,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -24152,7 +24728,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24187,7 +24764,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4210
+            "y": 846
           },
           "id": 573,
           "options": {
@@ -24198,10 +24775,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24248,6 +24827,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -24278,7 +24858,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24313,7 +24894,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4210
+            "y": 846
           },
           "id": 574,
           "options": {
@@ -24324,10 +24905,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24374,6 +24957,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -24411,7 +24995,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24427,7 +25012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4218
+            "y": 854
           },
           "id": 600,
           "options": {
@@ -24438,10 +25023,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24477,6 +25064,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -24514,7 +25102,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24530,7 +25119,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4218
+            "y": 854
           },
           "id": 601,
           "options": {
@@ -24541,10 +25130,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24626,7 +25217,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4226
+            "y": 862
           },
           "id": 575,
           "options": {
@@ -24720,7 +25311,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24735,7 +25327,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4669
+            "y": 841
           },
           "id": 570,
           "options": {
@@ -24746,11 +25338,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24826,7 +25419,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24841,7 +25435,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4669
+            "y": 841
           },
           "id": 577,
           "options": {
@@ -24852,11 +25446,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -24931,7 +25526,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -24946,7 +25542,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4677
+            "y": 849
           },
           "id": 578,
           "options": {
@@ -24957,11 +25553,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25027,7 +25624,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -25042,7 +25640,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4677
+            "y": 849
           },
           "id": 571,
           "options": {
@@ -25053,11 +25651,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25106,6 +25705,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -25136,7 +25736,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -25148,7 +25749,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 5276
+            "y": 842
           },
           "id": 582,
           "options": {
@@ -25159,10 +25760,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25197,6 +25800,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -25227,7 +25831,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -25239,7 +25844,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 5276
+            "y": 842
           },
           "id": 583,
           "options": {
@@ -25250,10 +25855,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25289,6 +25896,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -25319,7 +25927,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -25331,7 +25940,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 5276
+            "y": 842
           },
           "id": 584,
           "options": {
@@ -25342,10 +25951,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25395,6 +26006,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -25425,7 +26037,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               }
@@ -25436,7 +26049,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4213
+            "y": 843
           },
           "id": 596,
           "options": {
@@ -25447,10 +26060,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25505,7 +26120,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -25533,7 +26149,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4213
+            "y": 843
           },
           "id": 597,
           "options": {
@@ -25550,7 +26166,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25595,7 +26211,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4221
+            "y": 851
           },
           "id": 598,
           "options": {
@@ -25633,7 +26249,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25676,7 +26292,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -25720,7 +26337,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4221
+            "y": 851
           },
           "id": 599,
           "options": {
@@ -25743,7 +26360,7 @@
               }
             ]
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25795,6 +26412,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -25826,7 +26444,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -25842,7 +26461,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4003
+            "y": 844
           },
           "id": 680,
           "options": {
@@ -25853,11 +26472,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25893,6 +26513,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -25924,7 +26545,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -25940,7 +26562,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4003
+            "y": 844
           },
           "id": 666,
           "options": {
@@ -25951,11 +26573,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -25997,7 +26620,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4011
+            "y": 852
           },
           "id": 681,
           "options": {
@@ -26038,7 +26661,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -26095,7 +26718,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4011
+            "y": 852
           },
           "id": 682,
           "options": {
@@ -26136,7 +26759,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -26249,7 +26872,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4214
+            "y": 845
           },
           "id": 664,
           "maxPerRow": 6,
@@ -26296,6 +26919,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 41,
   "tags": [],
@@ -26438,5 +27062,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "zeebe-dashboard",
-  "version": 47
+  "version": 48
 }


### PR DESCRIPTION
## Description

Adds a new metric to the RdbmsWriterMetrics:
- count meter per deleted entity row 

Adds three dashboards to the RDBMS Exporter:
 - bucket heatmap for  how many rows have been deleted per delete statement
 - bucket heatmap for the history cleanup duration
 - graph for deleted entity rows during history cleanup