### PR TITLE
test: release preparation - unskip tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-global-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-global-api-tests.spec.ts
@@ -69,8 +69,8 @@ test.describe.parallel('Cluster Variable API Tests - Global Scope', () => {
     });
     await assertUnauthorizedRequest(res);
   });
-  // // Skipped due to bug 42045: https://github.com/camunda/camunda/issues/42045
-  test.skip('Create Global Cluster Variable Missing Name Invalid Body 400', async ({
+
+  test('Create Global Cluster Variable Missing Name Invalid Body 400', async ({
     request,
   }) => {
     const body = {value: {testKey: 'testValue'}};
@@ -80,8 +80,8 @@ test.describe.parallel('Cluster Variable API Tests - Global Scope', () => {
     });
     await assertBadRequest(res, /name/i, 'INVALID_ARGUMENT');
   });
-  // // Skipped due to bug 42047: https://github.com/camunda/camunda/issues/42047
-  test.skip('Create Global Cluster Variable Missing Value Invalid Body 400', async ({
+
+  test('Create Global Cluster Variable Missing Value Invalid Body 400', async ({
     request,
   }) => {
     const body = {name: 'test-var'};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-tenant-api-tests.spec.ts
@@ -67,7 +67,7 @@ test.describe.parallel('Cluster Variable API Tests - Tenant Scope', () => {
         },
       );
 
-      expect(res.status()).toBe(200); 
+      expect(res.status()).toBe(200);
       const json = await res.json();
       assertRequiredFields(json, clusterVariableRequiredFields);
       expect(json.name).toBe(variable.name);
@@ -89,8 +89,7 @@ test.describe.parallel('Cluster Variable API Tests - Tenant Scope', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // skipped due to bug https://github.com/camunda/camunda/issues/42045
-  test.skip('Create Tenant Cluster Variable Missing Name Invalid Body 400', async ({
+  test('Create Tenant Cluster Variable Missing Name Invalid Body 400', async ({
     request,
   }) => {
     const tenantId = state['tenantId1'] as string;
@@ -105,8 +104,7 @@ test.describe.parallel('Cluster Variable API Tests - Tenant Scope', () => {
     await assertBadRequest(res, /name/i, 'INVALID_ARGUMENT');
   });
 
-  // skipped due to bug 42048: https://github.com/camunda/camunda/issues/42048
-  test.skip('Create Tenant Cluster Variable Missing Value Invalid Body 400', async ({
+  test('Create Tenant Cluster Variable Missing Value Invalid Body 400', async ({
     request,
   }) => {
     const tenantId = state['tenantId1'] as string;
@@ -153,7 +151,7 @@ test.describe.parallel('Cluster Variable API Tests - Tenant Scope', () => {
           headers: jsonHeaders(),
         },
       );
-      expect(res.status()).toBe(200); 
+      expect(res.status()).toBe(200);
       const json = await res.json();
       assertRequiredFields(json, clusterVariableRequiredFields);
       expect(json.name).toBe(variableName);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
@@ -449,8 +449,7 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  // Skipped due to bug 39819:  https://github.com/camunda/camunda/issues/39819
-  test.skip('Evaluate Decision Definition Invalid Data', async ({request}) => {
+  test('Evaluate Decision Definition Invalid Data', async ({request}) => {
     await expect(async () => {
       const res = await request.post(
         buildUrl('/decision-definitions/evaluation'),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
@@ -461,8 +461,8 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
 
       await assertBadRequest(
         res,
-        'At least one of [decisionDefinitionId, decisionDefinitionKey] is required.',
-        'INVALID_ARGUMENT',
+        'At least one of [decisionDefinitionId, decisionDefinitionKey] is required',
+        'Bad Request',
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-api.spec.ts
@@ -205,8 +205,7 @@ test.describe.parallel('Process instance Tests', () => {
     await cancelProcessInstance(json.processInstanceKey);
   });
 
-  // Skipped due to bug 39819:  https://github.com/camunda/camunda/issues/39819
-  test.skip('Create Process Instance - Failure - Missing process definition id and key', async ({
+  test('Create Process Instance - Failure - Missing process definition id and key', async ({
     request,
   }) => {
     const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-api.spec.ts
@@ -217,9 +217,9 @@ test.describe.parallel('Process instance Tests', () => {
 
     await assertStatusCode(res, 400);
     const json = await res.json();
-    expect(json.title).toBe('INVALID_ARGUMENT');
+    expect(json.title).toBe('Bad Request');
     expect(json.detail).toBe(
-      'At least one of [processDefinitionId, processDefinitionKey] is required.',
+      'At least one of [processDefinitionId, processDefinitionKey] is required',
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -171,8 +171,7 @@ test.describe.parallel('Users API Tests', () => {
     await assertBadRequest(res, 'No password provided', 'INVALID_ARGUMENT');
   });
 
-  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
-  test.skip('Create User Missing Email Success', async ({request}) => {
+  test('Create User Missing Email Success', async ({request}) => {
     const body = {
       username: `username-${generateUniqueId()}`,
       name: 'user',
@@ -196,8 +195,7 @@ test.describe.parallel('Users API Tests', () => {
     createdUserIds.push(json.username);
   });
 
-  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
-  test.skip('Create User Missing Name Success', async ({request}) => {
+  test('Create User Missing Name Success', async ({request}) => {
     const body = {
       username: `username-${generateUniqueId()}`,
       email: 'user@example.com',
@@ -342,8 +340,7 @@ test.describe.parallel('Users API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
-  test.skip('Update User Missing Name Success', async ({request}) => {
+  test('Update User Missing Name Success', async ({request}) => {
     const p = {username: state['username6'] as string};
     const requestBody = {
       email: `updated-${generateUniqueId()}-email@example.com`,
@@ -366,8 +363,7 @@ test.describe.parallel('Users API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
-  test.skip('Update User Missing Email Success', async ({request}) => {
+  test('Update User Missing Email Success', async ({request}) => {
     const p = {username: state['username7'] as string};
     const requestBody = {
       name: `updated-${generateUniqueId()}-name`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -348,7 +348,7 @@ test.describe.parallel('Users API Tests', () => {
     const expectedBody = {
       ...p,
       ...requestBody,
-      name: state['name6'],
+      name: '',
     };
 
     await expect(async () => {
@@ -371,7 +371,7 @@ test.describe.parallel('Users API Tests', () => {
     const expectedBody = {
       ...p,
       ...requestBody,
-      email: state['email7'],
+      email: '',
     };
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -48,8 +48,7 @@ test.describe.parallel('Search User Task Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 39819:  https://github.com/camunda/camunda/issues/39819
-  test.skip('Search user tasks - bad request - invalid payload', async ({
+  test('Search user tasks - bad request - invalid payload', async ({
     request,
   }) => {
     const res = await request.post(buildUrl('/user-tasks/search'), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -58,7 +58,10 @@ test.describe.parallel('Search User Task Tests', () => {
         page: 'invalidValue',
       },
     });
-    await assertBadRequest(res, 'Request property [page] cannot be parsed');
+    await assertBadRequest(
+      res,
+      'At least one of [from, after, before, limit] is required.',
+    );
   });
 
   test('Search user task - filter by processInstanceKey', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
@@ -97,8 +97,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  // Skipped due to bug 39819:  https://github.com/camunda/camunda/issues/39819
-  test.skip('Search user task variables - unauthorized', async ({request}) => {
+  test('Search user task variables - unauthorized', async ({request}) => {
     const userTaskKey = await findUserTask(
       request,
       state['processInstanceKey'] as string,
@@ -116,8 +115,7 @@ test.describe.parallel('Search User Task Variables Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug 39819:  https://github.com/camunda/camunda/issues/39819
-  test.skip('Search user task variables - bad request - invalid payload', async ({
+  test('Search user task variables - bad request - invalid payload', async ({
     request,
   }) => {
     const userTaskKey = await findUserTask(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
@@ -133,7 +133,10 @@ test.describe.parallel('Search User Task Variables Tests', () => {
         },
       },
     );
-    await assertBadRequest(res, 'Request property [page] cannot be parsed');
+    await assertBadRequest(
+      res,
+      'At least one of [from, after, before, limit] is required.',
+    );
   });
 
   test('Search user task variables - bad request - invalid user task key', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -126,8 +126,7 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  // Skipped due to bug 40968:  https://github.com/camunda/camunda/issues/40968
-  test.skip('Admin user can grant and revoke component authorization for user', async ({
+  test('Admin user can grant and revoke component authorization for user', async ({
     page,
     loginPage,
     identityUsersPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -145,8 +145,7 @@ test.describe.serial('component authorizations CRUD', () => {
     });
   });
 
-  // Skipped due to bug 40968:  https://github.com/camunda/camunda/issues/40968
-  test.skip('create component authorization for a role', async ({
+  test('create component authorization for a role', async ({
     identityUsersPage,
     identityAuthorizationsPage,
     identityHeader,
@@ -171,8 +170,7 @@ test.describe.serial('component authorizations CRUD', () => {
     });
   });
 
-  // Skipped due to bug 40968:  https://github.com/camunda/camunda/issues/40968
-  test.skip('delete component authorization for role', async ({
+  test('delete component authorization for role', async ({
     page,
     identityHeader,
     loginPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -151,11 +151,8 @@ test.describe.serial('component authorizations CRUD', () => {
     identityHeader,
     loginPage,
     page,
-    identityRolesPage,
   }) => {
-    await identityHeader.navigateToRoles();
     const role = NEW_AUTH_ROLE;
-    await identityRolesPage.createRole(role);
     await identityHeader.navigateToAuthorizations();
     await identityAuthorizationsPage.createAuthorization({
       ...NEW_COMPONENT_AUTHORIZATION,
@@ -176,24 +173,14 @@ test.describe.serial('component authorizations CRUD', () => {
     loginPage,
     identityUsersPage,
     identityAuthorizationsPage,
-    identityRolesPage,
   }) => {
     await test.step(`Delete component authorization for role`, async () => {
-      await identityHeader.navigateToRoles();
       const role = NEW_AUTH_ROLE;
-      await identityRolesPage.createRole(role);
       await identityHeader.navigateToAuthorizations();
       const componentAuth = NEW_COMPONENT_AUTHORIZATION;
-      await identityAuthorizationsPage.createAuthorization({
-        ...componentAuth,
-        ownerId: role.name,
-      });
-
       const resourceType = componentAuth.resourceType;
       await identityAuthorizationsPage.selectResourceTypeTab(resourceType);
-      await identityAuthorizationsPage.clickDeleteAuthorizationButton(
-        role.name,
-      );
+      await identityAuthorizationsPage.clickDeleteAuthorizationButton(role.id);
 
       await expect(
         identityAuthorizationsPage.deleteAuthorizationModal,
@@ -204,7 +191,7 @@ test.describe.serial('component authorizations CRUD', () => {
       ).toBeHidden();
 
       await identityAuthorizationsPage.selectResourceTypeTab(resourceType);
-      const item = identityAuthorizationsPage.getAuthorizationCell(role.name);
+      const item = identityAuthorizationsPage.getAuthorizationCell(role.id);
       await waitForItemInList(page, item, {
         shouldBeVisible: false,
         onAfterReload: () =>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -13,6 +13,7 @@ import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {DATE_REGEX} from 'utils/constants';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from '../../utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -67,7 +68,7 @@ test.describe('Process Instance', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Resolve an incident', async ({operateProcessInstancePage}) => {
+  test('Resolve an incident', async ({page, operateProcessInstancePage}) => {
     await test.step('Navigate to process instance with incident', async () => {
       await operateProcessInstancePage.gotoProcessInstancePage({
         id: instanceWithIncidentToResolve.processInstanceKey,
@@ -107,13 +108,20 @@ test.describe('Process Instance', () => {
           /Condition error/i,
         ),
       ).toBeVisible();
-
-      await expect
-        .poll(
-          async () =>
-            await operateProcessInstancePage.incidentsTableOperationSpinner.isVisible(),
-        )
-        .toBe(false);
+      await waitForAssertion({
+        assertion: async () => {
+          await expect
+            .poll(
+              async () =>
+                await operateProcessInstancePage.incidentsTableOperationSpinner.isVisible(),
+            )
+            .toBe(false);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await sleep(5000);
+        },
+      });
 
       await expect(operateProcessInstancePage.incidentsTableRows).toHaveCount(
         1,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

Unskipped tests since bugs were closed.

Successful run [here](https://github.com/camunda/camunda/actions/runs/20437674795).

1. https://github.com/camunda/camunda/issues/42045 – Bug: Cluster Variable API returns generic Problem Details for missing name field
2. https://github.com/camunda/camunda/issues/42047 – Bug: Global cluster variable creation returns 409 Conflict on missing 'value' instead of 400 Bad Request
3. https://github.com/camunda/camunda/issues/42048 – Bug: Tenant cluster variable creation returns 200 OK on missing 'value' instead of 400 Bad Request
4. https://github.com/camunda/camunda/issues/39819 – Improve error handling after the introduction of the strong specification
5. https://github.com/camunda/camunda/issues/37720 – Error when optional fields are omitted in Create/Update User
6. https://github.com/camunda/camunda/issues/40968 – Cannot create authorization


<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
