### PR TITLE
[Backport stable/8.8] deps: update kotlin-stdlib to 2.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,11 @@
     <version.revapi>0.28.4</version.revapi>
     <version.resilience4j>2.3.0</version.resilience4j>
     <version.kotlin-stdlib>2.1.0</version.kotlin-stdlib>
+<<<<<<< HEAD
     <version.immutables>2.10.1</version.immutables>
+=======
+    <version.immutables>2.11.4</version.immutables>
+>>>>>>> ecf07f5a (deps: update kotlin-stdlib to 2.1.0)
     <version.jsr305>3.0.2</version.jsr305>
     <version.classgraph>4.8.184</version.classgraph>
     <version.servlet-api>2.5</version.servlet-api>


### PR DESCRIPTION
# Description
Backport of #42663 to `stable/8.8`.

relates to #42660