### PR TITLE
ci: fixing the shell script for adding comments to released issues

### DIFF
--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -73,7 +73,7 @@ jobs:
           DAYS_BACK: ${{ github.event.inputs.days_back || '10' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         shell: bash
-        run: .github/scripts/add-release-comments.sh
+        run: bash .github/scripts/add-release-comments.sh
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

To fix [this](https://github.com/camunda/camunda/actions/runs/20339011625/job/58432897799) issue, the script has to have bash explicitly stated on the command.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
