### PR TITLE
[Backport stable/8.8] fix: use threadsafe map for lastScheduledPositions

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
@@ -18,6 +18,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
@@ -35,7 +36,8 @@ public class ImportPositionHolder {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportPositionHolder.class);
 
   // this is the in-memory only storage
-  private final Map<String, ImportPositionEntity> lastScheduledPositions = new HashMap<>();
+  private final Map<String, ImportPositionEntity> lastScheduledPositions =
+      new ConcurrentHashMap<>();
 
   private final Map<String, ImportPositionEntity> pendingImportPositionUpdates = new HashMap<>();
   private final Map<String, ImportPositionEntity> inflightImportPositions = new HashMap<>();


### PR DESCRIPTION
# Description
Backport of #42749 to `stable/8.8`.

relates to #42554