### PR TITLE
Make max rockDB memory fraction configurable.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -31,6 +31,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
   private double memoryFraction = 0.1;
+  private double maxMemoryFraction = -1;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -90,6 +91,14 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
+  }
+
+  public double getMaxMemoryFraction() {
+    return maxMemoryFraction;
+  }
+
+  public void setMaxMemoryFraction(final double maxMemoryFraction) {
+    this.maxMemoryFraction = maxMemoryFraction;
   }
 
   public int getMaxOpenFiles() {
@@ -177,6 +186,8 @@ public final class RocksdbCfg implements ConfigurationEntry {
         + memoryAllocationStrategy
         + ", memoryFraction="
         + memoryFraction
+        + ", maxMemoryFraction="
+        + maxMemoryFraction
         + ", maxOpenFiles="
         + maxOpenFiles
         + ", maxWriteBufferNumber="


### PR DESCRIPTION
## Description

This PR makes the validation for max RocksDB size in relation to the total size of RAM configurable and disabled by default.
This validation was removed [here](https://github.com/camunda/camunda/pull/42922) since this was blocking some clusters in QA that were using more than default rocksDB size. 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/42278
