### PR TITLE
feat: backup scheduler metrics

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -22455,41 +22455,16 @@
           },
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "mode": "fixed"
-              },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": []
+              },
+              "color": {
+                "mode": "fixed"
               }
             },
             "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 835
-          },
-          "id": 329,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "value_and_name",
-            "wideLayout": true
           },
           "pluginVersion": "12.1.0",
           "targets": [
@@ -22506,8 +22481,28 @@
               "refId": "A"
             }
           ],
-          "title": "Current In-Progress Backups",
-          "type": "stat"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "auto",
+            "textMode": "value_and_name",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard",
+            "text": {}
+          }
         },
         {
           "datasource": {
@@ -23105,6 +23100,226 @@
           ],
           "title": "Current Checkpoint ID",
           "type": "stat"
+        },
+        {
+          "id": 696,
+          "type": "stat",
+          "title": "Next scheduled checkpoint",
+          "gridPos": {
+            "x": 12,
+            "y": 21,
+            "h": 4,
+            "w": 6
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "dateTimeAsIsoNoDateIfToday"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "expr": "camunda_checkpoint_scheduler_next_checkpoint_time_millis{type=\"MARKER\"}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          }
+        },
+        {
+          "id": 695,
+          "type": "stat",
+          "title": "Last scheduled checkpoint created",
+          "gridPos": {
+            "x": 12,
+            "y": 25,
+            "h": 4,
+            "w": 6
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "dateTimeAsIsoNoDateIfToday"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_time_millis{type=\"MARKER\"}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          }
+        },
+        {
+          "id": 698,
+          "type": "stat",
+          "title": "Next scheduled backup execution",
+          "gridPos": {
+            "x": 18,
+            "y": 25,
+            "h": 4,
+            "w": 6
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "dateTimeAsIsoNoDateIfToday"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "expr": "camunda_checkpoint_scheduler_next_checkpoint_time_millis{type=\"SCHEDULED_BACKUP\"}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          }
+        },
+        {
+          "id": 697,
+          "type": "stat",
+          "title": "Last scheduled backup created",
+          "gridPos": {
+            "x": 18,
+            "y": 25,
+            "h": 4,
+            "w": 6
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "dateTimeAsIsoNoDateIfToday"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_time_millis{type=\"SCHEDULED_BACKUP\"}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          }
         }
       ],
       "title": "Backups",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -22449,9 +22449,14 @@
       "id": 315,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+          "id": 701,
+          "type": "stat",
+          "title": "Current In-Progress Backups",
+          "gridPos": {
+            "x": 0,
+            "y": 21,
+            "h": 3,
+            "w": 12
           },
           "fieldConfig": {
             "defaults": {
@@ -23214,7 +23219,7 @@
         {
           "id": 698,
           "type": "stat",
-          "title": "Next scheduled backup execution",
+          "title": "Next scheduled backup",
           "gridPos": {
             "x": 18,
             "y": 25,
@@ -23319,6 +23324,122 @@
             "justifyMode": "center",
             "showPercentChange": false,
             "percentChangeColorMode": "standard"
+          }
+        },
+        {
+          "id": 699,
+          "type": "stat",
+          "title": "Last scheduled checkpoint id",
+          "gridPos": {
+            "x": 12,
+            "y": 29,
+            "h": 4,
+            "w": 6
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_id{type=\"MARKER\"}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard",
+            "text": {
+              "valueSize": 50
+            }
+          }
+        },
+        {
+          "id": 700,
+          "type": "stat",
+          "title": "Last scheduled backup id",
+          "gridPos": {
+            "x": 18,
+            "y": 29,
+            "h": 4,
+            "w": 6
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.1.0",
+          "targets": [
+            {
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_id{type=\"SCHEDULED_BACKUP\"}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard",
+            "text": {
+              "valueSize": 50
+            }
           }
         }
       ],

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -58,7 +58,14 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
   @Override
   protected void onActorStarted() {
     LOG.debug("Checkpoint scheduler started");
+    metrics.register();
     actor.run(this::reschedulingTask);
+  }
+
+  @Override
+  protected void onActorClosed() {
+    LOG.debug("Checkpoint scheduler stopped");
+    metrics.close();
   }
 
   private void reschedulingTask() {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -204,7 +204,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
       metrics.recordNextExecution(next, CheckpointType.MARKER);
     } else {
       next = nextExecution(backupSchedule, state.lastBackup);
-      metrics.recordNextExecution(next, CheckpointType.MARKER);
+      metrics.recordNextExecution(next, CheckpointType.SCHEDULED_BACKUP);
     }
     return next.toEpochMilli() - now.toEpochMilli();
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/SchedulerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/SchedulerMetrics.java
@@ -18,13 +18,11 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class SchedulerMetrics implements CloseableSilently {
-  private static final String NAMESPACE = "camunda.checkpoint.scheduler";
-  private static final String LAST_CHECKPOINT_GAUGE_NAME =
-      NAMESPACE + ".last.checkpoint.time.millis";
-  private static final String LAST_CHECKPOINT_ID_GAUGE_NAME = NAMESPACE + ".last.checkpoint.id";
-  private static final String NEXT_CHECKPOINT_GAUGE_NAME =
-      NAMESPACE + ".next.checkpoint.time.millis";
-  private static final String TYPE_TAG = "type";
+  static final String NAMESPACE = "camunda.checkpoint.scheduler";
+  static final String LAST_CHECKPOINT_GAUGE_NAME = NAMESPACE + ".last.checkpoint.time.millis";
+  static final String LAST_CHECKPOINT_ID_GAUGE_NAME = NAMESPACE + ".last.checkpoint.id";
+  static final String NEXT_CHECKPOINT_GAUGE_NAME = NAMESPACE + ".next.checkpoint.time.millis";
+  static final String TYPE_TAG = "type";
 
   private final MeterRegistry meterRegistry;
   private final Set<Id> registeredMeterIds = new HashSet<>();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/SchedulerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/SchedulerMetrics.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.schedule;
+
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Instant;
+
+public class SchedulerMetrics {
+  private static final String NAMESPACE = "camunda.checkpoint.scheduler";
+  private static final String LAST_CHECKPOINT_GAUGE_NAME =
+      NAMESPACE + ".last.checkpoint.time.millis";
+  private static final String NEXT_CHECKPOINT_GAUGE_NAME =
+      NAMESPACE + ".next.checkpoint.time.millis";
+
+  private long nextCheckpointTimestamp = 0L;
+  private long nextBackupTimestamp = 0L;
+  private long lastBackupTimestamp = 0L;
+  private long lastCheckpointTimestamp = 0L;
+
+  public SchedulerMetrics(final MeterRegistry meterRegistry) {
+
+    Gauge.builder(LAST_CHECKPOINT_GAUGE_NAME, () -> lastCheckpointTimestamp)
+        .description("Timestamp in milliseconds of the last checkpoint created")
+        .tag("type", CheckpointType.MARKER.name())
+        .strongReference(true)
+        .register(meterRegistry);
+
+    Gauge.builder(LAST_CHECKPOINT_GAUGE_NAME, () -> lastBackupTimestamp)
+        .description("Timestamp in milliseconds of the last checkpoint created")
+        .tag("type", CheckpointType.SCHEDULED_BACKUP.name())
+        .strongReference(true)
+        .register(meterRegistry);
+
+    Gauge.builder(NEXT_CHECKPOINT_GAUGE_NAME, () -> nextCheckpointTimestamp)
+        .description("Next scheduler's expected checkpoint execution delay in seconds")
+        .tag("type", CheckpointType.MARKER.name())
+        .strongReference(true)
+        .register(meterRegistry);
+
+    Gauge.builder(NEXT_CHECKPOINT_GAUGE_NAME, () -> nextBackupTimestamp)
+        .description("Next scheduler's expected backup execution delay in seconds")
+        .tag("type", CheckpointType.SCHEDULED_BACKUP.name())
+        .strongReference(true)
+        .register(meterRegistry);
+  }
+
+  public void recordLastCheckpointTime(final Instant timestamp, final CheckpointType type) {
+    if (type == CheckpointType.SCHEDULED_BACKUP) {
+      lastBackupTimestamp = timestamp.toEpochMilli();
+    }
+    // since backups lead to checkpoints as well, we always update the last checkpoint time
+    lastCheckpointTimestamp = timestamp.toEpochMilli();
+  }
+
+  public void recordNextExecution(final Instant timestamp, final CheckpointType type) {
+    if (type == CheckpointType.SCHEDULED_BACKUP) {
+      nextBackupTimestamp = timestamp.toEpochMilli();
+    } else {
+      nextCheckpointTimestamp = timestamp.toEpochMilli();
+    }
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -8,6 +8,12 @@
 package io.camunda.zeebe.backup.schedule;
 
 import static io.camunda.zeebe.backup.schedule.CheckpointScheduler.SKIP_CHECKPOINT_THRESHOLD;
+import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.LAST_CHECKPOINT_GAUGE_NAME;
+import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.LAST_CHECKPOINT_ID_GAUGE_NAME;
+import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.NEXT_CHECKPOINT_GAUGE_NAME;
+import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.TYPE_TAG;
+import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -27,9 +33,12 @@ import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
@@ -48,10 +57,12 @@ public class CheckpointScheduleTest {
   public final ControlledActorSchedulerExtension actorScheduler =
       new ControlledActorSchedulerExtension();
 
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private CheckpointScheduler checkpointScheduler;
 
   @BeforeEach
   void setup() {
+    meterRegistry.clear();
     backupRequestHandler = mock(BackupRequestHandler.class);
     brokerClient = mock(BrokerClient.class);
     final var topologyManager = mock(BrokerTopologyManager.class);
@@ -96,6 +107,20 @@ public class CheckpointScheduleTest {
     verify(backupRequestHandler, times(1))
         .takeBackup(anyLong(), argThat(type -> type == CheckpointType.MARKER));
     verifyNoMoreInteractions(backupRequestHandler);
+
+    final var recordedTimestampValue =
+        getGaugeValue(LAST_CHECKPOINT_GAUGE_NAME, CheckpointType.MARKER);
+    final var recordedCheckpointIdValue =
+        getGaugeValue(LAST_CHECKPOINT_ID_GAUGE_NAME, CheckpointType.MARKER);
+    final var nextCheckpointTimestampValue =
+        getGaugeValue(NEXT_CHECKPOINT_GAUGE_NAME, CheckpointType.MARKER);
+
+    assertThat(recordedTimestampValue).isEqualTo(now.plusSeconds(5).toEpochMilli());
+    assertThat(nextCheckpointTimestampValue).isEqualTo(now.plusSeconds(10).toEpochMilli());
+    // id generation is not bound to the actor clock, so the value must be close to when we
+    // initially stopped the clock
+    assertThat(Instant.ofEpochMilli(recordedCheckpointIdValue))
+        .isCloseTo(now, within(1, ChronoUnit.SECONDS));
   }
 
   @Test
@@ -121,6 +146,25 @@ public class CheckpointScheduleTest {
     verify(backupRequestHandler, times(1))
         .takeBackup(anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
     verifyNoMoreInteractions(backupRequestHandler);
+
+    var recordedTimestampValue = getGaugeValue(LAST_CHECKPOINT_GAUGE_NAME, CheckpointType.MARKER);
+    var recordedCheckpointIdValue =
+        getGaugeValue(LAST_CHECKPOINT_ID_GAUGE_NAME, CheckpointType.MARKER);
+
+    assertThat(recordedTimestampValue).isEqualTo(now.plusSeconds(5).toEpochMilli());
+    assertThat(Instant.ofEpochMilli(recordedCheckpointIdValue))
+        .isCloseTo(now, within(1, ChronoUnit.SECONDS));
+
+    recordedTimestampValue =
+        getGaugeValue(LAST_CHECKPOINT_GAUGE_NAME, CheckpointType.SCHEDULED_BACKUP);
+    recordedCheckpointIdValue =
+        getGaugeValue(LAST_CHECKPOINT_ID_GAUGE_NAME, CheckpointType.SCHEDULED_BACKUP);
+    final var nextCheckpointTimestampValue =
+        getGaugeValue(NEXT_CHECKPOINT_GAUGE_NAME, CheckpointType.SCHEDULED_BACKUP);
+    assertThat(recordedTimestampValue).isEqualTo(now.plusSeconds(5).toEpochMilli());
+    assertThat(nextCheckpointTimestampValue).isEqualTo(now.plusSeconds(10).toEpochMilli());
+    assertThat(Instant.ofEpochMilli(recordedCheckpointIdValue))
+        .isCloseTo(now, within(1, ChronoUnit.SECONDS));
   }
 
   @Test
@@ -307,6 +351,55 @@ public class CheckpointScheduleTest {
     verifyNoMoreInteractions(backupRequestHandler);
   }
 
+  @Test
+  void shouldRegisterMetricsOnStartup() {
+    // given
+    final var now = actorScheduler.getClock().getCurrentTime();
+    checkpointScheduler =
+        createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
+
+    when(backupRequestHandler.getCheckpointState())
+        .thenReturn(
+            CompletableFuture.completedStage(
+                checkpointState(0L, now.minus(1, ChronoUnit.DAYS).toEpochMilli())));
+
+    // when
+    actorScheduler.submitActor(checkpointScheduler);
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(getGauge(LAST_CHECKPOINT_GAUGE_NAME, CheckpointType.MARKER)).isNotNull();
+    assertThat(getGauge(LAST_CHECKPOINT_ID_GAUGE_NAME, CheckpointType.MARKER)).isNotNull();
+    assertThat(getGauge(NEXT_CHECKPOINT_GAUGE_NAME, CheckpointType.MARKER)).isNotNull();
+    assertThat(getGauge(LAST_CHECKPOINT_GAUGE_NAME, CheckpointType.SCHEDULED_BACKUP)).isNotNull();
+    assertThat(getGauge(LAST_CHECKPOINT_ID_GAUGE_NAME, CheckpointType.SCHEDULED_BACKUP))
+        .isNotNull();
+    assertThat(getGauge(NEXT_CHECKPOINT_GAUGE_NAME, CheckpointType.SCHEDULED_BACKUP)).isNotNull();
+  }
+
+  @Test
+  void shouldRemoveMetricsOnShutdown() {
+    // given
+    final var now = actorScheduler.getClock().getCurrentTime();
+    checkpointScheduler =
+        createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
+
+    when(backupRequestHandler.getCheckpointState())
+        .thenReturn(
+            CompletableFuture.completedStage(
+                checkpointState(0L, now.minus(1, ChronoUnit.DAYS).toEpochMilli())));
+
+    // when
+    actorScheduler.submitActor(checkpointScheduler);
+    actorScheduler.workUntilDone();
+    assertThat(meterRegistry.getMeters()).isNotEmpty();
+    checkpointScheduler.closeAsync();
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(meterRegistry.getMeters()).isEmpty();
+  }
+
   private CheckpointStateResponse checkpointState(
       final long checkpointTimestamp, final long backupTimestamp) {
     final var response = new CheckpointStateResponse();
@@ -331,8 +424,7 @@ public class CheckpointScheduleTest {
       final Schedule checkpointSchedule, final Schedule backupSchedule) {
     try {
       final var scheduler =
-          new CheckpointScheduler(
-              checkpointSchedule, backupSchedule, brokerClient, new SimpleMeterRegistry());
+          new CheckpointScheduler(checkpointSchedule, backupSchedule, brokerClient, meterRegistry);
       final Field checkpointCreatorField =
           CheckpointScheduler.class.getDeclaredField("backupRequestHandler");
       checkpointCreatorField.setAccessible(true);
@@ -343,5 +435,13 @@ public class CheckpointScheduleTest {
     } catch (final NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private Gauge getGauge(final String gaugeName, final CheckpointType type) {
+    return meterRegistry.get(gaugeName).tag(TYPE_TAG, type.name()).gauge();
+  }
+
+  private long getGaugeValue(final String gaugeName, final CheckpointType type) {
+    return (long) getGauge(gaugeName, type).value();
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -330,7 +331,8 @@ public class CheckpointScheduleTest {
       final Schedule checkpointSchedule, final Schedule backupSchedule) {
     try {
       final var scheduler =
-          new CheckpointScheduler(checkpointSchedule, backupSchedule, brokerClient);
+          new CheckpointScheduler(
+              checkpointSchedule, backupSchedule, brokerClient, new SimpleMeterRegistry());
       final Field checkpointCreatorField =
           CheckpointScheduler.class.getDeclaredField("backupRequestHandler");
       checkpointCreatorField.setAccessible(true);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
@@ -21,6 +21,7 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
 
     final var backupCfg = brokerStartupContext.getBrokerConfiguration().getData().getBackup();
     final var scheduler = brokerStartupContext.getActorSchedulingService();
+    final var meterRegistry = brokerStartupContext.getMeterRegistry();
 
     if (backupCfg.isContinuous()) {
       concurrencyControl.run(
@@ -30,7 +31,8 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
                     brokerStartupContext.getClusterServices().getMembershipService(),
                     scheduler,
                     backupCfg,
-                    brokerStartupContext.getBrokerClient());
+                    brokerStartupContext.getBrokerClient(),
+                    meterRegistry);
 
             concurrencyControl.runOnCompletion(
                 scheduler.submitActor(schedulingService),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Comparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,17 +34,20 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   private final BackupCfg backupCfg;
   private final BrokerClient brokerClient;
   private final ActorSchedulingService actorScheduler;
+  private final MeterRegistry meterRegistry;
   private CheckpointScheduler checkpointScheduler;
 
   public CheckpointSchedulingService(
       final ClusterMembershipService membershipService,
       final ActorSchedulingService actorScheduler,
       final BackupCfg backupCfg,
-      final BrokerClient brokerClient) {
+      final BrokerClient brokerClient,
+      final MeterRegistry meterRegistry) {
     this.membershipService = membershipService;
     this.actorScheduler = actorScheduler;
     this.backupCfg = backupCfg;
     this.brokerClient = brokerClient;
+    this.meterRegistry = meterRegistry;
   }
 
   @Override
@@ -60,7 +64,8 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
       LOG.info("Backup scheduler initialized with interval {}", backupSchedule);
     }
 
-    checkpointScheduler = new CheckpointScheduler(checkpointSchedule, backupSchedule, brokerClient);
+    checkpointScheduler =
+        new CheckpointScheduler(checkpointSchedule, backupSchedule, brokerClient, meterRegistry);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Set;
@@ -81,7 +82,11 @@ public class CheckpointSchedulerServiceTest {
 
     schedulingService =
         new CheckpointSchedulingService(
-            membershipService, scheduler, brokerConfig.getData().getBackup(), brokerClient);
+            membershipService,
+            scheduler,
+            brokerConfig.getData().getBackup(),
+            brokerClient,
+            new SimpleMeterRegistry());
   }
 
   @Test
@@ -235,7 +240,11 @@ public class CheckpointSchedulerServiceTest {
 
     schedulingService =
         new CheckpointSchedulingService(
-            membershipService, scheduler, brokerConfig.getData().getBackup(), brokerClient);
+            membershipService,
+            scheduler,
+            brokerConfig.getData().getBackup(),
+            brokerClient,
+            new SimpleMeterRegistry());
 
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce checkpoint scheduler metrics. Also, expose them in the Grafana monitoring dashboard. Including:
- Last checkpoint/backup execution time
- Next checkpoint/backup execution time - this can change if manual backups are created in between
- Last checkpoint/backup ID generated by a schedulers execution

<img width="1686" height="718" alt="image" src="https://github.com/user-attachments/assets/a0e6d2f9-5c47-4aa6-a26a-3288f7ae5877" />



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40445