### PR TITLE
feat: add rootProcessInstanceKey to variable records

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -69,6 +69,11 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
     return bpmnProcessId;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return -1L; // not used in Optimize
+  }
+
   public void setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
   }
@@ -98,6 +103,12 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(
+        name, value, scopeKey, processInstanceKey, processDefinitionKey, bpmnProcessId, tenantId);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (o == null || getClass() != o.getClass()) {
       return false;
@@ -110,12 +121,6 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
         && Objects.equals(value, that.value)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(tenantId, that.tenantId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        name, value, scopeKey, processInstanceKey, processDefinitionKey, bpmnProcessId, tenantId);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -325,6 +325,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
                     scopeKey,
                     context.getProcessDefinitionKey(),
                     context.getProcessInstanceKey(),
+                    context.getRootProcessInstanceKey(),
                     context.getBpmnProcessId(),
                     context.getTenantId(),
                     eventTrigger.getVariables());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -73,6 +73,7 @@ public final class BpmnAdHocSubProcessBehavior {
           adHocSubProcessInnerInstanceKey,
           context.getProcessDefinitionKey(),
           context.getProcessInstanceKey(),
+          context.getRootProcessInstanceKey(),
           context.getBpmnProcessId(),
           context.getTenantId(),
           variablesBuffer);
