### PR TITLE
[CPT: DSL] feat: Assert process instance

### DIFF
--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/ProcessInstanceSelector.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/ProcessInstanceSelector.java
@@ -15,9 +15,19 @@
  */
 package io.camunda.process.test.api.dsl;
 
-/** A collection of supported test case instruction types. */
-public class TestCaseInstructionType {
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Optional;
+import org.immutables.value.Value;
 
-  public static final String CREATE_PROCESS_INSTANCE = "CREATE_PROCESS_INSTANCE";
-  public static final String ASSERT_PROCESS_INSTANCE = "ASSERT_PROCESS_INSTANCE";
+/** A selector to identify a process instance. */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableProcessInstanceSelector.Builder.class)
+public interface ProcessInstanceSelector {
+
+  /**
+   * The process definition ID of the process instance.
+   *
+   * @return the process definition id
+   */
+  Optional<String> getProcessDefinitionId();
 }

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstruction.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstruction.java
@@ -29,11 +29,11 @@ import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruc
     visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(
-      value = CreateProcessInstanceInstruction.class,
-      name = TestCaseInstructionType.CREATE_PROCESS_INSTANCE),
-  @JsonSubTypes.Type(
       value = AssertProcessInstanceInstruction.class,
-      name = TestCaseInstructionType.ASSERT_PROCESS_INSTANCE)
+      name = TestCaseInstructionType.ASSERT_PROCESS_INSTANCE),
+  @JsonSubTypes.Type(
+      value = CreateProcessInstanceInstruction.class,
+      name = TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
 })
 public interface TestCaseInstruction {
 

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstruction.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstruction.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.api.dsl;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import io.camunda.process.test.api.dsl.instructions.AssertProcessInstanceInstruction;
 import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruction;
 
 /** An instruction to define an action or an assertion to be performed in a test case. */
@@ -29,7 +30,10 @@ import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruc
 @JsonSubTypes({
   @JsonSubTypes.Type(
       value = CreateProcessInstanceInstruction.class,
-      name = TestCaseInstructionType.CREATE_PROCESS_INSTANCE)
+      name = TestCaseInstructionType.CREATE_PROCESS_INSTANCE),
+  @JsonSubTypes.Type(
+      value = AssertProcessInstanceInstruction.class,
+      name = TestCaseInstructionType.ASSERT_PROCESS_INSTANCE)
 })
 public interface TestCaseInstruction {
 

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstructionType.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/TestCaseInstructionType.java
@@ -18,6 +18,6 @@ package io.camunda.process.test.api.dsl;
 /** A collection of supported test case instruction types. */
 public class TestCaseInstructionType {
 
-  public static final String CREATE_PROCESS_INSTANCE = "CREATE_PROCESS_INSTANCE";
   public static final String ASSERT_PROCESS_INSTANCE = "ASSERT_PROCESS_INSTANCE";
+  public static final String CREATE_PROCESS_INSTANCE = "CREATE_PROCESS_INSTANCE";
 }

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/AssertProcessInstanceInstruction.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/AssertProcessInstanceInstruction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.dsl.instructions;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.process.test.api.dsl.ProcessInstanceSelector;
+import io.camunda.process.test.api.dsl.TestCaseInstruction;
+import io.camunda.process.test.api.dsl.TestCaseInstructionType;
+import io.camunda.process.test.api.dsl.instructions.assertProcessInstance.ProcessInstanceState;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/** An instruction to assert the state of a process instance. */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableAssertProcessInstanceInstruction.Builder.class)
+public interface AssertProcessInstanceInstruction extends TestCaseInstruction {
+
+  @Value.Default
+  @Override
+  default String getType() {
+    return TestCaseInstructionType.ASSERT_PROCESS_INSTANCE;
+  }
+
+  /**
+   * The selector to identify the process instance.
+   *
+   * @return the process instance selector
+   */
+  ProcessInstanceSelector getProcessInstanceSelector();
+
+  /**
+   * The expected state of the process instance. Optional.
+   *
+   * @return the expected state or empty if not asserted
+   */
+  Optional<ProcessInstanceState> getState();
+
+  /**
+   * Whether the process instance has active incidents. Optional.
+   *
+   * @return the expected incident presence or empty if not asserted
+   */
+  Optional<Boolean> hasActiveIncidents();
+}

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/assertProcessInstance/ProcessInstanceState.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/assertProcessInstance/ProcessInstanceState.java
@@ -19,6 +19,6 @@ package io.camunda.process.test.api.dsl.instructions.assertProcessInstance;
 public enum ProcessInstanceState {
   IS_ACTIVE,
   IS_COMPLETED,
-  IS_TERMINATED,
-  IS_CREATED
+  IS_CREATED,
+  IS_TERMINATED
 }

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/assertProcessInstance/ProcessInstanceState.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/assertProcessInstance/ProcessInstanceState.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.process.test.api.dsl;
+package io.camunda.process.test.api.dsl.instructions.assertProcessInstance;
 
