### PR TITLE
fix: set key on user task migration export update to not generate a n…

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -115,6 +115,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       case UserTaskIntent.CREATING -> createTaskEntity(entity, record);
       case UserTaskIntent.CREATED, UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED -> {
         entity.setState(TaskState.CREATED);
+        entity.setCompletionTime(null);
         updateChangedAttributes(record, entity);
       }
       case UserTaskIntent.COMPLETED -> handleCompletion(record, entity);
@@ -189,6 +190,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       updateFields.put(TaskTemplate.STATE, entity.getState());
       // Add update fields for migrated user tasks
       if (entity.getState() == TaskState.CREATED) {
+        updateFields.put(TaskTemplate.KEY, entity.getKey());
         if (entity.getImplementation() != null) {
           updateFields.put(TaskTemplate.IMPLEMENTATION, entity.getImplementation());
         }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -853,6 +853,7 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getAssignee()).isEqualTo(taskRecordValue.getAssignee());
@@ -896,6 +897,7 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.ASSIGNEE, null);
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getAssignee()).isEqualTo(null);
@@ -998,6 +1000,7 @@ public class UserTaskHandlerTest {
         List.of(
             "priority", "dueDate", "followUpDate", "candidateUsersList", "candidateGroupsList"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
@@ -1064,6 +1067,7 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("priority", "assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
@@ -1136,6 +1140,7 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.IMPLEMENTATION, taskEntity.getImplementation());
     expectedUpdates.put(TaskTemplate.FORM_ID, taskEntity.getFormId());
     expectedUpdates.put(TaskTemplate.FORM_KEY, taskEntity.getFormKey());
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
ES creates a new key if we don't override it by setting the original key, so we need to add this to the update fields.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/29269
