### PR TITLE
[Backport stable/optimize-8.6] deps: update netty to 4.1.130.Final

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -58,7 +58,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
-    <netty.version>4.1.127.Final</netty.version>
+    <netty.version>4.1.130.Final</netty.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.19</logback.version>
     <slf4j.version>2.0.16</slf4j.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.8</version.msgpack>
-    <version.netty>4.1.127.Final</version.netty>
+    <version.netty>4.1.130.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch.testcontainers>2.1.0</version.opensearch.testcontainers>


### PR DESCRIPTION
# Description
Backport of #43021 to `stable/optimize-8.6`.

relates to camunda/camunda#42893
original author: @kristinkomschow