### PR TITLE
feat: audit: added identity group operations handler

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
@@ -151,6 +152,17 @@ public record AuditLogInfo(
       case DecisionEvaluationIntent.EVALUATED:
       case DecisionEvaluationIntent.FAILED:
         return AuditLogOperationType.EVALUATE;
+
+      case GroupIntent.CREATED:
+        return AuditLogOperationType.CREATE;
+      case GroupIntent.UPDATED:
+        return AuditLogOperationType.UPDATE;
+      case GroupIntent.DELETED:
+        return AuditLogOperationType.DELETE;
+      case GroupIntent.ENTITY_ADDED:
+        return AuditLogOperationType.ASSIGN;
+      case GroupIntent.ENTITY_REMOVED:
+        return AuditLogOperationType.UNASSIGN;
 
       case IncidentIntent.RESOLVED:
       case IncidentIntent.RESOLVE:

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
+import static io.camunda.zeebe.protocol.record.ValueType.GROUP;
 import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MIGRATION;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -66,6 +68,14 @@ public class AuditLogTransformerConfigs {
   public static final TransformerConfig DECISION_EVALUATION_CONFIG =
       TransformerConfig.with(DECISION_EVALUATION)
           .withIntents(DecisionEvaluationIntent.EVALUATED, DecisionEvaluationIntent.FAILED);
+
+  public static final TransformerConfig GROUP_CONFIG =
+      TransformerConfig.with(GROUP)
+          .withIntents(GroupIntent.CREATED, GroupIntent.UPDATED, GroupIntent.DELETED);
+
+  public static final TransformerConfig GROUP_ENTITY_CONFIG =
+      TransformerConfig.with(GROUP)
+          .withIntents(GroupIntent.ENTITY_ADDED, GroupIntent.ENTITY_REMOVED);
 
   public static final TransformerConfig INCIDENT_RESOLUTION_CONFIG =
       TransformerConfig.with(ValueType.INCIDENT)

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfoTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfoTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
@@ -184,6 +185,11 @@ class AuditLogInfoTest {
         Arguments.of(BatchOperationIntent.SUSPENDED, AuditLogOperationType.SUSPEND),
         Arguments.of(DecisionEvaluationIntent.EVALUATED, AuditLogOperationType.EVALUATE),
         Arguments.of(DecisionEvaluationIntent.FAILED, AuditLogOperationType.EVALUATE),
+        Arguments.of(GroupIntent.CREATED, AuditLogOperationType.CREATE),
+        Arguments.of(GroupIntent.UPDATED, AuditLogOperationType.UPDATE),
+        Arguments.of(GroupIntent.DELETED, AuditLogOperationType.DELETE),
+        Arguments.of(GroupIntent.ENTITY_ADDED, AuditLogOperationType.ASSIGN),
+        Arguments.of(GroupIntent.ENTITY_REMOVED, AuditLogOperationType.UNASSIGN),
         Arguments.of(IncidentIntent.RESOLVED, AuditLogOperationType.RESOLVE),
         Arguments.of(IncidentIntent.RESOLVE, AuditLogOperationType.RESOLVE),
         Arguments.of(MappingRuleIntent.CREATED, AuditLogOperationType.CREATE),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -71,6 +71,8 @@ import io.camunda.exporter.handlers.auditlog.AuthorizationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.DecisionEvaluationAuditLogTransformer;
+import io.camunda.exporter.handlers.auditlog.GroupAuditLogTransformer;
+import io.camunda.exporter.handlers.auditlog.GroupEntityAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.IncidentResolutionAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.MappingRuleAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.ProcessInstanceCancelAuditLogTransformer;
@@ -471,6 +473,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
           .addHandler(new BatchOperationCreationAuditLogTransformer())
           .addHandler(new BatchOperationLifecycleManagementAuditLogTransformer())
           .addHandler(new DecisionEvaluationAuditLogTransformer())
+          .addHandler(new GroupAuditLogTransformer())
+          .addHandler(new GroupEntityAuditLogTransformer())
           .addHandler(new IncidentResolutionAuditLogTransformer())
           .addHandler(new MappingRuleAuditLogTransformer())
           .addHandler(new ProcessInstanceCancelAuditLogTransformer())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/GroupAuditLogTransformer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/GroupAuditLogTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+
+public class GroupAuditLogTransformer
+    implements AuditLogTransformer<GroupRecordValue, AuditLogEntity> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.GROUP_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<GroupRecordValue> record, final AuditLogEntity entity) {
+    entity.setTenantScope(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/GroupEntityAuditLogTransformer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/GroupEntityAuditLogTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+
+public class GroupEntityAuditLogTransformer
+    implements AuditLogTransformer<GroupRecordValue, AuditLogEntity> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.GROUP_ENTITY_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<GroupRecordValue> record, final AuditLogEntity entity) {
+    entity.setTenantScope(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -18,6 +18,8 @@ import io.camunda.exporter.handlers.auditlog.AuthorizationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.DecisionEvaluationAuditLogTransformer;
+import io.camunda.exporter.handlers.auditlog.GroupAuditLogTransformer;
+import io.camunda.exporter.handlers.auditlog.GroupEntityAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.IncidentResolutionAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.MappingRuleAuditLogTransformer;
 import io.camunda.exporter.handlers.auditlog.ProcessInstanceCancelAuditLogTransformer;
@@ -183,6 +185,8 @@ public class DefaultExporterResourceProviderTest {
                 BatchOperationLifecycleManagementAuditLogTransformer.class,
                 ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
             Map.entry(DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
+            Map.entry(GroupAuditLogTransformer.class, ValueType.GROUP),
+            Map.entry(GroupEntityAuditLogTransformer.class, ValueType.GROUP),
             Map.entry(IncidentResolutionAuditLogTransformer.class, ValueType.INCIDENT),
             Map.entry(MappingRuleAuditLogTransformer.class, ValueType.MAPPING_RULE),
             Map.entry(ProcessInstanceCancelAuditLogTransformer.class, ValueType.PROCESS_INSTANCE),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/GroupAuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/GroupAuditLogHandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class GroupAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final GroupAuditLogTransformer transformer = new GroupAuditLogTransformer();
+
+  @Test
+  void shouldTransformGroupRecord() {
+    // given
+    final GroupRecordValue recordValue =
+        ImmutableGroupRecordValue.builder()
+            .from(factory.generateObject(GroupRecordValue.class))
+            .withGroupId("group-123")
+            .withName("Test Group")
+            .build();
+
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(
+            ValueType.GROUP, r -> r.withIntent(GroupIntent.CREATED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getTenantScope()).isEqualTo(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/GroupEntityAuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/GroupEntityAuditLogHandlerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class GroupEntityAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final GroupEntityAuditLogTransformer transformer = new GroupEntityAuditLogTransformer();
+
+  @Test
+  void shouldTransformGroupEntityRecord() {
+    // given
+    final GroupRecordValue recordValue =
+        ImmutableGroupRecordValue.builder()
+            .from(factory.generateObject(GroupRecordValue.class))
+            .withGroupId("group-123")
+            .withEntityId("entity-456")
+            .withEntityType(EntityType.USER)
+            .build();
+
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(
+            ValueType.GROUP, r -> r.withIntent(GroupIntent.ENTITY_ADDED).withValue(recordValue));
+
+    // when
+    final AuditLogEntity entity = new AuditLogEntity();
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getTenantScope()).isEqualTo(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -47,6 +47,8 @@ import io.camunda.exporter.rdbms.handlers.auditlog.AuthorizationAuditLogTransfor
 import io.camunda.exporter.rdbms.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.DecisionEvaluationAuditLogTransformer;
+import io.camunda.exporter.rdbms.handlers.auditlog.GroupAuditLogTransformer;
+import io.camunda.exporter.rdbms.handlers.auditlog.GroupEntityAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.IncidentResolutionAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.MappingRuleAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.ProcessInstanceCancelAuditLogTransformer;
@@ -306,6 +308,8 @@ public class RdbmsExporterWrapper implements Exporter {
             new BatchOperationCreationAuditLogTransformer(),
             new BatchOperationLifecycleManagementAuditLogTransformer(),
             new DecisionEvaluationAuditLogTransformer(),
+            new GroupAuditLogTransformer(),
+            new GroupEntityAuditLogTransformer(),
             new IncidentResolutionAuditLogTransformer(),
             new MappingRuleAuditLogTransformer(),
             new ProcessInstanceCancelAuditLogTransformer(),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupAuditLogTransformer.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupAuditLogTransformer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel.Builder;
+import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+
+public class GroupAuditLogTransformer implements AuditLogTransformer<GroupRecordValue, Builder> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.GROUP_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<GroupRecordValue> record, final Builder entity) {
+    entity.tenantScope(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupEntityAuditLogTransformer.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupEntityAuditLogTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel.Builder;
+import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+
+public class GroupEntityAuditLogTransformer
+    implements AuditLogTransformer<GroupRecordValue, Builder> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.GROUP_ENTITY_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<GroupRecordValue> record, final Builder entity) {
+    entity.tenantScope(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -21,6 +21,8 @@ import io.camunda.exporter.rdbms.handlers.auditlog.AuthorizationAuditLogTransfor
 import io.camunda.exporter.rdbms.handlers.auditlog.BatchOperationCreationAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.DecisionEvaluationAuditLogTransformer;
+import io.camunda.exporter.rdbms.handlers.auditlog.GroupAuditLogTransformer;
+import io.camunda.exporter.rdbms.handlers.auditlog.GroupEntityAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.IncidentResolutionAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.MappingRuleAuditLogTransformer;
 import io.camunda.exporter.rdbms.handlers.auditlog.ProcessInstanceCancelAuditLogTransformer;
@@ -99,6 +101,8 @@ class RdbmsExporterWrapperTest {
                 BatchOperationLifecycleManagementAuditLogTransformer.class,
                 ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
             Map.entry(DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
+            Map.entry(GroupAuditLogTransformer.class, ValueType.GROUP),
+            Map.entry(GroupEntityAuditLogTransformer.class, ValueType.GROUP),
             Map.entry(IncidentResolutionAuditLogTransformer.class, ValueType.INCIDENT),
             Map.entry(MappingRuleAuditLogTransformer.class, ValueType.MAPPING_RULE),
             Map.entry(ProcessInstanceCancelAuditLogTransformer.class, ValueType.PROCESS_INSTANCE),

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupAuditLogHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupAuditLogHandlerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class GroupAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final GroupAuditLogTransformer transformer = new GroupAuditLogTransformer();
+
+  @Test
+  void shouldTransformGroupRecord() {
+    // given
+    final GroupRecordValue recordValue =
+        ImmutableGroupRecordValue.builder()
+            .from(factory.generateObject(GroupRecordValue.class))
+            .withGroupId("group-123")
+            .withName("Test Group")
+            .build();
+
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(
+            ValueType.GROUP, r -> r.withIntent(GroupIntent.CREATED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.tenantScope()).isEqualTo(AuditLogTenantScope.GLOBAL);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupEntityAuditLogHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/auditlog/GroupEntityAuditLogHandlerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.auditlog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class GroupEntityAuditLogHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final GroupEntityAuditLogTransformer transformer = new GroupEntityAuditLogTransformer();
+
+  @Test
+  void shouldTransformGroupEntityRecord() {
+    // given
+    final GroupRecordValue recordValue =
+        ImmutableGroupRecordValue.builder()
+            .from(factory.generateObject(GroupRecordValue.class))
+            .withGroupId("group-123")
+            .withEntityId("entity-456")
+            .withEntityType(EntityType.USER)
+            .build();
+
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(
+            ValueType.GROUP, r -> r.withIntent(GroupIntent.ENTITY_ADDED).withValue(recordValue));
+
+    // when
+    final AuditLogDbModel.Builder builder = new AuditLogDbModel.Builder();
+    transformer.transform(record, builder);
+    final var entity = builder.build();
+
+    // then
+    assertThat(entity.tenantScope()).isEqualTo(AuditLogTenantScope.GLOBAL);
+  }
+}


### PR DESCRIPTION
## Description

feat: audit: added identity group operations handler

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41179
