### PR TITLE
fix: ProbesITs correctly accept the index prefix

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
@@ -32,7 +32,8 @@ class ProbesTestIT {
   @BeforeAll
   public static void init() {
     final String dbType =
-        (Optional.ofNullable("camunda.data.secondary-storage.type").orElse("elasticsearch"))
+        (Optional.ofNullable(System.getProperty("camunda.data.secondary-storage.type"))
+                .orElse("elasticsearch"))
             .toLowerCase();
     indexPrefixConfig = "camunda.data.secondary-storage." + dbType + ".index-prefix";
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ProbesTestIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ProbesTestIT.java
@@ -35,7 +35,8 @@ public class ProbesTestIT extends TasklistIntegrationTest {
   @BeforeAll
   public static void init() {
     final String dbType =
-        (Optional.ofNullable("camunda.data.secondary-storage.type").orElse("elasticsearch"))
+        (Optional.ofNullable(System.getProperty("camunda.data.secondary-storage.type"))
+                .orElse("elasticsearch"))
             .toLowerCase();
     indexPrefixConfig = "camunda.data.secondary-storage." + dbType + ".index-prefix";
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Actually retrieve the property of the secondary storage type to set the prefix to. The tests were failing because the index prefix was not set, thus leading to validation errors for non-prefixed indices

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #https://github.com/camunda/camunda/issues/42697
