### PR TITLE
docs: remove outdated troubleshooting entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,9 +266,6 @@ You can run the Camunda distribution via IntelliJ for development purposes.
 
 ##### Troubleshooting
 
-- If you receive an error on saving the project structure settings regarding the
-  `zeebe-gateway-protocol` not being able to contain the `src/main/proto` directory, fix this by
-  removing the mentioned source root from `zeebe-gateway-protocol` module in the _Modules_ tab.
 - If you notice errors in files referencing `GatewayOuterClass` (or its inner classes), you may need
   to increase the maximum file size for which IntelliJ provides code assistance. To do this,
   `Help -> Edit Custom Properties` and add the following line:


### PR DESCRIPTION
## Description

The cause of the zeebe-gateway-protocol source directory issue in IntelliJ got resolved with 0bb2852.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32654
