### PR TITLE
Include runtime variables in V1 search for completed user tasks

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/task/TasklistV1V2ApiMixUserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/task/TasklistV1V2ApiMixUserTaskIT.java
@@ -31,8 +31,13 @@ import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
+// Tasklist V1 APIs are not available with RDBMS secondary storage.
+// See the @ConditionalOnRdbmsDisabled annotation on
+// io.camunda.tasklist.webapp.api.rest.v1.controllers.TaskController
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 public class TasklistV1V2ApiMixUserTaskIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/task/TasklistV1V2ApiMixUserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/task/TasklistV1V2ApiMixUserTaskIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tasklist.v1.task;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+
+import io.camunda.application.Profile;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestRestTasklistClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.VariableSearchResponse;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class TasklistV1V2ApiMixUserTaskIT {
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withUnauthenticatedAccess()
+          .withAdditionalProfile(Profile.TASKLIST);
+
+  private static CamundaClient v2CamundaClient;
+
+  @Test
+  public void shouldRetrieveAllVariablesWithV1ApiWhenCompletingTaskWithV2Api() {
+
+    // given: a process containing a task started with some variables
+
+    // Define process with a single user task
+    final String processId = "processWithTask";
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .userTask("userTask")
+            .zeebeUserTask()
+            .done();
+    deployResource(v2CamundaClient, processDefinition, processId + ".bpmn");
+
+    // Provide variables when starting the process
+    final long processInstanceKey =
+        startProcessInstance(v2CamundaClient, processId, Map.of("var1", "value1", "var2", "value2"))
+            .getProcessInstanceKey();
+
+    // Retrieve user task key when it is available
+    final var taskKey = new AtomicLong();
+    Awaitility.await("should create user task")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .until(
+            () -> {
+              final SearchResponse<UserTask> searchResponse =
+                  v2CamundaClient
+                      .newUserTaskSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join();
+              if (searchResponse.items().isEmpty()) {
+                return false;
+              } else {
+                taskKey.set(searchResponse.items().getFirst().getUserTaskKey());
+                return true;
+              }
+            });
+
+    // when: the task is completed with V2 APIs, providing some but not all variables
+    v2CamundaClient
+        .newCompleteUserTaskCommand(taskKey.get())
+        .variables(Map.of("var1", "newvalue1", "var3", "value3"))
+        .send()
+        .join();
+
+    // then: search through V1 APIs should return all variables
+    try (final var v1TasklistClient = STANDALONE_CAMUNDA.newTasklistClient()) {
+
+      // Note: it could take some time for the changes to be available in tasklist
+      Awaitility.await("should return all variables")
+          .atMost(Duration.ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                // Retrieve the task with V1 APIs, requesting variables too
+                final var tasks =
+                    TestRestTasklistClient.OBJECT_MAPPER.readValue(
+                        v1TasklistClient
+                            .searchRequest(
+                                "v1/tasks/search",
+                                "{\"includeVariables\": [{\"name\": \"var1\"},{\"name\":\"var2\"},{\"name\": \"var3\"}]}")
+                            .body(),
+                        TaskSearchResponse[].class);
+
+                // Wait for the task to be marked complete (export could take a while)
+                Assertions.assertThat(tasks[0].getTaskState()).isEqualTo(TaskState.COMPLETED);
+                // Check correct variables are retrieved
+                final Map<String, String> expectedVariables =
+                    Map.of(
+                        "var1",
+                            "\"newvalue1\"", // from task completion (replacing original variable)
+                        "var2",
+                            "\"value2\"", // original value, not provided through task completion
+                        "var3", "\"value3\"" // from task completion
+                        );
+                final Map<String, String> actualVariables =
+                    Arrays.stream(tasks[0].getVariables())
+                        .collect(
+                            Collectors.toMap(
+                                VariableSearchResponse::getName, VariableSearchResponse::getValue));
+                Assertions.assertThat(actualVariables).isEqualTo(expectedVariables);
+              });
+    }
+  }
+}

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -40,7 +40,6 @@ import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTempla
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
-import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
 import java.io.IOException;
