### PR TITLE
Sort batch operation responses by actor type or actor id

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.ACTOR_ID;
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.ACTOR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.ID;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.START_DATE;
@@ -23,6 +25,8 @@ public class BatchOperationFieldSortingTransformer implements FieldSortingTransf
       case "operationType" -> TYPE;
       case "startDate" -> START_DATE;
       case "endDate" -> END_DATE;
+      case "actorType" -> ACTOR_TYPE;
+      case "actorId" -> ACTOR_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformerTest.java
@@ -28,7 +28,9 @@ public class BatchOperationFieldSortingTransformerTest extends AbstractSortTrans
         new TestArguments("state", SortOrder.DESC, s -> s.state().desc()),
         new TestArguments("type", SortOrder.ASC, s -> s.operationType().asc()),
         new TestArguments("startDate", SortOrder.DESC, s -> s.startDate().desc()),
-        new TestArguments("endDate", SortOrder.ASC, s -> s.endDate().asc()));
+        new TestArguments("endDate", SortOrder.ASC, s -> s.endDate().asc()),
+        new TestArguments("actorType", SortOrder.DESC, s -> s.actorType().desc()),
+        new TestArguments("actorId", SortOrder.ASC, s -> s.actorId().asc()));
   }
 
   @ParameterizedTest

--- a/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
@@ -56,6 +56,11 @@ public record BatchOperationSort(List<FieldSorting> orderings) implements SortOp
       return this;
     }
 
