### PR TITLE
feat: set default segment-preallocation-strategy to POSIX_OR_FILL

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -186,7 +186,7 @@ public class Raft {
    *   <li>POSIX_OR_FILL: use POSIX strategy or FILL if it's not possible.
    * </ul>
    */
-  private PreAllocationStrategy segmentPreallocationStrategy = PreAllocationStrategy.FILL;
+  private PreAllocationStrategy segmentPreallocationStrategy = PreAllocationStrategy.POSIX_OR_FILL;
 
   public Duration getHeartbeatInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/configuration/src/test/java/io/camunda/configuration/RaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RaftTest.java
@@ -99,7 +99,7 @@ public class RaftTest {
         context -> {
           final var brokerCfg = context.getBean(BrokerBasedProperties.class);
           assertThat(brokerCfg.getExperimental().getRaft().getSegmentPreallocationStrategy())
-              .isEqualTo(PreAllocationStrategy.FILL);
+              .isEqualTo(PreAllocationStrategy.POSIX_OR_FILL);
         });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -26,7 +26,7 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
   private static final PreAllocationStrategy DEFAULT_PREALLOCATE_SEGMENT_STRATEGY =
-      PreAllocationStrategy.FILL;
+      PreAllocationStrategy.POSIX_OR_FILL;
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
   private DataSize snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;


### PR DESCRIPTION
## Description
The performance looks good on our GCP clusters, I think it should be the default.
In the week I'll validate what happens with the NOOP strategy when the broker is out of disk.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
