### PR TITLE
fix: remove the overwriting of the oidcUserService to be more tolerant to missing userinfo URI

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -91,7 +91,6 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGra
 import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
 import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
-import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
@@ -784,16 +783,6 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public OidcUserService oidcUserService() {
-      final var userService = new OidcUserService();
-      // We need to consume the userinfo endpoint to support retrieving additional information about
-      // the principal (e.g., email, groups, etc.) in case the access token does not contain them
-      // Remove when https://github.com/camunda/camunda/issues/42751 is completed
-      userService.setRetrieveUserInfo(ignored -> true);
-      return userService;
-    }
-
-    @Bean
     @Order(ORDER_WEBAPP_API)
     @ConditionalOnProtectedApi
     public SecurityFilterChain oidcApiSecurity(
@@ -865,8 +854,7 @@ public class WebSecurityConfig {
         final CookieCsrfTokenRepository csrfTokenRepository,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
         final OAuth2AuthorizedClientManager authorizedClientManager,
-        final OidcTokenEndpointCustomizer tokenEndpointCustomizer,
-        final OidcUserService oidcUserService)
+        final OidcTokenEndpointCustomizer tokenEndpointCustomizer)
         throws Exception {
       final var filterChainBuilder =
           httpSecurity
@@ -911,7 +899,6 @@ public class WebSecurityConfig {
                                     authorizationRequestResolver(
                                         clientRegistrationRepository, oidcProviderRepository)))
                         .tokenEndpoint(tokenEndpointCustomizer)
-                        .userInfoEndpoint(c -> c.oidcUserService(oidcUserService))
                         .failureHandler(new OAuth2AuthenticationExceptionHandler());
                   })
               .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It was noticed in our E2E suite that access to the OC components (Identity, Operate, Tasklist) is failing for 8.9 and 8.8 currently. The error returned is 

```
{
"type": "about:blank",
"title": "Internal Server Error",
"status": 500,
"detail": "[missing_user_info_uri] Missing required UserInfo Uri in UserInfoEndpoint for Client Registration: oidc",
"instance": "/orchestration/sso-callback"
}
```

Upon investigation I noticed that in a setup where you configure the issuer URI then the userinfo is taken from the well known configuration, however, in an instance where you provide the individual URIs ([REF](https://docs.camunda.io/docs/self-managed/components/orchestration-cluster/identity/special-oidc-cases/#use-separate-oidc-provider-uris-for-browser-and-backend)) the code that grabs the userinfo fails because there is no `USERINFOURI` configured.

For context, initially we didn't override the `UserService` bean, with https://github.com/camunda/camunda/commit/68f978dc716e3f91f314d8c7751e34d4eb67294d we overrode that behaviour to prevent rate limiting but we need this functionality in place for customer needs so to ensure the behaviour remained https://github.com/camunda/camunda/pull/42772 reinstated the behaviour in a visible way. Instead of the visual revert (i.e. setting false to true), another option would have been to remove the bean and restore the initial behaviour fully (which is what this PR does).

I think this PR is the simplest approach without digging more into the code and the partial/visual revert was only a temporary solution.

