### PR TITLE
docs: update contribution guide with note on concurrent Maven execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,7 @@ This is a small overview of the contents of this repository:
 > [!NOTE]
 > All Camunda core modules are built and tested with JDK 21. Most modules use language level 21, exceptions are: camunda-client-java, camunda-process-test-java, zeebe-bpmn-model, zeebe-build-tools, camunda-client-java, zeebe-gateway-protocol zeebe-gateway-protocol-impl, zeebe-protocol, and zeebe-protocol-jackson which use language level 8.
 
+> [!NOTE]
 > To avoid concurrent Maven execution issues, ensure the project is only opened in one IDE at a time while running Maven build commands (e.g., `./mvnw clean install`). Opening the same project in multiple IDEs simultaneously can cause build failures due to conflicting Maven tasks.
 
 * **Quick build:** To **quickly** build all components for development, run the command: `./mvnw clean install -Dquickly` in the root folder. This flag is also used to skip Optimize, when building Camunda.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,7 @@ This is a small overview of the contents of this repository:
 
 > [!NOTE]
 > All Camunda core modules are built and tested with JDK 21. Most modules use language level 21, exceptions are: camunda-client-java, camunda-process-test-java, zeebe-bpmn-model, zeebe-build-tools, camunda-client-java, zeebe-gateway-protocol zeebe-gateway-protocol-impl, zeebe-protocol, and zeebe-protocol-jackson which use language level 8.
-
-> [!NOTE]
+>
 > To avoid concurrent Maven execution issues, ensure the project is only opened in one IDE at a time while running Maven build commands (e.g., `./mvnw clean install`). Opening the same project in multiple IDEs simultaneously can cause build failures due to conflicting Maven tasks.
 
 * **Quick build:** To **quickly** build all components for development, run the command: `./mvnw clean install -Dquickly` in the root folder. This flag is also used to skip Optimize, when building Camunda.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,8 @@ This is a small overview of the contents of this repository:
 > [!NOTE]
 > All Camunda core modules are built and tested with JDK 21. Most modules use language level 21, exceptions are: camunda-client-java, camunda-process-test-java, zeebe-bpmn-model, zeebe-build-tools, camunda-client-java, zeebe-gateway-protocol zeebe-gateway-protocol-impl, zeebe-protocol, and zeebe-protocol-jackson which use language level 8.
 
+> To avoid concurrent Maven execution issues, ensure the project is only opened in one IDE at a time while running Maven build commands (e.g., `./mvnw clean install`). Opening the same project in multiple IDEs simultaneously can cause build failures due to conflicting Maven tasks.
+
 * **Quick build:** To **quickly** build all components for development, run the command: `./mvnw clean install -Dquickly` in the root folder. This flag is also used to skip Optimize, when building Camunda.
 * **Full build:** To build the full distribution for local usage (skipping tests and checks), run the command `./mvnw clean install -DskipChecks -DskipTests`.
 * **Full build without frontends:** To build the full distribution for local usage without frontends (skipping tests), run the command `./mvnw clean install -DskipChecks -DskipTests -PskipFrontendBuild`.


### PR DESCRIPTION
## Description
This pull request adds a helpful note to the `CONTRIBUTING.md` documentation. The new note warns contributors to avoid opening the project in multiple IDEs at the same time when running Maven build commands, as this can cause build failures due to concurrent Maven execution issues.

closes #43019
