### PR TITLE
[Backport stable/8.8] fix: use distinct properties for incident alert version and tag

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
@@ -12,15 +12,7 @@ import java.util.Map;
 
 public record CachedProcessEntity(
     String name,
+    int version,
     String versionTag,
-    String version,
     List<String> callElementIds,
-    Map<String, String> flowNodesMap) {
-  public CachedProcessEntity(
-      final String name,
-      final String versionTag,
-      final List<String> callElementIds,
-      final Map<String, String> flowNodesMap) {
-    this(name, versionTag, null, callElementIds, flowNodesMap);
-  }
-}
+    Map<String, String> flowNodesMap) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
@@ -42,6 +42,7 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
               processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
       return new CachedProcessEntity(
           processEntity.getName(),
+          processEntity.getVersion(),
           processEntity.getVersionTag(),
           processDiagramData.callActivityIds(),
           processDiagramData.flowNodesMap());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
@@ -41,6 +41,7 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
               processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
       return new CachedProcessEntity(
           processEntity.getName(),
+          processEntity.getVersion(),
           processEntity.getVersionTag(),
           processDiagramData.callActivityIds(),
           processDiagramData.flowNodesMap());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -89,8 +89,8 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
     final var cachedProcessEntity =
         new CachedProcessEntity(
             entity.getName(),
+            entity.getVersion(),
             entity.getVersionTag(),
-            Integer.toString(entity.getVersion()),
             entity.getCallActivityIds(),
             getFlowNodesMap(entity.getFlowNodes()));
     processCache.put(process.getProcessDefinitionKey(), cachedProcessEntity);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -51,6 +51,7 @@ public class IncidentNotifier implements CloseableSilently {
   protected static final String FIELD_NAME_BPMN_PROCESS_ID = "bpmnProcessId";
   protected static final String FIELD_NAME_PROCESS_NAME = "processName";
   protected static final String FIELD_NAME_PROCESS_VERSION = "processVersion";
+  protected static final String FIELD_NAME_PROCESS_VERSION_TAG = "processVersionTag";
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentNotifier.class);
 
   private final M2mTokenManager m2mTokenManager;
@@ -177,11 +178,8 @@ public class IncidentNotifier implements CloseableSilently {
               cachedProcess -> {
                 incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, inc.getBpmnProcessId());
                 incidentFields.put(FIELD_NAME_PROCESS_NAME, cachedProcess.name());
-                final var processVersionField =
-                    cachedProcess.versionTag() != null
-                        ? cachedProcess.versionTag()
-                        : cachedProcess.version();
-                incidentFields.put(FIELD_NAME_PROCESS_VERSION, processVersionField);
+                incidentFields.put(FIELD_NAME_PROCESS_VERSION, cachedProcess.version());
+                incidentFields.put(FIELD_NAME_PROCESS_VERSION_TAG, cachedProcess.versionTag());
               });
       incidentList.add(incidentFields);
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -109,7 +109,7 @@ class ProcessCacheImplIT {
     expectedFlowNodesMap.put(startEventId, null);
     final var expectedCachedProcessEntity =
         new CachedProcessEntity(
-            "test", "v1", List.of("Banana", "Cherry", "apple"), expectedFlowNodesMap);
+            "test", 1, "v1", List.of("Banana", "Cherry", "apple"), expectedFlowNodesMap);
     assertThat(process).isPresent().get().isEqualTo(expectedCachedProcessEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -109,7 +109,7 @@ class ProcessCacheImplIT {
     expectedFlowNodesMap.put(startEventId, null);
     final var expectedCachedProcessEntity =
         new CachedProcessEntity(
-            "test", 1, "v1", List.of("Banana", "Cherry", "apple"), expectedFlowNodesMap);
+            "test", 0, "v1", List.of("Banana", "Cherry", "apple"), expectedFlowNodesMap);
     assertThat(process).isPresent().get().isEqualTo(expectedCachedProcessEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -93,6 +93,7 @@ class ProcessCacheImplIT {
         new ProcessEntity()
             .setId("3")
             .setName("test")
+            .setVersion(1)
             .setVersionTag("v1")
             .setBpmnProcessId("test")
             .setBpmnXml(convertToString(modelInstance));
@@ -109,7 +110,7 @@ class ProcessCacheImplIT {
     expectedFlowNodesMap.put(startEventId, null);
     final var expectedCachedProcessEntity =
         new CachedProcessEntity(
-            "test", 0, "v1", List.of("Banana", "Cherry", "apple"), expectedFlowNodesMap);
+            "test", 1, "v1", List.of("Banana", "Cherry", "apple"), expectedFlowNodesMap);
     assertThat(process).isPresent().get().isEqualTo(expectedCachedProcessEntity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -297,11 +297,12 @@ public class IncidentHandlerTest {
     processCache.put(
         processDefinitionKey1,
         new CachedProcessEntity(
-            null, null, List.of("0", "1", "2", callActivityId1), Map.of("FI1", "FN1")));
+            null, 1, null, List.of("0", "1", "2", callActivityId1), Map.of("FI1", "FN1")));
 
     processCache.put(
         processDefinitionKey2,
-        new CachedProcessEntity(null, null, List.of("0", callActivityId2), Map.of("FI1", "FN1")));
+        new CachedProcessEntity(
+            null, 1, null, List.of("0", callActivityId2), Map.of("FI1", "FN1")));
 
     // when
     final IncidentEntity incidentEntity = new IncidentEntity();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -251,7 +251,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     processCache.put(
         processInstanceRecordValue.getProcessDefinitionKey(),
         new CachedProcessEntity(
-            "test-process-name", "test-version-tag", new ArrayList<>(), Map.of()));
+            "test-process-name", 1, "test-version-tag", new ArrayList<>(), Map.of()));
 
     // when
     final ProcessInstanceForListViewEntity processInstanceForListViewEntity =
