### PR TITLE
fix: validate schema field differences when mapping should not be dynamic

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -10,6 +10,7 @@ package io.camunda.search.schema;
 import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.schema.IndexSchemaValidator.DynamicMappingValidationMode;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
@@ -71,7 +72,7 @@ public class SchemaManager implements CloseableSilently {
         indexOnlyDescriptors,
         indexTemplateDescriptors,
         config,
-        new IndexSchemaValidator(objectMapper),
+        new IndexSchemaValidator(objectMapper, getDynamicMappingValidationMode(config)),
         VersionUtil.getVersion(),
         null);
   }
@@ -512,5 +513,13 @@ public class SchemaManager implements CloseableSilently {
   @Override
   public void close() {
     virtualThreadExecutor.close();
+  }
+
+  private static DynamicMappingValidationMode getDynamicMappingValidationMode(
+      final SearchEngineConfiguration config) {
+    if (config.schemaManager().isUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings()) {
+      return DynamicMappingValidationMode.LEGACY;
+    }
+    return DynamicMappingValidationMode.STRICT;
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
@@ -15,6 +15,7 @@ public class SchemaManagerConfiguration {
   private boolean isCreateSchema = true;
   private SchemaManagerRetryConfiguration retry = new SchemaManagerRetryConfiguration();
   private boolean versionCheckRestrictionEnabled = true;
+  private boolean unsafeIgnoreSchemaFieldDifferencesForDynamicMappings;
 
   public boolean isCreateSchema() {
     return isCreateSchema;
@@ -38,6 +39,16 @@ public class SchemaManagerConfiguration {
 
   public void setVersionCheckRestrictionEnabled(final boolean versionCheckRestrictionEnabled) {
     this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+  }
+
+  public boolean isUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings() {
+    return unsafeIgnoreSchemaFieldDifferencesForDynamicMappings;
+  }
+
+  public void setUnsafeIgnoreSchemaFieldDifferencesForDynamicMappings(
+      final boolean unsafeIgnoreSchemaFieldDifferencesForDynamicMappings) {
+    this.unsafeIgnoreSchemaFieldDifferencesForDynamicMappings =
+        unsafeIgnoreSchemaFieldDifferencesForDynamicMappings;
   }
 
   public static class SchemaManagerRetryConfiguration extends RetryConfiguration {

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.exceptions.IndexSchemaValidationException;
 import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
@@ -1159,6 +1160,33 @@ public class SchemaManagerIT {
     final var retrievedArchiveIndex2 = searchClientAdapter.getIndexAsNode(archiveIndexName2);
     assertThat(retrievedArchiveIndex2.at("/mappings/properties/foo/type").asText())
         .isEqualTo("keyword");
+  }
+
+  @TestTemplate
+  void shouldSkipDynamicPropertyMappingsDifferences2(
+      final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given
+    final var indexTemplate = createTestTemplateDescriptor("template_name", "/mappings.json");
+
+    final var runtimeIndexName = indexTemplate.getFullQualifiedName();
+
+    // index some data so ES/OS creates the index with a dnyamic mapping and difference field
+    // definitions
+    searchClientAdapter.index("123", runtimeIndexName, Map.of("hello", "a", "world", "b"));
+
+    final var schemaManager =
+        new SchemaManager(
+            searchEngineClientFromConfig(config),
+            Set.of(metadataIndex),
+            Set.of(indexTemplate),
+            config,
+            objectMapper);
+
+    assertThatThrownBy(schemaManager::startup)
+        .isInstanceOf(IndexSchemaValidationException.class)
+        .hasMessageContaining(
+            "Index name: custom-prefix-test-template_name-1.0.0_. Not supported index changes are introduced. Data migration is required.");
   }
 
   @TestTemplate

--- a/schema-manager/src/test/resources/mappings-dynamic.json
+++ b/schema-manager/src/test/resources/mappings-dynamic.json
@@ -1,0 +1,25 @@
+{
+  "mappings": {
+    "dynamic": true,
+    "properties": {
+      "hello": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "world": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
If we are not expecting an index's mapping to be dynamic, but it turns out to be then we should ensure we do validate the fields to ensure they are the correct type.

As ES/OS will auto-create indexes with dynamic mappings it would be quite a common thing for clients to accidentally have indexes setup this way. This can lead to unusual bugs and potentially hard to diagnose bugs e.g. if a field we expect to be "keyword" is actually "text" then term queries will behave in a very different way.

As it's quite likely we have self-managed clients with this happening I've added a flag to be able to turn this behaviour off (as a workaround).

I've also updated the logging for when we are ignoring these changes to WARN as it's probably quite an important thing to be aware of when looking into client issues.

Refs: #42869