### PR TITLE
[Backport stable/8.7] deps: update kotlin-stdlib to 2.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,9 +111,15 @@
     <version.json-smart>2.5.2</version.json-smart>
     <version.byte-buddy>1.15.11</version.byte-buddy>
     <version.revapi>0.28.4</version.revapi>
+<<<<<<< HEAD
     <version.resilience4j>2.2.0</version.resilience4j>
     <version.kotlin-stdlib>2.1.0</version.kotlin-stdlib>
     <version.immutables>2.10.1</version.immutables>
+=======
+    <version.resilience4j>2.3.0</version.resilience4j>
+    <version.kotlin-stdlib>2.1.0</version.kotlin-stdlib>
+    <version.immutables>2.11.4</version.immutables>
+>>>>>>> ecf07f5a (deps: update kotlin-stdlib to 2.1.0)
     <version.jsr305>3.0.2</version.jsr305>
     <version.classgraph>4.8.184</version.classgraph>
     <version.servlet-api>2.5</version.servlet-api>


### PR DESCRIPTION
# Description
Backport of #42663 to `stable/8.7`.

relates to #42660