### PR TITLE
[Backport stable/8.8] deps: update kotlin-stdlib to 2.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -117,6 +117,7 @@
     <version.byte-buddy>1.17.8</version.byte-buddy>
     <version.revapi>0.28.4</version.revapi>
     <version.resilience4j>2.3.0</version.resilience4j>
+    <version.kotlin-stdlib>2.1.0</version.kotlin-stdlib>
     <version.immutables>2.10.1</version.immutables>
     <version.jsr305>3.0.2</version.jsr305>
     <version.classgraph>4.8.184</version.classgraph>
@@ -1227,6 +1228,23 @@
         <groupId>io.github.resilience4j</groupId>
         <artifactId>resilience4j-core</artifactId>
         <version>${version.resilience4j}</version>
+      </dependency>
+
+      <!-- see https://github.com/camunda/camunda/issues/42660 -->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk7</artifactId>
+        <version>${version.kotlin-stdlib}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
# Description
Backport of #42663 to `stable/8.8`.

relates to #42660