### PR TITLE
[Backport stable/8.8] fix: ProbesITs correctly accept the index prefix

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
@@ -32,7 +32,8 @@ class ProbesTestIT {
   @BeforeAll
   public static void init() {
     final String dbType =
-        (Optional.ofNullable("camunda.data.secondary-storage.type").orElse("elasticsearch"))
+        (Optional.ofNullable(System.getProperty("camunda.data.secondary-storage.type"))
+                .orElse("elasticsearch"))
             .toLowerCase();
     indexPrefixConfig = "camunda.data.secondary-storage." + dbType + ".index-prefix";
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ProbesTestIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ProbesTestIT.java
@@ -35,7 +35,8 @@ public class ProbesTestIT extends TasklistIntegrationTest {
   @BeforeAll
   public static void init() {
     final String dbType =
-        (Optional.ofNullable("camunda.data.secondary-storage.type").orElse("elasticsearch"))
+        (Optional.ofNullable(System.getProperty("camunda.data.secondary-storage.type"))
+                .orElse("elasticsearch"))
             .toLowerCase();
     indexPrefixConfig = "camunda.data.secondary-storage." + dbType + ".index-prefix";
   }


### PR DESCRIPTION
# Description
Backport of #43155 to `stable/8.8`.

relates to 