### PR TITLE
fix: add name to security-validation module pom

### DIFF
--- a/security/security-validation/pom.xml
+++ b/security/security-validation/pom.xml
@@ -16,6 +16,8 @@
 
   <artifactId>camunda-security-validation</artifactId>
 
+  <name>Camunda Security Validation</name>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `security/security-validation/pom.xml` file by adding a `<name>` element to the project metadata. This helps clarify the project name in build tools and UIs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
