### PR TITLE
Filter batch operations by actor info

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
@@ -33,6 +33,8 @@ public final class BatchOperationFilterTransformer
     return and(
         stringOperations(ID, filter.batchOperationKeyOperations()),
         stringOperations(STATE, filter.stateOperations()),
-        stringOperations(TYPE, filter.operationTypeOperations()));
+        stringOperations(TYPE, filter.operationTypeOperations()),
+        stringOperations(ACTOR_TYPE, filter.actorTypeOperations()),
+        stringOperations(ACTOR_ID, filter.actorIdOperations()));
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformerTest.java
@@ -100,11 +100,54 @@ class BatchOperationFilterTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  void shouldQueryByActorType() {
+    // given
+    final var filter = FilterBuilders.batchOperation(f -> f.actorTypes("USER"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("actorType");
+              assertThat(t.value().stringValue()).isEqualTo("USER");
+            });
+  }
+
+  @Test
+  void shouldQueryByActorId() {
+    // given
+    final var filter = FilterBuilders.batchOperation(f -> f.actorIds("alice"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("actorId");
+              assertThat(t.value().stringValue()).isEqualTo("alice");
+            });
+  }
+
+  @Test
   void shouldQueryByAllFields() {
     // given
     final var filter =
         FilterBuilders.batchOperation(
-            f -> f.batchOperationKeys("123").states("ACTIVE").operationTypes("CREATE"));
+            f ->
+                f.batchOperationKeys("123")
+                    .states("ACTIVE")
+                    .operationTypes("CREATE")
+                    .actorTypes("USER")
+                    .actorIds("alice"));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -112,7 +155,7 @@ class BatchOperationFilterTransformerTest extends AbstractTransformerTest {
     // then
     final var queryVariant = searchRequest.queryOption();
     assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
-    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(3);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(5);
 
     assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
         .isInstanceOfSatisfying(
@@ -136,6 +179,22 @@ class BatchOperationFilterTransformerTest extends AbstractTransformerTest {
             t -> {
               assertThat(t.field()).isEqualTo("type");
               assertThat(t.value().stringValue()).isEqualTo("CREATE");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(3).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("actorType");
+              assertThat(t.value().stringValue()).isEqualTo("USER");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(4).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("actorId");
+              assertThat(t.value().stringValue()).isEqualTo("alice");
             });
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -283,6 +283,14 @@ components:
           description: The state of the batch operation.
           allOf:
             - $ref: '#/components/schemas/BatchOperationStateFilterProperty'
+        actorType:
+          description: The type of the actor who performed the operation.
+          allOf:
+            - $ref: '#/components/schemas/BatchOperationActorTypeEnum'
+        actorId:
+          description: The ID of the actor who performed the operation.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
 
     BatchOperationSearchQueryResult:
       description: The batch operation search query result.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryFilterMapper.java
@@ -345,6 +345,13 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getOperationType())
           .map(mapToOperations(String.class))
           .ifPresent(builder::operationTypeOperations);
+      ofNullable(filter.getActorType())
+          .map(io.camunda.zeebe.gateway.protocol.rest.BatchOperationActorTypeEnum::getValue)
+          .map(String::toUpperCase)
+          .ifPresent(builder::actorTypes);
+      ofNullable(filter.getActorId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::actorIdOperations);
     }
 
     return builder.build();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -220,6 +220,32 @@ class BatchOperationControllerTest extends RestControllerTest {
                     String.valueOf(BatchOperationStateEnum.ACTIVE)),
                 Operation.like("act"))),
         true);
+    customOperationTestCases(
+        streamBuilder,
+        "actorType",
+        ops ->
+            new io.camunda.search.filter.BatchOperationFilter.Builder()
+                .actorTypeOperations(ops)
+                .build(),
+        List.of(List.of(Operation.eq("USER")), List.of(Operation.eq("CLIENT"))),
+        true);
+
+    customOperationTestCases(
+        streamBuilder,
+        "actorId",
+        ops ->
+            new io.camunda.search.filter.BatchOperationFilter.Builder()
+                .actorIdOperations(ops)
+                .build(),
+        List.of(
+            List.of(Operation.eq("frodo.baggins@fellowship")),
+            List.of(Operation.neq("aragorn@fellowship")),
+            List.of(Operation.in("frodo@fellowship", "aragorn@fellowship")),
+            List.of(Operation.notIn("samwise@fellowship", "gandalf@fellowship")),
+            List.of(Operation.exists(true)),
+            List.of(Operation.exists(false)),
+            List.of(Operation.like("fro*"))),
+        true);
 
     return streamBuilder.build();
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -227,7 +227,9 @@ class BatchOperationControllerTest extends RestControllerTest {
             new io.camunda.search.filter.BatchOperationFilter.Builder()
                 .actorTypeOperations(ops)
                 .build(),
-        List.of(List.of(Operation.eq("USER")), List.of(Operation.eq("CLIENT"))),
+        List.of(
+            List.of(Operation.eq(String.valueOf(BatchOperationActorType.USER))),
+            List.of(Operation.eq(String.valueOf(BatchOperationActorType.CLIENT)))),
         true);
 
     customOperationTestCases(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the ability to filter batch operations by actor type and actor id when using the Search batch operation API.

The filtering options are aligned to the Audit Log actor filtering options for now, but can be evolved independently:
- `actorType`: only exact enum match filtering
- `actorId`: basic string filtering options like `eq`, `neq`, etc

## Related issues

closes #42069
