### PR TITLE
fix: set missing data source properties in CamundaRdbmsTestApplication

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
@@ -73,6 +74,14 @@ public final class CamundaRdbmsTestApplication
         rdbms.setUrl(jdbcDatabaseContainer.getJdbcUrl());
         rdbms.setUsername(jdbcDatabaseContainer.getUsername());
         rdbms.setPassword(jdbcDatabaseContainer.getPassword());
+        // In order to ensure that a test runs against the intended database, we also need to set
+        // Spring’s datasource properties. Otherwise, Spring might default to an embedded database
+        // (H2). See also property substitution in dist/application.properties for further details.
+        withAdditionalProperties(
+            Map.of(
+                "spring.datasource.url", rdbms.getUrl(),
+                "spring.datasource.username", rdbms.getUsername(),
+                "spring.datasource.password", rdbms.getPassword()));
       }
     }
 


### PR DESCRIPTION
## Description

This PR sets the missing data source properties in CamundaRdbmsTestApplication to ensure that tests run against the intended database.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
