### PR TITLE
Migrate child process instance migration to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -58,25 +58,28 @@ export class OperateOperationPanelPage {
   }
 
   getMigrationOperationEntry(successCount: number): Locator {
+    const operationText = successCount === 1 ? 'operation' : 'operations';
     return this.page
       .locator('[data-testid="operations-entry"]')
       .filter({hasText: 'Migrate'})
-      .filter({hasText: `${successCount} operations succeeded`});
+      .filter({hasText: `${successCount} ${operationText} succeeded`});
   }
 
   getRetryOperationEntry(successCount: number): Locator {
+    const retryText = successCount === 1 ? 'retry' : 'retries';
     return this.page
       .locator('[data-testid="operations-entry"]')
       .filter({hasText: 'Retry'})
-      .filter({hasText: `${successCount} retries succeeded`})
+      .filter({hasText: `${successCount} ${retryText} succeeded`})
       .first();
   }
 
   getCancelOperationEntry(successCount: number): Locator {
+    const operationText = successCount === 1 ? 'operation' : 'operations';
     return this.page
       .locator('[data-testid="operations-entry"]')
       .filter({hasText: 'Cancel'})
-      .filter({hasText: `${successCount} operations succeeded`});
+      .filter({hasText: `${successCount} ${operationText} succeeded`});
   }
 
   async clickOperationLink(operationEntry: Locator): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -59,16 +59,14 @@ export class OperateOperationPanelPage {
 
   getMigrationOperationEntry(successCount: number): Locator {
     const operationText = successCount === 1 ? 'operation' : 'operations';
-    return this.page
-      .locator('[data-testid="operations-entry"]')
+    return this.getAllOperationEntries()
       .filter({hasText: 'Migrate'})
       .filter({hasText: `${successCount} ${operationText} succeeded`});
   }
 
   getRetryOperationEntry(successCount: number): Locator {
     const retryText = successCount === 1 ? 'retry' : 'retries';
-    return this.page
-      .locator('[data-testid="operations-entry"]')
+    return this.getAllOperationEntries()
       .filter({hasText: 'Retry'})
       .filter({hasText: `${successCount} ${retryText} succeeded`})
       .first();
@@ -76,15 +74,14 @@ export class OperateOperationPanelPage {
 
   getCancelOperationEntry(successCount: number): Locator {
     const operationText = successCount === 1 ? 'operation' : 'operations';
-    return this.page
-      .locator('[data-testid="operations-entry"]')
+    return this.getAllOperationEntries()
       .filter({hasText: 'Cancel'})
       .filter({hasText: `${successCount} ${operationText} succeeded`});
   }
 
   async clickOperationLink(operationEntry: Locator): Promise<void> {
-    await operationEntry
-      .locator('[data-testid="operation-id"]')
-      .click({timeout: 30000});
+    await OperateOperationPanelPage.getOperationID(operationEntry).click({
+      timeout: 30000,
+    });
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -71,6 +71,7 @@ class OperateProcessInstancePage {
   readonly modalDialog: Locator;
   readonly noVariablesText: Locator;
   readonly variableCellByName: (name: string | RegExp) => Locator;
+  readonly viewAllChildProcessesLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -179,6 +180,9 @@ class OperateProcessInstancePage {
 
     this.variableCellByName = (name) =>
       this.variablesList.getByRole('cell', {name});
+    this.viewAllChildProcessesLink = this.instanceHeader.getByRole('link', {
+      name: 'View all',
+    });
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -590,6 +594,10 @@ class OperateProcessInstancePage {
     for (const elementId of elementIds) {
       await expect(this.getDiagramElement(elementId)).toBeVisible();
     }
+  }
+
+  async clickViewAllChildProcesses(): Promise<void> {
+    await this.viewAllChildProcessesLink.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -404,8 +404,9 @@ class OperateProcessesPage {
         }
       }
     }
+    const itemText = count === 1 ? 'item' : 'items';
     await expect(
-      this.page.getByText(`${count} items selected`).first(),
+      this.page.getByText(`${count} ${itemText} selected`).first(),
     ).toBeVisible();
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -45,17 +45,6 @@ class OperateProcessesPage {
   readonly continueButton: Locator;
   readonly processInstancesPanel: Locator;
   readonly migrateButton: Locator;
-  readonly operationsPanel: Locator;
-  readonly operationsList: Locator;
-  readonly latestOperationEntry: Locator;
-  readonly latestOperationLink: Locator;
-  readonly latestOperationMigrateHeading: Locator;
-  readonly latestOperationProgressBar: Locator;
-  readonly latestOperationEntryBeforeCompletion: Locator;
-  readonly operationSuccessMessage: Locator;
-  readonly collapsedOperationsPanel: Locator;
-  readonly expandOperationsButton: Locator;
-  readonly inProgressBar: Locator;
   readonly selectAllRowsCheckbox: Locator;
   readonly retryButton: Locator;
   readonly cancelButton: Locator;
@@ -67,7 +56,6 @@ class OperateProcessesPage {
     operation: string,
     resultCount?: number,
   ) => Locator;
-  getMigrationOperationEntry: (successCount: number) => Locator;
   getParentInstanceCell: (parentInstanceKey: string) => Locator;
   getVersionCells: (version: string) => Locator;
 
@@ -158,33 +146,6 @@ class OperateProcessesPage {
     this.migrateButton = this.processInstancesPanel.getByRole('button', {
       name: /^migrate$/i,
     });
-    this.operationsPanel = page.getByRole('region', {
-      name: 'Operations',
-    });
-    this.operationsList = page.getByTestId('operations-list');
-    this.latestOperationEntry = this.operationsList
-      .getByRole('listitem')
-      .first();
-    this.latestOperationEntryBeforeCompletion = this.operationsList
-      .getByRole('listitem')
-      .last();
-    this.latestOperationLink = page.getByTestId('operation-id').first();
-    this.latestOperationMigrateHeading = this.latestOperationEntry.getByRole(
-      'heading',
-      {name: 'Migrate'},
-    );
-    this.latestOperationProgressBar =
-      this.latestOperationEntry.getByRole('progressbar');
-    this.operationSuccessMessage = page
-      .getByText(/\d+ operations? succeeded/)
-      .first();
-    this.collapsedOperationsPanel = page.getByTestId('collapsed-panel');
-    this.expandOperationsButton = page.getByRole('button', {
-      name: 'Expand Operations',
-    });
-    this.inProgressBar = this.operationsList.locator(
-      '[role="progressbar"][aria-busy="true"]',
-    );
     this.selectAllRowsCheckbox = page.getByRole('columnheader', {
       name: 'Select all rows',
     });
@@ -208,11 +169,6 @@ class OperateProcessesPage {
         : new RegExp(`${operation}.*\\d+ results`);
       return page.locator('div').filter({hasText: pattern});
     };
-    this.getMigrationOperationEntry = (successCount: number) =>
-      page
-        .locator('[data-testid="operations-entry"]')
-        .filter({hasText: 'Migrate'})
-        .filter({hasText: `${successCount} operations succeeded`});
     this.getParentInstanceCell = (parentInstanceKey: string) =>
       this.dataList.getByRole('cell', {name: parentInstanceKey});
     this.getVersionCells = (version: string) =>
@@ -452,29 +408,6 @@ class OperateProcessesPage {
   async startMigration(): Promise<void> {
     await this.clickMigrateButton();
     await this.clickContinueButton();
-  }
-
-  async clickLatestOperationLink(): Promise<void> {
-    await this.latestOperationLink.click({timeout: 60000});
-  }
-
-  async expandOperationsPanel(): Promise<void> {
-    const isCollapsed = await this.collapsedOperationsPanel.isVisible();
-    if (isCollapsed) {
-      await this.expandOperationsButton.click();
-      await this.operationsList.waitFor({state: 'visible', timeout: 10000});
-    }
-  }
-
-  async waitForOperationToComplete(): Promise<void> {
-    try {
-      await expect(this.inProgressBar).toBeVisible({timeout: 5000});
-      await expect(this.inProgressBar).not.toBeVisible({timeout: 120000});
-    } catch {
-      console.log(
-        'Progress bar did not appear or disappeared too quickly - operation likely completed fast',
-      );
-    }
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -62,11 +62,14 @@ class OperateProcessesPage {
   readonly applyButton: Locator;
   readonly resultsCount: Locator;
   readonly scheduledOperationsIcons: Locator;
-  processInstanceLinkByKey: (processInstanceKey: string) => Locator;
+  getProcessInstanceLinkByKey: (processInstanceKey: string) => Locator;
   getOperationAndResultsContainer: (
     operation: string,
     resultCount?: number,
   ) => Locator;
+  getMigrationOperationEntry: (successCount: number) => Locator;
+  getParentInstanceCell: (parentInstanceKey: string) => Locator;
+  getVersionCells: (version: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -192,7 +195,7 @@ class OperateProcessesPage {
     this.scheduledOperationsIcons = page.getByTitle(
       /has scheduled operations/i,
     );
-    this.processInstanceLinkByKey = (processInstanceKey: string) =>
+    this.getProcessInstanceLinkByKey = (processInstanceKey: string) =>
       page.getByRole('link', {
         name: processInstanceKey,
       });
@@ -205,6 +208,15 @@ class OperateProcessesPage {
         : new RegExp(`${operation}.*\\d+ results`);
       return page.locator('div').filter({hasText: pattern});
     };
+    this.getMigrationOperationEntry = (successCount: number) =>
+      page
+        .locator('[data-testid="operations-entry"]')
+        .filter({hasText: 'Migrate'})
+        .filter({hasText: `${successCount} operations succeeded`});
+    this.getParentInstanceCell = (parentInstanceKey: string) =>
+      this.dataList.getByRole('cell', {name: parentInstanceKey});
+    this.getVersionCells = (version: string) =>
+      this.dataList.getByRole('cell', {name: version, exact: true});
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -446,10 +458,6 @@ class OperateProcessesPage {
     await this.latestOperationLink.click({timeout: 60000});
   }
 
-  getVersionCells(version: string): Locator {
-    return this.dataList.getByRole('cell', {name: version, exact: true});
-  }
-
   async expandOperationsPanel(): Promise<void> {
     const isCollapsed = await this.collapsedOperationsPanel.isVisible();
     if (isCollapsed) {
@@ -467,13 +475,6 @@ class OperateProcessesPage {
         'Progress bar did not appear or disappeared too quickly - operation likely completed fast',
       );
     }
-  }
-
-  getMigrationOperationEntry(successCount: number): Locator {
-    return this.page
-      .locator('[data-testid="operations-entry"]')
-      .filter({hasText: 'Migrate'})
-      .filter({hasText: `${successCount} operations succeeded`});
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityParentProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityParentProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="callActivityParentProcess" name="callActivityParentProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a3emhl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a3emhl" sourceRef="StartEvent_1" targetRef="Activity_13otele" />
+    <bpmn:callActivity id="Activity_13otele" name="Call Activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="childProcess" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a3emhl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j9hrgw</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1p0nsc7">
+      <bpmn:incoming>Flow_1j9hrgw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1j9hrgw" sourceRef="Activity_13otele" targetRef="Event_1p0nsc7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="callActivityParentProcess">
+      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j9hrgw_di" bpmnElement="Flow_1j9hrgw">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jff16t_di" bpmnElement="Activity_13otele">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p0nsc7_di" bpmnElement="Event_1p0nsc7">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/childProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/childProcess_v_1.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="childProcess" name="childProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0jj1k9v</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0jj1k9v" sourceRef="StartEvent_1" targetRef="Task" />
+    <bpmn:serviceTask id="Task" name="Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="Task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jj1k9v</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m49p31</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1shxuko" name="End">
+      <bpmn:incoming>Flow_0m49p31</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0m49p31" sourceRef="Task" targetRef="Event_1shxuko" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="childProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="122" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b6kzkt_di" bpmnElement="Task">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1shxuko_di" bpmnElement="Event_1shxuko">
+        <dc:Bounds x="432" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="122" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jj1k9v_di" bpmnElement="Flow_0jj1k9v">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m49p31_di" bpmnElement="Flow_0m49p31">
+        <di:waypoint x="370" y="97" />
+        <di:waypoint x="432" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/childProcess_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/childProcess_v_2.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="childProcess" name="childProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0jj1k9v</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0jj1k9v" sourceRef="StartEvent_1" targetRef="newTask" />
+    <bpmn:serviceTask id="newTask" name="New Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="newTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jj1k9v</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m49p31</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1shxuko" name="End">
+      <bpmn:incoming>Flow_0m49p31</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0m49p31" sourceRef="newTask" targetRef="Event_1shxuko" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="childProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="122" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b6kzkt_di" bpmnElement="newTask">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1shxuko_di" bpmnElement="Event_1shxuko">
+        <dc:Bounds x="432" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="122" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jj1k9v_di" bpmnElement="Flow_0jj1k9v">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m49p31_di" bpmnElement="Flow_0m49p31">
+        <di:waypoint x="370" y="97" />
+        <di:waypoint x="432" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+type ProcessDeployment = {
+  readonly bpmnProcessId: string;
+  readonly version: number;
+  readonly processDefinitionKey: string;
+};
+
+type TestProcesses = {
+  readonly parentProcess: ProcessDeployment;
+  readonly childProcessV1: ProcessDeployment;
+  readonly childProcessV2: ProcessDeployment;
+  readonly parentProcessInstanceKeys: string[];
+};
+
+let testProcesses: TestProcesses;
+
+test.beforeAll(async () => {
+  // Deploy parent and child process v1
+  await deploy([
+    './resources/callActivityParentProcess.bpmn',
+    './resources/childProcess_v_1.bpmn',
+  ]);
+
+  // We know the processes will be version 1 on first deployment
+  const parentProcess: ProcessDeployment = {
+    bpmnProcessId: 'callActivityParentProcess',
+    version: 1,
+    processDefinitionKey: '', // Will be retrieved from API if needed
+  };
+
+  const childProcessV1: ProcessDeployment = {
+    bpmnProcessId: 'childProcess',
+    version: 1,
+    processDefinitionKey: '',
+  };
+
+  // Create 2 instances of parent process
+  const parentInstances = await createInstances(
+    parentProcess.bpmnProcessId,
+    parentProcess.version,
+    2,
+  );
+
+  const parentProcessInstanceKeys = parentInstances.map(
+    (instance) => instance.processInstanceKey,
+  );
+
+  // Deploy child process v2
+  await deploy(['./resources/childProcess_v_2.bpmn']);
+
+  const childProcessV2: ProcessDeployment = {
+    bpmnProcessId: 'childProcess',
+    version: 2,
+    processDefinitionKey: '',
+  };
+
+  testProcesses = {
+    parentProcess,
+    childProcessV1,
+    childProcessV2,
+    parentProcessInstanceKeys,
+  };
+
+  // Wait for instances to be indexed in Operate
+  await sleep(2000);
+});
+
+test.describe.serial('Child Process Instance Migration', () => {
+  test.describe.configure({retries: 0});
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Migrate Child Process Instances', async ({
+    page,
+    operateFiltersPanelPage,
+    operateProcessesPage,
+    operateProcessInstancePage,
+    operateProcessMigrationModePage,
+    operateOperationPanelPage,
+  }) => {
+    test.slow();
+
+    const {
+      parentProcess,
+      childProcessV1,
+      childProcessV2,
+      parentProcessInstanceKeys,
+    } = testProcesses;
+    const parentInstanceKey = parentProcessInstanceKeys[0]!;
+
+    await test.step('Filter by parent process and version', async () => {
+      await operateFiltersPanelPage.selectProcess(parentProcess.bpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(
+        parentProcess.version.toString(),
+      );
+
+      await expect(page.getByText('2 results')).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Navigate to parent process instance', async () => {
+      await operateProcessesPage
+        .processInstanceLinkByKey(parentInstanceKey)
+        .click();
+
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+    });
+
+    let childVersion: string;
+
+    await test.step('Navigate to view called child process instances', async () => {
+      // Click on "View all" to see called child processes
+      await operateProcessInstancePage.instanceHeader
+        .getByRole('link', {
+          name: 'View all',
+        })
+        .click();
+
+      // Get child process version
+      childVersion = await operateProcessesPage.versionCell.first().innerText();
+
+      // Verify parent instance key is visible (filtering by parent is active)
+      await expect(
+        operateProcessesPage.dataList.getByRole('cell', {
+          name: parentInstanceKey,
+        }),
+      ).toBeVisible();
+    });
+
+    await test.step('Filter by child process and parent instance', async () => {
+      await operateFiltersPanelPage.selectProcess(childProcessV1.bpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(childVersion);
+
+      await expect(page.getByText('1 result')).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Select child process instance for migration', async () => {
+      await operateProcessesPage.selectProcessInstances(1);
+      await expect(page.getByText('1 item selected')).toBeVisible();
+
+      await expect(operateProcessesPage.migrateButton).toBeEnabled();
+    });
+
+    await test.step('Start migration process', async () => {
+      await operateProcessesPage.startMigration();
+    });
+
+    await test.step('Select target process and version', async () => {
+      // Select target process
+      await operateProcessMigrationModePage.targetProcessCombobox.click();
+      await operateProcessMigrationModePage
+        .getOptionByName(childProcessV2.bpmnProcessId)
+        .click();
+
+      // Select target version
+      await operateProcessMigrationModePage.targetVersionDropdown.click();
+      await operateProcessMigrationModePage
+        .getOptionByName(childProcessV2.version.toString())
+        .click();
+    });
+
+    await test.step('Map flow nodes', async () => {
+      await operateProcessMigrationModePage.mapFlowNode('Task', 'New Task');
+    });
+
+    await test.step('Complete migration', async () => {
+      await operateProcessMigrationModePage.nextButton.click();
+
+      await expect(
+        operateProcessMigrationModePage.summaryNotification,
+      ).toContainText(
+        `You are about to migrate 1 process instance from the process definition: ${childProcessV1.bpmnProcessId} - version ${childVersion} to the process definition: ${childProcessV2.bpmnProcessId} - version ${childProcessV2.version}`,
+      );
+
+      await operateProcessMigrationModePage.confirmButton.click();
+      await operateProcessMigrationModePage.fillMigrationConfirmation(
+        'MIGRATE',
+      );
+      await operateProcessMigrationModePage.clickMigrationConfirmationButton();
+    });
+
+    await test.step('Verify migration operation is created', async () => {
+      await expect(operateProcessesPage.operationsList).toBeVisible({
+        timeout: 30000,
+      });
+
+      await operateProcessesPage.expandOperationsPanel();
+    });
+
+    await test.step('Wait for migration to complete', async () => {
+      await operateProcessesPage.waitForOperationToComplete();
+    });
+
+    await test.step('Verify migration completed successfully', async () => {
+      const operationEntry =
+        operateOperationPanelPage.getMigrationOperationEntry(1);
+
+      await expect(operationEntry).toBeVisible({timeout: 120000});
+
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
+    });
+
+    await test.step('Verify process instance migrated to target version', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible({
+            timeout: 30000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      // Verify instance is at target version
+      await expect(
+        operateProcessesPage.getVersionCells(childProcessV2.version.toString()),
+      ).toHaveCount(1, {timeout: 30000});
+
+      // Verify parent instance key is still associated
+      await expect(
+        operateProcessesPage.dataList.getByRole('cell', {
+          name: parentInstanceKey,
+        }),
+      ).toBeVisible();
+    });
+
+    await test.step('Remove operation filter and verify source version instances', async () => {
+      await operateFiltersPanelPage.removeOptionalFilter('Operation Id');
+
+      await operateFiltersPanelPage.selectProcess(childProcessV1.bpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(childVersion);
+
+      await expect(page.getByText('1 result')).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Collapse operations panel', async () => {
+      await operateOperationPanelPage.collapseOperationIdField();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -36,11 +36,10 @@ test.beforeAll(async () => {
     './resources/childProcess_v_1.bpmn',
   ]);
 
-  // We know the processes will be version 1 on first deployment
   const parentProcess: ProcessDeployment = {
     bpmnProcessId: 'callActivityParentProcess',
     version: 1,
-    processDefinitionKey: '', // Will be retrieved from API if needed
+    processDefinitionKey: '',
   };
 
   const childProcessV1: ProcessDeployment = {
@@ -49,7 +48,6 @@ test.beforeAll(async () => {
     processDefinitionKey: '',
   };
 
-  // Create 2 instances of parent process
   const parentInstances = await createInstances(
     parentProcess.bpmnProcessId,
     parentProcess.version,
@@ -60,7 +58,6 @@ test.beforeAll(async () => {
     (instance) => instance.processInstanceKey,
   );
 
-  // Deploy child process v2
   await deploy(['./resources/childProcess_v_2.bpmn']);
 
   const childProcessV2: ProcessDeployment = {
@@ -76,7 +73,6 @@ test.beforeAll(async () => {
     parentProcessInstanceKeys,
   };
 
-  // Wait for instances to be indexed in Operate
   await sleep(2000);
 });
 
@@ -167,13 +163,13 @@ test.describe('Child Process Instance Migration', () => {
     });
 
     await test.step('Verify migration operation is created and completes', async () => {
-      await expect(operateProcessesPage.operationsList).toBeVisible({
+      await expect(operateOperationPanelPage.operationList).toBeVisible({
         timeout: 30000,
       });
 
-      await operateProcessesPage.expandOperationsPanel();
+      await operateOperationPanelPage.expandOperationsPanel();
 
-      await operateProcessesPage.waitForOperationToComplete();
+      await operateOperationPanelPage.waitForOperationToComplete();
 
       const operationEntry =
         operateOperationPanelPage.getMigrationOperationEntry(1);
@@ -214,7 +210,5 @@ test.describe('Child Process Instance Migration', () => {
         timeout: 30000,
       });
     });
-
-    await operateOperationPanelPage.collapseOperationIdField();
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -247,7 +247,7 @@ test.describe('Operations', () => {
       await Promise.all(
         instances.map((instance) =>
           expect(
-            operateProcessesPage.processInstanceLinkByKey(
+            operateProcessesPage.getProcessInstanceLinkByKey(
               instance.processInstanceKey,
             ),
           ).toBeVisible(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -207,12 +207,12 @@ test.describe('Operations', () => {
 
       await operateProcessesPage.applyButton.click();
 
-      await expect(operateProcessesPage.operationsList).toBeVisible({
+      await expect(operateOperationPanelPage.operationList).toBeVisible({
         timeout: 30000,
       });
       await sleep(500);
 
-      await operateProcessesPage.expandOperationsPanel();
+      await operateOperationPanelPage.expandOperationsPanel();
 
       await expect
         .poll(async () => {
@@ -262,12 +262,12 @@ test.describe('Operations', () => {
       await operateProcessesPage.cancelButton.click();
       await operateProcessesPage.applyButton.click();
 
-      await expect(operateProcessesPage.operationsList).toBeVisible({
+      await expect(operateOperationPanelPage.operationList).toBeVisible({
         timeout: 30000,
       });
       await sleep(500);
 
-      await operateProcessesPage.expandOperationsPanel();
+      await operateOperationPanelPage.expandOperationsPanel();
 
       await expect
         .poll(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -279,14 +279,14 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify migration operation is created and completes', async () => {
-      await expect(operateProcessesPage.operationsList).toBeVisible({
+      await expect(operateOperationPanelPage.operationList).toBeVisible({
         timeout: 30000,
       });
       await sleep(500);
     });
 
     await test.step('Verify 6 instances migrated to target version', async () => {
-      await operateProcessesPage.expandOperationsPanel();
+      await operateOperationPanelPage.expandOperationsPanel();
 
       const operationEntry =
         operateOperationPanelPage.getMigrationOperationEntry(6);
@@ -628,7 +628,7 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify migration operation is created and completes', async () => {
-      await operateProcessesPage.waitForOperationToComplete();
+      await operateOperationPanelPage.waitForOperationToComplete();
     });
 
     await test.step('Verify 3 instances migrated to target version', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Migrates `childProcessInstanceMigration.spec.ts` from `operate` component to the c8-orchestration-cluster-e2e-test-suite

## Changes
- Added `tests/operate/childProcessInstanceMigration.spec.ts` - tests child process migration from v1 to v2
- Moved operation panel locators from `OperateProcessesPage` to `OperateOperationPanelPage`
- Converted dynamic locators to arrow function pattern for consistency

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20338096603)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34098
