### PR TITLE
Process instance archiver task silently stops

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.tasks.util.ReschedulingTaskLogger;
 import io.camunda.zeebe.util.ExponentialBackoff;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -50,7 +51,13 @@ public final class ReschedulingTask implements RunnableTask {
   @Override
   public void run() {
     scheduled = true;
-    var result = task.execute();
+    CompletionStage<Integer> result;
+    try {
+      result = task.execute();
+    } catch (final Exception e) {
+      // in case the task throws an exception instead of returning a failed CompletionStage
+      result = CompletableFuture.failedFuture(e);
+    }
     // while we could always expect this to return a non-null result, we don't necessarily want to
     // stop, and more importantly, we want to make it transparent that something went wrong
     if (result == null) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -142,4 +142,9 @@ public interface ArchiverRepository extends AutoCloseable {
     @Override
     public void close() throws Exception {}
   }
+
+  enum ArchivingStatus {
+    BLOCKED,
+    NOT_BLOCKED
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/ReschedulingTaskTest.java
@@ -45,6 +45,25 @@ final class ReschedulingTaskTest {
   }
 
   @Test
+  void shouldRescheduleTaskOnException() {
+    // given
+    final BackgroundTask job =
+        () -> {
+          throw new RuntimeException("failure");
+        };
+    final var task = new ReschedulingTask(job, 1, 10, 1000, EXECUTOR, LOGGER);
+
+    // when
+    task.run();
+
+    // then
+    final var inOrder = Mockito.inOrder(EXECUTOR);
+    inOrder
+        .verify(EXECUTOR, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
   void shouldRescheduleTaskOnErrorWithDelay() {
     // given
     final var task = new ReschedulingTask(new FailingJob(), 1, 10, 1000, EXECUTOR, LOGGER);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.schema.config.RetentionConfiguration;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+abstract class AbstractArchiverRepositoryTest {
+
+  final RetentionConfiguration retention = new RetentionConfiguration();
+  ArchiverRepository repository;
+
+  @BeforeEach
+  void setup() {
+    repository = createRepository();
+  }
+
+  @AfterEach
+  void teardown() throws Exception {
+    if (repository != null) {
+      repository.close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("archiveBatchSuppliers")
+  void shouldReturnFailedFutureWhenGetNextBatchFails(
+      final Function<ArchiverRepository, CompletableFuture<ArchiveBatch>> archiveBatchSupplier) {
+    // when
+    final var result = archiveBatchSupplier.apply(repository);
+
+    // then fails when it tries to access ES/OS, since there is no backing database
+    assertThat(result)
+        .as("Should return a future that completes exceptionally, not throw synchronously")
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(ConnectException.class);
+  }
+
+  static Stream<Named<Function<ArchiverRepository, CompletableFuture<ArchiveBatch>>>>
+      archiveBatchSuppliers() {
+    return Stream.of(
+        Named.of("getProcessInstancesNextBatch", ArchiverRepository::getProcessInstancesNextBatch),
+        Named.of("getBatchOperationsNextBatch", ArchiverRepository::getBatchOperationsNextBatch),
+        Named.of("getUsageMetricTUNextBatch", ArchiverRepository::getUsageMetricTUNextBatch),
+        Named.of("getUsageMetricNextBatch", ArchiverRepository::getUsageMetricNextBatch),
+        Named.of(
+            "getStandaloneDecisionNextBatch", ArchiverRepository::getStandaloneDecisionNextBatch));
+  }
+
+  @Test
+  void shouldNotSetLifecycleIfRetentionIsDisabled() {
+    // given
+    retention.setEnabled(false);
+
+    // when
+    final var result = repository.setIndexLifeCycle("whatever");
+
+    // then - would normally fail if tried to access ES/OS, since there is no backing database
+    assertThat(result)
+        .as("did not try connecting to non existent ES/OS")
+        .succeedsWithin(Duration.ofSeconds(5));
+  }
+
+  abstract ArchiverRepository createRepository();
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -7,17 +7,13 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.json.SimpleJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
-import io.camunda.search.schema.config.RetentionConfiguration;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Duration;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.Test;
@@ -25,19 +21,14 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("resource")
-final class ElasticsearchArchiverRepositoryTest {
+final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverRepositoryTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepositoryTest.class);
 
   private final RestClientTransport transport = Mockito.spy(createRestClient());
-  private final RetentionConfiguration retention = new RetentionConfiguration();
 
   @Test
   void shouldCloseTransportOnClose() throws Exception {
-    // given
-    final var repository = createRepository();
-
     // when
     repository.close();
 
@@ -45,22 +36,8 @@ final class ElasticsearchArchiverRepositoryTest {
     Mockito.verify(transport, Mockito.times(1)).close();
   }
 
-  @Test
-  void shouldNotSetLifecycleIfRetentionIsDisabled() {
-    // given
-    final var repository = createRepository();
-    retention.setEnabled(false);
-
-    // when
-    final var result = repository.setIndexLifeCycle("whatever");
-
-    // then - would normally fail if tried to access ES, since there is no backing Elastic
-    assertThat(result)
-        .as("did not try connecting to non existent ES")
-        .succeedsWithin(Duration.ofSeconds(5));
-  }
-
-  private ElasticsearchArchiverRepository createRepository() {
+  @Override
+  ElasticsearchArchiverRepository createRepository() {
     final var client = new ElasticsearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -7,14 +7,10 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
-import io.camunda.search.schema.config.RetentionConfiguration;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Duration;
 import org.apache.http.HttpHost;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,18 +22,14 @@ import org.opensearch.client.transport.rest_client.RestClientTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class OpenSearchArchiverRepositoryTest {
+final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryTest {
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(ElasticsearchArchiverRepositoryTest.class);
+      LoggerFactory.getLogger(OpenSearchArchiverRepositoryTest.class);
 
   private final RestClientTransport transport = Mockito.spy(createRestClient());
-  private final RetentionConfiguration retention = new RetentionConfiguration();
 
   @Test
   void shouldCloseTransportOnClose() throws Exception {
-    // given
-    final var repository = createRepository();
-
     // when
     repository.close();
 
@@ -45,22 +37,8 @@ final class OpenSearchArchiverRepositoryTest {
     Mockito.verify(transport, Mockito.times(1)).close();
   }
 
-  @Test
-  void shouldNotSetLifecycleIfRetentionIsDisabled() {
-    // given
-    final var repository = createRepository();
-    retention.setEnabled(false);
-
-    // when
-    final var result = repository.setIndexLifeCycle("whatever");
-
-    // then - would normally fail if tried to access ES, since there is no backing Elastic
-    assertThat(result)
-        .as("did not try connecting to non existent ES")
-        .succeedsWithin(Duration.ofSeconds(5));
-  }
-
-  private OpenSearchArchiverRepository createRepository() {
+  @Override
+  OpenSearchArchiverRepository createRepository() {
     final var client = new OpenSearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* Updated `archivingIsBlocked()` in both `ElasticsearchArchiverRepository` and `OpenSearchArchiverRepository` to return a `CompletableFuture<Boolean>` instead of a synchronous boolean, making the `getProcessInstancesNextBatch `  block fully asynchronous to avoid any synchronous exception from skipping the [CompletableFuture chain]
* In `ReschedulingTask`, exceptions thrown by the background task execute() are caught and converted into failed futures. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42838 
