### PR TITLE
[Backport stable/optimize-8.7] ci: make release not latest

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -350,11 +350,10 @@ jobs:
         uses: octokit/request-action@v2.3.1
         with:
           route: POST /repos/camunda/camunda/releases
-          draft: false
+          make_latest: false
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
           generate_release_notes: true
-          make_latest: \"false\"
 
       - name: Docker log dump
         if: always()


### PR DESCRIPTION
# Description
Backport of #42585 to `stable/optimize-8.7`.

relates to 