@@ -325,11 +325,11 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             pi3Key);
     processCache.put(
         processDefinitionKey1,
-        new CachedProcessEntity(null, null, List.of("0", "1", "2", callActivityId1), Map.of()));
+        new CachedProcessEntity(null, 1, null, List.of("0", "1", "2", callActivityId1), Map.of()));
 
     processCache.put(
         processDefinitionKey2,
-        new CachedProcessEntity(null, null, List.of("0", callActivityId2), Map.of()));
+        new CachedProcessEntity(null, 1, null, List.of("0", callActivityId2), Map.of()));
 
     // when called process 3rd level
     final ProcessInstanceForListViewEntity processInstanceForListViewEntity3 =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -300,7 +300,8 @@ public class UserTaskHandlerTest {
     formCache.put(String.valueOf(formKey), new CachedFormEntity("my-form", 987L));
     processCache.put(
         processDefinitionKey,
-        new CachedProcessEntity("my-process", "v1", List.of(), Map.of(elementId, "my-flow-node")));
+        new CachedProcessEntity(
+            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node")));
 
     // when
     final TaskEntity taskEntity =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -304,7 +304,8 @@ public class UserTaskJobBasedHandlerTest {
     formCache.put(formKey, new CachedFormEntity("my-form", 987L));
     processCache.put(
         processDefinitionKey,
-        new CachedProcessEntity("my-process", "v1", List.of(), Map.of(elementId, "my-flow-node")));
+        new CachedProcessEntity(
+            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node")));
 
     // when
     final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(recordKey));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
@@ -77,7 +77,7 @@ class IncidentNotifierTest {
   private final IncidentState incidentState = IncidentState.ACTIVE;
   private final String bpmnProcessId = "testProcessId";
   private final String processName = "processName";
-  private final String processVersion = "234";
+  private final int processVersion = 1;
   private final String processVersionTag = "versionA";
   private final M2mTokenManager m2mTokenManager = mock(M2mTokenManager.class);
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
@@ -102,7 +102,7 @@ class IncidentNotifierTest {
         .thenReturn(
             Optional.of(
                 new CachedProcessEntity(
-                    processName, processVersionTag, processVersion, null, null)));
+                    processName, processVersion, processVersionTag, null, null)));
   }
 
   @Test
@@ -122,7 +122,7 @@ class IncidentNotifierTest {
     final ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
     verify(httpClient).send(requestCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString()));
     final HttpRequest request = requestCaptor.getValue();
-    assertThat(request.uri().toString()).isEqualTo(ALERT_WEBHOOKURL_URL);
+    assertThat(request.uri()).hasToString(ALERT_WEBHOOKURL_URL);
     assertThat(request.headers().allValues("Authorization").getFirst())
         .isEqualTo("Bearer " + m2mToken);
 
@@ -165,7 +165,7 @@ class IncidentNotifierTest {
     final HttpRequest request = requestCaptor.getValue();
     assertThat(request.headers().allValues("Authorization").getFirst())
         .isEqualTo("Bearer " + m2mToken);
-    assertThat(request.uri().toString()).isEqualTo(ALERT_WEBHOOKURL_URL);
+    assertThat(request.uri()).hasToString(ALERT_WEBHOOKURL_URL);
 
     final String body = extractBody(request.bodyPublisher().orElseThrow());
     final DocumentContext jsonContext = JsonPath.parse(body);
@@ -267,23 +267,21 @@ class IncidentNotifierTest {
   }
 
   private void assertIncidentFields(final HashMap incidentFields) {
-    assertThat(incidentFields.get(FIELD_NAME_MESSAGE)).isEqualTo(MESSAGE);
-    assertThat(incidentFields.get(FIELD_NAME_JOB_KEY)).isEqualTo(jobKey.intValue());
-    assertThat(incidentFields.get(FIELD_NAME_PROCESS_KEY))
-        .isEqualTo(processDefinitionKey.intValue());
-    assertThat(incidentFields.get(FIELD_NAME_BPMN_PROCESS_ID)).isEqualTo(bpmnProcessId);
-    assertThat(incidentFields.get(FIELD_NAME_PROCESS_NAME)).isEqualTo(processName);
-    assertThat(incidentFields.get(FIELD_NAME_PROCESS_VERSION)).isEqualTo(processVersion);
-    assertThat(incidentFields.get(FIELD_NAME_PROCESS_VERSION_TAG)).isEqualTo(processVersionTag);
-    assertThat(incidentFields.get(FIELD_NAME_FLOW_NODE_INSTANCE_KEY))
-        .isEqualTo(flowNodeInstanceId.intValue());
-    assertThat(incidentFields.get(FIELD_NAME_CREATION_TIME)).isNotNull();
-    assertThat(incidentFields.get(FIELD_NAME_ERROR_MESSAGE)).isEqualTo(errorMessage);
-    assertThat(incidentFields.get(FIELD_NAME_ERROR_TYPE)).isEqualTo(errorType.name());
-    assertThat(incidentFields.get(FIELD_NAME_FLOW_NODE_ID)).isEqualTo(flowNodeId);
-    assertThat(incidentFields.get(FIELD_NAME_STATE)).isEqualTo(incidentState.name());
-    assertThat(incidentFields.get(FIELD_NAME_PROCESS_INSTANCE_ID))
-        .isEqualTo(String.valueOf(processInstanceKey));
+    assertThat(incidentFields)
+        .containsEntry(FIELD_NAME_MESSAGE, MESSAGE)
+        .containsEntry(FIELD_NAME_JOB_KEY, jobKey.intValue())
+        .containsEntry(FIELD_NAME_PROCESS_KEY, processDefinitionKey.intValue())
+        .containsEntry(FIELD_NAME_BPMN_PROCESS_ID, bpmnProcessId)
+        .containsEntry(FIELD_NAME_PROCESS_NAME, processName)
+        .containsEntry(FIELD_NAME_PROCESS_VERSION, processVersion)
+        .containsEntry(FIELD_NAME_PROCESS_VERSION_TAG, processVersionTag)
+        .containsEntry(FIELD_NAME_FLOW_NODE_INSTANCE_KEY, flowNodeInstanceId.intValue())
+        .containsKey(FIELD_NAME_CREATION_TIME)
+        .containsEntry(FIELD_NAME_ERROR_MESSAGE, errorMessage)
+        .containsEntry(FIELD_NAME_ERROR_TYPE, errorType.name())
+        .containsEntry(FIELD_NAME_FLOW_NODE_ID, flowNodeId)
+        .containsEntry(FIELD_NAME_STATE, incidentState.name())
+        .containsEntry(FIELD_NAME_PROCESS_INSTANCE_ID, String.valueOf(processInstanceKey));
   }
 
   private IncidentEntity createIncident(final String id) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
@@ -20,6 +20,7 @@ import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_I
 import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_KEY;
 import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_NAME;
 import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_VERSION;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_VERSION_TAG;
 import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_STATE;
 import static io.camunda.exporter.notifier.IncidentNotifier.MESSAGE;
 import static io.camunda.webapps.schema.entities.incident.ErrorType.JOB_NO_RETRIES;
@@ -77,6 +78,7 @@ class IncidentNotifierTest {
   private final String bpmnProcessId = "testProcessId";
   private final String processName = "processName";
   private final String processVersion = "234";
+  private final String processVersionTag = "versionA";
   private final M2mTokenManager m2mTokenManager = mock(M2mTokenManager.class);
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
       mock(ExporterEntityCache.class);
@@ -97,7 +99,10 @@ class IncidentNotifierTest {
             null,
             TestObjectMapper.objectMapper());
     when(processCache.get(any()))
-        .thenReturn(Optional.of(new CachedProcessEntity(processName, processVersion, null, null)));
+        .thenReturn(
+            Optional.of(
+                new CachedProcessEntity(
+                    processName, processVersionTag, processVersion, null, null)));
   }
 
   @Test
@@ -269,6 +274,7 @@ class IncidentNotifierTest {
     assertThat(incidentFields.get(FIELD_NAME_BPMN_PROCESS_ID)).isEqualTo(bpmnProcessId);
     assertThat(incidentFields.get(FIELD_NAME_PROCESS_NAME)).isEqualTo(processName);
     assertThat(incidentFields.get(FIELD_NAME_PROCESS_VERSION)).isEqualTo(processVersion);
+    assertThat(incidentFields.get(FIELD_NAME_PROCESS_VERSION_TAG)).isEqualTo(processVersionTag);
     assertThat(incidentFields.get(FIELD_NAME_FLOW_NODE_INSTANCE_KEY))
         .isEqualTo(flowNodeInstanceId.intValue());
     assertThat(incidentFields.get(FIELD_NAME_CREATION_TIME)).isNotNull();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsProcessCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsProcessCacheLoader.java
@@ -39,6 +39,7 @@ public class RdbmsProcessCacheLoader implements CacheLoader<Long, CachedProcessE
           ProcessCacheUtil.extractProcessDiagramData(processDefinitionEntity);
       return new CachedProcessEntity(
           processDefinitionEntity.name(),
+          processDefinitionEntity.version(),
           processDefinitionEntity.versionTag(),
           processDiagramData.callActivityIds(),
           processDiagramData.flowNodesMap());
@@ -60,6 +61,7 @@ public class RdbmsProcessCacheLoader implements CacheLoader<Long, CachedProcessE
                   final var processDiagramData = ProcessCacheUtil.extractProcessDiagramData(pde);
                   return new CachedProcessEntity(
                       pde.name(),
+                      pde.version(),
                       pde.versionTag(),
                       processDiagramData.callActivityIds(),
                       processDiagramData.flowNodesMap());

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -52,6 +52,7 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
     processDefinitionWriter.create(map(value));
     final String resourceName = value.getResourceName();
     final var versionTag = value.getVersionTag();
+    final var version = value.getVersion();
     final var processModelReader =
         ProcessModelReader.of(value.getResource(), value.getBpmnProcessId());
     processModelReader.ifPresent(
@@ -60,7 +61,7 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
               ProcessCacheUtil.sortedCallActivityIds(reader.extractCallActivities());
           final var flowNodesMap = ProcessCacheUtil.getFlowNodesMap(reader.extractFlowNodes());
           final var cachedProcessEntity =
-              new CachedProcessEntity(resourceName, versionTag, activities, flowNodesMap);
+              new CachedProcessEntity(resourceName, version, versionTag, activities, flowNodesMap);
           processCache.put(value.getProcessDefinitionKey(), cachedProcessEntity);
         });
   }


### PR DESCRIPTION
# Description
Backport of #42944 to `stable/8.8`.

relates to #42555