### PR TITLE
ci: more memory for improved stability of database integration tests

### DIFF
--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx2048m"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
         # We need to configure ILM to run more often, to make sure data is cleaned up earlier
@@ -110,7 +110,7 @@ services:
       - discovery.type=single-node
       - plugins.security.disabled=true
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
-      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx2048m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
       - action.destructive_requires_name=false
         # Disabling the security to make sure we can access without tls in our tests


### PR DESCRIPTION
This increases the max heap size for ES and OS when running database integration tests. Hopefully resolves some stability issues, especially with OS: https://camunda.slack.com/archives/C071KP5BTHB/p1766144837900699