### PR TITLE
fix: the parameter resolver needs to be registered to the strategy

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -27,6 +27,7 @@ import io.camunda.client.annotation.value.JobWorkerValue.SourceAware.*;
 import io.camunda.client.annotation.value.VariableValue;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.response.UserTaskProperties;
 import io.camunda.client.bean.BeanInfo;
 import io.camunda.client.bean.MethodInfo;
 import io.camunda.client.bean.ParameterInfo;
@@ -87,6 +88,10 @@ public class AnnotationUtil {
     return KEY_ANNOTATIONS.keySet().stream()
             .anyMatch(parameterInfo.getParameter()::isAnnotationPresent)
         && KeyTargetType.isValidParameterType(parameterInfo.getParameter().getType());
+  }
+
+  public static boolean isUserTaskProperties(final ParameterInfo parameterInfo) {
+    return parameterInfo.getParameter().getType().isAssignableFrom(UserTaskProperties.class);
   }
 
   public static Optional<Function<ActivatedJob, Long>> getKeyResolver(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/parameter/DefaultParameterResolverStrategy.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/parameter/DefaultParameterResolverStrategy.java
@@ -21,6 +21,7 @@ import static io.camunda.client.annotation.AnnotationUtil.getVariableValue;
 import static io.camunda.client.annotation.AnnotationUtil.isCustomHeaders;
 import static io.camunda.client.annotation.AnnotationUtil.isDocument;
 import static io.camunda.client.annotation.AnnotationUtil.isKey;
+import static io.camunda.client.annotation.AnnotationUtil.isUserTaskProperties;
 import static io.camunda.client.annotation.AnnotationUtil.isVariable;
 import static io.camunda.client.annotation.AnnotationUtil.isVariablesAsType;
 
@@ -90,6 +91,8 @@ public class DefaultParameterResolverStrategy implements ParameterResolverStrate
     } else if (isKey(parameterInfo)) {
       return new KeyParameterResolver(
           KeyTargetType.from(parameterType), getKeyResolver(parameterInfo).get());
+    } else if (isUserTaskProperties(parameterInfo)) {
+      return new UserTaskPropertiesParameterResolver();
     }
     throw new IllegalStateException(
         "Could not create parameter resolver for parameter " + parameterInfo);

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/parameter/DefaultParameterResolverStrategyTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/parameter/DefaultParameterResolverStrategyTest.java
@@ -23,6 +23,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.Document;
 import io.camunda.client.annotation.ProcessInstanceKey;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.UserTaskProperties;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.bean.ParameterInfo;
 import io.camunda.client.impl.CamundaObjectMapper;
@@ -137,6 +138,19 @@ public class DefaultParameterResolverStrategyTest {
         .isEqualTo(KeyTargetType.STRING);
   }
 
+  @Test
+  void shouldResolveUserTaskProperties() {
+    final CamundaClient camundaClient = mock(CamundaClient.class);
+    final DefaultParameterResolverStrategy strategy =
+        new DefaultParameterResolverStrategy(new CamundaObjectMapper());
+    final List<ParameterInfo> parameters = parameterInfos(this, "userTaskProperties");
+    assertThat(parameters).hasSize(1);
+    final ParameterResolver parameterResolver =
+        strategy.createResolver(
+            new ParameterResolverStrategyContext(parameters.get(0), camundaClient));
+    assertThat(parameterResolver).isInstanceOf(UserTaskPropertiesParameterResolver.class);
+  }
+
   public void legacyMethod(
       final io.camunda.zeebe.client.api.worker.JobClient jobClient,
       final io.camunda.zeebe.client.api.response.ActivatedJob job) {}
@@ -150,4 +164,6 @@ public class DefaultParameterResolverStrategyTest {
   public void processInstanceKeyLong(@ProcessInstanceKey final Long processInstanceKey) {}
 
   public void processInstanceKeyString(@ProcessInstanceKey final String processInstanceKey) {}
+
+  public void userTaskProperties(UserTaskProperties userTaskProperties) {}
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes an issue where the parameter resolver for user task properties was not registered to the resolver strategy and the injection of these properties was not possible.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
