### PR TITLE
test: add Opensearch users and roles in OpenSearchBackendStrategy

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.schema.strategy;
 
+import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
 import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_OPENSEARCH_VERSION;
 
 import io.camunda.application.Profile;
@@ -28,13 +29,19 @@ import java.util.Objects;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
-import org.opensearch.testcontainers.OpenSearchContainer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
 
-  private OpenSearchContainer<?> container;
+  private static final String ADMIN_USER = "camunda-admin";
+  private static final String ADMIN_PASSWORD = "ComplexPassword123!";
+  private static final String APP_USER = "camunda-app";
+  private static final String APP_PASSWORD = "ComplexPassword123!";
+  private static final String INITIAL_ADMIN_PASSWORD = "Strong-Initial-Password123!";
+
+  private GenericContainer<?> container;
   private OpenSearchClient adminClient;
   private String url;
 
@@ -44,16 +51,29 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
       throw new IllegalStateException("Container is already started");
     }
     container =
-        new OpenSearchContainer<>(
+        new GenericContainer<>(
                 DockerImageName.parse("opensearchproject/opensearch")
                     .withTag(SUPPORTED_OPENSEARCH_VERSION))
+            .withEnv("discovery.type", "single-node")
+            .withEnv("DISABLE_SECURITY_PLUGIN", "false")
+            .withEnv("plugins.security.ssl.http.enabled", "false")
+            .withEnv("OPENSEARCH_INITIAL_ADMIN_PASSWORD", INITIAL_ADMIN_PASSWORD)
             // Configure with allowed repository storage path
             .withEnv("path.repo", "~/")
+            .withExposedPorts(9200)
             .withStartupTimeout(Duration.ofMinutes(5))
-            .withStartupAttempts(3);
+            .withStartupAttempts(3)
+            .waitingFor(
+                new HttpWaitStrategy()
+                    .forPort(9200)
+                    .withBasicCredentials("admin", INITIAL_ADMIN_PASSWORD)
+                    .forStatusCodeMatching(response -> response == 200 || response == 401)
+                    .withReadTimeout(Duration.ofSeconds(10))
+                    .withStartupTimeout(Duration.ofMinutes(5)));
 
     container.start();
-    url = container.getHttpHostAddress();
+    createUsersAndRoles();
+    url = "http://" + container.getHost() + ":" + container.getMappedPort(9200);
   }
 
   @Override
@@ -65,8 +85,8 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
   public void createAdminClient() throws Exception {
     final var cfg = new ConnectConfiguration();
     cfg.setUrl(url);
-    cfg.setUsername(container.getUsername());
-    cfg.setPassword(container.getPassword());
+    cfg.setUsername(ADMIN_USER);
+    cfg.setPassword(ADMIN_PASSWORD);
     adminClient = new OpensearchConnector(cfg).createClient();
   }
 
@@ -83,13 +103,16 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
         .withProperty(
             "zeebe.broker.exporters.opensearch.class-name", OpensearchExporter.class.getName())
         .withProperty("zeebe.broker.exporters.opensearch.args.url", url)
+        .withProperty("zeebe.broker.exporters.opensearch.args.authentication.username", ADMIN_USER)
+        .withProperty(
+            "zeebe.broker.exporters.opensearch.args.authentication.password", ADMIN_PASSWORD)
         .withSecondaryStorageType(SecondaryStorageType.opensearch)
         .withUnifiedConfig(
             cfg -> {
               final var opensearch = cfg.getData().getSecondaryStorage().getOpensearch();
               opensearch.setUrl(url);
-              opensearch.setUsername(container.getUsername());
-              opensearch.setPassword(container.getPassword());
+              opensearch.setUsername(ADMIN_USER);
+              opensearch.setPassword(ADMIN_PASSWORD);
             });
   }
 
