### PR TITLE
[Backport release-8.9.0-alpha3] fix: handle when optimize is excluded from the release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -898,6 +898,13 @@ jobs:
     runs-on: ubuntu-latest
     # Minor releases take more time since a lot of issues are included in the changelog
     timeout-minutes: 30
+    if: ${{ always() && !cancelled() && 
+      needs.release.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
+      needs.camunda-docker.result == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1022,6 +1029,14 @@ jobs:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
+    if: ${{ always() && !cancelled() && 
+      needs.release.result == 'success' &&
+      needs.github.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
+      needs.camunda-docker.result == 'success' }}
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
# Description
Backport of #43122 to `release-8.9.0-alpha3`.

relates to 