### PR TITLE
perf: flush after filling a new segment with zeroes

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -79,6 +79,7 @@ public interface SegmentAllocator {
         final FileChannel channel, final FileDescriptor fileDescriptor, final long segmentSize)
         throws IOException {
       IoUtil.fill(channel, 0, segmentSize, (byte) 0);
+      channel.force(true);
     }
   }
 }


### PR DESCRIPTION
## Description
The `FileChannel` is not flushed in `IOUtil.fill`, meaning that when the first time we `force()` it will have to write the entire file. 
Doing it before, outside of the hot path should limit the tail latency for this `SegmentAllocator`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