@@ -102,8 +125,8 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
             cfg -> {
               final var opensearch = cfg.getData().getSecondaryStorage().getOpensearch();
               opensearch.setUrl(url);
-              opensearch.setUsername(container.getUsername());
-              opensearch.setPassword(container.getPassword());
+              opensearch.setUsername(ADMIN_USER);
+              opensearch.setPassword(ADMIN_PASSWORD);
 
               cfg.getData()
                   .getSecondaryStorage()
@@ -118,12 +141,15 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
     camunda
         .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
         .withUnauthenticatedAccess()
-        .withProperty("camunda.database.url", url)
-        .withProperty("camunda.database.type", "opensearch")
+        .withProperty(CREATE_SCHEMA_PROPERTY, "false")
+        .withProperty("camunda.operate.opensearch.health-check-enabled", "false")
+        .withProperty("camunda.tasklist.opensearch.health-check-enabled", "false")
         .withSecondaryStorageType(SecondaryStorageType.opensearch)
         .withUnifiedConfig(
             cfg -> {
               cfg.getData().getSecondaryStorage().getOpensearch().setUrl(url);
+              cfg.getData().getSecondaryStorage().getOpensearch().setUsername(APP_USER);
+              cfg.getData().getSecondaryStorage().getOpensearch().setPassword(APP_PASSWORD);
               cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
             })
         .withExporter(
@@ -133,7 +159,15 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
               cfg.setArgs(
                   Map.of(
                       "connect",
-                      Map.of("url", url, "type", "opensearch"),
+                      Map.of(
+                          "url",
+                          url,
+                          "type",
+                          "opensearch",
+                          "username",
+                          APP_USER,
+                          "password",
+                          APP_PASSWORD),
                       "history",
                       Map.of("waitPeriodBeforeArchiving", "1s"),
                       "createSchema",
@@ -143,7 +177,14 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
             OpensearchExporter.class.getSimpleName(),
             cfg -> {
               cfg.setClassName(OpensearchExporter.class.getName());
-              cfg.setArgs(Map.of("url", url, "index", Map.of("createTemplate", true)));
+              cfg.setArgs(
+                  Map.of(
+                      "url",
+                      url,
+                      "index",
+                      Map.of("createTemplate", false),
+                      "authentication",
+                      Map.of("username", APP_USER, "password", APP_PASSWORD)));
             });
   }
 
@@ -210,11 +251,124 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
             q -> q.name(repositoryName).type("fs").settings(s -> s.location(repositoryName)));
   }
 
+  private void createUsersAndRoles() throws IOException, InterruptedException {
+    // Create camunda_app_role
+    container.execInContainer(
+        "curl",
+        "-X",
+        "PUT",
+        "-u",
+        "admin:" + INITIAL_ADMIN_PASSWORD,
+        "-H",
+        "Content-Type: application/json",
+        "http://localhost:9200/_plugins/_security/api/roles/camunda_app_role",
+        "-d",
+        """
+        {
+          "cluster_permissions": [
+            "indices:data/read/scroll/clear"
+          ],
+          "index_permissions": [
+            {
+              "index_patterns": [
+                "zeebe-*",
+                "operate-*",
+                "tasklist-*",
+                "camunda-*"
+              ],
+              "allowed_actions": [
+                "indices:data/write/*",
+                "indices:data/read/*",
+                "indices:admin/create",
+                "indices:admin/shards/search_shards"
+              ]
+            }
+          ]
+        }""");
+
+    // Create camunda-app user
+    container.execInContainer(
+        "curl",
+        "-X",
+        "PUT",
+        "-u",
+        "admin:" + INITIAL_ADMIN_PASSWORD,
+        "-H",
+        "Content-Type: application/json",
+        "http://localhost:9200/_plugins/_security/api/internalusers/" + APP_USER,
+        "-d",
+        """
+        {
+          "password": "%s",
+          "backend_roles": [
+            "camunda_app_role"
+          ]
+        }"""
+            .formatted(APP_PASSWORD));
+
+    // Create camunda-admin user
+    container.execInContainer(
+        "curl",
+        "-X",
+        "PUT",
+        "-u",
+        "admin:" + INITIAL_ADMIN_PASSWORD,
+        "-H",
+        "Content-Type: application/json",
+        "http://localhost:9200/_plugins/_security/api/internalusers/" + ADMIN_USER,
+        "-d",
+        """
+        {
+          "password": "%s",
+          "backend_roles": [
+            "camunda_admin_role"
+          ]
+        }"""
+            .formatted(ADMIN_PASSWORD));
+
+    // Map all_access role
+    container.execInContainer(
+        "curl",
+        "-X",
+        "PUT",
+        "-u",
+        "admin:" + INITIAL_ADMIN_PASSWORD,
+        "-H",
+        "Content-Type: application/json",
+        "http://localhost:9200/_plugins/_security/api/rolesmapping/all_access",
+        "-d",
+        """
+        {
+          "backend_roles": [
+            "admin",
+            "camunda_admin_role"
+          ]
+        }""");
+
+    // Map camunda_app_role
+    container.execInContainer(
+        "curl",
+        "-X",
+        "PUT",
+        "-u",
+        "admin:" + INITIAL_ADMIN_PASSWORD,
+        "-H",
+        "Content-Type: application/json",
+        "http://localhost:9200/_plugins/_security/api/rolesmapping/camunda_app_role",
+        "-d",
+        """
+        {
+          "backend_roles": [
+            "camunda_app_role"
+          ]
+        }""");
+  }
+
   private OpensearchExporterConfiguration exporterAdminConfig() {
     final var cfg = new OpensearchExporterConfiguration();
     cfg.url = url;
-    cfg.getAuthentication().setUsername(container.getUsername());
-    cfg.getAuthentication().setPassword(container.getPassword());
+    cfg.getAuthentication().setUsername(ADMIN_USER);
+    cfg.getAuthentication().setPassword(ADMIN_PASSWORD);
     cfg.index.createTemplate = true;
     return cfg;
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
@@ -300,7 +300,7 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
         """
         {
           "password": "%s",
-          "backend_roles": [
+          "opendistro_security_roles": [
             "camunda_app_role"
           ]
         }"""
@@ -320,48 +320,11 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
         """
         {
           "password": "%s",
-          "backend_roles": [
-            "camunda_admin_role"
+          "opendistro_security_roles": [
+            "all_access"
           ]
         }"""
             .formatted(ADMIN_PASSWORD));
