### PR TITLE
feat: remove Process Instance events panel from dashboard

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -4207,114 +4207,6 @@
         },
         {
           "datasource": {
-            "uid": "$DS_PROMETHEUS"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "links": [],
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 12,
-            "x": 0,
-            "y": 222
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.1.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "expr": "sum(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", type=\"PROCESS\"}) by (action)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Process Instance ({{action}})",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "uid": "$DS_PROMETHEUS"
-              },
-              "expr": "sum(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}) by (action)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Job ({{action}})",
-              "refId": "B"
-            }
-          ],
-          "title": "Process Instance Events",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
@@ -4378,8 +4270,8 @@
           },
           "gridPos": {
             "h": 6,
-            "w": 12,
-            "x": 12,
+            "w": 24,
+            "x": 0,
             "y": 222
           },
           "id": 3,


### PR DESCRIPTION
## Description
The "total" section is removed, because it's not stable across restarts. I don't find it particularly useful and it's been defined as a bit confusing by  @alessandrocavalli .
The resulting dashboard looks like this:

<img width="1782" height="482" alt="image" src="https://github.com/user-attachments/assets/5e6dbe01-f355-40fd-9b47-e52af2e2b4fd" />