-/** A collection of supported test case instruction types. */
-public class TestCaseInstructionType {
-
-  public static final String CREATE_PROCESS_INSTANCE = "CREATE_PROCESS_INSTANCE";
-  public static final String ASSERT_PROCESS_INSTANCE = "ASSERT_PROCESS_INSTANCE";
+/** The possible states of a process instance to assert. */
+public enum ProcessInstanceState {
+  IS_ACTIVE,
+  IS_COMPLETED,
+  IS_TERMINATED,
+  IS_CREATED
 }

--- a/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
+++ b/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
@@ -48,10 +48,10 @@
       "description": "An instruction to define an action or an assertion to be performed in a test case.",
       "oneOf": [
         {
-          "$ref": "#/definitions/CreateProcessInstanceInstruction"
+          "$ref": "#/definitions/AssertProcessInstanceInstruction"
         },
         {
-          "$ref": "#/definitions/AssertProcessInstanceInstruction"
+          "$ref": "#/definitions/CreateProcessInstanceInstruction"
         }
       ]
     },
@@ -161,8 +161,8 @@
           "enum": [
             "IS_ACTIVE",
             "IS_COMPLETED",
-            "IS_TERMINATED",
-            "IS_CREATED"
+            "IS_CREATED",
+            "IS_TERMINATED"
           ]
         },
         "hasActiveIncidents": {

--- a/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
+++ b/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
@@ -49,6 +49,9 @@
       "oneOf": [
         {
           "$ref": "#/definitions/CreateProcessInstanceInstruction"
+        },
+        {
+          "$ref": "#/definitions/AssertProcessInstanceInstruction"
         }
       ]
     },
@@ -138,6 +141,58 @@
           "additionalProperties": false
         }
       ]
