### PR TITLE
ci: make SARIF non-blocking for merge group

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -341,6 +341,7 @@ jobs:
           verbose: true
       - name: Upload Hadolint Results
         if: always()
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ./hadolint.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -838,6 +838,7 @@ jobs:
           verbose: true
       - name: Upload Hadolint Results
         if: always()
+        continue-on-error: ${{ github.event_name == 'merge_group' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ./hadolint.sarif


### PR DESCRIPTION
## Description

This pull request makes a small change to the CI workflow configuration to improve robustness when running in a merge group context. Specifically, it updates the Hadolint SARIF upload steps in both `ci.yml` and `ci-zeebe.yml` workflows to allow them to continue on error if the event is a merge group.

- CI workflow robustness:
  * Added `continue-on-error` condition to the "Upload Hadolint Results" step in `.github/workflows/ci.yml` and `.github/workflows/ci-zeebe.yml` to prevent workflow failures during merge group events. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR841) [[2]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718R344)

Related to this incident: https://camunda.slack.com/archives/C0A4PF1BUJW

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