-
-    // Map all_access role
-    container.execInContainer(
-        "curl",
-        "-X",
-        "PUT",
-        "-u",
-        "admin:" + INITIAL_ADMIN_PASSWORD,
-        "-H",
-        "Content-Type: application/json",
-        "http://localhost:9200/_plugins/_security/api/rolesmapping/all_access",
-        "-d",
-        """
-        {
-          "backend_roles": [
-            "admin",
-            "camunda_admin_role"
-          ]
-        }""");
-
-    // Map camunda_app_role
-    container.execInContainer(
-        "curl",
-        "-X",
-        "PUT",
-        "-u",
-        "admin:" + INITIAL_ADMIN_PASSWORD,
-        "-H",
-        "Content-Type: application/json",
-        "http://localhost:9200/_plugins/_security/api/rolesmapping/camunda_app_role",
-        "-d",
-        """
-        {
-          "backend_roles": [
-            "camunda_app_role"
-          ]
-        }""");
   }
 
   private OpensearchExporterConfiguration exporterAdminConfig() {

--- a/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
@@ -48,7 +48,7 @@ class OpensearchConnectorTest {
         List.of(new PluginConfiguration("plg1", TestPlugin.class.getName(), null)));
 
     final var connector = Mockito.spy(new OpenSearchConnector());
-    Mockito.doReturn(true).when(connector).checkHealth(Mockito.any(OpenSearchClient.class));
+    Mockito.doReturn(true).when(connector).isHealthy(Mockito.any(OpenSearchClient.class));
     connector.setOsClientRepository(pluginRepository);
     connector.setTasklistProperties(taskListProperties);
     connector.setTasklistObjectMapper(new ObjectMapper());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchRepository.java
@@ -114,7 +114,7 @@ public class OpensearchRepository implements AutoCloseable {
                 logger.warn(
                     """
                         Failed to clear scroll context; this could eventually lead to \
-                        increased resource usage in Elastic""",
+                        increased resource usage in OpenSearch""",
                     clearError);
 
                 return null;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`OpenSearchBackendStrategy` that is used in [StandaloneSchemaManagerIT](https://github.com/camunda/camunda/blob/main/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java) and [StandaloneBackupManagerIT](https://github.com/camunda/camunda/blob/main/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java) and defines OS users and roles for camunda apps, to ensure that the camunda app can be run with minimal permissions, while delegating the privileged permission to the standalone schema manager and backup manager apps
* Replaced `OpenSearchContainer` with `GenericContainer` for OpenSearch, enabling more granular environment setup. `OpenSearchContainer` forces the usage of TLS when the security package is enabled, which is not necessary for the test.
* Introduced a `createUsersAndRoles` method to programmatically create admin and app users, assign roles, and configure permissions in the OpenSearch instance

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/36802
