### PR TITLE
test: migrate callActivities.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -22,11 +22,14 @@ export class OperateDiagramPage {
   readonly showIncidentButton: Locator;
   readonly showMetadataButton: Locator;
   readonly viewRootCauseDecisionLink: Locator;
+  readonly popoverLink: (name: string | RegExp) => Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.diagram = this.page.getByTestId('diagram');
     this.popover = this.page.getByTestId('popover');
+    this.popoverLink = (name: string | RegExp) =>
+      this.popover.getByRole('link', {name});
     this.resetDiagramZoomButton = this.page.getByRole('button', {
       name: 'Reset diagram zoom',
     });
@@ -227,5 +230,9 @@ export class OperateDiagramPage {
       timeout: 30000,
     });
     await this.viewRootCauseDecisionLink.click();
+  }
+
+  async clickPopoverLink(name: string | RegExp): Promise<void> {
+    await this.popoverLink(name).click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -20,17 +20,18 @@ type OptionalFilter =
 
 export class OperateFiltersPanelPage {
   private page: Page;
-  readonly activeCheckbox: Locator;
-  readonly incidentsCheckbox: Locator;
+  readonly activeInstancesCheckbox: Locator;
+  readonly incidentsInstancesCheckbox: Locator;
   readonly runningInstancesCheckbox: Locator;
-  readonly completedCheckbox: Locator;
-  readonly canceledCheckbox: Locator;
+  readonly completedInstancesCheckbox: Locator;
+  readonly canceledInstancesCheckbox: Locator;
   readonly finishedInstancesCheckbox: Locator;
   readonly processNameFilter: Locator;
   readonly processVersionFilter: Locator;
   readonly processInstanceKeysFilter: Locator;
   readonly processInstanceKeysFilterOption: Locator;
   readonly parentProcessInstanceKey: Locator;
+  readonly processInstanceKey: Locator;
   readonly flowNodeFilter: Locator;
   readonly operationIdFilter: Locator;
   readonly resetFiltersButton: Locator;
@@ -50,24 +51,27 @@ export class OperateFiltersPanelPage {
   readonly dialogEditVariableValueText: Locator;
   readonly dialogEditMultipleVariableValueText: Locator;
   readonly dialogCancelButton: Locator;
+  readonly getOptionByName: (name: string, exact?: boolean) => Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.activeCheckbox = this.page.getByRole('checkbox', {name: 'Active'});
-    this.incidentsCheckbox = this.page.getByRole('checkbox', {
+    this.runningInstancesCheckbox = this.page.getByRole('checkbox', {
+      name: 'Running',
+    });
+    this.activeInstancesCheckbox = this.page.getByRole('checkbox', {
+      name: 'Active',
+    });
+    this.incidentsInstancesCheckbox = this.page.getByRole('checkbox', {
       name: 'Incidents',
     });
-    this.runningInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Running Instances',
-    });
-    this.completedCheckbox = this.page.getByRole('checkbox', {
+    this.completedInstancesCheckbox = this.page.getByRole('checkbox', {
       name: 'Completed',
     });
-    this.canceledCheckbox = this.page.getByRole('checkbox', {
+    this.canceledInstancesCheckbox = this.page.getByRole('checkbox', {
       name: 'Canceled',
     });
     this.finishedInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Finished Instances',
+      name: 'Finished',
     });
     this.processNameFilter = this.page.getByRole('combobox', {
       name: 'Name',
@@ -83,6 +87,9 @@ export class OperateFiltersPanelPage {
     });
     this.parentProcessInstanceKey = page.getByRole('textbox', {
       name: 'parent process instance key',
+    });
+    this.processInstanceKey = page.getByRole('textbox', {
+      name: 'process instance key',
     });
     this.flowNodeFilter = this.page.getByRole('combobox', {
       name: 'flow node',
@@ -126,6 +133,8 @@ export class OperateFiltersPanelPage {
     this.dialogCancelButton = this.variableEditorDialog.getByRole('button', {
       name: 'cancel',
     });
+    this.getOptionByName = (name: string, exact = true) =>
+      this.page.getByRole('option', {name, exact});
   }
 
   async validateCheckedState(
@@ -157,17 +166,17 @@ export class OperateFiltersPanelPage {
 
   async selectProcess(option: string) {
     await this.processNameFilter.click();
-    await this.page.getByRole('option', {name: option, exact: true}).click();
+    await this.getOptionByName(option).click({timeout: 30000});
   }
 
   async selectVersion(option: string) {
     await this.processVersionFilter.click();
-    await this.page.getByRole('option', {name: option, exact: true}).click();
+    await this.getOptionByName(option).click({timeout: 30000});
   }
 
   async selectFlowNode(option: string) {
     await this.flowNodeFilter.click();
-    await this.page.getByRole('option', {name: option}).click();
+    await this.getOptionByName(option, false).click();
   }
 
   async fillVariableNameFilter(name: string) {
@@ -238,6 +247,10 @@ export class OperateFiltersPanelPage {
     await this.errorMessageFilter.fill(errorMessage);
   }
 
+  async fillOperationIdFilter(operationId: string) {
+    await this.operationIdFilter.fill(operationId);
+  }
+
   async clickJsonEditorModal() {
     await this.jsonEditorModalButton.click();
   }
@@ -248,5 +261,28 @@ export class OperateFiltersPanelPage {
 
   async clickMultipleVariablesSwitch() {
     await this.multipleVariablesSwitch.click({force: true});
+  }
+
+  async clickRunningInstancesCheckbox(): Promise<void> {
+    await this.runningInstancesCheckbox.click({timeout: 60000});
+  }
+
+  async clickActiveInstancesCheckbox(): Promise<void> {
+    await this.activeInstancesCheckbox.click();
+  }
+
+  async clickIncidentsInstancesCheckbox(): Promise<void> {
+    await this.incidentsInstancesCheckbox.click({timeout: 60000});
+  }
+
+  async clickFinishedInstancesCheckbox(): Promise<void> {
+    await this.finishedInstancesCheckbox.click({timeout: 60000});
+  }
+
+  async clickCompletedInstancesCheckbox(): Promise<void> {
+    await this.completedInstancesCheckbox.click({timeout: 60000});
+  }
+  async clickCanceledInstancesCheckbox(): Promise<void> {
+    await this.canceledInstancesCheckbox.click({timeout: 60000});
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -72,6 +72,9 @@ class OperateProcessInstancePage {
   readonly noVariablesText: Locator;
   readonly variableCellByName: (name: string | RegExp) => Locator;
   readonly viewAllChildProcessesLink: Locator;
+  readonly instanceHeaderSkeleton: Locator;
+  readonly viewAllCalledInstancesLink: Locator;
+  readonly viewParentInstanceLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -182,6 +185,13 @@ class OperateProcessInstancePage {
       this.variablesList.getByRole('cell', {name});
     this.viewAllChildProcessesLink = this.instanceHeader.getByRole('link', {
       name: 'View all',
+    });
+    this.instanceHeaderSkeleton = page.getByTestId('instance-header-skeleton');
+    this.viewAllCalledInstancesLink = page.getByRole('link', {
+      name: /view all called instances/i,
+    });
+    this.viewParentInstanceLink = page.getByRole('link', {
+      name: /view parent instance/i,
     });
   }
 
@@ -598,6 +608,14 @@ class OperateProcessInstancePage {
 
   async clickViewAllChildProcesses(): Promise<void> {
     await this.viewAllChildProcessesLink.click();
+  }
+
+  async clickViewAllCalledInstances(): Promise<void> {
+    await this.viewAllCalledInstancesLink.click();
+  }
+
+  async clickViewParentInstance(): Promise<void> {
+    await this.viewParentInstanceLink.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -51,13 +51,18 @@ class OperateProcessesPage {
   readonly applyButton: Locator;
   readonly resultsCount: Locator;
   readonly scheduledOperationsIcons: Locator;
-  getProcessInstanceLinkByKey: (processInstanceKey: string) => Locator;
-  getOperationAndResultsContainer: (
+  readonly viewParentInstanceLinkInList: Locator;
+  readonly processInstanceLinkByKey: (processInstanceKey: string) => Locator;
+  readonly operationAndResultsContainer: (
     operation: string,
     resultCount?: number,
   ) => Locator;
-  getParentInstanceCell: (parentInstanceKey: string) => Locator;
-  getVersionCells: (version: string) => Locator;
+  readonly parentInstanceCell: (parentInstanceKey: string) => Locator;
+  readonly versionCells: (version: string) => Locator;
+  readonly calledInstanceCell: (
+    rowIndex?: number,
+    cellIndex?: number,
+  ) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -156,11 +161,11 @@ class OperateProcessesPage {
     this.scheduledOperationsIcons = page.getByTitle(
       /has scheduled operations/i,
     );
-    this.getProcessInstanceLinkByKey = (processInstanceKey: string) =>
+    this.processInstanceLinkByKey = (processInstanceKey: string) =>
       page.getByRole('link', {
         name: processInstanceKey,
       });
-    this.getOperationAndResultsContainer = (
+    this.operationAndResultsContainer = (
       operation: string,
       resultCount?: number,
     ) => {
@@ -169,10 +174,19 @@ class OperateProcessesPage {
         : new RegExp(`${operation}.*\\d+ results`);
       return page.locator('div').filter({hasText: pattern});
     };
-    this.getParentInstanceCell = (parentInstanceKey: string) =>
+    this.parentInstanceCell = (parentInstanceKey: string) =>
       this.dataList.getByRole('cell', {name: parentInstanceKey});
-    this.getVersionCells = (version: string) =>
+    this.versionCells = (version: string) =>
       this.dataList.getByRole('cell', {name: version, exact: true});
+    this.viewParentInstanceLinkInList = this.dataList.getByRole('link', {
+      name: /view parent instance/i,
+    });
+    this.calledInstanceCell = (rowIndex = 0, cellIndex = 2) =>
+      this.dataList
+        .getByRole('row')
+        .nth(rowIndex)
+        .getByRole('cell')
+        .nth(cellIndex);
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -408,6 +422,10 @@ class OperateProcessesPage {
   async startMigration(): Promise<void> {
     await this.clickMigrateButton();
     await this.clickContinueButton();
+  }
+
+  async clickViewParentInstanceFromList(): Promise<void> {
+    await this.viewParentInstanceLinkInList.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessDeployment = {
+  readonly processInstanceKey: string;
+};
+
+let callActivityProcessInstance: ProcessDeployment;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/callActivityProcess.bpmn',
+    './resources/calledProcess.bpmn',
+  ]);
+
+  const instance = await createSingleInstance('CallActivityProcess', 1);
+  callActivityProcessInstance = {
+    processInstanceKey: instance.processInstanceKey,
+  };
+
+  await sleep(2000);
+});
+
+test.describe('Call Activities', () => {
+  test.describe.configure({retries: 0});
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Navigate to called and parent process instances', async ({
+    operateProcessInstancePage,
+    operateProcessesPage,
+    operateDiagramPage,
+  }) => {
+    test.slow();
+    const processInstanceKey = callActivityProcessInstance.processInstanceKey;
+
+    await test.step('Navigate to the call activity process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      await expect(
+        operateProcessInstancePage.instanceHeaderSkeleton,
+      ).toBeHidden();
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('View all called instances', async () => {
+      await operateProcessInstancePage.clickViewAllCalledInstances();
+
+      await expect(operateProcessesPage.processInstancesTable).toHaveCount(1);
+      await expect(
+        operateProcessesPage.processInstancesTable.getByText('Called Process'),
+      ).toBeVisible();
+    });
+
+    let calledProcessInstanceId: string;
+
+    await test.step('Get called process instance ID', async () => {
+      calledProcessInstanceId = await operateProcessesPage
+        .calledInstanceCell()
+        .innerText();
+    });
+
+    await test.step('Navigate back to parent instance from list', async () => {
+      await operateProcessesPage.clickViewParentInstanceFromList();
+
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify instance history on parent process', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('StartEvent_1'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Call Activity', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_1p0nsc7'),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify diagram shows call activity', async () => {
+      await expect(
+        operateDiagramPage.getFlowNode('Activity_13otele'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to called process instance via diagram', async () => {
+      await operateDiagramPage.clickFlowNode('Activity_13otele');
+
+      await expect(
+        operateDiagramPage.getPopoverText(/Called Process Instance/),
+      ).toBeVisible();
+
+      await operateDiagramPage.clickPopoverLink(
+        /view called process instance/i,
+      );
+    });
+
+    await test.step('Verify called process instance header and history', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          calledProcessInstanceId,
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText('Called Process', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Called Process', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Process started'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_0y6k56d'),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify called process diagram', async () => {
+      await expect(
+        operateDiagramPage.getFlowNode('StartEvent_1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate back to parent instance from header', async () => {
+      await operateProcessInstancePage.clickViewParentInstance();
+
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify parent process instance history and diagram again', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('StartEvent_1'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Call Activity', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_1p0nsc7'),
+      ).toBeVisible();
+
+      await expect(
+        operateDiagramPage.getFlowNode('Activity_13otele'),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -114,12 +114,19 @@ test.describe('Child Process Instance Migration', () => {
         testProcesses.parentProcess.version.toString(),
       );
 
-      await expect(page.getByText('2 results')).toBeVisible({
-        timeout: 30000,
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible({
+            timeout: 30000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
       });
 
       await operateProcessesPage
-        .getProcessInstanceLinkByKey(parentInstanceKey)
+        .processInstanceLinkByKey(parentInstanceKey)
         .click();
 
       await operateProcessInstancePage.clickViewAllChildProcesses();
@@ -129,14 +136,21 @@ test.describe('Child Process Instance Migration', () => {
         .innerText();
 
       await expect(
-        operateProcessesPage.getParentInstanceCell(parentInstanceKey),
+        operateProcessesPage.parentInstanceCell(parentInstanceKey),
       ).toBeVisible();
 
       await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(childVersion);
 
-      await expect(page.getByText('1 result')).toBeVisible({
-        timeout: 30000,
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible({
+            timeout: 30000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
       });
     });
 
@@ -192,11 +206,11 @@ test.describe('Child Process Instance Migration', () => {
       });
 
       await expect(
-        operateProcessesPage.getVersionCells(targetVersion),
+        operateProcessesPage.versionCells(targetVersion),
       ).toHaveCount(1, {timeout: 30000});
 
       await expect(
-        operateProcessesPage.getParentInstanceCell(parentInstanceKey),
+        operateProcessesPage.parentInstanceCell(parentInstanceKey),
       ).toBeVisible();
     });
 
@@ -206,8 +220,15 @@ test.describe('Child Process Instance Migration', () => {
       await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(sourceVersion);
 
-      await expect(page.getByText('1 result')).toBeVisible({
-        timeout: 30000,
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible({
+            timeout: 30000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
       });
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -235,7 +235,7 @@ test.describe('Operations', () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(
-            operateProcessesPage.getOperationAndResultsContainer('cancel', 5),
+            operateProcessesPage.operationAndResultsContainer('cancel', 5),
           ).toBeVisible({
             timeout: 30000,
           });
@@ -247,7 +247,7 @@ test.describe('Operations', () => {
       await Promise.all(
         instances.map((instance) =>
           expect(
-            operateProcessesPage.getProcessInstanceLinkByKey(
+            operateProcessesPage.processInstanceLinkByKey(
               instance.processInstanceKey,
             ),
           ).toBeVisible(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -308,7 +308,7 @@ test.describe.serial('Process Instance Migration', () => {
         },
       });
 
-      await expect(operateProcessesPage.getVersionCells('2')).toHaveCount(6, {
+      await expect(operateProcessesPage.versionCells('2')).toHaveCount(6, {
         timeout: 30000,
       });
     });
@@ -644,7 +644,7 @@ test.describe.serial('Process Instance Migration', () => {
       await validateURL(page, /operationId=/);
 
       await expect(
-        operateProcessesPage.getVersionCells(targetVersion),
+        operateProcessesPage.versionCells(targetVersion),
       ).toHaveCount(3, {timeout: 60000});
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -87,13 +87,21 @@ test.describe('Processes', () => {
       await expect(
         operateFiltersPanelPage.runningInstancesCheckbox,
       ).toBeChecked();
-      await expect(operateFiltersPanelPage.activeCheckbox).toBeChecked();
-      await expect(operateFiltersPanelPage.incidentsCheckbox).toBeChecked();
+      await expect(
+        operateFiltersPanelPage.activeInstancesCheckbox,
+      ).toBeChecked();
+      await expect(
+        operateFiltersPanelPage.incidentsInstancesCheckbox,
+      ).toBeChecked();
       await expect(
         operateFiltersPanelPage.finishedInstancesCheckbox,
       ).not.toBeChecked();
-      await expect(operateFiltersPanelPage.completedCheckbox).not.toBeChecked();
-      await expect(operateFiltersPanelPage.canceledCheckbox).not.toBeChecked();
+      await expect(
+        operateFiltersPanelPage.completedInstancesCheckbox,
+      ).not.toBeChecked();
+      await expect(
+        operateFiltersPanelPage.canceledInstancesCheckbox,
+      ).not.toBeChecked();
     });
 
     await test.step('Validate no process selected message', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR migrates the callActivities test from the operate component folder to the OC e2e test suite, consolidating test coverage for call activities functionality.

## Changes:
- **Migrated** `callActivities.spec.ts` to OC test suite with comprehensive call activity navigation tests
- **Enhanced** page objects (`OperateDiagramPage`, `OperateProcessInstancePage`, `OperateProcessesPage`) with methods needed for call activity interactions  
- **Fixed** flaky checkbox assertion issues by updating `OperateFiltersPanelPage` locators to use proper `getByRole('checkbox')` instead of label selectors


🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/20425346595/job/58684555793)
❗ Failing API tests are not related to my changes as they are broken on main as well
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34097