+    },
+    "AssertProcessInstanceInstruction": {
+      "description": "An instruction to assert the state of a process instance.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of the instruction.",
+          "type": "string",
+          "const": "ASSERT_PROCESS_INSTANCE"
+        },
+        "processInstanceSelector": {
+          "description": "The selector to identify the process instance.",
+          "$ref": "#/definitions/ProcessInstanceSelector"
+        },
+        "state": {
+          "description": "The expected state of the process instance.",
+          "type": "string",
+          "enum": [
+            "IS_ACTIVE",
+            "IS_COMPLETED",
+            "IS_TERMINATED",
+            "IS_CREATED"
+          ]
+        },
+        "hasActiveIncidents": {
+          "description": "Whether the process instance has active incidents.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "processInstanceSelector"
+      ],
+      "additionalProperties": false
+    },
+    "ProcessInstanceSelector": {
+      "description": "A selector to identify a process instance.",
+      "type": "object",
+      "properties": {
+        "processDefinitionId": {
+          "description": "The process definition ID of the process instance.",
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "processDefinitionId"
+          ]
+        }
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
+++ b/testing/camunda-process-test-dsl/src/main/resources/schema/test-scenario-dsl.schema.json
@@ -127,20 +127,20 @@
     "ProcessDefinitionSelector": {
       "description": "A selector to identify a process definition.",
       "type": "object",
+      "properties": {
+        "processDefinitionId": {
+          "description": "The ID of the process definition.",
+          "type": "string"
+        }
+      },
       "anyOf": [
         {
-          "properties": {
-            "processDefinitionId": {
-              "description": "The ID of the process definition.",
-              "type": "string"
-            }
-          },
           "required": [
             "processDefinitionId"
-          ],
-          "additionalProperties": false
+          ]
         }
-      ]
+      ],
+      "additionalProperties": false
     },
     "AssertProcessInstanceInstruction": {
       "description": "An instruction to assert the state of a process instance.",

--- a/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/PojoCompatibilityTest.java
+++ b/testing/camunda-process-test-dsl/src/test/java/io/camunda/process/test/dsl/PojoCompatibilityTest.java
@@ -26,11 +26,14 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import io.camunda.process.test.api.dsl.ImmutableProcessDefinitionSelector;
+import io.camunda.process.test.api.dsl.ImmutableProcessInstanceSelector;
 import io.camunda.process.test.api.dsl.ImmutableTestCase;
 import io.camunda.process.test.api.dsl.ImmutableTestScenario;
 import io.camunda.process.test.api.dsl.TestCaseInstruction;
 import io.camunda.process.test.api.dsl.TestScenario;
+import io.camunda.process.test.api.dsl.instructions.ImmutableAssertProcessInstanceInstruction;
 import io.camunda.process.test.api.dsl.instructions.ImmutableCreateProcessInstanceInstruction;
+import io.camunda.process.test.api.dsl.instructions.assertProcessInstance.ProcessInstanceState;
 import io.camunda.process.test.api.dsl.instructions.createProcessInstance.ImmutableCreateProcessInstanceStartInstruction;
 import io.camunda.process.test.api.dsl.instructions.createProcessInstance.ImmutableCreateProcessInstanceTerminateRuntimeInstruction;
 import java.io.IOException;
@@ -132,6 +135,26 @@ public class PojoCompatibilityTest {
                         ImmutableCreateProcessInstanceTerminateRuntimeInstruction.builder()
                             .afterElementId("task2")
                             .build())
+                    .build())),
+        Arguments.of(
+            "assert process instance: minimal",
+            singleTestCase(
+                ImmutableAssertProcessInstanceInstruction.builder()
+                    .processInstanceSelector(
+                        ImmutableProcessInstanceSelector.builder()
+                            .processDefinitionId("my-process")
+                            .build())
+                    .build())),
+        Arguments.of(
+            "assert process instance: full",
+            singleTestCase(
+                ImmutableAssertProcessInstanceInstruction.builder()
+                    .processInstanceSelector(
+                        ImmutableProcessInstanceSelector.builder()
+                            .processDefinitionId("my-process")
+                            .build())
+                    .state(ProcessInstanceState.IS_COMPLETED)
+                    .hasActiveIncidents(false)
                     .build())));
   }
 

--- a/testing/camunda-process-test-dsl/src/test/resources/full-test-scenario.json
+++ b/testing/camunda-process-test-dsl/src/test/resources/full-test-scenario.json
@@ -23,6 +23,13 @@
               "afterElementId": "task2"
             }
           ]
+        },
+        {
+          "type": "ASSERT_PROCESS_INSTANCE",
+          "processInstanceSelector": {
+            "processDefinitionId": "order-process"
+          },
+          "state": "IS_COMPLETED"
         }
       ]
     }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/AssertionFacade.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/AssertionFacade.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
