### PR TITLE
ci: Adding test owner env variable to add release comments GHA

### DIFF
--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -53,6 +53,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      TEST_OWNER: Engineering Operations
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -55,6 +55,8 @@ jobs:
         shell: bash
     env:
       TEST_OWNER: Engineering Operations
+      TEST_PRODUCT: Orchestration Cluster
+      TEST_TYPE: CI Helper
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixing the script by adding the missing environment variable to the print metadata section. Otherwise [this](https://github.com/camunda/camunda/actions/runs/20329076801) error happens when running the dry run.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
