### PR TITLE
[Backport stable/8.6] deps: Update log4j2 monorepo to v2.25.3 (stable/8.8) (patch)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -69,7 +69,7 @@
     <version.jackson>2.18.5</version.jackson>
     <version.junit>5.11.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
-    <version.log4j>2.24.3</version.log4j>
+    <version.log4j>2.25.3</version.log4j>
     <version.minlog>1.3.1</version.minlog>
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>


### PR DESCRIPTION
# Description
Backport of #42980 to `stable/8.6`.

relates to 