### PR TITLE
Add TTL to authorization cache

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration.engine;
 
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import java.time.Duration;
 
 public final class CachesCfg implements ConfigurationEntry {
   private int drgCacheCapacity = EngineConfiguration.DEFAULT_DRG_CACHE_CAPACITY;
@@ -17,6 +18,7 @@ public final class CachesCfg implements ConfigurationEntry {
   private int resourceCacheCapacity = EngineConfiguration.DEFAULT_PROCESS_CACHE_CAPACITY;
   private int authorizationsCacheCapacity =
       EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
+  private Duration authorizationsCacheTtl = EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_TTL;
 
   public int getDrgCacheCapacity() {
     return drgCacheCapacity;
@@ -58,6 +60,14 @@ public final class CachesCfg implements ConfigurationEntry {
     this.authorizationsCacheCapacity = authorizationsCacheCapacity;
   }
 
+  public Duration getAuthorizationsCacheTtl() {
+    return authorizationsCacheTtl;
+  }
+
+  public void setAuthorizationsCacheTtl(final Duration authorizationsCacheTtl) {
+    this.authorizationsCacheTtl = authorizationsCacheTtl;
+  }
+
   @Override
   public String toString() {
     return "CachesCfg{"
@@ -71,6 +81,8 @@ public final class CachesCfg implements ConfigurationEntry {
         + resourceCacheCapacity
         + ", authorizationsCacheCapacity="
         + authorizationsCacheCapacity
+        + ", authorizationsCacheTtl="
+        + authorizationsCacheTtl
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -138,6 +138,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setResourceCacheCapacity(caches.getResourceCacheCapacity())
         .setProcessCacheCapacity(caches.getProcessCacheCapacity())
         .setAuthorizationsCacheCapacity(caches.getAuthorizationsCacheCapacity())
+        .setAuthorizationsCacheTtl(caches.getAuthorizationsCacheTtl())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
         .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -24,6 +24,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_FORM_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_PROCESS_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY = 1000;
+  public static final Duration DEFAULT_AUTHORIZATIONS_CACHE_TTL = Duration.ofSeconds(30);
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
@@ -60,6 +61,7 @@ public final class EngineConfiguration {
   private int resourceCacheCapacity = DEFAULT_FORM_CACHE_CAPACITY;
   private int processCacheCapacity = DEFAULT_FORM_CACHE_CAPACITY;
   private int authorizationsCacheCapacity = DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
+  private Duration authorizationsCacheTtl = DEFAULT_AUTHORIZATIONS_CACHE_TTL;
 
   private Duration jobsTimeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
   private int jobsTimeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
@@ -154,6 +156,15 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setAuthorizationsCacheCapacity(final int authorizationsCacheCapacity) {
     this.authorizationsCacheCapacity = authorizationsCacheCapacity;
+    return this;
+  }
+
+  public Duration getAuthorizationsCacheTtl() {
+    return authorizationsCacheTtl;
+  }
+
+  public EngineConfiguration setAuthorizationsCacheTtl(final Duration authorizationsCacheTtl) {
+    this.authorizationsCacheTtl = authorizationsCacheTtl;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -86,6 +86,7 @@ public final class AuthorizationCheckBehavior {
 
     authorizationsCache =
         CacheBuilder.newBuilder()
+            .expireAfterAccess(config.getAuthorizationsCacheTtl())
             .maximumSize(config.getAuthorizationsCacheCapacity())
             .build(
                 new CacheLoader<>() {


### PR DESCRIPTION
## Description

- add TTL to authorization cache -- default set to `30s`
- wire authorization check cache into broker config
- test authorization check cache ttl addition
  - cache denial with low ttl (1ms)
  - cache expired
  - permissions provided
  - cache recomputed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38532
