### PR TITLE
[Backport stable/8.8] test: migrate callActivities.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -22,11 +22,14 @@ export class OperateDiagramPage {
   readonly showIncidentButton: Locator;
   readonly showMetadataButton: Locator;
   readonly viewRootCauseDecisionLink: Locator;
+  readonly popoverLink: (name: string | RegExp) => Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.diagram = this.page.getByTestId('diagram');
     this.popover = this.page.getByTestId('popover');
+    this.popoverLink = (name: string | RegExp) =>
+      this.popover.getByRole('link', {name});
     this.resetDiagramZoomButton = this.page.getByRole('button', {
       name: 'Reset diagram zoom',
     });
@@ -271,5 +274,9 @@ export class OperateDiagramPage {
       timeout: 30000,
     });
     await this.viewRootCauseDecisionLink.click();
+  }
+
+  async clickPopoverLink(name: string | RegExp): Promise<void> {
+    await this.popoverLink(name).click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -64,6 +64,9 @@ class OperateProcessInstancePage {
   readonly incidentsViewHeader: Locator;
   readonly variableCellByName: (name: string | RegExp) => Locator;
   readonly viewAllChildProcessesLink: Locator;
+  readonly instanceHeaderSkeleton: Locator;
+  readonly viewAllCalledInstancesLink: Locator;
+  readonly viewParentInstanceLink: Locator;
   readonly processInstanceKeyCell: Locator;
 
   constructor(page: Page) {
@@ -160,6 +163,13 @@ class OperateProcessInstancePage {
       this.variablesList.getByRole('cell', {name});
     this.viewAllChildProcessesLink = this.instanceHeader.getByRole('link', {
       name: 'View all',
+    });
+    this.instanceHeaderSkeleton = page.getByTestId('instance-header-skeleton');
+    this.viewAllCalledInstancesLink = page.getByRole('link', {
+      name: /view all called instances/i,
+    });
+    this.viewParentInstanceLink = page.getByRole('link', {
+      name: /view parent instance/i,
     });
     this.processInstanceKeyCell = this.instanceHeader
       .locator('table tbody tr td')
@@ -597,6 +607,14 @@ class OperateProcessInstancePage {
 
   async clickViewAllChildProcesses(): Promise<void> {
     await this.viewAllChildProcessesLink.click();
+  }
+
+  async clickViewAllCalledInstances(): Promise<void> {
+    await this.viewAllCalledInstancesLink.click();
+  }
+
+  async clickViewParentInstance(): Promise<void> {
+    await this.viewParentInstanceLink.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -52,9 +52,9 @@ class OperateProcessesPage {
   readonly applyButton: Locator;
   readonly resultsCount: Locator;
   readonly scheduledOperationsIcons: Locator;
-  readonly processInstanceLinkByName: (name: string) => Locator;
+  readonly viewParentInstanceLinkInList: Locator;
   readonly processInstanceLinkByKey: (processInstanceKey: string) => Locator;
-  getOperationAndResultsContainer: (
+  readonly operationAndResultsContainer: (
     operation: string,
     resultCount?: number,
   ) => Locator;
@@ -164,13 +164,7 @@ class OperateProcessesPage {
       page.getByRole('link', {
         name: processInstanceKey,
       });
-    this.processInstanceLinkByName = (name: string) =>
-      page
-        .getByRole('row')
-        .filter({hasText: name})
-        .first()
-        .getByRole('link', {name: /^View instance \d+/});
-    this.getOperationAndResultsContainer = (
+    this.operationAndResultsContainer = (
       operation: string,
       resultCount?: number,
     ) => {
@@ -179,9 +173,9 @@ class OperateProcessesPage {
         : new RegExp(`${operation}.*\\d+ results`);
       return page.locator('div').filter({hasText: pattern});
     };
-    this.getParentInstanceCell = (parentInstanceKey: string) =>
+    this.parentInstanceCell = (parentInstanceKey: string) =>
       this.dataList.getByRole('cell', {name: parentInstanceKey});
-    this.getVersionCells = (version: string) =>
+    this.versionCells = (version: string) =>
       this.dataList.getByRole('cell', {name: version, exact: true});
     this.viewParentInstanceLinkInList = this.dataList.getByRole('link', {
       name: /view parent instance/i,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -52,15 +52,19 @@ class OperateProcessesPage {
   readonly applyButton: Locator;
   readonly resultsCount: Locator;
   readonly scheduledOperationsIcons: Locator;
-  readonly viewParentInstanceLinkInList: Locator;
+  readonly processInstanceLinkByName: (name: string) => Locator;
   readonly processInstanceLinkByKey: (processInstanceKey: string) => Locator;
-  readonly operationAndResultsContainer: (
+  getOperationAndResultsContainer: (
     operation: string,
     resultCount?: number,
   ) => Locator;
   getParentInstanceCell: (parentInstanceKey: string) => Locator;
   getVersionCells: (version: string) => Locator;
   readonly viewParentInstanceLinkInList: Locator;
+  readonly calledInstanceCell: (
+    rowIndex?: number,
+    cellIndex?: number,
+  ) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -164,7 +168,13 @@ class OperateProcessesPage {
       page.getByRole('link', {
         name: processInstanceKey,
       });
-    this.operationAndResultsContainer = (
+    this.processInstanceLinkByName = (name: string) =>
+      page
+        .getByRole('row')
+        .filter({hasText: name})
+        .first()
+        .getByRole('link', {name: /^View instance \d+/});
+    this.getOperationAndResultsContainer = (
       operation: string,
       resultCount?: number,
     ) => {
@@ -173,13 +183,19 @@ class OperateProcessesPage {
         : new RegExp(`${operation}.*\\d+ results`);
       return page.locator('div').filter({hasText: pattern});
     };
-    this.parentInstanceCell = (parentInstanceKey: string) =>
+    this.getParentInstanceCell = (parentInstanceKey: string) =>
       this.dataList.getByRole('cell', {name: parentInstanceKey});
-    this.versionCells = (version: string) =>
+    this.getVersionCells = (version: string) =>
       this.dataList.getByRole('cell', {name: version, exact: true});
     this.viewParentInstanceLinkInList = this.dataList.getByRole('link', {
       name: /view parent instance/i,
     });
+    this.calledInstanceCell = (rowIndex = 0, cellIndex = 2) =>
+      this.dataList
+        .getByRole('row')
+        .nth(rowIndex)
+        .getByRole('cell')
+        .nth(cellIndex);
   }
 
   async filterByProcessName(name: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityNavigationProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callActivityNavigationProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="CallActivityNavigationProcess" name="Call Activity Navigation Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a3emhl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a3emhl" sourceRef="StartEvent_1" targetRef="Activity_13otele" />
+    <bpmn:callActivity id="Activity_13otele" name="Call Activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="CalledProcess" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a3emhl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j9hrgw</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1p0nsc7">
+      <bpmn:incoming>Flow_1j9hrgw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1j9hrgw" sourceRef="Activity_13otele" targetRef="Event_1p0nsc7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CallActivityNavigationProcess">
+      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j9hrgw_di" bpmnElement="Flow_1j9hrgw">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jff16t_di" bpmnElement="Activity_13otele">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p0nsc7_di" bpmnElement="Event_1p0nsc7">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -66,8 +66,8 @@ test.describe('Call Activities', () => {
       ).toBeHidden();
       await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
       await expect(
-        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
-      ).toBeVisible();
+        operateProcessInstancePage.processInstanceKeyCell,
+      ).toHaveText(processInstanceKey);
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
           'Call Activity Process',
@@ -96,8 +96,8 @@ test.describe('Call Activities', () => {
       await operateProcessesPage.clickViewParentInstanceFromList();
 
       await expect(
-        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
-      ).toBeVisible();
+        operateProcessInstancePage.processInstanceKeyCell,
+      ).toHaveText(processInstanceKey);
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
           'Call Activity Process',
@@ -177,8 +177,8 @@ test.describe('Call Activities', () => {
       await operateProcessInstancePage.clickViewParentInstance();
 
       await expect(
-        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
-      ).toBeVisible();
+        operateProcessInstancePage.processInstanceKeyCell,
+      ).toHaveText(processInstanceKey);
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
           'Call Activity Process',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessDeployment = {
+  readonly processInstanceKey: string;
+};
+
+let callActivityProcessInstance: ProcessDeployment;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/callActivityProcess.bpmn',
+    './resources/calledProcess.bpmn',
+  ]);
+
+  const instance = await createSingleInstance('CallActivityProcess', 1);
+  callActivityProcessInstance = {
+    processInstanceKey: instance.processInstanceKey,
+  };
+
+  await sleep(2000);
+});
+
+test.describe('Call Activities', () => {
+  test.describe.configure({retries: 0});
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Navigate to called and parent process instances', async ({
+    operateProcessInstancePage,
+    operateProcessesPage,
+    operateDiagramPage,
+  }) => {
+    test.slow();
+    const processInstanceKey = callActivityProcessInstance.processInstanceKey;
+
+    await test.step('Navigate to the call activity process instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: processInstanceKey,
+      });
+
+      await expect(
+        operateProcessInstancePage.instanceHeaderSkeleton,
+      ).toBeHidden();
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('View all called instances', async () => {
+      await operateProcessInstancePage.clickViewAllCalledInstances();
+
+      await expect(operateProcessesPage.processInstancesTable).toHaveCount(1);
+      await expect(
+        operateProcessesPage.processInstancesTable.getByText('Called Process'),
+      ).toBeVisible();
+    });
+
+    let calledProcessInstanceId: string;
+
+    await test.step('Get called process instance ID', async () => {
+      calledProcessInstanceId = await operateProcessesPage
+        .calledInstanceCell()
+        .innerText();
+    });
+
+    await test.step('Navigate back to parent instance from list', async () => {
+      await operateProcessesPage.clickViewParentInstanceFromList();
+
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify instance history on parent process', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('StartEvent_1'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Call Activity', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_1p0nsc7'),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify diagram shows call activity', async () => {
+      await expect(
+        operateDiagramPage.getFlowNode('Activity_13otele'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate to called process instance via diagram', async () => {
+      await operateDiagramPage.clickFlowNode('Activity_13otele');
+
+      await expect(
+        operateDiagramPage.getPopoverText(/Called Process Instance/),
+      ).toBeVisible();
+
+      await operateDiagramPage.clickPopoverLink(
+        /view called process instance/i,
+      );
+    });
+
+    await test.step('Verify called process instance header and history', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          calledProcessInstanceId,
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText('Called Process', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Called Process', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Process started'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_0y6k56d'),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify called process diagram', async () => {
+      await expect(
+        operateDiagramPage.getFlowNode('StartEvent_1'),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate back to parent instance from header', async () => {
+      await operateProcessInstancePage.clickViewParentInstance();
+
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(processInstanceKey),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify parent process instance history and diagram again', async () => {
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText(
+          'Call Activity Process',
+        ),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('StartEvent_1'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Call Activity', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHistory.getByText('Event_1p0nsc7'),
+      ).toBeVisible();
+
+      await expect(
+        operateDiagramPage.getFlowNode('Activity_13otele'),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -21,11 +21,14 @@ let callActivityProcessInstance: ProcessDeployment;
 
 test.beforeAll(async () => {
   await deploy([
-    './resources/callActivityProcess.bpmn',
+    './resources/callActivityNavigationProcess.bpmn',
     './resources/calledProcess.bpmn',
   ]);
 
-  const instance = await createSingleInstance('CallActivityProcess', 1);
+  const instance = await createSingleInstance(
+    'CallActivityNavigationProcess',
+    1,
+  );
   callActivityProcessInstance = {
     processInstanceKey: instance.processInstanceKey,
   };
@@ -70,7 +73,7 @@ test.describe('Call Activities', () => {
       ).toHaveText(processInstanceKey);
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
-          'Call Activity Process',
+          'Call Activity Navigation Process',
         ),
       ).toBeVisible();
     });
@@ -100,7 +103,7 @@ test.describe('Call Activities', () => {
       ).toHaveText(processInstanceKey);
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
-          'Call Activity Process',
+          'Call Activity Navigation Process',
         ),
       ).toBeVisible();
     });
@@ -108,7 +111,7 @@ test.describe('Call Activities', () => {
     await test.step('Verify instance history on parent process', async () => {
       await expect(
         operateProcessInstancePage.instanceHistory.getByText(
-          'Call Activity Process',
+          'Call Activity Navigation Process',
         ),
       ).toBeVisible();
       await expect(
@@ -181,7 +184,7 @@ test.describe('Call Activities', () => {
       ).toHaveText(processInstanceKey);
       await expect(
         operateProcessInstancePage.instanceHeader.getByText(
-          'Call Activity Process',
+          'Call Activity Navigation Process',
         ),
       ).toBeVisible();
     });
@@ -189,7 +192,7 @@ test.describe('Call Activities', () => {
     await test.step('Verify parent process instance history and diagram again', async () => {
       await expect(
         operateProcessInstancePage.instanceHistory.getByText(
-          'Call Activity Process',
+          'Call Activity Navigation Process',
         ),
       ).toBeVisible();
       await expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -82,7 +82,7 @@ test.beforeAll(async () => {
     parentProcessInstanceKeys,
   };
 
-  await sleep(2500);
+  await sleep(3000);
 });
 
 test.describe('Child Process Instance Migration', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -232,7 +232,7 @@ test.describe('Operations', () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(
-            operateProcessesPage.operationAndResultsContainer('cancel', 5),
+            operateProcessesPage.getOperationAndResultsContainer('cancel', 5),
           ).toBeVisible({
             timeout: 30000,
           });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -232,7 +232,7 @@ test.describe('Operations', () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(
-            operateProcessesPage.getOperationAndResultsContainer('cancel', 5),
+            operateProcessesPage.operationAndResultsContainer('cancel', 5),
           ).toBeVisible({
             timeout: 30000,
           });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -511,7 +511,7 @@ test.describe.serial('Process Instance Migration', () => {
 
       await expect(
         operateProcessesPage.versionCells(targetVersion),
-      ).toHaveCount(6, {
+      ).toHaveCount(3, {
         timeout: 30000,
       });
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -279,7 +279,7 @@ test.describe.serial('Process Instance Migration', () => {
         },
       });
 
-      await expect(operateProcessesPage.versionCells('2')).toHaveCount(6, {
+      await expect(operateProcessesPage.getVersionCells('2')).toHaveCount(6, {
         timeout: 30000,
       });
     });
@@ -510,7 +510,7 @@ test.describe.serial('Process Instance Migration', () => {
       await validateURL(page, /operationId=/);
 
       await expect(
-        operateProcessesPage.versionCells(targetVersion),
+        operateProcessesPage.getVersionCells(targetVersion),
       ).toHaveCount(3, {
         timeout: 30000,
       });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -279,7 +279,7 @@ test.describe.serial('Process Instance Migration', () => {
         },
       });
 
-      await expect(operateProcessesPage.getVersionCells('2')).toHaveCount(6, {
+      await expect(operateProcessesPage.versionCells('2')).toHaveCount(6, {
         timeout: 30000,
       });
     });
@@ -510,8 +510,10 @@ test.describe.serial('Process Instance Migration', () => {
       await validateURL(page, /operationId=/);
 
       await expect(
-        operateProcessesPage.getVersionCells(targetVersion),
-      ).toHaveCount(3, {timeout: 60000});
+        operateProcessesPage.versionCells(targetVersion),
+      ).toHaveCount(6, {
+        timeout: 30000,
+      });
     });
 
     await test.step('Verify remaining instances still at source version', async () => {


### PR DESCRIPTION
# Description
Backport of #43102 to `stable/8.8`.


🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20717642161)


relates to camunda/camunda#34097