### PR TITLE
feat: add a posix SegmentAllocator using fallocate syscall

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -179,7 +179,11 @@ public class Raft {
    *   <li>POSIX: reserves the space required on disk using `fallocate` posix system call. Depending
    *       on the filesystem, this may not ensure that enough disk space is available. This strategy
    *       reduces the write throughput to disk which can be particularly useful when using network
-   *       file systems.
+   *       file systems. Running `fallocate` requires a POSIX filesystem and JNI calls which might
+   *       not be available. If you want to make sure that `fallocate` is used, configure this
+   *       strategies, otherwise use the below ones.
+   *   <li>POSIX_OR_NOOP: use POSIX strategy or NOOP if it's not possible.
+   *   <li>POSIX_OR_FILL: use POSIX strategy or FILL if it's not possible.
    * </ul>
    */
   private PreAllocateStrategy segmentPreallocationStrategy = PreAllocateStrategy.FILL;

--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -14,7 +14,7 @@ import static io.camunda.zeebe.broker.system.configuration.ExperimentalCfg.DEFAU
 import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_SNAPSHOT_CHUNK_SIZE;
 import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
 
-import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.PreAllocateStrategy;
+import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.PreAllocationStrategy;
 import java.time.Duration;
 import java.util.Set;
 import org.springframework.util.unit.DataSize;
@@ -186,7 +186,7 @@ public class Raft {
    *   <li>POSIX_OR_FILL: use POSIX strategy or FILL if it's not possible.
    * </ul>
    */
-  private PreAllocateStrategy segmentPreallocationStrategy = PreAllocateStrategy.FILL;
+  private PreAllocationStrategy segmentPreallocationStrategy = PreAllocationStrategy.FILL;
 
   public Duration getHeartbeatInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -383,20 +383,20 @@ public class Raft {
     this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 
-  public PreAllocateStrategy getSegmentPreallocationStrategy() {
+  public PreAllocationStrategy getSegmentPreallocationStrategy() {
     if (!isPreallocateSegmentFiles()) {
-      return PreAllocateStrategy.NOOP;
+      return PreAllocationStrategy.NOOP;
     }
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         PREFIX + ".segment-preallocation-strategy",
         segmentPreallocationStrategy,
-        PreAllocateStrategy.class,
+        PreAllocationStrategy.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
         Set.of(LEGACY_SEGMENT_PREALLOCATION_STRATEGY));
   }
 
   public void setSegmentPreallocationStrategy(
-      final PreAllocateStrategy segmentPreallocationStrategy) {
+      final PreAllocationStrategy segmentPreallocationStrategy) {
     this.segmentPreallocationStrategy = segmentPreallocationStrategy;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -483,6 +483,10 @@ public class BrokerBasedPropertiesOverride {
         .getExperimental()
         .getRaft()
         .setPreallocateSegmentFiles(raft.isPreallocateSegmentFiles());
+    override
+        .getExperimental()
+        .getRaft()
+        .setSegmentPreallocationStrategy(raft.getSegmentPreallocationStrategy());
   }
 
   private void populateFromClusterMetadata(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/RaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftTest.java
@@ -12,117 +12,126 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.PreAllocateStrategy;
-import org.junit.jupiter.api.Nested;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-@SpringJUnitConfig({
-  UnifiedConfiguration.class,
-  BrokerBasedPropertiesOverride.class,
-  UnifiedConfigurationHelper.class
-})
-@ActiveProfiles("broker")
 public class RaftTest {
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.cluster.raft.preallocate-segment-files=true",
-        "camunda.cluster.raft.segment-preallocation-strategy=POSIX"
-      })
-  class WithOnlyUnifiedConfigSet {
-    final BrokerBasedProperties brokerCfg;
+  private final ApplicationContextRunner brokerRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class)
+          .withPropertyValues("spring.profiles.active=broker");
 
-    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
-      this.brokerCfg = brokerCfg;
-    }
-
-    @Test
-    void shouldSetSegmentPreallocationStrategy() {
-      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-          .isEqualTo(PreAllocateStrategy.POSIX);
-    }
+  private static Stream<Arguments> segmentPreallocationStrategies() {
+    return Stream.of(PreAllocateStrategy.values()).map(s -> Arguments.of(s.name(), s));
   }
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
-        "zeebe.broker.experimental.raft.segmentPreallocationStrategy=POSIX"
-      })
-  class WithOnlyLegacySet {
-    final BrokerBasedProperties brokerCfg;
-
-    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
-      this.brokerCfg = brokerCfg;
-    }
-
-    @Test
-    void shouldSetSegmentPreallocationStrategyFromLegacy() {
-      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-          .isEqualTo(PreAllocateStrategy.POSIX);
-    }
+  @Test
+  void shouldSetSegmentPreallocationStrategyFromUnifiedConfig() {
+    brokerRunner
+        .withPropertyValues(
+            "camunda.cluster.raft.preallocate-segment-files=true",
+            "camunda.cluster.raft.segment-preallocation-strategy=POSIX")
+        .run(
+            context -> {
+              final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+              assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+                  .isEqualTo(PreAllocateStrategy.POSIX);
+            });
   }
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        // new
-        "camunda.cluster.raft.preallocate-segment-files=true",
-        "camunda.cluster.raft.segment-preallocation-strategy=FILL",
-        // legacy
-        "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
-        "zeebe.broker.experimental.raft.segmentPreallocationStrategy=POSIX"
-      })
-  class WithNewAndLegacySet {
-    final BrokerBasedProperties brokerCfg;
-
-    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
-      this.brokerCfg = brokerCfg;
-    }
-
-    @Test
-    void shouldPreferNewSegmentPreallocationStrategy() {
-      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-          .isEqualTo(PreAllocateStrategy.FILL);
-    }
+  @Test
+  void shouldSetSegmentPreallocationStrategyFromLegacyConfig() {
+    brokerRunner
+        .withPropertyValues(
+            "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
+            "zeebe.broker.experimental.raft.segmentPreallocationStrategy=POSIX")
+        .run(
+            context -> {
+              final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+              assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+                  .isEqualTo(PreAllocateStrategy.POSIX);
+            });
   }
 
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.cluster.raft.preallocate-segment-files=false",
-        "camunda.cluster.raft.segment-preallocation-strategy=POSIX"
-      })
-  class WithPreallocationDisabled {
-    final BrokerBasedProperties brokerCfg;
-
-    WithPreallocationDisabled(@Autowired final BrokerBasedProperties brokerCfg) {
-      this.brokerCfg = brokerCfg;
-    }
-
-    @Test
-    void shouldForceStrategyToNoop() {
-      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-          .isEqualTo(PreAllocateStrategy.NOOP);
-    }
+  @Test
+  void shouldPreferNewSegmentPreallocationStrategyWhenBothAreSet() {
+    brokerRunner
+        .withPropertyValues(
+            // new
+            "camunda.cluster.raft.preallocate-segment-files=true",
+            "camunda.cluster.raft.segment-preallocation-strategy=FILL",
+            // legacy
+            "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
+            "zeebe.broker.experimental.raft.segmentPreallocationStrategy=POSIX")
+        .run(
+            context -> {
+              final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+              assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+                  .isEqualTo(PreAllocateStrategy.FILL);
+            });
   }
 
-  @Nested
-  class WithoutNewAndLegacySet {
-    final BrokerBasedProperties brokerCfg;
+  @Test
+  void shouldForceStrategyToNoopWhenPreallocationDisabled() {
+    brokerRunner
+        .withPropertyValues(
+            "camunda.cluster.raft.preallocate-segment-files=false",
+            "camunda.cluster.raft.segment-preallocation-strategy=POSIX")
+        .run(
+            context -> {
+              final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+              assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+                  .isEqualTo(PreAllocateStrategy.NOOP);
+            });
+  }
 
-    WithoutNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
-      this.brokerCfg = brokerCfg;
-    }
+  @Test
+  void shouldUseDefaultSegmentPreallocationStrategy() {
+    brokerRunner.run(
+        context -> {
+          final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+          assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+              .isEqualTo(PreAllocateStrategy.FILL);
+        });
+  }
 
-    @Test
-    void shouldUseDefaultSegmentPreallocationStrategy() {
-      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-          .isEqualTo(PreAllocateStrategy.FILL);
-    }
+  @ParameterizedTest(name = "unified strategy '{0}' maps to {1}")
+  @MethodSource("segmentPreallocationStrategies")
+  void shouldMapUnifiedStrategyStringToEnum(
+      final String strategy, final PreAllocateStrategy expected) {
+    brokerRunner
+        .withPropertyValues(
+            "camunda.cluster.raft.preallocate-segment-files=true",
+            "camunda.cluster.raft.segment-preallocation-strategy=" + strategy)
+        .run(
+            context -> {
+              final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+              assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+                  .isEqualTo(expected);
+            });
+  }
+
+  @ParameterizedTest(name = "legacy strategy '{0}' maps to {1}")
+  @MethodSource("segmentPreallocationStrategies")
+  void shouldMapLegacyStrategyStringToEnum(
+      final String strategy, final PreAllocateStrategy expected) {
+    brokerRunner
+        .withPropertyValues(
+            "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
+            "zeebe.broker.experimental.raft.segmentPreallocationStrategy=" + strategy)
+        .run(
+            context -> {
+              final var brokerCfg = context.getBean(BrokerBasedProperties.class);
+              assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+                  .isEqualTo(expected);
+            });
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/RaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.PreAllocateStrategy;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class RaftTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.raft.preallocate-segment-files=true",
+        "camunda.cluster.raft.segment-preallocation-strategy=POSIX"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetSegmentPreallocationStrategy() {
+      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+          .isEqualTo(PreAllocateStrategy.POSIX);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
+        "zeebe.broker.experimental.raft.segmentPreallocationStrategy=POSIX"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetSegmentPreallocationStrategyFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+          .isEqualTo(PreAllocateStrategy.POSIX);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.raft.preallocate-segment-files=true",
+        "camunda.cluster.raft.segment-preallocation-strategy=FILL",
+        // legacy
+        "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",
+        "zeebe.broker.experimental.raft.segmentPreallocationStrategy=POSIX"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldPreferNewSegmentPreallocationStrategy() {
+      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+          .isEqualTo(PreAllocateStrategy.FILL);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.raft.preallocate-segment-files=false",
+        "camunda.cluster.raft.segment-preallocation-strategy=POSIX"
+      })
+  class WithPreallocationDisabled {
+    final BrokerBasedProperties brokerCfg;
+
+    WithPreallocationDisabled(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldForceStrategyToNoop() {
+      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+          .isEqualTo(PreAllocateStrategy.NOOP);
+    }
+  }
+
+  @Nested
+  class WithoutNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithoutNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldUseDefaultSegmentPreallocationStrategy() {
+      assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
+          .isEqualTo(PreAllocateStrategy.FILL);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/RaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.PreAllocateStrategy;
+import io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.PreAllocationStrategy;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,7 +30,7 @@ public class RaftTest {
           .withPropertyValues("spring.profiles.active=broker");
 
   private static Stream<Arguments> segmentPreallocationStrategies() {
-    return Stream.of(PreAllocateStrategy.values()).map(s -> Arguments.of(s.name(), s));
+    return Stream.of(PreAllocationStrategy.values()).map(s -> Arguments.of(s.name(), s));
   }
 
   @Test
@@ -43,7 +43,7 @@ public class RaftTest {
             context -> {
               final var brokerCfg = context.getBean(BrokerBasedProperties.class);
               assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-                  .isEqualTo(PreAllocateStrategy.POSIX);
+                  .isEqualTo(PreAllocationStrategy.POSIX);
             });
   }
 
@@ -57,7 +57,7 @@ public class RaftTest {
             context -> {
               final var brokerCfg = context.getBean(BrokerBasedProperties.class);
               assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-                  .isEqualTo(PreAllocateStrategy.POSIX);
+                  .isEqualTo(PreAllocationStrategy.POSIX);
             });
   }
 
@@ -75,7 +75,7 @@ public class RaftTest {
             context -> {
               final var brokerCfg = context.getBean(BrokerBasedProperties.class);
               assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-                  .isEqualTo(PreAllocateStrategy.FILL);
+                  .isEqualTo(PreAllocationStrategy.FILL);
             });
   }
 
@@ -89,7 +89,7 @@ public class RaftTest {
             context -> {
               final var brokerCfg = context.getBean(BrokerBasedProperties.class);
               assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-                  .isEqualTo(PreAllocateStrategy.NOOP);
+                  .isEqualTo(PreAllocationStrategy.NOOP);
             });
   }
 
@@ -99,14 +99,14 @@ public class RaftTest {
         context -> {
           final var brokerCfg = context.getBean(BrokerBasedProperties.class);
           assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-              .isEqualTo(PreAllocateStrategy.FILL);
+              .isEqualTo(PreAllocationStrategy.FILL);
         });
   }
 
   @ParameterizedTest(name = "unified strategy '{0}' maps to {1}")
   @MethodSource("segmentPreallocationStrategies")
   void shouldMapUnifiedStrategyStringToEnum(
-      final String strategy, final PreAllocateStrategy expected) {
+      final String strategy, final PreAllocationStrategy expected) {
     brokerRunner
         .withPropertyValues(
             "camunda.cluster.raft.preallocate-segment-files=true",
@@ -122,7 +122,7 @@ public class RaftTest {
   @ParameterizedTest(name = "legacy strategy '{0}' maps to {1}")
   @MethodSource("segmentPreallocationStrategies")
   void shouldMapLegacyStrategyStringToEnum(
-      final String strategy, final PreAllocateStrategy expected) {
+      final String strategy, final PreAllocationStrategy expected) {
     brokerRunner
         .withPropertyValues(
             "zeebe.broker.experimental.raft.preallocateSegmentFiles=true",

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -781,7 +781,8 @@
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
-            -Dfile.encoding=UTF-8 -Xshare:auto</extraJvmArguments>
+            -Dfile.encoding=UTF-8 -Xshare:auto
+            --add-opens=java.base/java.io=ALL-UNNAMED</extraJvmArguments>
           <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
           <endorsedDir>driver-lib</endorsedDir>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -130,6 +130,7 @@
     <version.jcip>1.0</version.jcip>
     <version.jnr-ffi>2.2.18</version.jnr-ffi>
     <version.jnr-posix>3.1.21</version.jnr-posix>
+    <version.jnr-constants>0.10.3</version.jnr-constants>
     <version.zpt>8.7.9</version.zpt>
     <version.feign>13.6</version.feign>
     <version.google-sdk>26.64.0</version.google-sdk>
@@ -1749,6 +1750,11 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <version>${version.jnr-posix}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-constants</artifactId>
+        <version>${version.jnr-constants}</version>
       </dependency>
 
       <dependency>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -120,7 +120,8 @@ public class RaftStorageConfig {
         + freeDiskSpace
         + ", journalIndexDensity="
         + journalIndexDensity
-        + ", segmentAllocator ="
+        + ", segmentAllocator="
+        + segmentAllocator
         + '}';
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -19,6 +19,7 @@ package io.atomix.raft.partition;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.atomix.utils.concurrent.ThreadContext;
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 
 /** Raft storage configuration. */
 public class RaftStorageConfig {
@@ -35,7 +36,7 @@ public class RaftStorageConfig {
   private RaftLogFlusher.Factory flusherFactory = DEFAULT_FLUSHER_FACTORY;
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
-  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
+  private SegmentAllocator segmentAllocator = SegmentAllocator.defaultAllocator();
 
   /**
    * Returns the Raft log segment size.
@@ -108,23 +109,6 @@ public class RaftStorageConfig {
     return this;
   }
 
-  /**
-   * @return true to preallocate segment files, false otherwise
-   */
-  public boolean isPreallocateSegmentFiles() {
-    return preallocateSegmentFiles;
-  }
-
-  /**
-   * Sets whether segment files are pre-allocated at creation. If true, segment files are
-   * pre-allocated to {@link #segmentSize} at creation before any writes happen.
-   *
-   * @param preallocateSegmentFiles true to preallocate files, false otherwise
-   */
-  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
-    this.preallocateSegmentFiles = preallocateSegmentFiles;
-  }
-
   @Override
   public String toString() {
     return "RaftStorageConfig{"
@@ -136,8 +120,21 @@ public class RaftStorageConfig {
         + freeDiskSpace
         + ", journalIndexDensity="
         + journalIndexDensity
-        + ", preallocateSegmentFiles="
-        + preallocateSegmentFiles
+        + ", segmentAllocator ="
         + '}';
+  }
+
+  public SegmentAllocator getSegmentAllocator() {
+    return segmentAllocator;
+  }
+
+  /**
+   * Sets whether segment files are pre-allocated at creation. If true, segment files are
+   * pre-allocated to {@link #segmentSize} at creation before any writes happen.
+   *
+   * @param segmentAllocator to use to preallocate files
+   */
+  public void setSegmentAllocator(final SegmentAllocator segmentAllocator) {
+    this.segmentAllocator = segmentAllocator;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -309,7 +309,7 @@ public class RaftPartitionServer implements HealthMonitorable {
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
-        .withPreallocateSegmentFiles(storageConfig.isPreallocateSegmentFiles())
+        .withSegmentAllocator(storageConfig.getSegmentAllocator())
         .build();
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -19,6 +19,7 @@ import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalMetaStore;
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -121,11 +122,11 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
    * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
    * before any writes happen.
    *
-   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @param segmentAllocator to use
    * @return this builder for chaining
    */
-  public RaftLogBuilder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
-    journalBuilder.withPreallocateSegmentFiles(preallocateSegmentFiles);
+  public RaftLogBuilder withSegmentAllocator(final SegmentAllocator segmentAllocator) {
+    journalBuilder.withSegmentAllocator(segmentAllocator);
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -81,8 +81,8 @@ public final class RaftPartitionFactory {
     storageConfig.setFreeDiskSpace(
         brokerCfg.getData().getDisk().getFreeSpace().getReplication().toBytes());
     storageConfig.setJournalIndexDensity(brokerCfg.getData().getLogIndexDensity());
-    storageConfig.setPreallocateSegmentFiles(
-        brokerCfg.getExperimental().getRaft().isPreallocateSegmentFiles());
+    storageConfig.setSegmentAllocator(
+        brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy().segmentAllocator());
 
     partitionConfig.setStorageConfig(storageConfig);
     partitionConfig.setEntryValidator(new ZeebeEntryValidator());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -116,7 +116,9 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   public enum PreAllocateStrategy {
     NOOP(SegmentAllocator.noop()),
     FILL(SegmentAllocator.fill()),
-    POSIX(SegmentAllocator.posix());
+    POSIX(SegmentAllocator.posix(null)),
+    POSIX_OR_NOOP(SegmentAllocator.posix(SegmentAllocator.noop())),
+    POSIX_OR_FILL(SegmentAllocator.posix(SegmentAllocator.fill()));
 
     private final SegmentAllocator segmentAllocator;
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -113,6 +113,24 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
     segmentPreallocationStrategy = preAllocationStrategy;
   }
 
+  /**
+   * Defines the strategy to use to preallocate segment files when "preallocateSegmentFiles" is set
+   * to true. Possible options are:
+   *
+   * <ul>
+   *   <li>NOOP: does not preallocate files, same as setting `preallocateSegmentFiles=false`
+   *   <li>FILL: fills the new segments with zeroes to ensure the disk space is reserved and the
+   *       file is initialized with zeroes
+   *   <li>POSIX: reserves the space required on disk using `fallocate` posix system call. Depending
+   *       on the filesystem, this may not ensure that enough disk space is available. This strategy
+   *       reduces the write throughput to disk which can be particularly useful when using network
+   *       file systems. Running `fallocate` requires a POSIX filesystem and JNI calls which might
+   *       not be available. If you want to make sure that `fallocate` is used, configure this
+   *       strategies, otherwise use the below ones.
+   *   <li>POSIX_OR_NOOP: use POSIX strategy or NOOP if it's not possible.
+   *   <li>POSIX_OR_FILL: use POSIX strategy or FILL if it's not possible.
+   * </ul>
+   */
   public enum PreAllocationStrategy {
     NOOP(SegmentAllocator.noop()),
     FILL(SegmentAllocator.fill()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -25,8 +25,8 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
-  private static final PreAllocateStrategy DEFAULT_PREALLOCATE_SEGMENT_STRATEGY =
-      PreAllocateStrategy.FILL;
+  private static final PreAllocationStrategy DEFAULT_PREALLOCATE_SEGMENT_STRATEGY =
+      PreAllocationStrategy.FILL;
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
   private DataSize snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;
@@ -36,7 +36,7 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
-  private PreAllocateStrategy segmentPreallocationStrategy = DEFAULT_PREALLOCATE_SEGMENT_STRATEGY;
+  private PreAllocationStrategy segmentPreallocationStrategy = DEFAULT_PREALLOCATE_SEGMENT_STRATEGY;
 
   public Duration getRequestTimeout() {
     return requestTimeout;
@@ -102,18 +102,18 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
     this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 
-  public PreAllocateStrategy getSegmentPreallocationStrategy() {
+  public PreAllocationStrategy getSegmentPreallocationStrategy() {
     if (!preallocateSegmentFiles) {
-      return PreAllocateStrategy.NOOP;
+      return PreAllocationStrategy.NOOP;
     }
     return segmentPreallocationStrategy;
   }
 
-  public void setSegmentPreallocationStrategy(final PreAllocateStrategy preAllocationStrategy) {
+  public void setSegmentPreallocationStrategy(final PreAllocationStrategy preAllocationStrategy) {
     segmentPreallocationStrategy = preAllocationStrategy;
   }
 
-  public enum PreAllocateStrategy {
+  public enum PreAllocationStrategy {
     NOOP(SegmentAllocator.noop()),
     FILL(SegmentAllocator.fill()),
     POSIX(SegmentAllocator.posix(null)),
@@ -122,7 +122,7 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
     private final SegmentAllocator segmentAllocator;
 
-    PreAllocateStrategy(final SegmentAllocator segmentAllocator) {
+    PreAllocationStrategy(final SegmentAllocator segmentAllocator) {
       this.segmentAllocator = segmentAllocator;
     }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -15,6 +15,7 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -222,8 +223,9 @@ public final class RaftPartitionFactoryTest {
     final var partition = buildRaftPartition(brokerCfg);
 
     // then
-    assertThat(partition.getPartitionConfig().getStorageConfig().isPreallocateSegmentFiles())
-        .isEqualTo(value);
+    final var expected = value ? SegmentAllocator.defaultAllocator() : SegmentAllocator.noop();
+    assertThat(partition.getPartitionConfig().getStorageConfig().getSegmentAllocator().getClass())
+        .isEqualTo(expected.getClass());
   }
 
   private RaftPartition buildRaftPartition(final BrokerCfg brokerCfg) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -15,7 +15,6 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.journal.file.SegmentAllocator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -223,9 +222,10 @@ public final class RaftPartitionFactoryTest {
     final var partition = buildRaftPartition(brokerCfg);
 
     // then
-    final var expected = value ? SegmentAllocator.defaultAllocator() : SegmentAllocator.noop();
-    assertThat(partition.getPartitionConfig().getStorageConfig().getSegmentAllocator().getClass())
-        .isEqualTo(expected.getClass());
+    final var expected =
+        brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy().segmentAllocator();
+    assertThat(partition.getPartitionConfig().getStorageConfig().getSegmentAllocator())
+        .isEqualTo(expected);
   }
 
   private RaftPartition buildRaftPartition(final BrokerCfg brokerCfg) {

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -56,6 +56,16 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-ffi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-constants</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -157,6 +167,25 @@
             -->
             <dependency>io.camunda:zeebe-protocol</dependency>
           </usedDependencies>
+        </configuration>
+      </plugin>
+
+      <!--      NEED to open java.base for FFI -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- required to access the raw file descriptor from FileDescriptor -->
+          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <!-- required to access the raw file descriptor from FileDescriptor -->
+          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
@@ -56,4 +56,9 @@ final class PosixSegmentAllocator implements SegmentAllocator {
     }
     return fallback;
   }
+
+  @Override
+  public String toString() {
+    return "PosixSegmentAllocator{fallback=" + fallback + "}";
+  }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.fs.PosixFs;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class PosixSegmentAllocator implements SegmentAllocator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PosixSegmentAllocator.class);
+  private final PosixFs posixFs;
+  private final SegmentAllocator fallback;
+
+  PosixSegmentAllocator(final PosixFs posixFs, final SegmentAllocator fallback) {
+    this.posixFs = posixFs;
+    this.fallback = fallback;
+  }
+
+  PosixSegmentAllocator(final SegmentAllocator fallback) {
+    this(new PosixFs(), fallback);
+  }
+
+  @Override
+  public void allocate(
+      final FileChannel channel, final FileDescriptor fileDescriptor, final long segmentSize)
+      throws IOException {
+    if (!posixFs.isPosixFallocateEnabled()) {
+      fallback.allocate(channel, fileDescriptor, segmentSize);
+      return;
+    }
+
+    try {
+      posixFs.posixFallocate(fileDescriptor, 0, segmentSize);
+    } catch (final UnsupportedOperationException e) {
+      LOGGER.warn(
+          "Failed to use native system call to pre-allocate file, will use fallback from now on {}",
+          fallback,
+          e);
+      posixFs.disablePosixFallocate();
+      fallback.allocate(channel, fileDescriptor, segmentSize);
+    }
+  }
+}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -12,7 +12,9 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import org.agrona.IoUtil;
 
-/** Defines the strategy when it comes to pre-allocating segment files. */
+/**
+ * Defines the strategy when it comes to pre-allocating segment files.
+ */
 @FunctionalInterface
 public interface SegmentAllocator {
 
@@ -29,6 +31,9 @@ public interface SegmentAllocator {
   void allocate(FileChannel channel, FileDescriptor fileDescriptor, final long segmentSize)
       throws IOException;
 
+  /**
+   * Returns the default allocator
+   */
   static SegmentAllocator defaultAllocator() {
     return posixOrFill();
   }
@@ -45,17 +50,22 @@ public interface SegmentAllocator {
 
   /**
    * Returns an allocator which will try to use the POSIX system call {@code posix_fallocate}, and
-   * fallback to {@link #fill()} if it isn't available.
+   * fallback to {@param fallback} if it isn't available.
    */
   static SegmentAllocator posix(final SegmentAllocator fallback) {
     return new PosixSegmentAllocator(fallback);
   }
 
+
+  /**
+   * Returns an allocator which will try to use the POSIX system call {@code posix_fallocate}, and
+   * fallback to {@link #fill()} if it isn't available.
+   */
   static SegmentAllocator posixOrFill() {
     return new PosixSegmentAllocator(Defaults.FILL);
   }
 
-  class Defaults {
+  private class Defaults {
     private static final SegmentAllocator NOOP = (c, fd, s) -> {};
     private static final SegmentAllocator FILL =
         (channel, fd, size) -> IoUtil.fill(channel, 0, size, (byte) 0);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -14,7 +14,7 @@ import org.agrona.IoUtil;
 
 /** Defines the strategy when it comes to pre-allocating segment files. */
 @FunctionalInterface
-interface SegmentAllocator {
+public interface SegmentAllocator {
 
   /**
    * Pre-allocates {@code segmentSize} disk space for file corresponding to the given descriptor and
@@ -30,17 +30,17 @@ interface SegmentAllocator {
       throws IOException;
 
   static SegmentAllocator defaultAllocator() {
-    return posix();
+    return Defaults.POSIX_FILL;
   }
 
   /** Returns an allocator which does nothing, i.e. does not allocate disk space. */
   static SegmentAllocator noop() {
-    return (c, fd, s) -> {};
+    return Defaults.NOOP;
   }
 
   /** Returns an allocator which fills the file by writing chunks of zeros to disk. */
   static SegmentAllocator fill() {
-    return (channel, fd, size) -> IoUtil.fill(channel, 0, size, (byte) 0);
+    return Defaults.FILL;
   }
 
   /**
@@ -52,6 +52,13 @@ interface SegmentAllocator {
   }
 
   static SegmentAllocator posix() {
-    return new PosixSegmentAllocator(noop());
+    return Defaults.POSIX_FILL;
+  }
+
+  class Defaults {
+    private static final SegmentAllocator NOOP = (c, fd, s) -> {};
+    private static final SegmentAllocator FILL =
+        (channel, fd, size) -> IoUtil.fill(channel, 0, size, (byte) 0);
+    private static final SegmentAllocator POSIX_FILL = new PosixSegmentAllocator(FILL);
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -30,7 +30,7 @@ public interface SegmentAllocator {
       throws IOException;
 
   static SegmentAllocator defaultAllocator() {
-    return Defaults.POSIX_FILL;
+    return posixOrFill();
   }
 
   /** Returns an allocator which does nothing, i.e. does not allocate disk space. */
@@ -51,14 +51,13 @@ public interface SegmentAllocator {
     return new PosixSegmentAllocator(fallback);
   }
 
-  static SegmentAllocator posix() {
-    return Defaults.POSIX_FILL;
+  static SegmentAllocator posixOrFill() {
+    return new PosixSegmentAllocator(Defaults.FILL);
   }
 
   class Defaults {
     private static final SegmentAllocator NOOP = (c, fd, s) -> {};
     private static final SegmentAllocator FILL =
         (channel, fd, size) -> IoUtil.fill(channel, 0, size, (byte) 0);
-    private static final SegmentAllocator POSIX_FILL = new PosixSegmentAllocator(FILL);
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import java.io.FileDescriptor;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import org.agrona.IoUtil;
@@ -20,19 +21,37 @@ interface SegmentAllocator {
    * channel.
    *
    * @param channel an open channel to the file to pre-allocate
+   * @param fileDescriptor the file descriptor of the opened file
    * @param segmentSize the desired size of the segment on disk, in bytes
    * @throws IOException if any error occur during pre-allocation; if this is thrown, no guarantees
    *     are made about the state of the file on disk, and no resources are closed
    */
-  void allocate(FileChannel channel, final long segmentSize) throws IOException;
+  void allocate(FileChannel channel, FileDescriptor fileDescriptor, final long segmentSize)
+      throws IOException;
+
+  static SegmentAllocator defaultAllocator() {
+    return posix();
+  }
 
   /** Returns an allocator which does nothing, i.e. does not allocate disk space. */
   static SegmentAllocator noop() {
-    return (c, s) -> {};
+    return (c, fd, s) -> {};
   }
 
   /** Returns an allocator which fills the file by writing chunks of zeros to disk. */
   static SegmentAllocator fill() {
-    return (channel, size) -> IoUtil.fill(channel, 0, size, (byte) 0);
+    return (channel, fd, size) -> IoUtil.fill(channel, 0, size, (byte) 0);
+  }
+
+  /**
+   * Returns an allocator which will try to use the POSIX system call {@code posix_fallocate}, and
+   * fallback to {@link #fill()} if it isn't available.
+   */
+  static SegmentAllocator posix(final SegmentAllocator fallback) {
+    return new PosixSegmentAllocator(fallback);
+  }
+
+  static SegmentAllocator posix() {
+    return new PosixSegmentAllocator(noop());
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -35,10 +35,6 @@ final class SegmentLoader {
   private final long minFreeDiskSpace;
   private final JournalMetrics metrics;
 
-  SegmentLoader(final int minFreeDiskSpace, final JournalMetrics metrics) {
-    this(minFreeDiskSpace, metrics, SegmentAllocator.fill());
-  }
-
   SegmentLoader(
       final long minFreeDiskSpace, final JournalMetrics metrics, final SegmentAllocator allocator) {
     this.minFreeDiskSpace = minFreeDiskSpace;

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.journal.file;
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.util.FileUtil;
+import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
@@ -199,14 +201,8 @@ final class SegmentLoader {
 
     checkDiskSpace(segmentPath, maxSegmentSize);
 
-    try (final var channel =
-        FileChannel.open(
-            segmentPath,
-            StandardOpenOption.READ,
-            StandardOpenOption.WRITE,
-            StandardOpenOption.CREATE_NEW)) {
-      allocateSegment(maxSegmentSize, channel);
-      return mapSegment(channel, maxSegmentSize);
+    try {
+      Files.createFile(segmentPath);
     } catch (final FileAlreadyExistsException e) {
       LOGGER.warn(
           "Failed to create segment {}: an unused file already existed, and will be replaced",
@@ -214,6 +210,13 @@ final class SegmentLoader {
           e);
       Files.delete(segmentPath);
       return mapNewSegment(segmentPath, descriptor);
+    }
+
+    try (final var raf = new RandomAccessFile(segmentPath.toFile(), "rw");
+        final var channel = raf.getChannel(); ) {
+      allocateSegment(maxSegmentSize, channel, raf.getFD());
+      raf.setLength(maxSegmentSize);
+      return mapSegment(channel, maxSegmentSize);
     }
   }
 
@@ -227,10 +230,11 @@ final class SegmentLoader {
     }
   }
 
-  private void allocateSegment(final int maxSegmentSize, final FileChannel channel)
+  private void allocateSegment(
+      final int maxSegmentSize, final FileChannel channel, final FileDescriptor fileDescriptor)
       throws IOException {
     try (final var ignored = metrics.observeSegmentAllocation()) {
-      allocator.allocate(channel, maxSegmentSize);
+      allocator.allocate(channel, fileDescriptor, maxSegmentSize);
     }
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -170,7 +170,7 @@ public class SegmentedJournalBuilder {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     final var journalMetrics = new JournalMetrics(meterRegistry);
     final var segmentAllocator =
-        preallocateSegmentFiles ? SegmentAllocator.fill() : SegmentAllocator.noop();
+        preallocateSegmentFiles ? SegmentAllocator.defaultAllocator() : SegmentAllocator.noop();
     final var segmentLoader = new SegmentLoader(freeDiskSpace, journalMetrics, segmentAllocator);
     final var segmentsManager =
         new SegmentsManager(

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -43,11 +43,11 @@ public class SegmentedJournalBuilder {
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
-  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
   private int partitionId = DEFAULT_PARTITION_ID;
 
   private JournalMetaStore journalMetaStore;
   private final MeterRegistry meterRegistry;
+  private SegmentAllocator segmentAllocator = SegmentAllocator.defaultAllocator();
 
   SegmentedJournalBuilder(final MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
@@ -136,12 +136,11 @@ public class SegmentedJournalBuilder {
    * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
    * before any writes happen.
    *
-   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @param segmentAllocator to use to preallocate files
    * @return this builder for chaining
    */
-  public SegmentedJournalBuilder withPreallocateSegmentFiles(
-      final boolean preallocateSegmentFiles) {
-    this.preallocateSegmentFiles = preallocateSegmentFiles;
+  public SegmentedJournalBuilder withSegmentAllocator(final SegmentAllocator segmentAllocator) {
+    this.segmentAllocator = segmentAllocator;
     return this;
   }
 
@@ -169,8 +168,6 @@ public class SegmentedJournalBuilder {
   public SegmentedJournal build() {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     final var journalMetrics = new JournalMetrics(meterRegistry);
-    final var segmentAllocator =
-        preallocateSegmentFiles ? SegmentAllocator.defaultAllocator() : SegmentAllocator.noop();
     final var segmentLoader = new SegmentLoader(freeDiskSpace, journalMetrics, segmentAllocator);
     final var segmentsManager =
         new SegmentsManager(

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.fs;
+
+import io.camunda.zeebe.util.Loggers;
+import java.util.Map;
+import jnr.ffi.LibraryLoader;
+import jnr.ffi.LibraryOption;
+import jnr.ffi.Platform;
+import jnr.ffi.annotations.In;
+import jnr.ffi.types.off_t;
+
+/**
+ * Used to bind certain calls from libc to Java methods via JNA.
+ *
+ * <p>Note that method names do not follow our conventions, but this is necessary here because the
+ * names must match those of the C library.
+ *
+ * <p>See {@link #ofNativeLibrary()} for an example of how to use this.
+ */
+@SuppressWarnings({"checkstyle:methodname", "java:S100"})
+public interface LibC {
+  int posix_fallocate(final @In int fd, final @In @off_t long offset, final @In @off_t long len);
+
+  /**
+   * Returns an instance of LibC bound to the system's C library (e.g. glibc, musl, etc.).
+   *
+   * <p>If it fails to bind to the C library, it will return a {@link InvalidLibC} instance which
+   * throws {@link UnsupportedOperationException} on every call.
+   *
+   * @return an instance of this library
+   */
+  static LibC ofNativeLibrary() {
+    try {
+      return LibraryLoader.loadLibrary(
+          LibC.class,
+          Map.of(LibraryOption.LoadNow, true),
+          Platform.getNativePlatform().getStandardCLibraryName());
+    } catch (final UnsatisfiedLinkError e) {
+      Loggers.FILE_LOGGER.warn(
+          "Failed to load C library; any native calls will not be available", e);
+      return new InvalidLibC();
+    }
+  }
+
+  /**
+   * Dummy implementation which throws {@link UnsupportedOperationException} on every call.
+   * Explicitly left non-final so test classes can extend it and overload only these methods they
+   * care about.
+   */
+  class InvalidLibC implements LibC {
+
+    @Override
+    public int posix_fallocate(final int fd, final long offset, final long len) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal.fs;
+
+import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import jnr.constants.platform.Errno;
+import jnr.ffi.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A helper class to deal with native Unix file system calls, e.g. posix_fallocate. As of now its
+ * goal is just to cover Unix platforms (e.g. Linux, macOS). If this diverges, do refactor or split
+ * this class.
+ */
+public final class PosixFs {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PosixFs.class);
+  private static final VarHandle FILE_DESCRIPTOR_FD_FIELD;
+
+  static {
+    VarHandle fileDescriptorFd;
+    try {
+      fileDescriptorFd =
+          MethodHandles.privateLookupIn(FileDescriptor.class, MethodHandles.lookup())
+              .findVarHandle(FileDescriptor.class, "fd", int.class);
+    } catch (final NoSuchFieldException | IllegalAccessException e) {
+      LOGGER.warn("Cannot look up file descriptor via reflection; NativeFS will be disabled", e);
+      fileDescriptorFd = null;
+    }
+
+    FILE_DESCRIPTOR_FD_FIELD = fileDescriptorFd;
+  }
+
+  // by default, we assume non-Windows platforms support posix_fallocate. some may not, and some
+  // file systems may not, and normally C libraries will emulate the behavior, but some (e.g. musl)
+  // may return EOPNOTSUPP, in which case we want to set this flag to false.
+  //
+  // note that this flag assumes there is only one underlying filesystem for the whole application
+  private volatile boolean supportsPosixFallocate =
+      FILE_DESCRIPTOR_FD_FIELD != null && Platform.getNativePlatform().isUnix();
+
+  private final LibC libC;
+
+  public PosixFs() {
+    this(LibC.ofNativeLibrary());
+  }
+
+  public PosixFs(final LibC libC) {
+    this.libC = libC;
+  }
+
+  /**
+   * Returns whether calls to {@link #posixFallocate(FileDescriptor, long, long)} are supported or
+   * not. If this returns false, then a call to {@link #posixFallocate(FileDescriptor, long, long)}
+   * will throw an {@link UnsupportedOperationException}.
+   *
+   * @return true if supported, false otherwise
+   */
+  public boolean isPosixFallocateEnabled() {
+    return supportsPosixFallocate;
+  }
+
+  /**
+   * Disables usage of {@link #posixFallocate(FileDescriptor, long, long)}. After calling this,
+   * {@link #isPosixFallocateEnabled()} will return false.
+   */
+  public void disablePosixFallocate() {
+    LOGGER.debug("Disabling usage of posix_fallocate optimization");
+    supportsPosixFallocate = false;
+  }
+
+  /**
+   * Calls posix_fallocate system call, delegating the allocation of the blocks to the C library.
+   *
+   * <p>For glibc, this means it will delegate the call to the file system. If it supports it (e.g.
+   * ext4), this is much more performant than writing a file, as the blocks are reserved for the
+   * file, but no I/O operations take place (other than updating the file's metadata). Not only
+   * this, but the blocks reserved are in most cases contiguous, making for less disk fragmentation.
+   *
+   * <p>When the file system does not support the call, then the library will emulate it by actually
+   * zero-ing the file. In some cases (e.g. musl), the library will do no emulation, and instead we
+   * will throw an {@link UnsupportedOperationException} and set {@link #isPosixFallocateEnabled()}
+   * to false.
+   *
+   * <p><a href="https://man7.org/linux/man-pages/man3/posix_fallocate.3.html">See the man pages for
+   * posix_fallocate</a>
+   *
+   * @param descriptor the file descriptor of the file we want to grow
+   * @param offset the offset at which we want to start growing the file
+   * @param length the length, in bytes, of the region to grow
+   * @throws IllegalArgumentException if offset or length is negative
+   * @throws InterruptedIOException if an interrupt occurs while it was allocating the file, meaning
+   *     it may not have been fully allocated
+   * @throws UnsupportedOperationException if the underlying file system does not support this or if
+   *     this function is disabled via {@link #disablePosixFallocate()}
+   * @throws OutOfDiskSpace if there is not enough disk space to allocate the file
+   * @throws IOException if the file descriptor is invalid (e.g. not opened for writing, not
+   *     pointing to a regular file, etc.)
+   */
+  public void posixFallocate(final FileDescriptor descriptor, final long offset, final long length)
+      throws IOException {
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot allocate file with a negative offset of [%d]", offset));
+    }
+
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot allocate file with a negative length of [%d]", length));
+    }
+
+    if (!isPosixFallocateEnabled()) {
+      throw new UnsupportedOperationException(
+          "Failed to pre-allocate file natively: posix_fallocate is disabled");
+    }
+
+    final int fd = (int) FILE_DESCRIPTOR_FD_FIELD.get(descriptor);
+    final int result = libC.posix_fallocate(fd, offset, length);
+    final Errno error = Errno.valueOf(result);
+
+    // success
+    if (result == 0) {
+      return;
+    }
+
+    throwExceptionFromErrno(offset, length, error);
+  }
+
+  private void throwExceptionFromErrno(final long offset, final long length, final Errno error)
+      throws IOException {
+    switch (error) {
+      case EBADF ->
+          throw new IOException(
+              "Failed to pre-allocate file: it doesn't have a valid file descriptor, or it's not "
+                  + "opened for writing");
+      case EFBIG ->
+          throw new IOException(
+              String.format(
+                  "Failed to pre-allocate file: it's length [%d] would exceed the system's maximum "
+                      + "file length",
+                  offset + length));
+      case EINTR ->
+          throw new InterruptedIOException("Failed to pre-allocate file interrupted during call");
+      case ENODEV, ESPIPE ->
+          throw new IOException(
+              "Failed to pre-allocate file: the descriptor does not point to a regular file");
+      case ENOSPC ->
+          throw new OutOfDiskSpace("Failed to pre-allocate file: there is not enough space");
+      default -> {
+        throw new UnsupportedOperationException(
+            "Failed to pre-allocate file: the underlying filesystem does not support this operation");
+      }
+    }
+  }
+}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
@@ -158,7 +158,8 @@ public final class PosixFs {
           throw new OutOfDiskSpace("Failed to pre-allocate file: there is not enough space");
       default -> {
         throw new UnsupportedOperationException(
-            "Failed to pre-allocate file: the underlying filesystem does not support this operation");
+            "Failed to pre-allocate file: the underlying filesystem does not support this operation: errorCode="
+                + error);
       }
     }
   }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/PosixSegmentAllocatorTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/PosixSegmentAllocatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.journal.fs.LibC;
+import io.camunda.zeebe.journal.fs.PosixFs;
+import io.camunda.zeebe.journal.util.PosixPathAssert;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class PosixSegmentAllocatorTest {
+  @Test
+  void shouldUseFallbackWhenPosixNotSupported(final @TempDir Path tmpDir) throws IOException {
+    // given
+    final var posixFs = new PosixFs(new LibC.InvalidLibC());
+    final var fallback = SegmentAllocator.fill();
+    final var allocator = new PosixSegmentAllocator(posixFs, fallback);
+    final var segmentFile = tmpDir.resolve("file");
+    final var size = 1024 * 1024;
+
+    // when
+    try (final var file = new RandomAccessFile(segmentFile.toFile(), "rw")) {
+      allocator.allocate(file.getChannel(), file.getFD(), size);
+    }
+
+    // then
+    PosixPathAssert.assertThat(segmentFile).hasRealSize(size);
+    assertThat(posixFs.isPosixFallocateEnabled()).as("has disabled posixFallocate").isFalse();
+  }
+
+  @Test
+  void shouldPreallocateFile(final @TempDir Path tmpDir) throws IOException {
+    // given
+    final var allocator =
+        new PosixSegmentAllocator(
+            ((a, b, c) -> {
+              throw new IllegalStateException("Cannot ");
+            }));
+    final var segmentFile = tmpDir.resolve("file");
+    final var size = 1024 * 1024;
+
+    // when
+    try (final var file = new RandomAccessFile(segmentFile.toFile(), "rw")) {
+      allocator.allocate(file.getChannel(), file.getFD(), size);
+    }
+
+    // then
+    PosixPathAssert.assertThat(segmentFile).hasRealSize(size);
+  }
+}

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -31,7 +31,11 @@ final class SegmentLoaderTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var descriptor =
         SegmentDescriptor.builder().withId(1).withIndex(1).withMaxSegmentSize(segmentSize).build();
-    final var segmentLoader = new SegmentLoader(segmentSize * 2, new JournalMetrics(meterRegistry));
+    final var segmentLoader =
+        new SegmentLoader(
+            segmentSize * 2,
+            new JournalMetrics(meterRegistry),
+            SegmentAllocator.defaultAllocator());
     final var segmentFile = tmpDir.resolve("segment.log");
 
     // when - "unused" segment can happen if we crashed in the middle of creating the new segment

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -694,7 +694,7 @@ class SegmentedJournalTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var builder =
         SegmentedJournal.builder(meterRegistry)
-            .withPreallocateSegmentFiles(true)
+            .withSegmentAllocator(SegmentAllocator.defaultAllocator())
             .withMaxSegmentSize(segmentSize)
             .withDirectory(tmpDir.toFile())
             .withMetaStore(new MockJournalMetastore());
@@ -717,7 +717,7 @@ class SegmentedJournalTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var builder =
         SegmentedJournal.builder(meterRegistry)
-            .withPreallocateSegmentFiles(false)
+            .withSegmentAllocator(SegmentAllocator.noop())
             .withMaxSegmentSize(segmentSize)
             .withDirectory(tmpDir.toFile())
             .withMetaStore(new MockJournalMetastore());

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -968,11 +968,11 @@ class SegmentedJournalTest {
    */
   private SegmentAllocator createFailingSegmentAllocator(final int failAtSegmentCount) {
     final AtomicInteger segmentCount = new AtomicInteger(0);
-    return (channel, segmentSize) -> {
+    return (channel, fd, segmentSize) -> {
       if (segmentCount.incrementAndGet() >= failAtSegmentCount) {
         throw new OutOfDiskSpace("Nope, no free space.");
       } else {
-        SegmentAllocator.fill().allocate(channel, segmentSize);
+        SegmentAllocator.posix(SegmentAllocator.noop()).allocate(channel, fd, segmentSize);
       }
     };
   }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -44,7 +44,8 @@ final class SegmentedJournalWriterTest {
   private final SegmentDescriptorSerializer descriptorSerializer =
       new SegmentDescriptorSerializerSbe();
 
-  private void fillWithOnes(final FileChannel channel, final long size) {
+  private void fillWithOnes(
+      final FileChannel channel, final java.io.FileDescriptor fileDescriptor, final long size) {
     // Fill with ones to verify in tests that the append invalidates next entry by overwriting with
     // 0
     IoUtil.fill(channel, 0, size, (byte) 0xff);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -240,8 +240,8 @@ class SegmentsManagerTest {
             new SegmentLoader(
                 Long.MIN_VALUE,
                 journalFactory.metrics(),
-                (channel, segmentSize) -> {
-                  SegmentAllocator.fill().allocate(channel, segmentSize);
+                (channel, fd, segmentSize) -> {
+                  SegmentAllocator.posix().allocate(channel, fd, segmentSize);
                   throw expectedRootCause;
                 }))) {
       failingSegments.open();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -241,7 +241,7 @@ class SegmentsManagerTest {
                 Long.MIN_VALUE,
                 journalFactory.metrics(),
                 (channel, fd, segmentSize) -> {
-                  SegmentAllocator.posix().allocate(channel, fd, segmentSize);
+                  SegmentAllocator.posixOrFill().allocate(channel, fd, segmentSize);
                   throw expectedRootCause;
                 }))) {
       failingSegments.open();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -66,7 +66,7 @@ final class TestJournalFactory {
    * @param maxEntryCount the max number of entries per segment
    */
   TestJournalFactory(final String data, final int maxEntryCount) {
-    this(data, maxEntryCount, SegmentAllocator.noop());
+    this(data, maxEntryCount, SegmentAllocator.defaultAllocator());
   }
 
   TestJournalFactory(final String data, final int maxEntryCount, final SegmentAllocator allocator) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/PosixFsTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/PosixFsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal.fs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
+import io.camunda.zeebe.journal.fs.LibC.InvalidLibC;
+import io.camunda.zeebe.journal.util.PosixPathAssert;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import jnr.constants.platform.Errno;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not provide any LibC")
+@Execution(ExecutionMode.CONCURRENT)
+final class PosixFsTest {
+  private @TempDir Path tmpDir;
+
+  // while a fairly simple test, it's important that this does not break
+  @Test
+  void shouldDisablePosixFallocate() {
+    // given
+    final var posixFs = new PosixFs();
+    posixFs.disablePosixFallocate();
+
+    // then
+    assertThat(posixFs.isPosixFallocateEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldPreallocateFile() throws IOException {
+    // given
+    final var posixFs = new PosixFs();
+    final var path = tmpDir.resolve("file");
+    final var length = 1024 * 1024;
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      posixFs.posixFallocate(file.getFD(), 0, length);
+    }
+
+    // then
+    PosixPathAssert.assertThat(path).hasRealSize(length);
+  }
+
+  @Test
+  void shouldFailWithNegativeOffset() throws IOException {
+    // given
+    final var posixFs = new PosixFs();
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> posixFs.posixFallocate(file.getFD(), -10, 100))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  void shouldFailWithNegativeLength() throws IOException {
+    // given
+    final var posixFs = new PosixFs(LibC.ofNativeLibrary());
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> posixFs.posixFallocate(file.getFD(), 0, -100))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @ParameterizedTest(name = "{0} => {1}")
+  @MethodSource("provideErrorPairs")
+  void shouldMapErrNoToException(final Errno errno, final Class<? extends Exception> exception)
+      throws IOException {
+    // given
+    final var posixFs = new PosixFs(new FailingPosixFallocate(errno));
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> posixFs.posixFallocate(file.getFD(), 0, 1024 * 1024))
+          .isInstanceOf(exception);
+    }
+  }
+
+  private static Stream<Arguments> provideErrorPairs() {
+    return Stream.of(
+        Arguments.of(Errno.EBADF, IOException.class),
+        Arguments.of(Errno.EFBIG, IOException.class),
+        Arguments.of(Errno.EINTR, InterruptedIOException.class),
+        Arguments.of(Errno.EINVAL, UnsupportedOperationException.class),
+        Arguments.of(Errno.ENODEV, IOException.class),
+        Arguments.of(Errno.ESPIPE, IOException.class),
+        Arguments.of(Errno.ENOSPC, OutOfDiskSpace.class));
+  }
+
+  private static final class FailingPosixFallocate extends InvalidLibC {
+    private final Errno errno;
+
+    private FailingPosixFallocate(final Errno errno) {
+      this.errno = errno;
+    }
+
+    @Override
+    public int posix_fallocate(final int fd, final long offset, final long len) {
+      return errno.intValue();
+    }
+  }
+}


### PR DESCRIPTION
## Description
Almost all the code is taken from PR #9816 that tried this approach around 3 years ago.
I temporarily set the posix allocator as the default, mostly for testing.
The advantage of the posix allocator is that the write throughput is halved, since we don't fill it with 0 when allocating it. This has benefits as tail latencies for other disk operations are much smaller due to queueing effects, especially on disk attached to the network.

The downside is that each write is slightly slower, due to having to zero the disk sector first.
<!-- Describe the goal and purpose of this PR. -->

I added some allocation strategies so that a fallback can be configured as well:
- `POSIX`: if `fallocated` cannot be used it fails
- `POSIX_OR_NOOP`: if `fallocate` cannot be used it uses `NOOP`
- `POSIX_OR_FILL`: if `fallocate` cannot be used it uses `FILL`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
- [x] Remove fallocate default before merging


## Related issues

closes #42761 