+
+/** Facade to provide assertions for different entities. */
+public interface AssertionFacade {
+
+  /**
+   * Returns the assertion object for the given process instance selector.
+   *
+   * @param processInstanceSelector the selector to identify the process instance
+   * @return the assertion object
+   */
+  ProcessInstanceAssert assertThatProcessInstance(
+      final ProcessInstanceSelector processInstanceSelector);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
@@ -47,12 +47,17 @@ public class CamundaTestScenarioRunner implements TestScenarioRunner {
     registerHandler(new AssertProcessInstanceInstructionHandler());
   }
 
-  private final AssertionFacade assertionFacade = new TestScenarioAssertionFacade();
-
   private final CamundaProcessTestContext context;
+  private final AssertionFacade assertionFacade;
 
   public CamundaTestScenarioRunner(final CamundaProcessTestContext context) {
+    this(context, new TestScenarioAssertionFacade());
+  }
+
+  public CamundaTestScenarioRunner(
+      final CamundaProcessTestContext context, final AssertionFacade assertionFacade) {
     this.context = context;
+    this.assertionFacade = assertionFacade;
   }
 
   private static void registerHandler(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
@@ -43,8 +43,8 @@ public class CamundaTestScenarioRunner implements TestScenarioRunner {
 
   static {
     // register instruction handlers here
-    registerHandler(new CreateProcessInstanceInstructionHandler());
     registerHandler(new AssertProcessInstanceInstructionHandler());
+    registerHandler(new CreateProcessInstanceInstructionHandler());
   }
 
   private final CamundaProcessTestContext context;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
@@ -16,7 +16,10 @@
 package io.camunda.process.test.impl.dsl;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.dsl.TestCase;
 import io.camunda.process.test.api.dsl.TestCaseInstruction;
 import io.camunda.process.test.api.dsl.TestScenarioRunner;
@@ -41,6 +44,8 @@ public class CamundaTestScenarioRunner implements TestScenarioRunner {
     // register instruction handlers here
     registerHandler(new CreateProcessInstanceInstructionHandler());
   }
+
+  private final AssertionFacade assertionFacade = new TestScenarioAssertionFacade();
 
   private final CamundaProcessTestContext context;
 
@@ -79,7 +84,7 @@ public class CamundaTestScenarioRunner implements TestScenarioRunner {
 
     try {
       //noinspection unchecked
-      instructionHandler.execute(instruction, context, camundaClient);
+      instructionHandler.execute(instruction, context, camundaClient, assertionFacade);
 
     } catch (final Exception e) {
       throw new TestScenarioRunException(
@@ -107,5 +112,13 @@ public class CamundaTestScenarioRunner implements TestScenarioRunner {
             () ->
                 new RuntimeException(
                     "Could not determine instruction interface of: " + instruction));
+  }
+
+  private static final class TestScenarioAssertionFacade implements AssertionFacade {
+
+    @Override
+    public ProcessInstanceAssert assertThatProcessInstance(final ProcessInstanceSelector selector) {
+      return CamundaAssert.assertThatProcessInstance(selector);
+    }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/CamundaTestScenarioRunner.java
@@ -23,6 +23,7 @@ import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.dsl.TestCase;
 import io.camunda.process.test.api.dsl.TestCaseInstruction;
 import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import io.camunda.process.test.impl.dsl.instructions.AssertProcessInstanceInstructionHandler;
 import io.camunda.process.test.impl.dsl.instructions.CreateProcessInstanceInstructionHandler;
 import java.time.Duration;
 import java.time.Instant;
@@ -43,6 +44,7 @@ public class CamundaTestScenarioRunner implements TestScenarioRunner {
   static {
     // register instruction handlers here
     registerHandler(new CreateProcessInstanceInstructionHandler());
+    registerHandler(new AssertProcessInstanceInstructionHandler());
   }
 
   private final AssertionFacade assertionFacade = new TestScenarioAssertionFacade();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/TestCaseInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/TestCaseInstructionHandler.java
@@ -27,13 +27,18 @@ import io.camunda.process.test.api.dsl.TestCaseInstruction;
 public interface TestCaseInstructionHandler<T extends TestCaseInstruction> {
 
   /**
-   * Executes the given instruction using the provided context and the Camunda client.
+   * Executes the given instruction.
    *
    * @param instruction the instruction to execute
    * @param context the test context with utilities
    * @param camundaClient the Camunda client to send commands
+   * @param assertionFacade the facade to perform assertions
    */
-  void execute(T instruction, CamundaProcessTestContext context, final CamundaClient camundaClient);
+  void execute(
+      final T instruction,
+      final CamundaProcessTestContext context,
+      final CamundaClient camundaClient,
+      final AssertionFacade assertionFacade);
 
   /**
    * Gets the type of instruction this handler can execute.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/instructions/AssertProcessInstanceInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/instructions/AssertProcessInstanceInstructionHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl.instructions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import io.camunda.process.test.api.dsl.instructions.AssertProcessInstanceInstruction;
+import io.camunda.process.test.api.dsl.instructions.assertProcessInstance.ProcessInstanceState;
+import io.camunda.process.test.impl.dsl.AssertionFacade;
+import io.camunda.process.test.impl.dsl.TestCaseInstructionHandler;
+
+public class AssertProcessInstanceInstructionHandler
+    implements TestCaseInstructionHandler<AssertProcessInstanceInstruction> {
+
+  @Override
+  public void execute(
+      final AssertProcessInstanceInstruction instruction,
+      final CamundaProcessTestContext context,
+      final CamundaClient camundaClient,
+      final AssertionFacade assertionFacade) {
+
+    final ProcessInstanceSelector processInstanceSelector =
+        instruction
+            .getProcessInstanceSelector()
+            .getProcessDefinitionId()
+            .map(ProcessInstanceSelectors::byProcessId)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException("Missing required property: processDefinitionId"));
+
+    final ProcessInstanceAssert processInstanceAssert =
+        assertionFacade.assertThatProcessInstance(processInstanceSelector);
+
+    instruction
+        .getState()
+        .ifPresent(expectedState -> assertState(processInstanceAssert, expectedState));
+
+    instruction
+        .hasActiveIncidents()
+        .ifPresent(
+            hasActiveIncidents -> assertActiveIncidents(processInstanceAssert, hasActiveIncidents));
+  }
+
+  @Override
+  public Class<AssertProcessInstanceInstruction> getInstructionType() {
+    return AssertProcessInstanceInstruction.class;
+  }
+
+  private static void assertState(
+      final ProcessInstanceAssert processInstanceAssert, final ProcessInstanceState expectedState) {
+    switch (expectedState) {
+      case IS_ACTIVE:
+        processInstanceAssert.isActive();
+        break;
+      case IS_COMPLETED:
+        processInstanceAssert.isCompleted();
+        break;
+      case IS_TERMINATED:
+        processInstanceAssert.isTerminated();
+        break;
+      case IS_CREATED:
+        processInstanceAssert.isCreated();
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported process instance state: " + expectedState);
+    }
+  }
+
+  private static void assertActiveIncidents(
+      final ProcessInstanceAssert processInstanceAssert, final Boolean hasActiveIncidents) {
+    if (hasActiveIncidents) {
+      processInstanceAssert.hasActiveIncidents();
+    } else {
+      processInstanceAssert.hasNoActiveIncidents();
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/instructions/CreateProcessInstanceInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/dsl/instructions/CreateProcessInstanceInstructionHandler.java
@@ -21,6 +21,7 @@ import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.dsl.instructions.CreateProcessInstanceInstruction;
 import io.camunda.process.test.api.dsl.instructions.createProcessInstance.CreateProcessInstanceRuntimeInstruction;
 import io.camunda.process.test.api.dsl.instructions.createProcessInstance.CreateProcessInstanceTerminateRuntimeInstruction;
+import io.camunda.process.test.impl.dsl.AssertionFacade;
 import io.camunda.process.test.impl.dsl.TestCaseInstructionHandler;
 
 public class CreateProcessInstanceInstructionHandler
@@ -30,7 +31,8 @@ public class CreateProcessInstanceInstructionHandler
   public void execute(
       final CreateProcessInstanceInstruction instruction,
       final CamundaProcessTestContext context,
-      final CamundaClient camundaClient) {
+      final CamundaClient camundaClient,
+      final AssertionFacade assertionFacade) {
 
     final String processDefinitionId =
         instruction

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/AssertProcessInstanceInstructionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/AssertProcessInstanceInstructionTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.dsl;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
+import io.camunda.process.test.api.dsl.ImmutableProcessInstanceSelector;
+import io.camunda.process.test.api.dsl.instructions.AssertProcessInstanceInstruction;
+import io.camunda.process.test.api.dsl.instructions.ImmutableAssertProcessInstanceInstruction;
+import io.camunda.process.test.api.dsl.instructions.assertProcessInstance.ProcessInstanceState;
+import io.camunda.process.test.impl.dsl.instructions.AssertProcessInstanceInstructionHandler;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AssertProcessInstanceInstructionTest {
+
+  private static final String PROCESS_DEFINITION_ID = "process";
+
+  @Mock private CamundaProcessTestContext processTestContext;
+  @Mock private CamundaClient camundaClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private AssertionFacade assertionFacade;
+
+  @Mock private ProcessInstanceFilter processInstanceFilter;
+  @Captor private ArgumentCaptor<ProcessInstanceSelector> processInstanceSelectorCaptor;
+
+  private final AssertProcessInstanceInstructionHandler instructionHandler =
+      new AssertProcessInstanceInstructionHandler();
+
+  @Test
+  void shouldSelectProcessInstanceByProcessDefinitionId() {
+    // given
+    final AssertProcessInstanceInstruction instruction =
+        ImmutableAssertProcessInstanceInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder()
+                    .processDefinitionId(PROCESS_DEFINITION_ID)
+                    .build())
+            .build();
+
+    // when
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+
+    // then
+    verify(assertionFacade).assertThatProcessInstance(processInstanceSelectorCaptor.capture());
+
+    processInstanceSelectorCaptor.getValue().applyFilter(processInstanceFilter);
+    verify(processInstanceFilter).processDefinitionId(PROCESS_DEFINITION_ID);
+
+    verifyNoMoreInteractions(camundaClient, processTestContext, assertionFacade);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("stateAssertionArgumentStream")
+  void shouldAssertState(
+      final ProcessInstanceState state, final Consumer<ProcessInstanceAssert> expectedAssertion) {
+    // given
+    final AssertProcessInstanceInstruction instruction =
+        ImmutableAssertProcessInstanceInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder()
+                    .processDefinitionId(PROCESS_DEFINITION_ID)
+                    .build())
+            .state(state)
+            .build();
+
+    // when
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+
+    // then
+    verify(assertionFacade).assertThatProcessInstance(any());
+
+    final ProcessInstanceAssert processInstanceAssert =
+        assertionFacade.assertThatProcessInstance(any());
+    expectedAssertion.accept(verify(processInstanceAssert));
+
+    verifyNoMoreInteractions(camundaClient, processTestContext, processInstanceAssert);
+  }
+
+  @Test
+  void shouldAssertHasActiveIncidents() {
+    // given
+    final AssertProcessInstanceInstruction instruction =
+        ImmutableAssertProcessInstanceInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder()
+                    .processDefinitionId(PROCESS_DEFINITION_ID)
+                    .build())
+            .hasActiveIncidents(true)
+            .build();
+
+    // when
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+
+    // then
+    verify(assertionFacade).assertThatProcessInstance(any());
+
+    final ProcessInstanceAssert processInstanceAssert =
+        assertionFacade.assertThatProcessInstance(any());
+    verify(processInstanceAssert).hasActiveIncidents();
+
+    verifyNoMoreInteractions(camundaClient, processTestContext, processInstanceAssert);
+  }
+
+  @Test
+  void shouldAssertHasNoActiveIncidents() {
+    // given
+    final AssertProcessInstanceInstruction instruction =
+        ImmutableAssertProcessInstanceInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder()
+                    .processDefinitionId(PROCESS_DEFINITION_ID)
+                    .build())
+            .hasActiveIncidents(false)
+            .build();
+
+    // when
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+
+    // then
+    verify(assertionFacade).assertThatProcessInstance(any());
+
+    final ProcessInstanceAssert processInstanceAssert =
+        assertionFacade.assertThatProcessInstance(any());
+    verify(processInstanceAssert).hasNoActiveIncidents();
+
+    verifyNoMoreInteractions(camundaClient, processTestContext, processInstanceAssert);
+  }
+
+  @Test
+  void shouldFailIfProcessDefinitionIdIsNotSet() {
+    // given
+    final AssertProcessInstanceInstruction instruction =
+        ImmutableAssertProcessInstanceInstruction.builder()
+            .processInstanceSelector(ImmutableProcessInstanceSelector.builder().build())
+            .build();
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                instructionHandler.execute(
+                    instruction, processTestContext, camundaClient, assertionFacade))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required property: processDefinitionId");
+  }
+
+  private static Stream<Arguments> stateAssertionArgumentStream() {
+    return Stream.of(
+        stateAssertionArguments(ProcessInstanceState.IS_ACTIVE, ProcessInstanceAssert::isActive),
+        stateAssertionArguments(
+            ProcessInstanceState.IS_COMPLETED, ProcessInstanceAssert::isCompleted),
+        stateAssertionArguments(
+            ProcessInstanceState.IS_TERMINATED, ProcessInstanceAssert::isTerminated),
+        stateAssertionArguments(ProcessInstanceState.IS_CREATED, ProcessInstanceAssert::isCreated));
+  }
+
+  private static Arguments stateAssertionArguments(
+      final ProcessInstanceState state, final Consumer<ProcessInstanceAssert> verification) {
+    return Arguments.of(state, verification);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/CreateProcessInstanceInstructionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/CreateProcessInstanceInstructionTest.java
@@ -31,7 +31,6 @@ import io.camunda.process.test.impl.dsl.instructions.CreateProcessInstanceInstru
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -48,12 +47,10 @@ public class CreateProcessInstanceInstructionTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private CamundaClient camundaClient;
 
-  private CreateProcessInstanceInstructionHandler instructionHandler;
+  @Mock private AssertionFacade assertionFacade;
 
-  @BeforeEach
-  void setup() {
-    instructionHandler = new CreateProcessInstanceInstructionHandler();
-  }
+  private final CreateProcessInstanceInstructionHandler instructionHandler =
+      new CreateProcessInstanceInstructionHandler();
 
   @Test
   void shouldCreateProcessInstanceByProcessDefinitionId() {
@@ -67,7 +64,7 @@ public class CreateProcessInstanceInstructionTest {
             .build();
 
     // when
-    instructionHandler.execute(instruction, processTestContext, camundaClient);
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
 
     // then
     verify(camundaClient).newCreateInstanceCommand();
@@ -81,7 +78,7 @@ public class CreateProcessInstanceInstructionTest {
 
     verify(mockCommand).send();
 
-    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand);
+    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand, assertionFacade);
   }
 
   @Test
@@ -101,7 +98,7 @@ public class CreateProcessInstanceInstructionTest {
             .build();
 
     // when
-    instructionHandler.execute(instruction, processTestContext, camundaClient);
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
 
     // then
     verify(camundaClient).newCreateInstanceCommand();
@@ -115,7 +112,7 @@ public class CreateProcessInstanceInstructionTest {
 
     verify(mockCommand).send();
 
-    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand);
+    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand, assertionFacade);
   }
 
   @Test
@@ -134,7 +131,7 @@ public class CreateProcessInstanceInstructionTest {
             .build();
 
     // when
-    instructionHandler.execute(instruction, processTestContext, camundaClient);
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
 
     // then
     verify(camundaClient).newCreateInstanceCommand();
@@ -150,7 +147,7 @@ public class CreateProcessInstanceInstructionTest {
     verify(mockCommand).startBeforeElement("task2");
     verify(mockCommand).send();
 
-    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand);
+    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand, assertionFacade);
   }
 
   @Test
@@ -173,7 +170,7 @@ public class CreateProcessInstanceInstructionTest {
             .build();
 
     // when
-    instructionHandler.execute(instruction, processTestContext, camundaClient);
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
 
     // then
     verify(camundaClient).newCreateInstanceCommand();
@@ -189,7 +186,7 @@ public class CreateProcessInstanceInstructionTest {
     verify(mockCommand).terminateAfterElement("task2");
     verify(mockCommand).send();
 
-    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand);
+    verifyNoMoreInteractions(camundaClient, processTestContext, mockCommand, assertionFacade);
   }
 
   @Test
@@ -202,7 +199,9 @@ public class CreateProcessInstanceInstructionTest {
 
     // when/then
     assertThatThrownBy(
-            () -> instructionHandler.execute(instruction, processTestContext, camundaClient))
+            () ->
+                instructionHandler.execute(
+                    instruction, processTestContext, camundaClient, assertionFacade))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Missing required property: processDefinitionId");
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/TestScenarioRunnerTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/dsl/TestScenarioRunnerTest.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.dsl;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,11 +26,14 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.dsl.ImmutableProcessDefinitionSelector;
+import io.camunda.process.test.api.dsl.ImmutableProcessInstanceSelector;
 import io.camunda.process.test.api.dsl.ImmutableTestCase;
 import io.camunda.process.test.api.dsl.TestCase;
 import io.camunda.process.test.api.dsl.TestCaseInstruction;
 import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import io.camunda.process.test.api.dsl.instructions.ImmutableAssertProcessInstanceInstruction;
 import io.camunda.process.test.api.dsl.instructions.ImmutableCreateProcessInstanceInstruction;
+import io.camunda.process.test.api.dsl.instructions.assertProcessInstance.ProcessInstanceState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -43,6 +47,8 @@ public class TestScenarioRunnerTest {
 
   @Mock(answer = Answers.RETURNS_MOCKS)
   private CamundaClient camundaClient;
+
+  @Mock private AssertionFacade assertionFacade;
 
   @Test
   void shouldExecuteInstruction() {
@@ -114,6 +120,29 @@ public class TestScenarioRunnerTest {
         .hasMessageContaining(
             "Failed to execute instruction '%s': %s", instruction.getType(), instruction.toString())
         .hasCause(clientException);
+  }
+
+  @Test
+  void shouldThrowAssertionError() {
+    // given
+    final TestScenarioRunner runner =
+        new CamundaTestScenarioRunner(processTestContext, assertionFacade);
+
+    final AssertionError assertionError = new AssertionError("expected");
+    when(assertionFacade.assertThatProcessInstance(any())).thenThrow(assertionError);
+
+    final TestCaseInstruction instruction =
+        ImmutableAssertProcessInstanceInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder().processDefinitionId("process").build())
+            .state(ProcessInstanceState.IS_CREATED)
+            .build();
+    final TestCase testCase = createTestCase(instruction);
+
+    // when/then
+    assertThatThrownBy(() -> runner.run(testCase))
+        .isInstanceOf(AssertionError.class)
+        .isEqualTo(assertionError);
   }
 
   private static TestCase createTestCase(final TestCaseInstruction instruction) {

--- a/testing/camunda-process-test-java/src/test/resources/scenarios/example-test-scenario.json
+++ b/testing/camunda-process-test-java/src/test/resources/scenarios/example-test-scenario.json
@@ -12,6 +12,13 @@
           "variables": {
             "order_id": "order-1"
           }
+        },
+        {
+          "type": "ASSERT_PROCESS_INSTANCE",
+          "processInstanceSelector": {
+            "processDefinitionId": "process"
+          },
+          "state": "IS_COMPLETED"
         }
       ]
     }

--- a/testing/camunda-process-test-spring/src/test/resources/scenarios/example-test-scenario.json
+++ b/testing/camunda-process-test-spring/src/test/resources/scenarios/example-test-scenario.json
@@ -12,6 +12,13 @@
           "variables": {
             "order_id": "order-1"
           }
+        },
+        {
+          "type": "ASSERT_PROCESS_INSTANCE",
+          "processInstanceSelector": {
+            "processDefinitionId": "process"
+          },
+          "state": "IS_COMPLETED"
         }
       ]
     }


### PR DESCRIPTION
## Description

The PR adds a new instruction `ASSERT_PROCESS_INSTANCE` to assert the state of a process instance.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41298 