+    public Builder actorType() {
+      currentOrdering = new FieldSorting("actorType", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
@@ -51,6 +51,11 @@ public record BatchOperationSort(List<FieldSorting> orderings) implements SortOp
       return this;
     }
 
+    public Builder actorId() {
+      currentOrdering = new FieldSorting("actorId", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
@@ -30,6 +30,8 @@ public class BatchOperationTemplate extends AbstractTemplateDescriptor implement
 
   // New fields for engine batch operations
   public static final String STATE = "state";
+  public static final String ACTOR_TYPE = "actorType";
+  public static final String ACTOR_ID = "actorId";
   public static final String OPERATIONS_FAILED_COUNT = "operationsFailedCount";
   public static final String OPERATIONS_COMPLETED_COUNT = "operationsCompletedCount";
   public static final String ERRORS = "errors";

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -243,6 +243,7 @@ components:
             - state
             - startDate
             - endDate
+            - actorId
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -243,6 +243,7 @@ components:
             - state
             - startDate
             - endDate
+            - actorType
             - actorId
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -290,6 +290,7 @@ public class SearchQuerySortRequestMapper {
         case OPERATION_TYPE -> builder.operationType();
         case START_DATE -> builder.startDate();
         case END_DATE -> builder.endDate();
+        case ACTOR_ID -> builder.actorId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -290,6 +290,7 @@ public class SearchQuerySortRequestMapper {
         case OPERATION_TYPE -> builder.operationType();
         case START_DATE -> builder.startDate();
         case END_DATE -> builder.endDate();
+        case ACTOR_TYPE -> builder.actorType();
         case ACTOR_ID -> builder.actorId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.BatchOperationSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
@@ -341,31 +342,37 @@ class BatchOperationControllerTest extends RestControllerTest {
         Arguments.of(
             "startDate",
             "ASC",
+            BatchOperationSort.of(s -> s.startDate().asc()),
             List.of(entityWithEarlyStart, entityWithLateStart),
             List.of("2025-03-18T10:57:43.000+01:00", "2025-03-18T10:57:45.000+01:00")),
         Arguments.of(
             "startDate",
             "DESC",
+            BatchOperationSort.of(s -> s.startDate().desc()),
             List.of(entityWithLateStart, entityWithEarlyStart),
             List.of("2025-03-18T10:57:45.000+01:00", "2025-03-18T10:57:43.000+01:00")),
         Arguments.of(
             "actorId",
             "ASC",
+            BatchOperationSort.of(s -> s.actorId().asc()),
             List.of(entityAragorn, entityFrodo),
             List.of("aragorn@fellowship", "frodo@fellowship")),
         Arguments.of(
             "actorId",
             "DESC",
+            BatchOperationSort.of(s -> s.actorId().desc()),
             List.of(entityFrodo, entityAragorn),
             List.of("frodo@fellowship", "aragorn@fellowship")),
         Arguments.of(
             "actorType",
             "ASC",
+            BatchOperationSort.of(s -> s.actorType().asc()),
             List.of(entityActorClient, entityActorUser),
             List.of("CLIENT", "USER")),
         Arguments.of(
             "actorType",
             "DESC",
+            BatchOperationSort.of(s -> s.actorType().desc()),
             List.of(entityActorUser, entityActorClient),
             List.of("USER", "CLIENT")));
   }
@@ -375,6 +382,7 @@ class BatchOperationControllerTest extends RestControllerTest {
   void shouldSearchBatchOperationsSorted(
       final String sortedByField,
       final String order,
+      final BatchOperationSort sort,
       final List<BatchOperationEntity> searchResultItems,
       final List<String> expectedOrder) {
     // given
@@ -390,7 +398,7 @@ class BatchOperationControllerTest extends RestControllerTest {
             new SearchQueryResult<>(
                 searchResultItems.size(), false, searchResultItems, null, null));
 
-    // when / then
+    // when
     webClient
         .post()
         .uri("/v2/batch-operations/search")
@@ -404,6 +412,9 @@ class BatchOperationControllerTest extends RestControllerTest {
         .isEqualTo(expectedOrder.get(0))
         .jsonPath("$.items[1].%s".formatted(sortedByField))
         .isEqualTo(expectedOrder.get(1));
+
+    // then
+    verify(batchOperationServices).search(new BatchOperationQuery.Builder().sort(sort).build());
   }
 
   private static BatchOperationEntity getBatchOperationEntity(final String batchOperationKey) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -332,6 +332,10 @@ class BatchOperationControllerTest extends RestControllerTest {
             "2", OffsetDateTime.parse("2025-03-18T10:57:45+01:00"));
     final var entityAragorn = getBatchOperationEntityWithActorId("3", "aragorn@fellowship");
     final var entityFrodo = getBatchOperationEntityWithActorId("4", "frodo@fellowship");
+    final var entityActorClient =
+        getBatchOperationEntityWithActorType("5", BatchOperationActorType.CLIENT);
+    final var entityActorUser =
+        getBatchOperationEntityWithActorType("6", BatchOperationActorType.USER);
 
     return Stream.of(
         Arguments.of(
@@ -353,7 +357,17 @@ class BatchOperationControllerTest extends RestControllerTest {
             "actorId",
             "DESC",
             List.of(entityFrodo, entityAragorn),
-            List.of("frodo@fellowship", "aragorn@fellowship")));
+            List.of("frodo@fellowship", "aragorn@fellowship")),
+        Arguments.of(
+            "actorType",
+            "ASC",
+            List.of(entityActorClient, entityActorUser),
+            List.of("CLIENT", "USER")),
+        Arguments.of(
+            "actorType",
+            "DESC",
+            List.of(entityActorUser, entityActorClient),
+            List.of("USER", "CLIENT")));
   }
 
   @ParameterizedTest
@@ -433,6 +447,22 @@ class BatchOperationControllerTest extends RestControllerTest {
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
         BatchOperationActorType.USER,
         actorId,
+        10,
+        0,
+        10,
+        emptyList());
+  }
+
+  private static BatchOperationEntity getBatchOperationEntityWithActorType(
+      final String batchOperationKey, final BatchOperationActorType actorType) {
+    return new BatchOperationEntity(
+        batchOperationKey,
+        BatchOperationState.COMPLETED,
+        BatchOperationType.CANCEL_PROCESS_INSTANCE,
+        OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
+        OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
+        actorType,
+        "frodo@fellowship",
         10,
         0,
         10,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -330,6 +330,8 @@ class BatchOperationControllerTest extends RestControllerTest {
     final var entityWithLateStart =
         getBatchOperationEntityWithStartDate(
             "2", OffsetDateTime.parse("2025-03-18T10:57:45+01:00"));
+    final var entityAragorn = getBatchOperationEntityWithActorId("3", "aragorn@fellowship");
+    final var entityFrodo = getBatchOperationEntityWithActorId("4", "frodo@fellowship");
 
     return Stream.of(
         Arguments.of(
@@ -341,7 +343,17 @@ class BatchOperationControllerTest extends RestControllerTest {
             "startDate",
             "DESC",
             List.of(entityWithLateStart, entityWithEarlyStart),
-            List.of("2025-03-18T10:57:45.000+01:00", "2025-03-18T10:57:43.000+01:00")));
+            List.of("2025-03-18T10:57:45.000+01:00", "2025-03-18T10:57:43.000+01:00")),
+        Arguments.of(
+            "actorId",
+            "ASC",
+            List.of(entityAragorn, entityFrodo),
+            List.of("aragorn@fellowship", "frodo@fellowship")),
+        Arguments.of(
+            "actorId",
+            "DESC",
+            List.of(entityFrodo, entityAragorn),
+            List.of("frodo@fellowship", "aragorn@fellowship")));
   }
 
   @ParameterizedTest
@@ -405,6 +417,22 @@ class BatchOperationControllerTest extends RestControllerTest {
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
         BatchOperationActorType.USER,
         "frodo@fellowship",
+        10,
+        0,
+        10,
+        emptyList());
+  }
+
+  private static BatchOperationEntity getBatchOperationEntityWithActorId(
+      final String batchOperationKey, final String actorId) {
+    return new BatchOperationEntity(
+        batchOperationKey,
+        BatchOperationState.COMPLETED,
+        BatchOperationType.CANCEL_PROCESS_INSTANCE,
+        OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
+        OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
+        BatchOperationActorType.USER,
+        actorId,
         10,
         0,
         10,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the ability to batch operation responses by `actorType` or `actorId`. Both ascending and descending order are supported.

Note that no special care is taken to deal with `null` values. But, we'll consider this in the IT that will be added with:
- https://github.com/camunda/camunda/issues/42070

## Related issues

closes #42068
