### PR TITLE
ci: reduce unit test forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,9 +380,9 @@ jobs:
         shell: bash
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=7
+          -D forkCount=3
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
-          -D junitThreadCount=16
+          -D junitThreadCount=8
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Reduce Unit Test job junitthread and fork count to stabilize CI as the job's assigned worker was being forcefully killed by OOM. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
Ref thread: https://camunda.slack.com/archives/C071KP5BTHB/p1766163109458419
closes #
