### PR TITLE
[Backport stable/8.6] fix: renew OIDC access token when refresh token is not JWT in tasklist

### DIFF
--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -186,6 +186,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/SecurityTestUtil.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/SecurityTestUtil.java
@@ -15,7 +15,9 @@ import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.util.Date;
@@ -85,5 +87,13 @@ public class SecurityTestUtil {
         .issuer("http://localhost")
         .expirationTime(new Date(new Date().getTime() + 60 * 1000))
         .build();
+  }
+
+  public static RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthenticationTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthenticationTest.java
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -88,9 +87,6 @@ class IdentityAuthenticationTest {
   public void authenticationShouldReturnTrueWhenAccessTokenExpiredButRefreshTokenValid() {
     // given
     identityAuthentication.setAuthenticated(true);
-
-    ReflectionTestUtils.setField(
-        identityAuthentication, "refreshTokenExpiresAt", new Date(futureTime));
 
     final List<String> permissionsList =
         Arrays.asList(


### PR DESCRIPTION
# Description
Backport of #42676 to `stable/8.6`.

relates to #39080