### PR TITLE
build: skip redundant spec validation in client modules

### DIFF
--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -309,8 +309,8 @@
           <generateModels>true</generateModels>
           <generateModelDocumentation>false</generateModelDocumentation>
           <generateModelTests>false</generateModelTests>
-          <!-- validate the spec on every generation -->
-          <skipValidateSpec>false</skipValidateSpec>
+          <!-- no need to validate the spec here - this happens in zeebe-gateway-rest already -->
+          <skipValidateSpec>true</skipValidateSpec>
           <configOptions>
             <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
             <documentationProvider>none</documentationProvider>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -317,8 +317,8 @@
           <generateModelDocumentation>false</generateModelDocumentation>
           <generateModelTests>false</generateModelTests>
           <templateDirectory>${project.basedir}/src/main/resources/templates</templateDirectory>
-          <!-- validate the spec on every generation -->
-          <skipValidateSpec>false</skipValidateSpec>
+          <!-- no need to validate the spec here - this happens in zeebe-gateway-rest already -->
+          <skipValidateSpec>true</skipValidateSpec>
           <configOptions>
             <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
             <documentationProvider>none</documentationProvider>


### PR DESCRIPTION
## Description

Low hanging fruit to reduce build overhead, as spec validation is already done on the rest-gateway module and once per reactor build is suffice. I would argue there is no need for spec validation to be done on client modules, it should happen on server side modules serving the API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #42746
