### PR TITLE
[Backport stable/8.8] ci: make release not latest

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -381,10 +381,9 @@ jobs:
         uses: octokit/request-action@v2.4.0
         with:
           route: POST /repos/camunda/camunda/releases
-          draft: false
+          make_latest: false
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}
-          make_latest: \"false\"
           body: |
             Please refer to the [Camunda Monorepo ${{ env.RELEASE_VERSION }} Release Notes](https://github.com/camunda/camunda/releases/tag/${{ env.RELEASE_VERSION }}) for full details.
 


### PR DESCRIPTION
# Description
Backport of #42585 to `stable/8.8`.

relates to 