### PR TITLE
fix: handle when optimize is excluded from the release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -898,6 +898,13 @@ jobs:
     runs-on: ubuntu-latest
     # Minor releases take more time since a lot of issues are included in the changelog
     timeout-minutes: 30
+    if: ${{ always() && !cancelled() && 
+      needs.release.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
+      needs.camunda-docker.result == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1022,6 +1029,14 @@ jobs:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
+    if: ${{ always() && !cancelled() && 
+      needs.release.result == 'success' &&
+      needs.github.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
+      needs.camunda-docker.result == 'success' }}
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Description

This pull request updates the workflow conditions in `.github/workflows/camunda-platform-release.yml` to ensure that jobs only run if all required dependencies have succeeded (or, in the case of `optimize-docker`, have either succeeded or been skipped). This unblock current release which skipped GH release and FOSSA steps: https://github.com/camunda/camunda/actions/runs/20383601242/job/58579700693

**Workflow condition improvements:**

* Added explicit `if` conditions to jobs to check that all required dependencies have succeeded, and that the workflow is not cancelled, before proceeding. This includes allowing the jobs to run if `optimize-docker` is either successful or skipped. (`.github/workflows/camunda-platform-release.yml`) [[1]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R901-R907) [[2]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R1032-R1039)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
