### PR TITLE
[stable/8.6] deps: Update spring boot to v3.5.9

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -16,7 +16,7 @@
 
 package io.camunda.zeebe.client.impl;
 
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
@@ -33,9 +33,9 @@ import java.util.function.Function;
 public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
     extends CompletableFuture<ClientResponse>
     implements ZeebeFuture<ClientResponse>,
-        ClientResponseObserver<GeneratedMessageV3, BrokerResponse> {
+        ClientResponseObserver<GeneratedMessage, BrokerResponse> {
 
-  protected ClientCallStreamObserver<GeneratedMessageV3> clientCall;
+  protected ClientCallStreamObserver<GeneratedMessage> clientCall;
   private final Function<BrokerResponse, ClientResponse> responseMapper;
 
   public ZeebeClientFutureImpl() {
@@ -105,7 +105,7 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   }
 
   @Override
-  public void beforeStart(final ClientCallStreamObserver<GeneratedMessageV3> requestStream) {
+  public void beforeStart(final ClientCallStreamObserver<GeneratedMessage> requestStream) {
     if (isDone()) {
       requestStream.cancel("Call was completed by the client before it was started", null);
       return;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.client.util;
 
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -85,11 +85,11 @@ import java.util.function.Supplier;
 
 public final class RecordingGatewayService extends GatewayImplBase {
 
-  private final BlockingDeque<GeneratedMessageV3> requests = new LinkedBlockingDeque<>();
+  private final BlockingDeque<GeneratedMessage> requests = new LinkedBlockingDeque<>();
 
-  private final Map<Class<? extends GeneratedMessageV3>, RequestHandler> requestHandlers =
+  private final Map<Class<? extends GeneratedMessage>, RequestHandler> requestHandlers =
       new HashMap<>();
-  private final Map<Class<? extends GeneratedMessageV3>, Supplier<Throwable>> errorHandlers =
+  private final Map<Class<? extends GeneratedMessage>, Supplier<Throwable>> errorHandlers =
       new HashMap<>();
 
   public RecordingGatewayService() {
@@ -578,7 +578,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
   }
 
   public void errorOnRequest(
-      final Class<? extends GeneratedMessageV3> requestClass,
+      final Class<? extends GeneratedMessage> requestClass,
       final Supplier<Exception> errorSupplier) {
     addRequestHandler(
         requestClass,
@@ -588,29 +588,29 @@ public final class RecordingGatewayService extends GatewayImplBase {
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends GeneratedMessageV3> T getLastRequest() {
+  public <T extends GeneratedMessage> T getLastRequest() {
     return (T) requests.getLast();
   }
 
-  public <T extends GeneratedMessageV3> void addRequestHandler(
+  public <T extends GeneratedMessage> void addRequestHandler(
       final Class<T> requestClass,
-      final RequestHandler<T, ? extends GeneratedMessageV3> requestHandler) {
+      final RequestHandler<T, ? extends GeneratedMessage> requestHandler) {
     errorHandlers.remove(requestClass);
     requestHandlers.put(requestClass, requestHandler);
   }
 
   public void addRequestHandler(
-      final Class<? extends GeneratedMessageV3> requestClass, final Supplier<Throwable> thrower) {
+      final Class<? extends GeneratedMessage> requestClass, final Supplier<Throwable> thrower) {
     requestHandlers.remove(requestClass);
     errorHandlers.put(requestClass, thrower);
   }
 
   @SuppressWarnings("unchecked")
-  private <RequestT extends GeneratedMessageV3, ResponseT extends GeneratedMessageV3> void handle(
+  private <RequestT extends GeneratedMessage, ResponseT extends GeneratedMessage> void handle(
       final RequestT request, final StreamObserver<ResponseT> responseObserver) {
     requests.add(request);
     try {
-      final Class<? extends GeneratedMessageV3> requestType = request.getClass();
+      final Class<? extends GeneratedMessage> requestType = request.getClass();
       final RequestHandler<RequestT, ResponseT> requestHandler = requestHandlers.get(requestType);
       if (requestHandler != null) {
         requestHandler.handleMultiple(request).forEach(responseObserver::onNext);
@@ -629,8 +629,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
   }
 
   @FunctionalInterface
-  interface RequestHandler<
-      RequestT extends GeneratedMessageV3, ResponseT extends GeneratedMessageV3> {
+  interface RequestHandler<RequestT extends GeneratedMessage, ResponseT extends GeneratedMessage> {
     ResponseT handle(RequestT request) throws Exception;
 
     default Collection<ResponseT> handleMultiple(final RequestT request) throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/RestTemplateNoRedirectFollowConfiguration.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/RestTemplateNoRedirectFollowConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings.Redirects;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class RestTemplateNoRedirectFollowConfiguration {
+  @Bean
+  RestTemplateBuilder noRedirectTemplateBuilder() {
+    return new RestTemplateBuilder().redirects(Redirects.DONT_FOLLOW);
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings.Redirects;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -56,7 +57,9 @@ public class OldRoutesRedirectionControllerIT {
   @MethodSource("redirectionTestDataProvider")
   public void testRedirections(final String path) {
     final ResponseEntity<String> response =
-        restTemplate.getForEntity(baseUrl() + path, String.class);
+        restTemplate
+            .withRedirects(Redirects.DONT_FOLLOW)
+            .getForEntity(baseUrl() + path, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
     assertThat(response.getHeaders().getLocation().toString())
         .isEqualTo(baseUrl() + "/operate" + path);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationWithPersistentSessionsIT.java
@@ -28,6 +28,7 @@ import io.camunda.operate.schema.indices.OperateWebSessionIndex;
 import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
 import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.util.RestTemplateNoRedirectFollowConfiguration;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.controllers.OperateIndexController;
 import io.camunda.operate.webapp.elasticsearch.ElasticsearchSessionRepository;
@@ -98,6 +99,7 @@ import org.springframework.test.context.junit4.SpringRunner;
       DatabaseInfo.class,
       OperateIndexController.class,
       WebappsModuleConfiguration.class,
+      RestTemplateNoRedirectFollowConfiguration.class,
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationWithPersistentSessionsIT.CONTEXT_PATH,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationIT.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.management.IndicesCheck;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.RestTemplateNoRedirectFollowConfiguration;
 import io.camunda.operate.util.SpringContextHolder;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.controllers.OperateIndexController;
@@ -93,6 +94,7 @@ import org.springframework.web.client.RestTemplate;
       OperateProfileService.class,
       OperateIndexController.class,
       WebappsModuleConfiguration.class,
+      RestTemplateNoRedirectFollowConfiguration.class,
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationIT.CONTEXT_PATH,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
@@ -39,6 +39,7 @@ import io.camunda.operate.schema.indices.OperateWebSessionIndex;
 import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
 import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.util.RestTemplateNoRedirectFollowConfiguration;
 import io.camunda.operate.util.SpringContextHolder;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.controllers.OperateIndexController;
@@ -123,6 +124,7 @@ import org.springframework.web.client.RestTemplate;
       DatabaseInfo.class,
       OperateIndexController.class,
       WebappsModuleConfiguration.class,
+      RestTemplateNoRedirectFollowConfiguration.class,
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationWithPersistentSessionsIT.CONTEXT_PATH,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/CsrfTokenIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/CsrfTokenIT.java
@@ -26,6 +26,7 @@ import com.auth0.AuthorizeUrl;
 import com.auth0.Tokens;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.RestTemplateNoRedirectFollowConfiguration;
 import io.camunda.operate.util.SpringContextHolder;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.api.v1.dao.ProcessDefinitionDao;
@@ -90,7 +91,8 @@ import org.springframework.web.client.RestTemplate;
       OperateProperties.class,
       OperateProfileService.class,
       ProcessRestService.class,
-      ProcessDefinitionController.class
+      ProcessDefinitionController.class,
+      RestTemplateNoRedirectFollowConfiguration.class,
     },
     properties = {
       "server.servlet.context-path=" + CsrfTokenIT.CONTEXT_PATH,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,7 @@
     <version.rest-assured>5.5.6</version.rest-assured>
     <version.spring>6.2.15</version.spring>
     <version.spring-security>6.5.7</version.spring-security>
-    <version.spring-boot>3.4.13</version.spring-boot>
+    <version.spring-boot>3.5.9</version.spring-boot>
     <version.tomcat>10.1.50</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,8 +79,8 @@
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>3.25.8</version.protobuf>
-    <version.protobuf-common>2.44.0</version.protobuf-common>
+    <version.protobuf>4.31.1</version.protobuf>
+    <version.protobuf-common>2.59.2</version.protobuf-common>
     <version.micrometer>1.15.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.8</version.protobuf>
     <version.protobuf-common>2.44.0</version.protobuf-common>
-    <version.micrometer>1.14.14</version.micrometer>
+    <version.micrometer>1.15.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/RestTemplateNoRedirectFollowConfiguration.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/RestTemplateNoRedirectFollowConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.util;
+
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings.Redirects;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class RestTemplateNoRedirectFollowConfiguration {
+  @Bean
+  RestTemplateBuilder noRedirectTemplateBuilder() {
+    return new RestTemplateBuilder().redirects(Redirects.DONT_FOLLOW);
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings.Redirects;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -38,7 +39,9 @@ public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
   @MethodSource("redirectionTestDataProvider")
   public void testRedirections(final String path) {
     final ResponseEntity<String> response =
-        restTemplate.getForEntity(baseUrl() + path, String.class);
+        restTemplate
+            .withRedirects(Redirects.DONT_FOLLOW)
+            .getForEntity(baseUrl() + path, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
     assertThat(response.getHeaders().getLocation().toString())
         .isEqualTo(baseUrl() + "/tasklist" + path);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationIT.java
@@ -40,6 +40,7 @@ import com.auth0.Tokens;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphql.spring.boot.test.GraphQLResponse;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.RestTemplateNoRedirectFollowConfiguration;
 import io.camunda.tasklist.util.apps.sso.AuthSSOApplication;
 import io.camunda.tasklist.webapp.graphql.entity.C8AppLink;
 import io.camunda.tasklist.webapp.graphql.entity.UserDTO;
@@ -79,7 +80,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest(
-    classes = {AuthSSOApplication.class},
+    classes = {
+      AuthSSOApplication.class,
+      RestTemplateNoRedirectFollowConfiguration.class,
+    },
     properties = {
       "camunda.tasklist.auth0.clientId=1",
       "camunda.tasklist.auth0.clientSecret=2",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
@@ -35,6 +35,7 @@ import com.auth0.Tokens;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphql.spring.boot.test.GraphQLResponse;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.RestTemplateNoRedirectFollowConfiguration;
 import io.camunda.tasklist.util.apps.sso.AuthSSOApplication;
 import io.camunda.tasklist.webapp.graphql.entity.C8AppLink;
 import io.camunda.tasklist.webapp.security.AssigneeMigrator;
@@ -71,6 +72,7 @@ import org.springframework.web.client.RestTemplate;
 @SpringBootTest(
     classes = {
       AuthSSOApplication.class,
+      RestTemplateNoRedirectFollowConfiguration.class,
     },
     properties = {
       "camunda.tasklist.auth0.clientId=1",


### PR DESCRIPTION
## Description

[Spring-Boot 3.4.x runs out of support 12-2025](https://spring.io/projects/spring-boot#support), thus updating to 3.5.x.

Micrometer had to get upgraded as well to resolve runtime issues see https://docs.spring.io/spring-boot/3.5/appendix/dependency-versions/coordinates.html , because of that also protobuf had to get upgraded.
The dependency versions of these are now aligned with stable/8.8 which is already on spring-boot 3.5.x.

Spring Framework and Spring Security are already aligned with their [versions as managed by Spring-Boot 3.5](https://docs.spring.io/spring-boot/3.5/appendix/dependency-versions/coordinates.html).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #42284
