### PR TITLE
[Backport release-8.9.0-alpha3] ci: reduce unit test forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,9 +380,9 @@ jobs:
         shell: bash
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=7
+          -D forkCount=3
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
-          -D junitThreadCount=16
+          -D junitThreadCount=8
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify


### PR DESCRIPTION
# Description
Backport of #43175 to `release-8.9.0-alpha3`.

relates to 