@@ -322,8 +321,6 @@ public class VariableStoreElasticSearch implements VariableStore {
       final List<Long> processInstanceKeys) {
     final TermsQueryBuilder processInstanceKeyQuery =
         termsQuery(FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY, processInstanceKeys);
-    final var flowNodeInstanceStateQuery =
-        termsQuery(FlowNodeInstanceTemplate.STATE, FlowNodeState.ACTIVE.toString());
 
     final TermsQueryBuilder typeQuery =
         QueryBuilders.termsQuery(
@@ -336,9 +333,7 @@ public class VariableStoreElasticSearch implements VariableStore {
             FlowNodeType.MULTI_INSTANCE_BODY.toString(),
             FlowNodeType.PROCESS.toString());
 
-    final var query =
-        ElasticsearchUtil.joinWithAnd(
-            typeQuery, processInstanceKeyQuery, flowNodeInstanceStateQuery);
+    final var query = ElasticsearchUtil.joinWithAnd(typeQuery, processInstanceKeyQuery);
     return new SearchRequest(flowNodeInstanceIndex.getFullQualifiedName())
         .source(
             new SearchSourceBuilder()

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -320,15 +320,10 @@ public class VariableStoreElasticSearch implements VariableStore {
 
   private SearchRequest buildSearchFNIByProcessInstanceKeysRequest(
       final List<Long> processInstanceKeys) {
-    final BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
-
     final TermsQueryBuilder processInstanceKeyQuery =
         termsQuery(FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY, processInstanceKeys);
     final var flowNodeInstanceStateQuery =
         termsQuery(FlowNodeInstanceTemplate.STATE, FlowNodeState.ACTIVE.toString());
-
-    queryBuilder.must(flowNodeInstanceStateQuery);
-    queryBuilder.must(processInstanceKeyQuery);
 
     final TermsQueryBuilder typeQuery =
         QueryBuilders.termsQuery(
@@ -340,7 +335,6 @@ public class VariableStoreElasticSearch implements VariableStore {
             FlowNodeType.EVENT_SUB_PROCESS.toString(),
             FlowNodeType.MULTI_INSTANCE_BODY.toString(),
             FlowNodeType.PROCESS.toString());
-    queryBuilder.must(typeQuery);
 
     final var query =
         ElasticsearchUtil.joinWithAnd(

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -32,7 +32,6 @@ import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTempla
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
-import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
 import java.io.IOException;
@@ -54,7 +53,6 @@ import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.ConstantScoreQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
 import org.opensearch.client.opensearch.core.*;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
@@ -348,12 +346,6 @@ public class VariableStoreOpenSearch implements VariableStore {
                                         .map(FieldValue::of)
                                         .collect(toList()))))
             .toQuery();
-    final var flowNodeInstanceStateQuery =
-        TermQuery.of(
-                t ->
-                    t.field(FlowNodeInstanceTemplate.STATE)
-                        .value(v -> v.stringValue(FlowNodeState.ACTIVE.toString())))
-            .toQuery();
 
     final var typeQuery =
         new Query.Builder()
@@ -378,10 +370,7 @@ public class VariableStoreOpenSearch implements VariableStore {
 
     final Query.Builder combinedQuery = new Query.Builder();
     combinedQuery.constantScore(
-        cs ->
-            cs.filter(
-                OpenSearchUtil.joinWithAnd(
-                    processInstanceKeyQuery, flowNodeInstanceStateQuery, typeQuery)));
+        cs -> cs.filter(OpenSearchUtil.joinWithAnd(processInstanceKeyQuery, typeQuery)));
 
     return new SearchRequest.Builder()
         .index(flowNodeInstanceIndex.getFullQualifiedName())


### PR DESCRIPTION
## Description

The V1 task search API looks for **snapshot** variables when dealing with completed tasks. These are normally persisted by the V1 completion command, but when the task is completed through the V2 API then only the variables explicitly provided to the command are saved as snapshots. The result is that some variables are not returned when searching through V1 APIs for a task which was completed through V2 APIs.

This PR solves this by changing the V1 API implementation to fall back to searching runtime variables when snapshot variables are not found for completed tasks, ensuring all available variables are included in the response.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40231
