### PR TITLE
Delete process instance related data from RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -11,7 +11,7 @@ import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import java.util.List;
 
-public interface AuditLogMapper {
+public interface AuditLogMapper extends ProcessInstanceDependantMapper {
 
   void insert(AuditLogDbModel auditLog);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/CorrelatedMessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/CorrelatedMessageSubscriptionMapper.java
@@ -11,7 +11,8 @@ import io.camunda.db.rdbms.read.domain.CorrelatedMessageSubscriptionDbQuery;
 import io.camunda.db.rdbms.write.domain.CorrelatedMessageSubscriptionDbModel;
 import java.util.List;
 
-public interface CorrelatedMessageSubscriptionMapper extends HistoryCleanupMapper {
+public interface CorrelatedMessageSubscriptionMapper
+    extends HistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   Long count(CorrelatedMessageSubscriptionDbQuery query);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
@@ -12,7 +12,8 @@ import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import java.util.List;
 
-public interface DecisionInstanceMapper extends ProcessBasedHistoryCleanupMapper {
+public interface DecisionInstanceMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(DecisionInstanceDbModel decisionInstance);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
@@ -13,7 +13,8 @@ import io.camunda.search.entities.FlowNodeInstanceEntity;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public interface FlowNodeInstanceMapper extends ProcessBasedHistoryCleanupMapper {
+public interface FlowNodeInstanceMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(FlowNodeInstanceDbModel flowNode);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/HistoryDeletionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/HistoryDeletionMapper.java
@@ -20,4 +20,6 @@ public interface HistoryDeletionMapper {
 
   int delete(
       @Param("resourceKey") long resourceKey, @Param("batchOperationKey") long batchOperationKey);
+
+  int deleteByResourceKeys(final List<Long> resourceKeys);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
@@ -12,7 +12,8 @@ import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.search.entities.IncidentEntity;
 import java.util.List;
 
-public interface IncidentMapper extends ProcessBasedHistoryCleanupMapper {
+public interface IncidentMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(IncidentDbModel incident);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
@@ -11,7 +11,8 @@ import io.camunda.db.rdbms.read.domain.JobDbQuery;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
 import java.util.List;
 
-public interface JobMapper extends ProcessBasedHistoryCleanupMapper {
+public interface JobMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(JobDbModel job);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
@@ -13,7 +13,8 @@ import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.search.entities.ProcessDefinitionMessageSubscriptionStatisticsEntity;
 import java.util.List;
 
-public interface MessageSubscriptionMapper extends HistoryCleanupMapper {
+public interface MessageSubscriptionMapper
+    extends HistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(MessageSubscriptionDbModel messageSubscription);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import java.util.List;
+
+/**
+ * Mapper interface for deleting data related to process instances. As a rule of thumb, this
+ * interface should be extended by mappers that should delete process instance related data upon a
+ * process instance deletion.
+ */
+public interface ProcessInstanceDependantMapper {
+
+  int deleteProcessInstanceRelatedData(DeleteProcessInstanceRelatedDataDto dto);
+
+  record DeleteProcessInstanceRelatedDataDto(List<Long> processInstanceKeys, int limit) {}
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -34,6 +34,8 @@ public interface ProcessInstanceMapper extends ProcessBasedHistoryCleanupMapper 
 
   List<ProcessFlowNodeStatisticsEntity> flowNodeStatistics(long processInstanceKey);
 
+  void deleteByKeys(List<Long> processInstanceKeys);
+
   record EndProcessInstanceDto(
       long processInstanceKey,
       ProcessInstanceEntity.ProcessInstanceState state,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/SequenceFlowMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/SequenceFlowMapper.java
@@ -11,7 +11,8 @@ import io.camunda.db.rdbms.read.domain.SequenceFlowDbQuery;
 import io.camunda.db.rdbms.write.domain.SequenceFlowDbModel;
 import java.util.List;
 
-public interface SequenceFlowMapper extends ProcessBasedHistoryCleanupMapper {
+public interface SequenceFlowMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   List<SequenceFlowDbModel> search(SequenceFlowDbQuery processInstanceKey);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UserTaskMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UserTaskMapper.java
@@ -12,7 +12,8 @@ import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.UserTaskMigrationDbModel;
 import java.util.List;
 
-public interface UserTaskMapper extends ProcessBasedHistoryCleanupMapper {
+public interface UserTaskMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(UserTaskDbModel taskDbModel);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
@@ -13,7 +13,8 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
-public interface VariableMapper extends ProcessBasedHistoryCleanupMapper {
+public interface VariableMapper
+    extends ProcessBasedHistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(VariableDbModel variable);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
@@ -53,6 +54,7 @@ public class RdbmsWriterFactory {
   private final MessageSubscriptionMapper messageSubscriptionMapper;
   private final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper;
   private final ClusterVariableMapper clusterVariableMapper;
+  private final HistoryDeletionMapper historyDeletionMapper;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -75,7 +77,8 @@ public class RdbmsWriterFactory {
       final BatchOperationMapper batchOperationMapper,
       final MessageSubscriptionMapper messageSubscriptionMapper,
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
-      final ClusterVariableMapper clusterVariableMapper) {
+      final ClusterVariableMapper clusterVariableMapper,
+      final HistoryDeletionMapper historyDeletionMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -97,6 +100,7 @@ public class RdbmsWriterFactory {
     this.messageSubscriptionMapper = messageSubscriptionMapper;
     this.correlatedMessageSubscriptionMapper = correlatedMessageSubscriptionMapper;
     this.clusterVariableMapper = clusterVariableMapper;
+    this.historyDeletionMapper = historyDeletionMapper;
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {
@@ -129,6 +133,7 @@ public class RdbmsWriterFactory {
         batchOperationMapper,
         messageSubscriptionMapper,
         correlatedMessageSubscriptionMapper,
-        clusterVariableMapper);
+        clusterVariableMapper,
+        historyDeletionMapper);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -44,6 +44,7 @@ import io.camunda.db.rdbms.write.service.JobWriter;
 import io.camunda.db.rdbms.write.service.MappingRuleWriter;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
+import io.camunda.db.rdbms.write.service.ProcessInstanceDependant;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.db.rdbms.write.service.RdbmsWriter;
@@ -56,6 +57,7 @@ import io.camunda.db.rdbms.write.service.UserTaskWriter;
 import io.camunda.db.rdbms.write.service.UserWriter;
 import io.camunda.db.rdbms.write.service.VariableWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class RdbmsWriters {
@@ -256,6 +258,13 @@ public class RdbmsWriters {
 
   public HistoryDeletionWriter getHistoryDeletionWriter() {
     return getWriter(HistoryDeletionWriter.class);
+  }
+
+  public List<ProcessInstanceDependant> getProcessInstanceDependantWriters() {
+    return writers.values().stream()
+        .filter(ProcessInstanceDependant.class::isInstance)
+        .map(ProcessInstanceDependant.class::cast)
+        .toList();
   }
 
   private <W> W getWriter(final Class<W> writerClass) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
@@ -92,7 +93,8 @@ public class RdbmsWriters {
       final BatchOperationMapper batchOperationMapper,
       final MessageSubscriptionMapper messageSubscriptionMapper,
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
-      final ClusterVariableMapper clusterVariableMapper) {
+      final ClusterVariableMapper clusterVariableMapper,
+      final HistoryDeletionMapper historyDeletionMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     this.metrics = metrics;
@@ -153,7 +155,9 @@ public class RdbmsWriters {
     writers.put(
         ClusterVariableWriter.class,
         new ClusterVariableWriter(executionQueue, vendorDatabaseProperties));
-    writers.put(HistoryDeletionWriter.class, new HistoryDeletionWriter(executionQueue));
+    writers.put(
+        HistoryDeletionWriter.class,
+        new HistoryDeletionWriter(executionQueue, historyDeletionMapper));
   }
 
   public AuthorizationWriter getAuthorizationWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -15,7 +15,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class AuditLogWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
 
@@ -23,6 +23,7 @@ public class AuditLogWriter implements RdbmsWriter, ProcessInstanceDependant {
       final ExecutionQueue executionQueue,
       final AuditLogMapper mapper,
       final VendorDatabaseProperties vendorDatabaseProperties) {
+    super(mapper);
     this.executionQueue = executionQueue;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -15,7 +15,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class AuditLogWriter implements RdbmsWriter {
+public class AuditLogWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/CorrelatedMessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/CorrelatedMessageSubscriptionWriter.java
@@ -18,13 +18,15 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class CorrelatedMessageSubscriptionWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class CorrelatedMessageSubscriptionWriter extends ProcessInstanceDependant
+    implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final CorrelatedMessageSubscriptionMapper mapper;
 
   public CorrelatedMessageSubscriptionWriter(
       final ExecutionQueue executionQueue, final CorrelatedMessageSubscriptionMapper mapper) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/CorrelatedMessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/CorrelatedMessageSubscriptionWriter.java
@@ -18,7 +18,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class CorrelatedMessageSubscriptionWriter implements RdbmsWriter {
+public class CorrelatedMessageSubscriptionWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final CorrelatedMessageSubscriptionMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -20,7 +20,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class DecisionInstanceWriter implements RdbmsWriter {
+public class DecisionInstanceWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final DecisionInstanceMapper mapper;
   private final ExecutionQueue executionQueue;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -20,7 +20,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class DecisionInstanceWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class DecisionInstanceWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final DecisionInstanceMapper mapper;
   private final ExecutionQueue executionQueue;
@@ -32,6 +32,7 @@ public class DecisionInstanceWriter implements RdbmsWriter, ProcessInstanceDepen
       final ExecutionQueue executionQueue,
       final VendorDatabaseProperties vendorDatabaseProperties,
       final RdbmsWriterConfig config) {
+    super(mapper);
     this.mapper = mapper;
     this.executionQueue = executionQueue;
     this.vendorDatabaseProperties = vendorDatabaseProperties;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
@@ -24,7 +24,7 @@ import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
 
-public class FlowNodeInstanceWriter implements RdbmsWriter {
+public class FlowNodeInstanceWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final FlowNodeInstanceMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
@@ -24,13 +24,14 @@ import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
 
-public class FlowNodeInstanceWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class FlowNodeInstanceWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final FlowNodeInstanceMapper mapper;
 
   public FlowNodeInstanceWriter(
       final ExecutionQueue executionQueue, final FlowNodeInstanceMapper mapper) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -67,7 +67,7 @@ public class HistoryDeletionService {
                 });
 
     if (allProcessInstanceDependantDataDeleted) {
-      // TODO delete from PI table
+      rdbmsWriters.getProcessInstanceWriter().deleteByKeys(processInstanceKeys);
       // TODO delete from HistoryDeletion table
     }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriter.java
@@ -7,19 +7,24 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.List;
 import java.util.Map;
 
 public class HistoryDeletionWriter implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
+  private final HistoryDeletionMapper historyDeletionMapper;
 
-  public HistoryDeletionWriter(final ExecutionQueue executionQueue) {
+  public HistoryDeletionWriter(
+      final ExecutionQueue executionQueue, final HistoryDeletionMapper historyDeletionMapper) {
     this.executionQueue = executionQueue;
+    this.historyDeletionMapper = historyDeletionMapper;
   }
 
   public void create(final HistoryDeletionDbModel dbModel) {
@@ -43,5 +48,9 @@ public class HistoryDeletionWriter implements RdbmsWriter {
             id,
             "io.camunda.db.rdbms.sql.HistoryDeletionMapper.delete",
             Map.of("resourceKey", resourceKey, "batchOperationKey", batchOperationKey)));
+  }
+
+  public int deleteByResourceKeys(final List<Long> resourceKeys) {
+    return historyDeletionMapper.deleteByResourceKeys(resourceKeys);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IncidentWriter implements RdbmsWriter {
+public class IncidentWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private static final Logger LOG = LoggerFactory.getLogger(IncidentWriter.class);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IncidentWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class IncidentWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private static final Logger LOG = LoggerFactory.getLogger(IncidentWriter.class);
 
@@ -37,6 +37,7 @@ public class IncidentWriter implements RdbmsWriter, ProcessInstanceDependant {
       final ExecutionQueue executionQueue,
       final IncidentMapper mapper,
       final VendorDatabaseProperties vendorDatabaseProperties) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -19,7 +19,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class JobWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final JobMapper mapper;
@@ -29,6 +29,7 @@ public class JobWriter implements RdbmsWriter, ProcessInstanceDependant {
       final ExecutionQueue executionQueue,
       final JobMapper mapper,
       final VendorDatabaseProperties vendorDatabaseProperties) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -19,7 +19,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class JobWriter implements RdbmsWriter {
+public class JobWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final JobMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -18,13 +18,14 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class MessageSubscriptionWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class MessageSubscriptionWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final MessageSubscriptionMapper mapper;
 
   public MessageSubscriptionWriter(
       final ExecutionQueue executionQueue, final MessageSubscriptionMapper mapper) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -18,7 +18,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class MessageSubscriptionWriter implements RdbmsWriter {
+public class MessageSubscriptionWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final MessageSubscriptionMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
@@ -7,4 +7,22 @@
  */
 package io.camunda.db.rdbms.write.service;
 
-public interface ProcessInstanceDependant {}
+import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper;
+import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper.DeleteProcessInstanceRelatedDataDto;
+import java.util.List;
+
+public abstract class ProcessInstanceDependant {
+
+  private final ProcessInstanceDependantMapper processInstanceDependantMapper;
+
+  public ProcessInstanceDependant(
+      final ProcessInstanceDependantMapper processInstanceDependantMapper) {
+    this.processInstanceDependantMapper = processInstanceDependantMapper;
+  }
+
+  public int deleteProcessInstanceRelatedData(
+      final List<Long> processInstanceKeys, final int limit) {
+    return processInstanceDependantMapper.deleteProcessInstanceRelatedData(
+        new DeleteProcessInstanceRelatedDataDto(processInstanceKeys, limit));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+public interface ProcessInstanceDependant {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
@@ -21,6 +21,7 @@ import io.camunda.db.rdbms.write.queue.UpsertMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.function.Function;
 
 public class ProcessInstanceWriter implements RdbmsWriter {
@@ -144,5 +145,9 @@ public class ProcessInstanceWriter implements RdbmsWriter {
             .cleanupDate(cleanupDate)
             .limit(rowsToRemove)
             .build());
+  }
+
+  public void deleteByKeys(final List<Long> processInstanceKeys) {
+    mapper.deleteByKeys(processInstanceKeys);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
@@ -18,12 +18,13 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class SequenceFlowWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class SequenceFlowWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final SequenceFlowMapper mapper;
 
   public SequenceFlowWriter(final ExecutionQueue executionQueue, final SequenceFlowMapper mapper) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
@@ -18,7 +18,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class SequenceFlowWriter implements RdbmsWriter {
+public class SequenceFlowWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final SequenceFlowMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
@@ -20,12 +20,13 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class UserTaskWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class UserTaskWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final UserTaskMapper mapper;
 
   public UserTaskWriter(final ExecutionQueue executionQueue, final UserTaskMapper mapper) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
@@ -20,7 +20,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class UserTaskWriter implements RdbmsWriter {
+public class UserTaskWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final UserTaskMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -19,7 +19,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class VariableWriter implements RdbmsWriter {
+public class VariableWriter implements RdbmsWriter, ProcessInstanceDependant {
 
   private final ExecutionQueue executionQueue;
   private final VariableMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -19,7 +19,7 @@ import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 
-public class VariableWriter implements RdbmsWriter, ProcessInstanceDependant {
+public class VariableWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final VariableMapper mapper;
@@ -29,6 +29,7 @@ public class VariableWriter implements RdbmsWriter, ProcessInstanceDependant {
       final ExecutionQueue executionQueue,
       final VariableMapper mapper,
       final VendorDatabaseProperties vendorDatabaseProperties) {
+    super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -275,5 +275,10 @@
     )
   </insert>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'AUDIT_LOG'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
 </mapper>
 

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -204,6 +204,46 @@
                    LIMIT #{limit})
   </sql>
 
+  <sql id="historyDeletion">
+    DELETE
+    FROM ${prefix}${tableName}
+    WHERE PROCESS_INSTANCE_KEY IN
+    <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
+      #{key}
+    </foreach>
+    LIMIT #{limit}
+  </sql>
+  <sql id="historyDeletion" databaseId="mssql">
+    DELETE TOP (#{limit})
+    FROM ${prefix}${tableName}
+    WHERE PROCESS_INSTANCE_KEY IN
+    <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
+      #{key}
+    </foreach>
+  </sql>
+  <sql id="historyDeletion" databaseId="oracle">
+    DELETE
+    FROM ${prefix}${tableName}
+    WHERE rowid IN (SELECT rowid
+                    FROM ${prefix}${tableName}
+                    WHERE PROCESS_INSTANCE_KEY IN
+                    <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
+                      #{key}
+                    </foreach>
+                    AND ROWNUM &lt;= #{limit})
+  </sql>
+  <sql id="historyDeletion" databaseId="postgresql">
+    DELETE
+    FROM ${prefix}${tableName}
+    WHERE ctid IN (SELECT ctid
+                   FROM ${prefix}${tableName}
+                   WHERE PROCESS_INSTANCE_KEY IN
+                   <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
+                     #{key}
+                   </foreach>
+                   LIMIT #{limit})
+  </sql>
+
   <resultMap id="flowNodeStatisticsResultMap"
     type="io.camunda.search.entities.ProcessFlowNodeStatisticsEntity">
     <constructor>

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
@@ -206,4 +206,9 @@
     <bind name="tableName" value="'CORRELATED_MESSAGE_SUBSCRIPTION'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
+
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'CORRELATED_MESSAGE_SUBSCRIPTION'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -323,4 +323,9 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'DECISION_INSTANCE'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -256,4 +256,9 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'FLOW_NODE_INSTANCE'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/HistoryDeletionMapper.xml
@@ -67,4 +67,12 @@
       AND BATCH_OPERATION_KEY = #{batchOperationKey}
   </delete>
 
+  <delete id="deleteByResourceKeys">
+    DELETE FROM ${prefix}HISTORY_DELETION
+    WHERE RESOURCE_KEY IN
+    <foreach collection="resourceKeys" item="resourceKey" open="(" separator="," close=")">
+      #{resourceKey}
+    </foreach>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -234,4 +234,9 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'INCIDENT'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -297,4 +297,9 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'JOB'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -218,6 +218,11 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'MESSAGE_SUBSCRIPTION'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
   <!-- Message Subscription Process Definition Statistics Aggregation -->
   <select id="getProcessDefinitionStatistics"
     parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionMessageSubscriptionStatisticsDbQuery"

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -460,4 +460,13 @@
     <bind name="tableName" value="'PROCESS_INSTANCE'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
+
+  <delete id="deleteByKeys">
+    DELETE FROM ${prefix}PROCESS_INSTANCE
+    WHERE PROCESS_INSTANCE_KEY IN
+    <foreach collection="processInstanceKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -201,6 +201,11 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'SEQUENCE_FLOW'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel">
     DELETE FROM ${prefix}SEQUENCE_FLOW
     WHERE FLOW_NODE_ID = #{flowNodeId}

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -399,4 +399,9 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'USER_TASK'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -170,6 +170,11 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'VARIABLE'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
   <update id="migrateToProcess" parameterType="java.util.Map">
       UPDATE ${prefix}VARIABLE
       SET PROCESS_DEFINITION_ID = #{processDefinitionId}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -7,13 +7,23 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 public class HistoryDeletionServiceTest {
 
@@ -23,7 +33,7 @@ public class HistoryDeletionServiceTest {
 
   @BeforeEach
   void setUp() {
-    rdbmsWritersMock = mock(RdbmsWriters.class);
+    rdbmsWritersMock = mock(RdbmsWriters.class, Answers.RETURNS_DEEP_STUBS);
     historyDeletionDbReaderMock = mock(HistoryDeletionDbReader.class);
     historyDeletionService =
         new HistoryDeletionService(rdbmsWritersMock, historyDeletionDbReaderMock);
@@ -39,5 +49,46 @@ public class HistoryDeletionServiceTest {
 
     // then
     verify(historyDeletionDbReaderMock).getNextBatch(partitionId, 100);
+  }
+
+  @Test
+  void shouldApplyExponentialBackoffIfNothingToDelete() {
+    // given
+    final var partitionId = 1;
+
+    // when
+    final var interval1 = historyDeletionService.deleteHistory(partitionId);
+    final var interval2 = historyDeletionService.deleteHistory(partitionId);
+    final var interval3 = historyDeletionService.deleteHistory(partitionId);
+    final var interval4 = historyDeletionService.deleteHistory(partitionId);
+    final var interval5 = historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    assertThat(interval1).isEqualTo(Duration.ofSeconds(2));
+    assertThat(interval2).isEqualTo(Duration.ofSeconds(4));
+    assertThat(interval3).isEqualTo(Duration.ofSeconds(8));
+    assertThat(interval4).isEqualTo(Duration.ofSeconds(16));
+    assertThat(interval5).isEqualTo(Duration.ofSeconds(32));
+  }
+
+  @Test
+  void shouldImmediatelyContinueIfDeletionsWereMade() {
+    // given
+    final var partitionId = 1;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            List.of(
+                new HistoryDeletionDbModel(
+                    1L, HistoryDeletionTypeDbModel.PROCESS_INSTANCE, 2L, partitionId)));
+    when(rdbmsWritersMock.getProcessInstanceDependantWriters()).thenReturn(Collections.emptyList());
+    when(rdbmsWritersMock.getHistoryDeletionWriter().deleteByResourceKeys(anyList())).thenReturn(1);
+
+    // when
+    final var interval1 = historyDeletionService.deleteHistory(partitionId);
+    final var interval2 = historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    assertThat(interval1).isEqualTo(Duration.ofSeconds(1));
+    assertThat(interval2).isEqualTo(Duration.ofSeconds(1));
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class HistoryDeletionWriterTest {
 
   private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
-  private final HistoryDeletionWriter writer = new HistoryDeletionWriter(executionQueue);
+  private final HistoryDeletionWriter writer = new HistoryDeletionWriter(executionQueue, null);
 
   @Test
   void shouldInsertHistoryDeletion() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionWriterTest.java
@@ -11,19 +11,24 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.Test;
 
 class HistoryDeletionWriterTest {
 
   private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
-  private final HistoryDeletionWriter writer = new HistoryDeletionWriter(executionQueue, null);
+  private final HistoryDeletionMapper historyDeletionMapper = mock(HistoryDeletionMapper.class);
+  private final HistoryDeletionWriter writer =
+      new HistoryDeletionWriter(executionQueue, historyDeletionMapper);
 
   @Test
   void shouldInsertHistoryDeletion() {
@@ -64,5 +69,15 @@ class HistoryDeletionWriterTest {
                     "2251799813685312_2251799813685385",
                     "io.camunda.db.rdbms.sql.HistoryDeletionMapper.delete",
                     Map.of("resourceKey", resourceKey, "batchOperationKey", batchOperationKey))));
+  }
+
+  @Test
+  void shouldDeleteByResourceKeys() {
+    final var resourceKeys =
+        List.of(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+
+    writer.deleteByResourceKeys(resourceKeys);
+
+    verify(historyDeletionMapper).deleteByResourceKeys(resourceKeys);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -292,7 +292,7 @@ public class RdbmsConfiguration {
 
   @Bean
   public HistoryDeletionDbReader historyDeletionDbReader(
-      HistoryDeletionMapper historyDeletionMapper) {
+      final HistoryDeletionMapper historyDeletionMapper) {
     return new HistoryDeletionDbReader(historyDeletionMapper);
   }
 
@@ -337,7 +337,8 @@ public class RdbmsConfiguration {
       final BatchOperationMapper batchOperationMapper,
       final MessageSubscriptionMapper messageSubscriptionMapper,
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
-      final ClusterVariableMapper clusterVariableMapper) {
+      final ClusterVariableMapper clusterVariableMapper,
+      final HistoryDeletionMapper historyDeletionMapper) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -359,7 +360,8 @@ public class RdbmsConfiguration {
         batchOperationMapper,
         messageSubscriptionMapper,
         correlatedMessageSubscriptionMapper,
-        clusterVariableMapper);
+        clusterVariableMapper,
+        historyDeletionMapper);
   }
 
   @Bean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the deletion logic to the scheduler we have in the RDBMS exporter. It will delete all process instance dependant data. Then it will delete the process instance itself, and finally it will delete the entry from the history deletion table.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41110 
