### PR TITLE
fix: validate schema field differences when mapping should not be dynamic

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -114,6 +114,8 @@ public class OperateProperties {
   @NestedConfigurationProperty
   private MultiTenancyProperties multiTenancy = new MultiTenancyProperties();
 
+  private boolean unsafeIgnoreSchemaFieldDifferencesForDynamicMappings;
+
   public boolean isImporterEnabled() {
     return importerEnabled;
   }
@@ -410,5 +412,15 @@ public class OperateProperties {
 
   public void setMaxIncidentSearchGroups(final int maxIncidentSearchGroups) {
     this.maxIncidentSearchGroups = maxIncidentSearchGroups;
+  }
+
+  public boolean isUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings() {
+    return unsafeIgnoreSchemaFieldDifferencesForDynamicMappings;
+  }
+
+  public void setUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings(
+      final boolean unsafeIgnoreSchemaFieldDifferencesForDynamicMappings) {
+    this.unsafeIgnoreSchemaFieldDifferencesForDynamicMappings =
+        unsafeIgnoreSchemaFieldDifferencesForDynamicMappings;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
@@ -125,6 +125,22 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
   }
 
   @Test
+  public void shouldValidateFieldDifferencesWhenIndexIsNotMeantToBeDynamic() {
+    // let ES create the index with default dynamic mapping
+    // all the fields will end up as type "text" with sub-field "keyword"
+    final Map<String, Object> document =
+        Map.of("propA", "test", "propB", "test", "propC", "testing 123");
+    clientTestHelper.createDocument(testIndex.getFullQualifiedName(), "1", document);
+
+    // the index is meant to be dynamic=strict and has some of those fields marked as "keyword" only
+    // which should force an exception
+    assertThatThrownBy(() -> validator.validateIndexMappings())
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining(
+            "Index name: testindex. Not supported index changes are introduced. Data migration is required. Changes found:");
+  }
+
+  @Test
   public void shouldIgnoreMissingIndexes() {
     // given an empty schema
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
@@ -126,11 +126,7 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
 
   @Test
   public void shouldValidateFieldDifferencesWhenIndexIsNotMeantToBeDynamic() {
-    // let ES create the index with default dynamic mapping
-    // all the fields will end up as type "text" with sub-field "keyword"
-    final Map<String, Object> document =
-        Map.of("propA", "test", "propB", "test", "propC", "testing 123");
-    clientTestHelper.createDocument(testIndex.getFullQualifiedName(), "1", document);
+    createTestIndexWithDefaultDynamicMapping();
 
     // the index is meant to be dynamic=strict and has some of those fields marked as "keyword" only
     // which should force an exception
@@ -138,6 +134,19 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
         .isInstanceOf(OperateRuntimeException.class)
         .hasMessageContaining(
             "Index name: testindex. Not supported index changes are introduced. Data migration is required. Changes found:");
+  }
+
+  @Test
+  public void shouldIgnoreFieldDifferencesWhenIndexAreDynamicIfFlagEnabled() {
+    validator.operateProperties.setUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings(true);
+
+    createTestIndexWithDefaultDynamicMapping();
+
+    // although there are differences, they should be ignored as we've flipped the flag
+    final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
+        validator.validateIndexMappings();
+
+    assertThat(indexDiff).isEmpty();
   }
 
   @Test
@@ -324,5 +333,13 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
 
     // then
     assertThat(indexDiff).isEmpty();
+  }
+
+  private void createTestIndexWithDefaultDynamicMapping() {
+    // let ES create the index with default dynamic mapping
+    // all the fields will end up as type "text" with sub-field "keyword"
+    final Map<String, Object> document =
+        Map.of("propA", "test", "propB", "test", "propC", "testing 123");
+    clientTestHelper.createDocument(testIndex.getFullQualifiedName(), "1", document);
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -259,7 +259,9 @@ public class SchemaStartupIT extends AbstractSchemaIT {
   void shouldStoreSchemaVersionWhenSchemaVersionMetadataIsMissing() throws MigrationException {
     // given
     schemaHelper.createIndex(
-        metadataIndex, metadataIndex.getIndexName(), metadataIndex.getSchemaClasspathFilename());
+        metadataIndex,
+        metadataIndex.getFullQualifiedName(),
+        metadataIndex.getSchemaClasspathFilename());
     assertThat(metadataStore.getSchemaVersion()).isNull();
 
     // when
@@ -276,7 +278,9 @@ public class SchemaStartupIT extends AbstractSchemaIT {
       final String schemaVersion, final boolean shouldUpdate) throws MigrationException {
     // given
     schemaHelper.createIndex(
-        metadataIndex, metadataIndex.getIndexName(), metadataIndex.getSchemaClasspathFilename());
+        metadataIndex,
+        metadataIndex.getFullQualifiedName(),
+        metadataIndex.getSchemaClasspathFilename());
     clientTestHelper.createDocument(
         metadataIndex.getFullQualifiedName(),
         SCHEMA_VERSION_METADATA_ID,

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
@@ -210,7 +210,6 @@ public class IndexSchemaValidator {
   private IndexMappingDifference getIndexMappingDifference(
       final IndexDescriptor indexDescriptor, final Map<String, IndexMapping> indexMappingsGroup) {
     final IndexMapping indexMappingMustBe = schemaManager.getExpectedIndexFields(indexDescriptor);
-
     IndexMappingDifference difference = null;
     // compare every index in group
     for (final Map.Entry<String, IndexMapping> singleIndexMapping : indexMappingsGroup.entrySet()) {
@@ -265,12 +264,13 @@ public class IndexSchemaValidator {
   private void validateFieldsDifferBetweenIndices(
       final IndexMappingDifference difference, final IndexDescriptor indexDescriptor) {
     if (indexIsDynamic(difference.getLeftIndexMapping())) {
-      LOGGER.debug(
+      LOGGER.warn(
           String.format(
               "Left index name: %s is dynamic, ignoring changes found: %s",
               indexDescriptor.getIndexName(), difference.getEntriesDiffering()));
-    } else if (indexIsDynamic(difference.getRightIndexMapping())) {
-      LOGGER.debug(
+    } else if (indexIsDynamic(difference.getRightIndexMapping())
+        && operateProperties.isUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings()) {
+      LOGGER.warn(
           String.format(
               "Right index name: %s is dynamic, ignoring changes found: %s",
               indexDescriptor.getIndexName(), difference.getEntriesDiffering()));

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
@@ -35,7 +35,7 @@ public class IndexSchemaValidator {
 
   @Autowired SchemaManager schemaManager;
 
-  @Autowired private OperateProperties operateProperties;
+  @Autowired OperateProperties operateProperties;
 
   private Set<String> getAllIndexNamesForIndex(final String index) {
     final String indexPattern = String.format("%s-%s*", getIndexPrefix(), index);


### PR DESCRIPTION
If we are not expecting an index's mapping to be dynamic, but it turns out to be then we should ensure we do validate the fields to ensure they are the correct type.

As ES/OS will auto-create indexes with dynamic mappings it would be quite a common thing for clients to accidentally have indexes setup this way.  This can lead to unusual bugs and potentially hard to diagnose bugs  e.g. if a field we expect to be "keyword" is actually "text" then term queries will behave in a very different way.

As it's quite likely we have self-managed clients with this happening I've added a flag to be able to turn this behaviour off (as a workaround).  i.e. you can set:

```
CAMUNDA_OPERATE_UNSAFEIGNORESCHEMAFIELDDIFFERENCESFORDYNAMICMAPPINGS=true
```

I've also updated the logging for when we are ignoring these changes to WARN as it's probably quite an important thing to be aware of when looking into client issues.

~This will need a similar fix on main/8.8 too, but the schema checking code has had some refactoring, so I'll do that manually instead of trying to backport via cherry-picking.~ _Looks like main/8.8 wasn't affect by the issue._

## Follow up

Need to document the setting and ensure clients are aware.  Any client who would be impacted by this would also have problems upgrading to 8.8 as that would suddenly enforce the schema validation.

## Related issues

closes #42869
