### PR TITLE
fix: added client methods for resource endpoints

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -122,6 +122,8 @@ import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
+import io.camunda.client.api.fetch.ResourceContentGetRequest;
+import io.camunda.client.api.fetch.ResourceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
 import io.camunda.client.api.fetch.TenantGetRequest;
@@ -3251,4 +3253,34 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   IncidentProcessInstanceStatisticsByDefinitionRequest
       newIncidentProcessInstanceStatisticsByDefinitionRequest(int errorHashCode);
+
+  /**
+   * Retrieves a resource by key.
+   *
+   * <pre>
+   * long resourceKey = ...;
+   *
+   * camundaClient
+   *  .newResourceGetRequest(resourceKey)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the request to get a resource
+   */
+  ResourceGetRequest newResourceGetRequest(long resourceKey);
+
+  /**
+   * Retrieves a resource content by key.
+   *
+   * <pre>
+   * long resourceKey = ...;
+   *
+   * camundaClient
+   *  .newResourceContentGetRequest(resourceKey)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the request to get a resource content
+   */
+  ResourceContentGetRequest newResourceContentGetRequest(long resourceKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceContentGetRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+
+public interface ResourceContentGetRequest extends FinalCommandStep<String> {}

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.Resource;
+
+public interface ResourceGetRequest extends FinalCommandStep<Resource> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -133,6 +133,8 @@ import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
+import io.camunda.client.api.fetch.ResourceContentGetRequest;
+import io.camunda.client.api.fetch.ResourceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
 import io.camunda.client.api.fetch.TenantGetRequest;
@@ -298,6 +300,8 @@ import io.camunda.client.impl.fetch.ProcessDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetCallHierarchyRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetRequestImpl;
+import io.camunda.client.impl.fetch.ResourceContentGetRequestImpl;
+import io.camunda.client.impl.fetch.ResourceGetRequestImpl;
 import io.camunda.client.impl.fetch.RoleGetRequestImpl;
 import io.camunda.client.impl.fetch.TenantGetRequestImpl;
 import io.camunda.client.impl.fetch.TenantScopedClusterVariableGetRequestImpl;
@@ -1614,6 +1618,16 @@ public final class CamundaClientImpl implements CamundaClient {
       newIncidentProcessInstanceStatisticsByDefinitionRequest(final int errorHashCode) {
     return new IncidentProcessInstanceStatisticsByDefinitionRequestImpl(
         httpClient, jsonMapper, errorHashCode);
+  }
+
+  @Override
+  public ResourceGetRequest newResourceGetRequest(final long resourceKey) {
+    return new ResourceGetRequestImpl(httpClient, resourceKey);
+  }
+
+  @Override
+  public ResourceContentGetRequest newResourceContentGetRequest(final long resourceKey) {
+    return new ResourceContentGetRequestImpl(httpClient, resourceKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceContentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceContentGetRequestImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.fetch.ResourceContentGetRequest;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ResourceContentGetRequestImpl implements ResourceContentGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long resourceKey;
+
+  public ResourceContentGetRequestImpl(final HttpClient httpClient, final long resourceKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.resourceKey = resourceKey;
+  }
+
+  @Override
+  public ResourceContentGetRequest requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<String> send() {
+    final HttpCamundaFuture<String> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/resources/%d/content", resourceKey),
+        httpRequestConfig.build(),
+        String.class,
+        s -> s,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceGetRequestImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.fetch.ResourceGetRequest;
+import io.camunda.client.api.response.Resource;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.ResourceResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ResourceGetRequestImpl implements ResourceGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long resourceKey;
+
+  public ResourceGetRequestImpl(final HttpClient httpClient, final long resourceKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.resourceKey = resourceKey;
+  }
+
+  @Override
+  public ResourceGetRequest requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Resource> send() {
+    final HttpCamundaFuture<Resource> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/resources/%d", resourceKey),
+        httpRequestConfig.build(),
+        ResourceResult.class,
+        SearchResponseMapper::toResourceGetResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.response.Resource;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
@@ -52,6 +53,7 @@ import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.client.api.search.response.User;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.response.ResourceImpl;
 import io.camunda.client.impl.search.response.BatchOperationItemsImpl.BatchOperationItemImpl;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.*;
@@ -83,6 +85,15 @@ public final class SearchResponseMapper {
 
   public static ProcessInstance toProcessInstanceGetResponse(final ProcessInstanceResult response) {
     return new ProcessInstanceImpl(response);
+  }
+
+  public static Resource toResourceGetResponse(final ResourceResult response) {
+    return new ResourceImpl(
+        response.getResourceId(),
+        Long.parseLong(response.getResourceKey()),
+        response.getVersion(),
+        response.getResourceName(),
+        response.getTenantId());
   }
 
   public static SearchResponse<ProcessInstance> toProcessInstanceSearchResponse(

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
@@ -26,11 +26,18 @@ import org.junit.jupiter.api.Test;
 public class GetResourceContentTest extends ClientRestTest {
   @Test
   void shouldGetResourceContent() {
-    gatewayService.onResourceContentGetRequest(123L, "test content");
-    client.newResourceContentGetRequest(123L).execute();
+    // given
+    final String resourceContent = "test content";
+    gatewayService.onResourceContentGetRequest(123L, resourceContent);
+
+    // when
+    final String response = client.newResourceContentGetRequest(123L).execute();
+
     // then
-    final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getResourceContentUrl("123"));
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    LoggedRequestAssert.assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.GET)
+        .hasUrl(RestGatewayPaths.getResourceContentUrl("123"));
+
+    assertThat(response).isEqualTo(resourceContent);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.junit.jupiter.api.Test;
+
+public class GetResourceContentTest extends ClientRestTest {
+  @Test
+  void shouldGetResource() {
+    gatewayService.onResourceContentGetRequest(123L, "test content");
+    client.newResourceContentGetRequest(123L).execute();
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getResourceContentUrl("123"));
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 public class GetResourceContentTest extends ClientRestTest {
   @Test
-  void shouldGetResource() {
+  void shouldGetResourceContent() {
     gatewayService.onResourceContentGetRequest(123L, "test content");
     client.newResourceContentGetRequest(123L).execute();
     // then

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
@@ -18,9 +18,10 @@ package io.camunda.client.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import io.camunda.client.util.assertions.LoggedRequestAssert;
 import org.junit.jupiter.api.Test;
 
 public class GetResourceContentTest extends ClientRestTest {

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.ResourceResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.junit.jupiter.api.Test;
+
+public class GetResourceTest extends ClientRestTest {
+  @Test
+  void shouldGetResource() {
+    gatewayService.onResourceGetRequest(
+        123L,
+        new ResourceResult()
+            .resourceKey("123")
+            .resourceId("test.bpmn")
+            .resourceName("Test process")
+            .version(1));
+    client.newResourceGetRequest(123L).execute();
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getResourceUrl("123"));
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
@@ -18,10 +18,12 @@ package io.camunda.client.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.response.Resource;
 import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import io.camunda.client.util.assertions.LoggedRequestAssert;
 import org.junit.jupiter.api.Test;
 
 public class GetResourceTest extends ClientRestTest {
@@ -48,6 +50,5 @@ public class GetResourceTest extends ClientRestTest {
     assertThat(response.getResourceId()).isEqualTo("test.bpmn");
     assertThat(response.getResourceName()).isEqualTo("Test process");
     assertThat(response.getVersion()).isEqualTo(1);
-  }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
@@ -18,18 +18,28 @@ package io.camunda.client.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+<<<<<<< HEAD
 import io.camunda.client.api.response.Resource;
 import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
 import io.camunda.client.util.assertions.LoggedRequestAssert;
+=======
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.ResourceResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+>>>>>>> 570afd0fb7a (test: added tests to assert that the endpoints are called by the client)
 import org.junit.jupiter.api.Test;
 
 public class GetResourceTest extends ClientRestTest {
   @Test
   void shouldGetResource() {
+<<<<<<< HEAD
     // given
+=======
+>>>>>>> 570afd0fb7a (test: added tests to assert that the endpoints are called by the client)
     gatewayService.onResourceGetRequest(
         123L,
         new ResourceResult()
@@ -37,6 +47,7 @@ public class GetResourceTest extends ClientRestTest {
             .resourceId("test.bpmn")
             .resourceName("Test process")
             .version(1));
+<<<<<<< HEAD
 
     // when
     final Resource response = client.newResourceGetRequest(123L).execute();
@@ -50,5 +61,12 @@ public class GetResourceTest extends ClientRestTest {
     assertThat(response.getResourceId()).isEqualTo("test.bpmn");
     assertThat(response.getResourceName()).isEqualTo("Test process");
     assertThat(response.getVersion()).isEqualTo(1);
+=======
+    client.newResourceGetRequest(123L).execute();
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getResourceUrl("123"));
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+>>>>>>> 570afd0fb7a (test: added tests to assert that the endpoints are called by the client)
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 public class GetResourceTest extends ClientRestTest {
   @Test
   void shouldGetResource() {
+    // given
     gatewayService.onResourceGetRequest(
         123L,
         new ResourceResult()
@@ -34,10 +35,19 @@ public class GetResourceTest extends ClientRestTest {
             .resourceId("test.bpmn")
             .resourceName("Test process")
             .version(1));
-    client.newResourceGetRequest(123L).execute();
+
+    // when
+    final Resource response = client.newResourceGetRequest(123L).execute();
+
     // then
-    final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getResourceUrl("123"));
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    LoggedRequestAssert.assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.GET)
+        .hasUrl(RestGatewayPaths.getResourceUrl("123"));
+
+    assertThat(response.getResourceKey()).isEqualTo(123);
+    assertThat(response.getResourceId()).isEqualTo("test.bpmn");
+    assertThat(response.getResourceName()).isEqualTo("Test process");
+    assertThat(response.getVersion()).isEqualTo(1);
+  }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
@@ -18,28 +18,18 @@ package io.camunda.client.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-<<<<<<< HEAD
 import io.camunda.client.api.response.Resource;
 import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
 import io.camunda.client.util.assertions.LoggedRequestAssert;
-=======
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.protocol.rest.ResourceResult;
-import io.camunda.client.util.ClientRestTest;
-import io.camunda.client.util.RestGatewayPaths;
->>>>>>> 570afd0fb7a (test: added tests to assert that the endpoints are called by the client)
 import org.junit.jupiter.api.Test;
 
 public class GetResourceTest extends ClientRestTest {
   @Test
   void shouldGetResource() {
-<<<<<<< HEAD
     // given
-=======
->>>>>>> 570afd0fb7a (test: added tests to assert that the endpoints are called by the client)
     gatewayService.onResourceGetRequest(
         123L,
         new ResourceResult()
@@ -47,7 +37,6 @@ public class GetResourceTest extends ClientRestTest {
             .resourceId("test.bpmn")
             .resourceName("Test process")
             .version(1));
-<<<<<<< HEAD
 
     // when
     final Resource response = client.newResourceGetRequest(123L).execute();
@@ -61,12 +50,5 @@ public class GetResourceTest extends ClientRestTest {
     assertThat(response.getResourceId()).isEqualTo("test.bpmn");
     assertThat(response.getResourceName()).isEqualTo("Test process");
     assertThat(response.getVersion()).isEqualTo(1);
-=======
-    client.newResourceGetRequest(123L).execute();
-    // then
-    final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getResourceUrl("123"));
-    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
->>>>>>> 570afd0fb7a (test: added tests to assert that the endpoints are called by the client)
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -459,14 +459,6 @@ public class RestGatewayPaths {
     return URL_GLOBAL_JOB_STATISTICS;
   }
 
-  public static String getResourceUrl(final String resourceKey) {
-    return String.format(URL_RESOURCE, resourceKey);
-  }
-
-  public static String getResourceContentUrl(final String resourceKey) {
-    return String.format(URL_RESOURCE_CONTENT, resourceKey);
-  }
-
   public static String getResourceDeletionUrl(final long resourceKey) {
     return String.format(URL_RESOURCE_DELETION, resourceKey);
   }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -447,6 +447,14 @@ public class RestGatewayPaths {
     return URL_INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_PROCESS_DEFINITION;
   }
 
+  public static String getResourceUrl(final String resourceKey) {
+    return String.format(URL_RESOURCE, resourceKey);
+  }
+
+  public static String getResourceContentUrl(final String resourceKey) {
+    return String.format(URL_RESOURCE_CONTENT, resourceKey);
+  }
+
   public static String getGlobalJobStatisticsUrl() {
     return URL_GLOBAL_JOB_STATISTICS;
   }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -118,6 +118,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/process-definitions/statistics/process-instances-by-version";
   private static final String URL_INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_PROCESS_DEFINITION =
       REST_API_PATH + "/incidents/statistics/process-instances-by-definition";
+  private static final String URL_RESOURCE = REST_API_PATH + "/resources/%s";
+  private static final String URL_RESOURCE_CONTENT = URL_RESOURCE + "/content";
   private static final String URL_INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR =
       REST_API_PATH + "/incidents/statistics/process-instances-by-error";
   private static final String URL_GLOBAL_JOB_STATISTICS = REST_API_PATH + "/jobs/statistics/global";
@@ -447,6 +449,14 @@ public class RestGatewayPaths {
 
   public static String getGlobalJobStatisticsUrl() {
     return URL_GLOBAL_JOB_STATISTICS;
+  }
+
+  public static String getResourceUrl(final String resourceKey) {
+    return String.format(URL_RESOURCE, resourceKey);
+  }
+
+  public static String getResourceContentUrl(final String resourceKey) {
+    return String.format(URL_RESOURCE_CONTENT, resourceKey);
   }
 
   public static String getResourceDeletionUrl(final long resourceKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -57,6 +57,7 @@ import io.camunda.client.protocol.rest.ProcessDefinitionInstanceVersionStatistic
 import io.camunda.client.protocol.rest.ProcessDefinitionResult;
 import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import io.camunda.client.protocol.rest.ProcessInstanceSequenceFlowsQueryResult;
+import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.protocol.rest.RoleCreateResult;
 import io.camunda.client.protocol.rest.RoleResult;
 import io.camunda.client.protocol.rest.RoleUpdateResult;
@@ -504,5 +505,13 @@ public class RestGatewayService {
         .register(
             WireMock.get(RestGatewayPaths.getStatusUrl())
                 .willReturn(WireMock.aResponse().withStatus(statusCode)));
+  }
+
+  public void onResourceGetRequest(final long resourceKey, final ResourceResult response) {
+    registerGet(RestGatewayPaths.getResourceUrl(String.valueOf(resourceKey)), response);
+  }
+
+  public void onResourceContentGetRequest(final long resourceKey, final String response) {
+    registerGet(RestGatewayPaths.getResourceContentUrl(String.valueOf(resourceKey)), response);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the missing methods for the endpoints 

[GET resource/:resourceKey](https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/specifications/get-resource/)

[GET resource/:resourceKey/content](https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/specifications/get-resource-content/)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/31111
