### PR TITLE
feat: Support property based authorization checks (engine)

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -43,16 +43,8 @@ import java.util.stream.Stream;
 
 public final class AuthorizationCheckBehavior {
 
-  public static final String FORBIDDEN_ERROR_MESSAGE =
-      "Insufficient permissions to perform operation '%s' on resource '%s'";
-  public static final String FORBIDDEN_FOR_TENANT_ERROR_MESSAGE =
-      "Expected to perform operation '%s' on resource '%s' for tenant '%s', but user is not assigned to this tenant";
-  public static final String FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE =
-      FORBIDDEN_ERROR_MESSAGE + ", required resource identifiers are one of '[*, %s]'";
   public static final String NOT_FOUND_ERROR_MESSAGE =
       "Expected to %s with key '%s', but no %s was found";
-  public static final String NOT_FOUND_FOR_TENANT_ERROR_MESSAGE =
-      "Expected to perform operation '%s' on resource '%s', but no resource was found for tenant '%s'";
   private final MappingRuleState mappingRuleState;
   private final ClaimsExtractor claimsExtractor;
   private final TenantResolver tenantResolver;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -399,8 +399,7 @@ public final class AuthorizationCheckBehavior {
    * @return true if assigned or multi-tenancy is disabled, false otherwise
    */
   public boolean isAssignedToTenant(final TypedRecord<?> command, final String tenantId) {
-    return tenantResolver.isAssignedToTenant(
-        AuthorizationRequest.builder().command(command).tenantId(tenantId).build());
+    return tenantResolver.isAssignedToTenant(command.getAuthorizations(), tenantId);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -335,7 +335,7 @@ public final class AuthorizationCheckBehavior {
     }
 
     final T typedProperties = expectedType.cast(properties);
-    return evaluator.matches(claims, typedProperties);
+    return evaluator.evaluateMatchingProperties(claims, typedProperties);
   }
 
   private Set<AuthorizationScope> getPropertyAuthorizedScopes(final AuthorizationRequest request) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -212,11 +212,10 @@ public final class AuthorizationCheckBehavior {
       return AUTHORIZED;
     }
 
-    // Step 3: Check property-based authorization
+    // Step 3: Check if request can be authorized by resource properties
     // Only if we have tenant access (from primary or mapping rules)
     if (request.hasResourceProperties() && mappingRuleResult.hasTenantAccess()) {
-      final boolean propertyAccess = checkPropertyBasedAuthorization(request, aggregatedRejections);
-      if (propertyAccess) {
+      if (isAuthorizedByProperties(request, aggregatedRejections)) {
         return AUTHORIZED;
       }
     }
@@ -283,7 +282,7 @@ public final class AuthorizationCheckBehavior {
     return new AuthorizationResult(tenantAccess, resourceAccess);
   }
 
-  private boolean checkPropertyBasedAuthorization(
+  private boolean isAuthorizedByProperties(
       final AuthorizationRequest request, final List<AuthorizationRejection> aggregatedRejections) {
 
     final var authorizationRejection =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/PropertyAuthorizationEvaluatorRegistry.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/PropertyAuthorizationEvaluatorRegistry.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.property;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.PropertyAuthorizationEvaluator;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+
+public final class PropertyAuthorizationEvaluatorRegistry {
+
+  private final Map<AuthorizationResourceType, PropertyAuthorizationEvaluator> evaluators =
+      new EnumMap<>(AuthorizationResourceType.class);
+
+  public PropertyAuthorizationEvaluatorRegistry register(
+      final PropertyAuthorizationEvaluator evaluator) {
+    evaluators.put(evaluator.resourceType(), evaluator);
+    return this;
+  }
+
+  public Optional<PropertyAuthorizationEvaluator> get(
+      final AuthorizationResourceType resourceType) {
+    return Optional.ofNullable(evaluators.get(resourceType));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/PropertyAuthorizationEvaluatorRegistry.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/PropertyAuthorizationEvaluatorRegistry.java
@@ -15,16 +15,16 @@ import java.util.Optional;
 
 public final class PropertyAuthorizationEvaluatorRegistry {
 
-  private final Map<AuthorizationResourceType, PropertyAuthorizationEvaluator> evaluators =
+  private final Map<AuthorizationResourceType, PropertyAuthorizationEvaluator<?>> evaluators =
       new EnumMap<>(AuthorizationResourceType.class);
 
   public PropertyAuthorizationEvaluatorRegistry register(
-      final PropertyAuthorizationEvaluator evaluator) {
+      final PropertyAuthorizationEvaluator<?> evaluator) {
     evaluators.put(evaluator.resourceType(), evaluator);
     return this;
   }
 
-  public Optional<PropertyAuthorizationEvaluator> get(
+  public Optional<PropertyAuthorizationEvaluator<?>> get(
       final AuthorizationResourceType resourceType) {
     return Optional.ofNullable(evaluators.get(resourceType));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/ResourceAuthorizationProperties.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/ResourceAuthorizationProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.property;
+
+import java.util.Set;
+
+/**
+ * Base interface for typed resource properties used in property-based authorization.
+ *
+ * <p>Each resource type that supports property-based authorization should have a corresponding
+ * implementation of this interface.
+ *
+ * <p>Implementations should be immutable records or classes with defensive copies of mutable
+ * fields.
+ */
+public interface ResourceAuthorizationProperties {
+
+  /**
+   * Checks if this properties object has at least one non-null/non-empty property set.
+   *
+   * @return true if any property is set, false otherwise
+   */
+  default boolean hasProperties() {
+    return !getPropertyNames().isEmpty();
+  }
+
+  /**
+   * Returns the names of properties that are set (non-null/non-empty).
+   *
+   * <p>These names correspond to authorization scope property names and are used for:
+   *
+   * <ul>
+   *   <li>Matching against configured authorization scopes
+   *   <li>Constructing error messages when authorization fails
+   * </ul>
+   *
+   * @return set of property names that have values set
+   */
+  Set<String> getPropertyNames();
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/UserTaskAuthorizationProperties.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/UserTaskAuthorizationProperties.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.property;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Type-safe container for user task authorization properties.
+ *
+ * <p>These properties are evaluated at runtime to determine if a principal has access to a specific
+ * user task based on assignment or candidacy.
+ *
+ * @param assignee the user assigned to this task (may be null or empty)
+ * @param candidateUsers list of users who are candidates for this task (may be null or empty)
+ * @param candidateGroups list of groups whose members are candidates for this task (may be null or
+ *     empty)
+ */
+public record UserTaskAuthorizationProperties(
+    String assignee, List<String> candidateUsers, List<String> candidateGroups)
+    implements ResourceAuthorizationProperties {
+
+  public static final String PROP_ASSIGNEE = "assignee";
+  public static final String PROP_CANDIDATE_USERS = "candidateUsers";
+  public static final String PROP_CANDIDATE_GROUPS = "candidateGroups";
+
+  public UserTaskAuthorizationProperties {
+    candidateUsers = candidateUsers != null ? List.copyOf(candidateUsers) : null;
+    candidateGroups = candidateGroups != null ? List.copyOf(candidateGroups) : null;
+  }
+
+  @Override
+  public boolean hasProperties() {
+    return hasAssignee() || hasCandidateUsers() || hasCandidateGroups();
+  }
+
+  @Override
+  public Set<String> getPropertyNames() {
+    final Set<String> names = new HashSet<>();
+    if (hasAssignee()) {
+      names.add(PROP_ASSIGNEE);
+    }
+    if (hasCandidateUsers()) {
+      names.add(PROP_CANDIDATE_USERS);
+    }
+    if (hasCandidateGroups()) {
+      names.add(PROP_CANDIDATE_GROUPS);
+    }
+    return names;
+  }
+
+  public boolean hasAssignee() {
+    return assignee != null && !assignee.isEmpty();
+  }
+
+  public boolean hasCandidateUsers() {
+    return candidateUsers != null && !candidateUsers.isEmpty();
+  }
+
+  public boolean hasCandidateGroups() {
+    return candidateGroups != null && !candidateGroups.isEmpty();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private String assignee;
+    private List<String> candidateUsers;
+    private List<String> candidateGroups;
+
+    private Builder() {}
+
+    public Builder assignee(final String assignee) {
+      this.assignee = assignee;
+      return this;
+    }
+
+    public Builder candidateUsers(final List<String> candidateUsers) {
+      this.candidateUsers = candidateUsers;
+      return this;
+    }
+
+    public Builder candidateGroups(final List<String> candidateGroups) {
+      this.candidateGroups = candidateGroups;
+      return this;
+    }
+
+    public UserTaskAuthorizationProperties build() {
+      return new UserTaskAuthorizationProperties(assignee, candidateUsers, candidateGroups);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/PropertyAuthorizationEvaluator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/PropertyAuthorizationEvaluator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator;
+
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Evaluates property-based authorization for a specific resource type.
+ *
+ * <p>Property-based authorization allows granting access based on runtime attributes of a resource
+ * rather than static resource IDs.
+ */
+public interface PropertyAuthorizationEvaluator {
+
+  /**
+   * @return the resource type this evaluator handles
+   */
+  AuthorizationResourceType resourceType();
+
+  /**
+   * Evaluates which resource properties the principal matches.
+   *
+   * @param claims authorization claims from the request
+   * @param resourceProperties runtime properties of the resource instance
+   * @return property names where the principal matches the resource value
+   */
+  Set<String> matches(Map<String, Object> claims, Map<String, Object> resourceProperties);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/PropertyAuthorizationEvaluator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/PropertyAuthorizationEvaluator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator;
 
+import io.camunda.zeebe.engine.processing.identity.authorization.property.ResourceAuthorizationProperties;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import java.util.Map;
 import java.util.Set;
@@ -16,20 +17,33 @@ import java.util.Set;
  *
  * <p>Property-based authorization allows granting access based on runtime attributes of a resource
  * rather than static resource IDs.
+ *
+ * @param <T> the type of resource properties this evaluator handles
  */
-public interface PropertyAuthorizationEvaluator {
+public interface PropertyAuthorizationEvaluator<T extends ResourceAuthorizationProperties> {
 
   /**
-   * @return the resource type this evaluator handles
+   * Returns the resource type this evaluator handles.
+   *
+   * @return the authorization resource type
    */
   AuthorizationResourceType resourceType();
+
+  /**
+   * Returns the class of properties this evaluator can process.
+   *
+   * <p>Used by the registry for type-safe dispatch.
+   *
+   * @return the properties class
+   */
+  Class<T> propertiesType();
 
   /**
    * Evaluates which resource properties the principal matches.
    *
    * @param claims authorization claims from the request
-   * @param resourceProperties runtime properties of the resource instance
-   * @return property names where the principal matches the resource value
+   * @param properties typed resource properties of the resource instance
+   * @return property names where the principal matches the resource value.
    */
-  Set<String> matches(Map<String, Object> claims, Map<String, Object> resourceProperties);
+  Set<String> matches(Map<String, Object> claims, T properties);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/PropertyAuthorizationEvaluator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/PropertyAuthorizationEvaluator.java
@@ -45,5 +45,5 @@ public interface PropertyAuthorizationEvaluator<T extends ResourceAuthorizationP
    * @param properties typed resource properties of the resource instance
    * @return property names where the principal matches the resource value.
    */
-  Set<String> matches(Map<String, Object> claims, T properties);
+  Set<String> evaluateMatchingProperties(Map<String, Object> claims, T properties);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator;
+
+import io.camunda.security.auth.MappingRuleMatcher;
+import io.camunda.zeebe.engine.processing.identity.authorization.resolver.ClaimsExtractor;
+import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
+import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public final class UserTaskPropertyAuthorizationEvaluator
+    implements PropertyAuthorizationEvaluator {
+
+  public static final String PROP_ASSIGNEE = "assignee";
+  public static final String PROP_CANDIDATE_USERS = "candidateUsers";
+  public static final String PROP_CANDIDATE_GROUPS = "candidateGroups";
+
+  private final ClaimsExtractor claimsExtractor;
+  private final MappingRuleState mappingRuleState;
+
+  public UserTaskPropertyAuthorizationEvaluator(
+      final ClaimsExtractor claimsExtractor, final MappingRuleState mappingRuleState) {
+    this.claimsExtractor = claimsExtractor;
+    this.mappingRuleState = mappingRuleState;
+  }
+
+  @Override
+  public AuthorizationResourceType resourceType() {
+    return AuthorizationResourceType.USER_TASK;
+  }
+
+  @Override
+  public Set<String> matches(
+      final Map<String, Object> claims, final Map<String, Object> resourceProperties) {
+    if (resourceProperties == null || resourceProperties.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    final Set<String> matched = new HashSet<>();
+
+    // only users can be assigned to user tasks or be part of candidateUsers
+    claimsExtractor
+        .getUsername(claims)
+        .ifPresent(
+            username -> {
+              if (matchesAssignee(username, resourceProperties.get(PROP_ASSIGNEE))) {
+                matched.add(PROP_ASSIGNEE);
+              }
+
+              if (matchesCandidateUsers(username, resourceProperties.get(PROP_CANDIDATE_USERS))) {
+                matched.add(PROP_CANDIDATE_USERS);
+              }
+            });
+
+    if (resourceProperties.containsKey(PROP_CANDIDATE_GROUPS)) {
+      final var allGroups = collectAllGroups(claims);
+      if (matchesCandidateGroups(allGroups, resourceProperties.get(PROP_CANDIDATE_GROUPS))) {
+        matched.add(PROP_CANDIDATE_GROUPS);
+      }
+    }
+
+    return matched;
+  }
+
+  /**
+   * Collects all groups the principal belongs to from all possible sources:
+   *
+   * <ul>
+   *   <li>Groups from client or user membership
+   *   <li>Groups from matching mapping rules
+   * </ul>
+   */
+  private Set<String> collectAllGroups(final Map<String, Object> claims) {
+
+    final Set<String> allGroups = new HashSet<>();
+
+    claimsExtractor
+        .getUsername(claims)
+        .ifPresentOrElse(
+            username ->
+                allGroups.addAll(claimsExtractor.getGroups(claims, EntityType.USER, username)),
+            () ->
+                claimsExtractor
+                    .getClientId(claims)
+                    .ifPresent(
+                        clientId ->
+                            allGroups.addAll(
+                                claimsExtractor.getGroups(claims, EntityType.CLIENT, clientId))));
+
+    getMatchingMappingRuleIds(claims)
+        .forEach(
+            mappingRuleId ->
+                allGroups.addAll(
+                    claimsExtractor.getGroups(claims, EntityType.MAPPING_RULE, mappingRuleId)));
+
+    return allGroups;
+  }
+
+  private Stream<String> getMatchingMappingRuleIds(final Map<String, Object> claims) {
+    final var tokenClaims = claimsExtractor.getTokenClaims(claims);
+    return MappingRuleMatcher.matchingRules(mappingRuleState.getAll().stream(), tokenClaims)
+        .map(PersistedMappingRule::getMappingRuleId);
+  }
+
+  private boolean matchesAssignee(final String userId, final Object assigneeValue) {
+    return userId != null
+        && assigneeValue instanceof String assignee
+        && !assignee.isEmpty()
+        && userId.equals(assignee);
+  }
+
+  private boolean matchesCandidateUsers(final String userId, final Object candidateUsersValue) {
+    if (userId == null || !(candidateUsersValue instanceof List<?> candidateUsers)) {
+      return false;
+    }
+    return candidateUsers.contains(userId);
+  }
+
+  private boolean matchesCandidateGroups(
+      final Set<String> groups, final Object candidateGroupsValue) {
+    if (groups.isEmpty() || !(candidateGroupsValue instanceof List<?> candidateGroups)) {
+      return false;
+    }
+    return candidateGroups.stream().anyMatch(g -> g instanceof String && groups.contains(g));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluator.java
@@ -60,7 +60,7 @@ public final class UserTaskPropertyAuthorizationEvaluator
   }
 
   @Override
-  public Set<String> matches(
+  public Set<String> evaluateMatchingProperties(
       final Map<String, Object> claims, final UserTaskAuthorizationProperties properties) {
     if (properties == null || !properties.hasProperties()) {
       return Collections.emptySet();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/resolver/TenantResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/resolver/TenantResolver.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.identity.authorization.resolver;
 import io.camunda.security.auth.MappingRuleMatcher;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
@@ -41,16 +40,18 @@ public final class TenantResolver {
   }
 
   /**
-   * Checks if the principal in the request is assigned to the request's tenant.
+   * Checks if a user is assigned to a specific tenant. If multi-tenancy is disabled, this method
+   * will always return true.
    *
-   * @param request the authorization request
-   * @return true if the user is assigned to the tenant or multi-tenancy is disabled
+   * @param claims the authorization claims map
+   * @param tenantId the tenant we want to check assignment for
+   * @return true if assigned or multi-tenancy is disabled, false otherwise
    */
-  public boolean isAssignedToTenant(final AuthorizationRequest request) {
+  public boolean isAssignedToTenant(final Map<String, Object> claims, final String tenantId) {
     if (!multiTenancyEnabled) {
       return true;
     }
-    return getAuthorizedTenants(request.claims()).isAuthorizedForTenantId(request.tenantId());
+    return getAuthorizedTenants(claims).isAuthorizedForTenantId(tenantId);
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -18,6 +18,7 @@ import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
 import io.camunda.zeebe.engine.state.appliers.MappingRuleCreatedApplier;
@@ -267,7 +268,11 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
             .command(command)
             .resourceType(resourceType)
             .permissionType(permissionType)
-            .addResourceProperty("candidateGroups", List.of("other-group", "group-b"))
+            .resourceProperties(
+                UserTaskAuthorizationProperties.builder()
+                    .assignee(user.getUsername())
+                    .candidateGroups(List.of("other-group", "group-b"))
+                    .build())
             .build();
 
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
@@ -298,7 +303,10 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
             .command(command)
             .resourceType(resourceType)
             .permissionType(permissionType)
-            .addResourceProperty("candidateGroups", List.of("sales", "marketing"))
+            .resourceProperties(
+                UserTaskAuthorizationProperties.builder()
+                    .candidateGroups(List.of("sales", "marketing"))
+                    .build())
             .build();
 
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
@@ -331,7 +339,10 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
             .command(command)
             .resourceType(resourceType)
             .permissionType(permissionType)
-            .addResourceProperty("candidateGroups", List.of("mapping-group-1", "other-group"))
+            .resourceProperties(
+                UserTaskAuthorizationProperties.builder()
+                    .candidateGroups(List.of("mapping-group-1", "other-group"))
+                    .build())
             .build();
 
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
@@ -360,7 +371,10 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
             .command(command)
             .resourceType(resourceType)
             .permissionType(permissionType)
-            .addResourceProperty("candidateGroups", List.of("group1", "otherGroup"))
+            .resourceProperties(
+                UserTaskAuthorizationProperties.builder()
+                    .candidateGroups(List.of("group1", "otherGroup"))
+                    .build())
             .build();
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -1061,12 +1061,16 @@ final class AuthorizationCheckBehaviorTest {
   void isAnyAuthorizedOrInternalCommandShouldBeAuthorizedForInternalCommand() {
     // given
     final var externalCommandRequest =
-        AuthorizationRequest.builder().command(mock(TypedRecord.class)).build();
+        AuthorizationRequest.builder().command(mock(TypedRecord.class))
+            .resourceType(AuthorizationResourceType.RESOURCE).permissionType(PermissionType.CREATE)
+            .build();
 
     final var internalCommand = mock(TypedRecord.class);
     when(internalCommand.isInternalCommand()).thenReturn(true);
     final var internalCommandRequest =
-        AuthorizationRequest.builder().command(internalCommand).build();
+        AuthorizationRequest.builder().command(internalCommand)
+            .resourceType(AuthorizationResourceType.RESOURCE)
+            .permissionType(PermissionType.DELETE_RESOURCE).build();
 
     // when
     final var result =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluatorTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator;
+
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_ASSIGNEE;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_CANDIDATE_GROUPS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_CANDIDATE_USERS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.resolver.ClaimsExtractor;
+import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
+import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
+import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
+import io.camunda.zeebe.engine.state.immutable.MembershipState;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class UserTaskPropertyAuthorizationEvaluatorTest {
+
+  @Mock private MembershipState membershipState;
+
+  @Mock private MappingRuleState mappingRuleState;
+
+  private UserTaskPropertyAuthorizationEvaluator evaluator;
+
+  @BeforeEach
+  void setUp() {
+    final ClaimsExtractor claimsExtractor = new ClaimsExtractor(membershipState);
+    evaluator = new UserTaskPropertyAuthorizationEvaluator(claimsExtractor, mappingRuleState);
+  }
+
+  @Test
+  void shouldReturnUserTaskResourceType() {
+    assertThat(evaluator.resourceType()).isEqualTo(AuthorizationResourceType.USER_TASK);
+  }
+
+  @ParameterizedTest
+  @MethodSource("emptyResourcePropertiesInputs")
+  void shouldReturnEmptySetWhenEmptyResourcePropertiesProvided(
+      final Map<String, Object> resourceProperties) {
+    // given
+    final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
+
+    // when
+    final var result = evaluator.matches(claims, resourceProperties);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  static Stream<Arguments> emptyResourcePropertiesInputs() {
+    return Stream.of(Arguments.of((Map) null), Arguments.of(Collections.emptyMap()));
+  }
+
+  @Test
+  void shouldMatchMultiplePropertiesWhenAllMatch() {
+    // given
+    final var username = "testUser";
+    final var userGroup = "userGroup";
+    final var claims =
+        Map.of(AUTHORIZED_USERNAME, username, USER_GROUPS_CLAIMS, List.of(userGroup));
+    final var resourceProperties =
+        Map.of(
+            PROP_ASSIGNEE, username,
+            PROP_CANDIDATE_USERS, List.of(username, "otherUser"),
+            PROP_CANDIDATE_GROUPS, List.of(userGroup, "otherGroup"));
+
+    // when
+    final var result = evaluator.matches(claims, resourceProperties);
+
+    // then
+    assertThat(result)
+        .containsExactlyInAnyOrder(PROP_ASSIGNEE, PROP_CANDIDATE_USERS, PROP_CANDIDATE_GROUPS);
+  }
+
+  @Nested
+  class AssigneeMatching {
+
+    @Test
+    void shouldMatchAssigneeWhenUsernameEqualsAssignee() {
+      // given
+      final var username = "testUser";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties = Map.<String, Object>of(PROP_ASSIGNEE, username);
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).containsExactly(PROP_ASSIGNEE);
+    }
+
+    @Test
+    void shouldNotMatchAssigneeWhenUsernameDoesNotEqualAssignee() {
+      // given
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
+      final var resourceProperties = Map.<String, Object>of(PROP_ASSIGNEE, "differentUser");
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchAssigneeWhenAssigneeIsNotString() {
+      // given
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
+      final var resourceProperties = Map.<String, Object>of(PROP_ASSIGNEE, 123);
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchAssigneeWhenNoUserId() {
+      // given
+      final var claims = Map.<String, Object>of();
+      final var resourceProperties = Map.<String, Object>of(PROP_ASSIGNEE, "testUser");
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  class CandidateUsersMatching {
+
+    @Test
+    void shouldMatchCandidateUsersWhenUsernameInList() {
+      // given
+      final var username = "testUser";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties =
+          Map.<String, Object>of(
+              PROP_CANDIDATE_USERS, List.of("otherUser", username, "anotherUser"));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).containsExactly(PROP_CANDIDATE_USERS);
+    }
+
+    @Test
+    void shouldNotMatchCandidateUsersWhenUsernameNotInList() {
+      // given
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_USERS, List.of("user1", "user2", "user3"));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchCandidateUsersWhenListIsEmpty() {
+      // given
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_USERS, Collections.emptyList());
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchCandidateUsersWhenNotAList() {
+      // given
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
+      final var resourceProperties = Map.<String, Object>of(PROP_CANDIDATE_USERS, "testUser");
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchCandidateUsersWhenNoUserId() {
+      // given
+      final var claims = Map.<String, Object>of();
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_USERS, List.of("user1", "user2"));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  class CandidateGroupsMatching {
+
+    @Test
+    void shouldMatchCandidateGroupsWhenUserGroupInList() {
+      // given
+      final var username = "testUser";
+      final var userGroup = "userGroup";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, List.of("group1", userGroup, "group2"));
+
+      when(membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP))
+          .thenReturn(List.of(userGroup));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
+    }
+
+    @Test
+    void shouldMatchCandidateGroupsWhenClientGroupInList() {
+      // given
+      final var clientId = "testClient";
+      final var clientGroup = "clientGroup";
+      final var claims = Map.<String, Object>of(AUTHORIZED_CLIENT_ID, clientId);
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, List.of("group1", clientGroup));
+
+      when(membershipState.getMemberships(EntityType.CLIENT, clientId, RelationType.GROUP))
+          .thenReturn(List.of(clientGroup));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
+    }
+
+    @Test
+    void shouldMatchCandidateGroupsWhenMappingRuleGroupInList() {
+      // given
+      final var claimName = "$.role";
+      final var claimValue = "admin";
+      final var mappingRuleId = "mapping-rule-1";
+      final var mappingGroup = "mappingGroup";
+      final var claims = Map.<String, Object>of(USER_TOKEN_CLAIMS, Map.of("role", claimValue));
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, List.of("group1", mappingGroup));
+
+      final var mappingRule =
+          new PersistedMappingRule()
+              .setMappingRuleId(mappingRuleId)
+              .setClaimName(claimName)
+              .setClaimValue(claimValue);
+      when(mappingRuleState.getAll()).thenReturn(List.of(mappingRule));
+
+      when(membershipState.getMemberships(
+              EntityType.MAPPING_RULE, mappingRuleId, RelationType.GROUP))
+          .thenReturn(List.of(mappingGroup));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
+    }
+
+    @Test
+    void shouldMatchCandidateGroupsWhenMultipleGroupSourcesMatch() {
+      // given
+      final var username = "testUser";
+      final var userGroup = "userGroup";
+      final var claimName = "$.role";
+      final var claimValue = "admin";
+      final var mappingRuleId = "mapping-rule-1";
+      final var mappingGroup = "mappingGroup";
+      final var claims =
+          Map.<String, Object>of(
+              AUTHORIZED_USERNAME, username, USER_TOKEN_CLAIMS, Map.of("role", claimValue));
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, List.of(mappingGroup, userGroup));
+
+      when(membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP))
+          .thenReturn(List.of(userGroup));
+
+      final var mappingRule =
+          new PersistedMappingRule()
+              .setMappingRuleId(mappingRuleId)
+              .setClaimName(claimName)
+              .setClaimValue(claimValue);
+      when(mappingRuleState.getAll()).thenReturn(List.of(mappingRule));
+
+      when(membershipState.getMemberships(
+              EntityType.MAPPING_RULE, mappingRuleId, RelationType.GROUP))
+          .thenReturn(List.of(mappingGroup));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
+    }
+
+    @Test
+    void shouldNotMatchCandidateGroupsWhenUserGroupNotInList() {
+      // given
+      final var username = "testUser";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, List.of("group1", "group2"));
+
+      when(membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP))
+          .thenReturn(List.of("differentGroup"));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchCandidateGroupsWhenUserHasNoGroups() {
+      // given
+      final var username = "testUser";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, List.of("group1", "group2"));
+
+      when(membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP))
+          .thenReturn(Collections.emptyList());
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchCandidateGroupsWhenNotAList() {
+      // given
+      final var username = "testUser";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties = Map.<String, Object>of(PROP_CANDIDATE_GROUPS, "group1");
+
+      when(membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP))
+          .thenReturn(List.of("group1"));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotMatchCandidateGroupsWhenCandidateGroupsListIsEmpty() {
+      // given
+      final var username = "testUser";
+      final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, username);
+      final var resourceProperties =
+          Map.<String, Object>of(PROP_CANDIDATE_GROUPS, Collections.emptyList());
+
+      when(membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP))
+          .thenReturn(List.of("group1"));
+
+      // when
+      final var result = evaluator.matches(claims, resourceProperties);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/property/evaluator/UserTaskPropertyAuthorizationEvaluatorTest.java
@@ -67,7 +67,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
     final var claims = Map.<String, Object>of(AUTHORIZED_USERNAME, "testUser");
 
     // when
-    final var result = evaluator.matches(claims, resourceProperties);
+    final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
     // then
     assertThat(result).isEmpty();
@@ -95,7 +95,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
             .build();
 
     // when
-    final var result = evaluator.matches(claims, resourceProperties);
+    final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
     // then
     assertThat(result)
@@ -114,7 +114,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           UserTaskAuthorizationProperties.builder().assignee(username).build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).containsExactly(PROP_ASSIGNEE);
@@ -128,7 +128,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           UserTaskAuthorizationProperties.builder().assignee("differentUser").build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -142,7 +142,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           UserTaskAuthorizationProperties.builder().assignee("testUser").build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -162,7 +162,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
               .candidateUsers(List.of("otherUser", username, "anotherUser"))
               .build();
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).containsExactly(PROP_CANDIDATE_USERS);
@@ -178,7 +178,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
               .build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -192,7 +192,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           UserTaskAuthorizationProperties.builder().candidateUsers(Collections.emptyList()).build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -208,7 +208,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
               .build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -233,7 +233,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           .thenReturn(List.of(userGroup));
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
@@ -254,7 +254,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           .thenReturn(List.of(clientGroup));
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
@@ -285,7 +285,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           .thenReturn(List.of(mappingGroup));
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
@@ -323,7 +323,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           .thenReturn(List.of(mappingGroup));
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).containsExactly(PROP_CANDIDATE_GROUPS);
@@ -343,7 +343,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           .thenReturn(List.of("differentGroup"));
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -363,7 +363,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
           .thenReturn(Collections.emptyList());
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();
@@ -380,7 +380,7 @@ final class UserTaskPropertyAuthorizationEvaluatorTest {
               .build();
 
       // when
-      final var result = evaluator.matches(claims, resourceProperties);
+      final var result = evaluator.evaluateMatchingProperties(claims, resourceProperties);
 
       // then
       assertThat(result).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequestTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/request/AuthorizationRequestTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity.authorization.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AuthorizationRequestTest {
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class BuildAuthorizationRequestValidationTest {
+
+    @Test
+    void shouldThrowWhenResourceTypeIsNull() {
+      // given
+      final var builder =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .permissionType(PermissionType.READ);
+
+      // when / then
+      assertThatThrownBy(builder::build)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("resourceType must be set");
+    }
+
+    @Test
+    void shouldThrowWhenPermissionTypeIsNull() {
+      // given
+      final var builder =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION);
+
+      // when / then
+      assertThatThrownBy(builder::build)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("permissionType must be set");
+    }
+
+    @Test
+    void shouldThrowWhenNeitherCommandNorClaimsAreProvided() {
+      // given
+      final var builder =
+          AuthorizationRequest.builder()
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.UPDATE_PROCESS_INSTANCE);
+
+      // when / then
+      assertThatThrownBy(builder::build)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("command or authorizationClaims must be provided");
+    }
+
+    @Test
+    void shouldThrowWhenBothCommandAndClaimsAreProvided() {
+      // given
+      final var command = mock(TypedRecord.class);
+      when(command.getAuthorizations())
+          .thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "demo-user_A"));
+
+      final var builder =
+          AuthorizationRequest.builder()
+              .command(command)
+              .authorizationClaims(Map.of(Authorization.AUTHORIZED_USERNAME, "demo-user_B"))
+              .resourceType(AuthorizationResourceType.RESOURCE)
+              .permissionType(PermissionType.DELETE_FORM);
+
+      // when / then
+      assertThatThrownBy(builder::build)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("command and authorizationClaims are mutually exclusive");
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyResourceIdInputs")
+    void shouldIgnoreEmptyResourceIds(final String resourceId) {
+      // given / when
+      final var request =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+              .addResourceId(resourceId)
+              .build();
+
+      // then
+      assertThat(request.resourceIds()).isEmpty();
+    }
+
+    Stream<Arguments> emptyResourceIdInputs() {
+      return Stream.of(Arguments.of((String) null), Arguments.of(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyResourcePropertyInputs")
+    void shouldIgnoreEmptyResourceProperties(
+        final String propertyName, final Object propertyValue) {
+      // given / when
+      final var request =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+              .addResourceProperty(propertyName, propertyValue)
+              .build();
+
+      // then
+      assertThat(request.resourceProperties()).isEmpty();
+    }
+
+    Stream<Arguments> emptyResourcePropertyInputs() {
+      return Stream.of(
+          Arguments.of(null, "value"), Arguments.of("", "value"), Arguments.of("property", null));
+    }
+
+    @Test
+    void shouldAddAllResourceIds() {
+      // given / when
+      final var request =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.UPDATE_USER_TASK)
+              .addAllResourceIds(List.of("id1", "id2", "id3"))
+              .build();
+
+      // then
+      assertThat(request.resourceIds()).containsExactlyInAnyOrder("id1", "id2", "id3");
+    }
+
+    @Test
+    void shouldAddAllResourceProperties() {
+      // given / when
+      final var request =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.UPDATE_USER_TASK)
+              .addResourceProperty("assignee", "user-1")
+              .addResourceProperty("candidateUsers", List.of("user-2", "user-3"))
+              .addResourceProperty("candidateGroups", List.of("group-1", "group-2"))
+              .build();
+
+      // then
+      assertThat(request.resourceProperties())
+          .containsExactlyInAnyOrderEntriesOf(
+              Map.of(
+                  "assignee", "user-1",
+                  "candidateUsers", List.of("user-2", "user-3"),
+                  "candidateGroups", List.of("group-1", "group-2")));
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class GetErrorMessageTest {
+
+    @ParameterizedTest
+    @MethodSource("forbiddenErrorMessageInputs")
+    void shouldReturnCorrectForbiddenErrorMessage(
+        final Set<String> resourceIds,
+        final Map<String, Object> resourceProperties,
+        final String expectedMessage) {
+      // given
+      final var builder =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.RESOURCE)
+              .permissionType(PermissionType.READ);
+
+      resourceIds.forEach(builder::addResourceId);
+      resourceProperties.forEach(builder::addResourceProperty);
+
+      final var request = builder.build();
+
+      // when
+      final var message = request.getForbiddenErrorMessage();
+
+      // then
+      assertThat(message).isEqualTo(expectedMessage);
+    }
+
+    Stream<Arguments> forbiddenErrorMessageInputs() {
+      return Stream.of(
+          // No resource ids and no resource properties
+          Arguments.of(
+              Collections.emptySet(),
+              Collections.emptyMap(),
+              "Insufficient permissions to perform operation 'READ' on resource 'RESOURCE'"),
+          // With resource ids
+          Arguments.of(
+              Set.of("id1"),
+              Collections.emptyMap(),
+              "Insufficient permissions to perform operation 'READ' on resource 'RESOURCE', required resource identifiers are one of '[*, id1]'"),
+          // With multiple resource ids (sorted alphabetically)
+          Arguments.of(
+              Set.of("id2", "id1", "id3"),
+              Collections.emptyMap(),
+              "Insufficient permissions to perform operation 'READ' on resource 'RESOURCE', required resource identifiers are one of '[*, id1, id2, id3]'"),
+          // With resource properties
+          Arguments.of(
+              Collections.emptySet(),
+              Map.of("prop1", "value1"),
+              "Insufficient permissions to perform operation 'READ' on resource 'RESOURCE', resource did not match property constraints '[prop1]'"),
+          // With multiple resource properties (sorted alphabetically)
+          Arguments.of(
+              Collections.emptySet(),
+              Map.of("propB", "value2", "propA", "value1"),
+              "Insufficient permissions to perform operation 'READ' on resource 'RESOURCE', resource did not match property constraints '[propA, propB]'"),
+          // With multiple resource ids and properties (sorted alphabetically)
+          Arguments.of(
+              Set.of("id5", "id1", "id9"),
+              Map.of("propD", "value2", "propY", "value1", "propA", "value1"),
+              "Insufficient permissions to perform operation 'READ' on resource 'RESOURCE', required resource identifiers are one of '[*, id1, id5, id9]' "
+                  + "or resource must match property constraints '[propA, propD, propY]'"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tenantErrorMessageInputs")
+    void shouldReturnCorrectTenantErrorMessage(
+        final boolean isNewResource, final String tenantId, final String expectedMessage) {
+      // given
+      final var builder =
+          AuthorizationRequest.builder()
+              .authorizationClaims(Map.of())
+              .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+              .permissionType(PermissionType.UPDATE_USER_TASK)
+              .tenantId(tenantId)
+              .isNewResource(isNewResource);
+
+      final var request = builder.build();
+
+      // when
+      final var message = request.getTenantErrorMessage();
+
+      // then
+      assertThat(message).isEqualTo(expectedMessage);
+    }
+
+    Stream<Arguments> tenantErrorMessageInputs() {
+      return Stream.of(
+          // New resource - should use forbidden message
+          Arguments.of(
+              true,
+              "tenant-1",
+              "Expected to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION' for tenant 'tenant-1', but user is not assigned to this tenant"),
+          // Existing resource - should use not found message
+          Arguments.of(
+              false,
+              "tenant-2",
+              "Expected to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', but no resource was found for tenant 'tenant-2'"));
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces property-based authorization checks in the Zeebe engine, enabling more flexible and dynamic authorization policies that grant permissions based on runtime resource properties rather than static resource IDs.

### Motivation

Resource ID-based authorization requires explicitly granting permissions for specific resource identifiers (e.g., process definition IDs) or to all resources (WILDCARD `*`). However, for user tasks, this approach is limiting because:
1. **Task assignments are dynamic** — Users need to operate on tasks they're assigned to or are candidates for, but the specific task IDs aren't known in advance. Organizations can to grant permissions like "users can complete tasks they are assigned to" without enumerating every possible task key.
2. **Reduced administrative overhead** — Property-based rules eliminate the need to create individual permission entries for each resource.

Property-based authorization solves this by allowing permissions to be granted based on resource attributes (e.g., `assignee`, `candidateUsers`, `candidateGroups`) that are evaluated at runtime.

## Main highlights

### New capabilities

- Property-based authorization for `USER_TASK` resources
  - Currently, property-based authorization is only supported for the `USER_TASK` authorization resource type
- Supported properties:
  - `assignee` — Matches when the requesting user is the task assignee
  - `cancidateUsers` — Matches when the requesting user is in the candidate users list
  - `candidateGroups` — Matches when any of the requesting principal's groups overlap with candidate groups
  
### Key changes

1. `AuthorizationRequest` refactoring:
   - Replaced private constructor with builder-based construction for improved readability
   - Added explicit validation for required fields and mutually exclusive inputs
   - Extended with `resourceProperties` support alongside existing `resourceIds`
   - Moved error message constants locally for better cohesion

2. New authorization evaluation pipeline:
   - Added `PropertyAuthorizationEvaluatorRegistry` for registering property evaluators per resource type
   - Introduced `PropertyAuthorizationEvaluator` interface for resource-type-specific property matching
   - Implemented `UserTaskPropertyAuthorizationEvaluator` for user task property evaluation
   - Authorization checks now follow a 3-step process:  primary entity -> mapping rules -> property-based (if properties present in request).

3. Group resolution for property matching:
   - Groups are collected from all sources:  user/client membership and matching mapping rules

## Adoption guide

To add property-based authorization support for other `AuthorizationResourceType` values:

### 1. Create a properties type

Implement the `ResourceAuthorizationProperties` interface for your resource type:

<details>
<summary><code>YourResourceAuthorizationProperties.java</code></summary>

```java
public record YourResourceAuthorizationProperties(
    String property1,
    List<String> property2
) implements ResourceAuthorizationProperties {

  public static final String PROP_PROPERTY1 = "property1";
  public static final String PROP_PROPERTY2 = "property2";

  @Override
  public boolean hasProperties() {
    return hasProperty1() || hasProperty2();
  }

  @Override
  public Set<String> getPropertyNames() {
    final Set<String> names = new HashSet<>();
    if (hasProperty1()) names.add(PROP_PROPERTY1);
    if (hasProperty2()) names.add(PROP_PROPERTY2);
    return names;
  }

  public boolean hasProperty1() {
    return property1 != null && ! property1.isEmpty();
  }

  public boolean hasProperty2() {
    return property2 != null && !property2.isEmpty();
  }

  public static Builder builder() {
    return new Builder();
  }

  // ... [Optional] Builder class ... 
}
```
</details>

### 2. Create a property evaluator

Implement the `PropertyAuthorizationEvaluator` interface:
<details>
<summary><code> YourPropertyAuthorizationEvaluator.java</code></summary>

```java
public final class YourPropertyAuthorizationEvaluator
    implements PropertyAuthorizationEvaluator<YourResourceAuthorizationProperties> {

  @Override
  public AuthorizationResourceType resourceType() {
    return AuthorizationResourceType.YOUR_RESOURCE_TYPE;
  }

  @Override
  public Class<YourResourceAuthorizationProperties> propertiesType() {
    return YourResourceAuthorizationProperties.class;
  }

  @Override
  public Set<String> evaluateMatchingProperties(
      final Map<String, Object> claims,
      final YourResourceAuthorizationProperties properties) {
    // Determine which properties the principal matches
    // Return the set of matched property names
  }
}
```
</details>

### 3. Register evaluator

Add your evaluator to the registry in `AuthorizationCheckBehavior` constructor:

```java
propertyEvaluatorRegistry =
    new PropertyAuthorizationEvaluatorRegistry()
        .register(new UserTaskPropertyAuthorizationEvaluator(claimsExtractor, mappingRuleState))
        .register(new YourPropertyAuthorizationEvaluator(/* dependencies */));
```

### 4. Use in authorization requests

```java
AuthorizationRequest.builder()
    .command(command)
    .resourceType(AuthorizationResourceType.YOUR_RESOURCE_TYPE)
    .permissionType(PermissionType.UPDATE)
    .resourceProperties(
        YourResourceAuthorizationProperties.builder()
            .property1(resource.getProperty1())
            .property2(resource.getProperty2())
            .build())
    .build();
```

## Related issues

closes #40114