@@ -120,6 +121,7 @@ public final class BpmnAdHocSubProcessBehavior {
                     innerInstanceKey,
                     innerInstanceRecord.getProcessDefinitionKey(),
                     innerInstanceRecord.getProcessInstanceKey(),
+                    innerInstanceRecord.getRootProcessInstanceKey(),
                     innerInstanceRecord.getBpmnProcessIdBuffer(),
                     innerInstanceRecord.getTenantId(),
                     variableName,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -220,6 +220,7 @@ public final class BpmnStateBehavior {
         context.getElementInstanceKey(),
         context.getProcessDefinitionKey(),
         context.getProcessInstanceKey(),
+        context.getRootProcessInstanceKey(),
         context.getBpmnProcessId(),
         context.getTenantId(),
         variableName,
@@ -240,6 +241,7 @@ public final class BpmnStateBehavior {
         targetScope,
         context.getProcessDefinitionKey(),
         context.getProcessInstanceKey(),
+        context.getRootProcessInstanceKey(),
         context.getBpmnProcessId(),
         context.getTenantId(),
         variablesAsDocument);
@@ -248,17 +250,21 @@ public final class BpmnStateBehavior {
   public void copyAllVariablesToProcessInstance(
       final long sourceScopeKey,
       final long targetProcessInstanceKey,
+      final long targetRootProcessInstanceKey,
       final DeployedProcess targetProcess) {
     final var variables = variablesState.getVariablesAsDocument(sourceScopeKey);
-    copyVariablesToProcessInstance(targetProcessInstanceKey, targetProcess, variables);
+    copyVariablesToProcessInstance(
+        targetProcessInstanceKey, targetRootProcessInstanceKey, targetProcess, variables);
   }
 
   public void copyLocalVariablesToProcessInstance(
       final long sourceScopeKey,
       final long targetProcessInstanceKey,
+      final long targetRootProcessInstanceKey,
       final DeployedProcess targetProcess) {
     final var variables = variablesState.getVariablesLocalAsDocument(sourceScopeKey);
-    copyVariablesToProcessInstance(targetProcessInstanceKey, targetProcess, variables);
+    copyVariablesToProcessInstance(
+        targetProcessInstanceKey, targetRootProcessInstanceKey, targetProcess, variables);
   }
 
   /**
@@ -275,12 +281,14 @@ public final class BpmnStateBehavior {
 
   private void copyVariablesToProcessInstance(
       final long targetProcessInstanceKey,
+      final long targetRootProcessInstanceKey,
       final DeployedProcess targetProcess,
       final DirectBuffer variables) {
     variableBehavior.mergeDocument(
         targetProcessInstanceKey,
         targetProcess.getKey(),
         targetProcessInstanceKey,
+        targetRootProcessInstanceKey,
         targetProcess.getBpmnProcessId(),
         targetProcess.getTenantId(),
         variables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -63,6 +63,7 @@ public final class BpmnVariableMappingBehavior {
     final long processInstanceKey = context.getProcessInstanceKey();
     final DirectBuffer bpmnProcessId = context.getBpmnProcessId();
     final Optional<Expression> inputMappingExpression = element.getInputMappings();
+    final long rootProcessInstanceKey = context.getRootProcessInstanceKey();
 
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor
@@ -73,6 +74,7 @@ public final class BpmnVariableMappingBehavior {
                     scopeKey,
                     processDefinitionKey,
                     processInstanceKey,
+                    rootProcessInstanceKey,
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
@@ -95,6 +97,7 @@ public final class BpmnVariableMappingBehavior {
     final long elementInstanceKey = context.getElementInstanceKey();
     final long processDefinitionKey = record.getProcessDefinitionKey();
     final long processInstanceKey = record.getProcessInstanceKey();
+    final long rootProcessInstanceKey = context.getRootProcessInstanceKey();
     final DirectBuffer bpmnProcessId = context.getBpmnProcessId();
     final long scopeKey = getVariableScopeKey(context);
     final String tenantId = context.getTenantId();
@@ -124,6 +127,7 @@ public final class BpmnVariableMappingBehavior {
             elementInstanceKey,
             processDefinitionKey,
             processInstanceKey,
+            rootProcessInstanceKey,
             bpmnProcessId,
             context.getTenantId(),
             variables);
@@ -139,6 +143,7 @@ public final class BpmnVariableMappingBehavior {
                     scopeKey,
                     processDefinitionKey,
                     processInstanceKey,
+                    rootProcessInstanceKey,
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
@@ -151,6 +156,7 @@ public final class BpmnVariableMappingBehavior {
           elementInstanceKey,
           processDefinitionKey,
           processInstanceKey,
+          rootProcessInstanceKey,
           bpmnProcessId,
           context.getTenantId(),
           variables);
@@ -163,6 +169,7 @@ public final class BpmnVariableMappingBehavior {
           scopeKey,
           processDefinitionKey,
           processInstanceKey,
+          rootProcessInstanceKey,
           bpmnProcessId,
           context.getTenantId(),
           localVariables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -104,17 +104,24 @@ public final class CallActivityProcessor
                   element.isPropagateAllParentVariablesEnabled();
               final var inputMappings = element.getInputMappings();
               final var callActivityInstanceKey = activated.getElementInstanceKey();
+              final var rootProcessInstanceKey = context.getRootProcessInstanceKey();
 
               if (propagateAllParentVariablesEnabled) {
                 stateBehavior.copyAllVariablesToProcessInstance(
-                    callActivityInstanceKey, childProcessInstanceKey, process);
+                    callActivityInstanceKey,
+                    childProcessInstanceKey,
+                    rootProcessInstanceKey,
+                    process);
               } else if (inputMappings.isPresent()) {
                 // when activating the call activity, the input mappings will be applied.
                 // Resulting in local variables in the (local) call activity scope.
                 // These local variables can simply be propagated to the called child
                 // process instance.
                 stateBehavior.copyLocalVariablesToProcessInstance(
-                    callActivityInstanceKey, childProcessInstanceKey, process);
+                    callActivityInstanceKey,
+                    childProcessInstanceKey,
+                    rootProcessInstanceKey,
+                    process);
               }
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -262,6 +262,7 @@ public class EventTriggerBehavior {
           eventInstanceKey,
           elementRecord.getProcessDefinitionKey(),
           elementRecord.getProcessInstanceKey(),
+          elementRecord.getRootProcessInstanceKey(),
           elementRecord.getBpmnProcessIdBuffer(),
           elementRecord.getTenantId(),
           variables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -306,6 +306,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
         targetAdHocSubProcess.getKey(),
         targetAdHocSubProcessInstanceValue.getProcessDefinitionKey(),
         targetAdHocSubProcessInstanceValue.getProcessInstanceKey(),
+        targetAdHocSubProcessInstanceValue.getRootProcessInstanceKey(),
         targetAdHocSubProcessInstanceValue.getBpmnProcessIdBuffer(),
         targetAdHocSubProcessInstanceValue.getTenantId(),
         completingJobRecord.getVariablesBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -152,6 +152,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
           value.getElementInstanceKey(),
           value.getProcessDefinitionKey(),
           value.getProcessInstanceKey(),
+          value.getRootProcessInstanceKey(),
           value.getBpmnProcessIdBuffer(),
           value.getTenantId(),
           variables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -211,6 +211,7 @@ public class ProcessInstanceCreationHelper {
         processInstance.getProcessInstanceKey(),
         processInstance.getProcessDefinitionKey(),
         processInstance.getProcessInstanceKey(),
+        processInstance.getRootProcessInstanceKey(),
         processInstance.getBpmnProcessIdBuffer(),
         processInstance.getTenantId(),
         variablesBuffer);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -1285,6 +1285,7 @@ public final class ProcessInstanceModificationModifyProcessor
                     scopeKey,
                     process.getKey(),
                     processInstance.getKey(),
+                    processInstance.getValue().getRootProcessInstanceKey(),
                     process.getBpmnProcessId(),
                     process.getTenantId(),
                     variableDocument));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -174,6 +174,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               userTaskRecord.getElementInstanceKey(),
               userTaskRecord.getProcessDefinitionKey(),
               userTaskRecord.getProcessInstanceKey(),
+              userTaskRecord.getRootProcessInstanceKey(),
               userTaskRecord.getBpmnProcessIdBuffer(),
               userTaskRecord.getTenantId(),
               variableRecord.getVariablesBuffer());
@@ -182,6 +183,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               userTaskRecord.getElementInstanceKey(),
               userTaskRecord.getProcessDefinitionKey(),
               userTaskRecord.getProcessInstanceKey(),
+              userTaskRecord.getRootProcessInstanceKey(),
               userTaskRecord.getBpmnProcessIdBuffer(),
               userTaskRecord.getTenantId(),
               variableRecord.getVariablesBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -69,6 +69,7 @@ public final class VariableBehavior {
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
+      final long rootProcessInstanceKey,
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer document) {
@@ -81,6 +82,7 @@ public final class VariableBehavior {
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(rootProcessInstanceKey)
         .setBpmnProcessId(bpmnProcessId)
         .setTenantId(tenantId);
     final List<VariableEvent> variableEvents = new ArrayList<>();
@@ -112,12 +114,14 @@ public final class VariableBehavior {
    * @param scopeKey the scope key for each variable
    * @param processDefinitionKey the process key to be associated with each variable
    * @param processInstanceKey the process instance key to be associated with each variable
+   * @param rootProcessInstanceKey the root process instance key to be associated with each variable
    * @param document the document to merge
    */
   public void mergeDocument(
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
+      final long rootProcessInstanceKey,
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer document) {
@@ -133,6 +137,7 @@ public final class VariableBehavior {
     variableRecord
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(rootProcessInstanceKey)
         .setBpmnProcessId(bpmnProcessId)
         .setTenantId(tenantId);
     while ((parentScope = variableState.getParentScopeKey(currentScope)) > 0) {
@@ -188,6 +193,7 @@ public final class VariableBehavior {
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
+      final long rootProcessInstanceKey,
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer name,
@@ -199,6 +205,7 @@ public final class VariableBehavior {
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(rootProcessInstanceKey)
         .setBpmnProcessId(bpmnProcessId)
         .setTenantId(tenantId)
         .setName(name)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -163,6 +163,7 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getElementInstanceKey(),
                 userTaskRecord.getProcessDefinitionKey(),
                 userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getRootProcessInstanceKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
                 value.getVariablesBuffer());
@@ -171,6 +172,7 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getElementInstanceKey(),
                 userTaskRecord.getProcessDefinitionKey(),
                 userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getRootProcessInstanceKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
                 value.getVariablesBuffer());
@@ -196,6 +198,7 @@ public final class VariableDocumentUpdateProcessor
 
     final long processDefinitionKey = scope.getValue().getProcessDefinitionKey();
     final long processInstanceKey = scope.getValue().getProcessInstanceKey();
+    final long rootProcessInstanceKey = scope.getValue().getRootProcessInstanceKey();
     final DirectBuffer bpmnProcessId = scope.getValue().getBpmnProcessIdBuffer();
     try {
       if (value.getUpdateSemantics() == VariableDocumentUpdateSemantic.LOCAL) {
@@ -203,6 +206,7 @@ public final class VariableDocumentUpdateProcessor
             scope.getKey(),
             processDefinitionKey,
             processInstanceKey,
+            rootProcessInstanceKey,
             bpmnProcessId,
             tenantId,
             value.getVariablesBuffer());
@@ -211,6 +215,7 @@ public final class VariableDocumentUpdateProcessor
             scope.getKey(),
             processDefinitionKey,
             processInstanceKey,
+            rootProcessInstanceKey,
             bpmnProcessId,
             tenantId,
             value.getVariablesBuffer());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -80,6 +80,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long childFooKey = 3;
+    final long rootKey = 4;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
@@ -92,6 +93,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -109,7 +111,8 @@ final class VariableBehaviorTest {
                   .hasProcessDefinitionKey(processDefinitionKey)
                   .hasProcessInstanceKey(parentScopeKey)
                   .hasBpmnProcessId("process")
-                  .hasTenantId(tenantId);
+                  .hasTenantId(tenantId)
+                  .hasRootProcessInstanceKey(rootKey);
             },
             event -> {
               assertThat(event.intent).isEqualTo(VariableIntent.UPDATED);
@@ -121,7 +124,8 @@ final class VariableBehaviorTest {
                   .hasProcessDefinitionKey(processDefinitionKey)
                   .hasProcessInstanceKey(parentScopeKey)
                   .hasBpmnProcessId("process")
-                  .hasTenantId(tenantId);
+                  .hasTenantId(tenantId)
+                  .hasRootProcessInstanceKey(rootKey);
             });
   }
 
@@ -130,6 +134,7 @@ final class VariableBehaviorTest {
     // given
     final long processDefinitionKey = 1;
     final long scopeKey = 1;
+    final long rootKey = 2;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of();
@@ -140,6 +145,7 @@ final class VariableBehaviorTest {
         scopeKey,
         processDefinitionKey,
         scopeKey,
+        rootKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -169,6 +175,7 @@ final class VariableBehaviorTest {
     behavior.mergeDocument(
         childScopeKey,
         processDefinitionKey,
+        rootScopeKey,
         rootScopeKey,
         bpmnProcessId,
         tenantId,
@@ -209,6 +216,7 @@ final class VariableBehaviorTest {
     // when
     behavior.mergeDocument(
         childScopeKey,
+        rootScopeKey,
         processDefinitionKey,
         rootScopeKey,
         bpmnProcessId,
@@ -263,6 +271,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         rootScopeKey,
+        rootScopeKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -291,6 +300,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long childFooKey = 3;
+    final long rootKey = 5;
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar");
@@ -304,6 +314,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -332,6 +343,7 @@ final class VariableBehaviorTest {
     final int processDefinitionKey = 1;
     final int parentScopeKey = 1;
     final int childScopeKey = 2;
+    final long rootKey = 5;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of();
@@ -345,6 +357,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -360,6 +373,7 @@ final class VariableBehaviorTest {
     final int processDefinitionKey = 1;
     final int parentScopeKey = 1;
     final int childScopeKey = 2;
+    final int rootProcessInstanceKey = 3;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
@@ -372,6 +386,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootProcessInstanceKey,
         bpmnProcessId,
         tenantId,
         variableName,
@@ -391,6 +406,7 @@ final class VariableBehaviorTest {
                   .hasScopeKey(childScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
                   .hasProcessInstanceKey(parentScopeKey)
+                  .hasRootProcessInstanceKey(rootProcessInstanceKey)
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId);
             });
@@ -403,6 +419,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long parentFooKey = 3;
+    final long rootProcessInstanceKey = 4;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
@@ -416,6 +433,7 @@ final class VariableBehaviorTest {
         parentScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootProcessInstanceKey,
         bpmnProcessId,
         tenantId,
         variableName,
@@ -436,6 +454,7 @@ final class VariableBehaviorTest {
                   .hasScopeKey(parentScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
                   .hasProcessInstanceKey(parentScopeKey)
+                  .hasRootProcessInstanceKey(rootProcessInstanceKey)
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId);
             });
@@ -448,6 +467,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long parentFooKey = 3;
+    final long rootProcessInstanceKey = 4;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
@@ -461,6 +481,7 @@ final class VariableBehaviorTest {
         parentScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootProcessInstanceKey,
         bpmnProcessId,
         tenantId,
         variableName,
@@ -481,6 +502,7 @@ final class VariableBehaviorTest {
     final int processDefinitionKey = 1;
     final int parentScopeKey = 1;
     final int childScopeKey = 2;
+    final int rootProcessInstanceKey = 3;
 
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
@@ -494,6 +516,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootProcessInstanceKey,
         bpmnProcessId,
         tenantId,
         variableName,
@@ -513,6 +536,7 @@ final class VariableBehaviorTest {
                   .hasScopeKey(childScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
                   .hasProcessInstanceKey(parentScopeKey)
+                  .hasRootProcessInstanceKey(rootProcessInstanceKey)
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId);
             });
@@ -527,6 +551,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long parentFooKey = 3;
+    final long rootProcessInstanceKey = 4;
 
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
@@ -542,6 +567,7 @@ final class VariableBehaviorTest {
         parentScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootProcessInstanceKey,
         bpmnProcessId,
         tenantId,
         variableName,
@@ -562,6 +588,7 @@ final class VariableBehaviorTest {
                   .hasScopeKey(parentScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
                   .hasProcessInstanceKey(parentScopeKey)
+                  .hasRootProcessInstanceKey(rootProcessInstanceKey)
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId);
             });
@@ -576,6 +603,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long childFooKey = 3;
+    final long rootKey = 4;
 
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
@@ -590,6 +618,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        rootKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -646,6 +675,7 @@ final class VariableBehaviorTest {
     behavior.mergeDocument(
         childScopeKey,
         processDefinitionKey,
+        rootScopeKey,
         rootScopeKey,
         bpmnProcessId,
         tenantId,

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -73,6 +74,7 @@ final class BulkIndexRequest implements ContentProducer {
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
           .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(VariableRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -40,6 +40,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -655,7 +655,8 @@ final class BulkIndexRequestTest {
           "PROCESS_INSTANCE_MIGRATION",
           "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
-          "USER_TASK"
+          "USER_TASK",
+          "VARIABLE",
         })
     void shouldIndexWithoutRootProcessInstanceKeyOnPreviousVersion(final ValueType valueType)
         throws Exception {
@@ -694,7 +695,8 @@ final class BulkIndexRequestTest {
           "PROCESS_INSTANCE_MIGRATION",
           "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
-          "USER_TASK"
+          "USER_TASK",
+          "VARIABLE",
         })
     void shouldIndexWithRootProcessInstanceKey(final ValueType valueType) throws Exception {
       // given

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -73,6 +74,7 @@ final class BulkIndexRequest implements ContentProducer {
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
           .addMixIn(UserTaskRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(VariableRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -40,6 +40,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -655,7 +655,8 @@ final class BulkIndexRequestTest {
           "PROCESS_INSTANCE_MIGRATION",
           "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
-          "USER_TASK"
+          "USER_TASK",
+          "VARIABLE",
         })
     void shouldIndexWithoutRootProcessInstanceKeyOnPreviousVersion(final ValueType valueType)
         throws Exception {
@@ -694,7 +695,8 @@ final class BulkIndexRequestTest {
           "PROCESS_INSTANCE_MIGRATION",
           "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
-          "USER_TASK"
+          "USER_TASK",
+          "VARIABLE",
         })
     void shouldIndexWithRootProcessInstanceKey(final ValueType valueType) throws Exception {
       // given

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -32,6 +32,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -42,16 +44,19 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public VariableRecord() {
-    super(7);
+    super(8);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(bpmnProcessIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   @Override
@@ -96,6 +101,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public VariableRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1589,6 +1589,7 @@ final class JsonSerializableToJsonTest {
               final long processInstanceKey = 2;
               final long processDefinitionKey = 4;
               final String bpmnProcessId = "process";
+              final long rootProcessInstanceKey = 5;
 
               return new VariableRecord()
                   .setName(wrapString(name))
@@ -1596,7 +1597,8 @@ final class JsonSerializableToJsonTest {
                   .setScopeKey(scopeKey)
                   .setProcessInstanceKey(processInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
-                  .setBpmnProcessId(wrapString(bpmnProcessId));
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
                 {
@@ -1606,7 +1608,8 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId": "process",
                   "name": "x",
                   "value": "1",
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": 5
                 }
                 """
       },
@@ -1622,6 +1625,7 @@ final class JsonSerializableToJsonTest {
               final long processInstanceKey = 2;
               final long processDefinitionKey = 4;
               final String bpmnProcessId = "process";
+              final long rootProcessInstanceKey = 5;
 
               return new VariableRecord()
                   .setName(wrapString(name))
@@ -1630,7 +1634,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setBpmnProcessId(wrapString(bpmnProcessId))
-                  .setTenantId("tenant-test");
+                  .setTenantId("tenant-test")
+                  .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
                 {
@@ -1640,7 +1645,8 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId": "process",
                   "name": "x",
                   "value": "1",
-                  "tenantId": "tenant-test"
+                  "tenantId": "tenant-test",
+                  "rootProcessInstanceKey": 5
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
@@ -32,6 +32,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -42,16 +44,19 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public VariableRecord() {
-    super(7);
+    super(8);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(bpmnProcessIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   @Override
@@ -96,6 +101,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public VariableRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -59,4 +59,14 @@ public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated
    * @return the BPMN process id this process instance belongs to.
    */
   String getBpmnProcessId();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For variables in top-level
+   * process instances, this is equal to {@link #getProcessInstanceKey()}. For variables in child
+   * process instances (created via call activities), this is the key of the topmost parent process
+   * instance.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds `rootProcessInstanceKey` throughout the variable event records 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41655
depends on https://github.com/camunda/camunda/pull/42708 and https://github.com/camunda/camunda/pull/42352