### PR TITLE
feat: Enforce operation-specific authorization checks for user task operations (engine)

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -25,11 +25,9 @@ import io.camunda.zeebe.engine.processing.identity.authorization.request.Authori
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionChecker;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -104,14 +102,6 @@ public class AuthorizationArchTest {
             .or(
                 ArchConditions.callMethod(
                     JobUpdateBehaviour.class, "isAuthorized", TypedRecord.class, JobRecord.class))
-            // Or the processor should have delegated authorization to the
-            // UserTaskCommandPreconditionChecker
-            .or(
-                ArchConditions.callMethod(
-                    UserTaskCommandPreconditionChecker.class,
-                    "checkProcessDefinitionUpdateUserTaskAuth",
-                    TypedRecord.class,
-                    UserTaskRecord.class))
             // Or the processor should have delegate authorization to the PermissionsBehavior
             .or(
                 ArchConditions.callMethod(
@@ -138,7 +128,6 @@ public class AuthorizationArchTest {
       @Override
       public boolean test(final JavaClass javaClass) {
         return Predicates.assignableFrom(JobUpdateBehaviour.class)
-            .or(Predicates.assignableFrom(UserTaskCommandPreconditionChecker.class))
             .or(Predicates.assignableFrom(PermissionsBehavior.class))
             .test(javaClass);
       }

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPre
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -97,7 +98,10 @@ public class AuthorizationArchTest {
             // UserTaskCommandPreconditionChecker
             .or(
                 ArchConditions.callMethod(
-                    UserTaskCommandPreconditionChecker.class, "check", TypedRecord.class))
+                    UserTaskCommandPreconditionChecker.class,
+                    "checkProcessDefinitionUpdateUserTaskAuth",
+                    TypedRecord.class,
+                    UserTaskRecord.class))
             // Or the processor should have delegate authorization to the PermissionsBehavior
             .or(
                 ArchConditions.callMethod(

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -88,8 +88,18 @@ public class AuthorizationArchTest {
             .or(
                 ArchConditions.callMethod(
                     AuthorizationCheckBehavior.class,
+                    "isAnyAuthorized",
+                    AuthorizationRequest[].class))
+            .or(
+                ArchConditions.callMethod(
+                    AuthorizationCheckBehavior.class,
                     "isAuthorizedOrInternalCommand",
                     AuthorizationRequest.class))
+            .or(
+                ArchConditions.callMethod(
+                    AuthorizationCheckBehavior.class,
+                    "isAnyAuthorizedOrInternalCommand",
+                    AuthorizationRequest[].class))
             // Or the processor should have delegated authorization to the JobUpdateBehaviour
             .or(
                 ArchConditions.callMethod(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -23,7 +25,6 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -114,36 +115,12 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
 
     final var userTaskKey = String.valueOf(persistedUserTask.getUserTaskKey());
-    final var userTaskProperties =
-        UserTaskAuthorizationProperties.builder()
-            .assignee(persistedUserTask.getAssignee())
-            .candidateUsers(persistedUserTask.getCandidateUsersList())
-            .candidateGroups(persistedUserTask.getCandidateGroupsList())
-            .build();
-
-    final var processDefinitionUpdateUserTaskRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .permissionType(PermissionType.UPDATE_USER_TASK)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(persistedUserTask.getBpmnProcessId())
-            .build();
-
-    final var userTaskUpdateRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER_TASK)
-            .permissionType(PermissionType.UPDATE)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(userTaskKey)
-            .resourceProperties(userTaskProperties)
-            .build();
 
     // First check: PROCESS_DEFINITION[UPDATE_USER_TASK] or USER_TASK[UPDATE]
     final var primaryAuthResult =
         authCheckBehavior.isAnyAuthorizedOrInternalCommand(
-            processDefinitionUpdateUserTaskRequest, userTaskUpdateRequest);
+            buildProcessDefinitionUpdateUserTaskRequest(command, persistedUserTask),
+            buildUserTaskRequest(command, persistedUserTask, PermissionType.UPDATE));
 
     if (primaryAuthResult.isRight()) {
       return Either.right(persistedUserTask);
@@ -160,19 +137,13 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     final var currentUsername = getCurrentUsername(command);
 
     if (newAssignee.isEmpty() && currentUsername.filter(currentAssignee::equals).isPresent()) {
-      final var userTaskClaimRequest =
-          AuthorizationRequest.builder()
-              .command(command)
-              .resourceType(AuthorizationResourceType.USER_TASK)
-              .permissionType(PermissionType.CLAIM)
-              .tenantId(persistedUserTask.getTenantId())
-              .addResourceId(userTaskKey)
-              .resourceProperties(
-                  UserTaskAuthorizationProperties.builder().assignee(currentAssignee).build())
-              .build();
-
       return authCheckBehavior
-          .isAuthorizedOrInternalCommand(userTaskClaimRequest)
+          .isAuthorizedOrInternalCommand(
+              buildUserTaskRequest(
+                  command,
+                  persistedUserTask,
+                  PermissionType.CLAIM,
+                  UserTaskAuthorizationProperties.builder().assignee(currentAssignee).build()))
           .map(ignored -> persistedUserTask);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAuthorizationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAuthorizationHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask.processors;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Utility class for building common authorization requests used across user task command
+ * processors.
+ */
+final class UserTaskAuthorizationHelper {
+
+  private UserTaskAuthorizationHelper() {
+    // Utility class, prevent instantiation
+  }
+
+  /**
+   * Builds an authorization request for PROCESS_DEFINITION[UPDATE_USER_TASK] permission.
+   *
+   * @param command the user task command
+   * @param persistedUserTask the persisted user task record
+   * @return the authorization request
+   */
+  static AuthorizationRequest buildProcessDefinitionUpdateUserTaskRequest(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
+    return AuthorizationRequest.builder()
+        .command(command)
+        .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .permissionType(PermissionType.UPDATE_USER_TASK)
+        .tenantId(persistedUserTask.getTenantId())
+        .addResourceId(persistedUserTask.getBpmnProcessId())
+        .build();
+  }
+
+  /**
+   * Builds an authorization request for USER_TASK permission with all standard properties.
+   *
+   * @param command the user task command
+   * @param persistedUserTask the persisted user task record
+   * @param permissionType the permission type (e.g., UPDATE, CLAIM, COMPLETE)
+   * @return the authorization request
+   */
+  static AuthorizationRequest buildUserTaskRequest(
+      final TypedRecord<UserTaskRecord> command,
+      final UserTaskRecord persistedUserTask,
+      final PermissionType permissionType) {
+    return buildUserTaskRequest(
+        command, persistedUserTask, permissionType, buildUserTaskProperties(persistedUserTask));
+  }
+
+  /**
+   * Builds an authorization request for USER_TASK permission with custom properties.
+   *
+   * @param command the user task command
+   * @param persistedUserTask the persisted user task record
+   * @param permissionType the permission type (e.g., UPDATE, CLAIM, COMPLETE)
+   * @param properties the user task authorization properties
+   * @return the authorization request
+   */
+  static AuthorizationRequest buildUserTaskRequest(
+      final TypedRecord<UserTaskRecord> command,
+      final UserTaskRecord persistedUserTask,
+      final PermissionType permissionType,
+      final UserTaskAuthorizationProperties properties) {
+    return AuthorizationRequest.builder()
+        .command(command)
+        .resourceType(AuthorizationResourceType.USER_TASK)
+        .permissionType(permissionType)
+        .tenantId(persistedUserTask.getTenantId())
+        .addResourceId(String.valueOf(persistedUserTask.getUserTaskKey()))
+        .resourceProperties(properties)
+        .build();
+  }
+
+  /**
+   * Builds the standard user task properties containing assignee, candidate users, and candidate
+   * groups.
+   *
+   * @param userTask the persisted user task record
+   * @return the user task authorization properties
+   */
+  private static UserTaskAuthorizationProperties buildUserTaskProperties(
+      final UserTaskRecord userTask) {
+    return UserTaskAuthorizationProperties.builder()
+        .assignee(userTask.getAssignee())
+        .candidateUsers(userTask.getCandidateUsersList())
+        .candidateGroups(userTask.getCandidateGroupsList())
+        .build();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -51,11 +51,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     this.asyncRequestBehavior = asyncRequestBehavior;
     commandChecker =
         new UserTaskCommandPreconditionChecker(
-            List.of(LifecycleState.CREATED),
-            "claim",
-            UserTaskClaimProcessor::checkClaim,
-            state.getUserTaskState(),
-            authCheckBehavior);
+            List.of(LifecycleState.CREATED), "claim", state.getUserTaskState(), authCheckBehavior);
   }
 
   @Override
@@ -65,7 +61,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
         .checkUserTaskExists(command)
         .flatMap(userTask -> checkAuthorization(command, userTask))
         .flatMap(userTask -> commandChecker.checkLifecycleState(command, userTask))
-        .flatMap(userTask -> commandChecker.applyAdditionalChecksIfPresent(command, userTask));
+        .flatMap(userTask -> checkClaim(command, userTask));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -23,7 +24,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -115,45 +115,11 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
 
   private Either<Rejection, UserTaskRecord> checkAuthorization(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
-    final var processDefinitionUpdateUserTaskRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .permissionType(PermissionType.UPDATE_USER_TASK)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(persistedUserTask.getBpmnProcessId())
-            .build();
-
-    final var userTaskKey = String.valueOf(persistedUserTask.getUserTaskKey());
-    final var userTaskProperties =
-        UserTaskAuthorizationProperties.builder()
-            .assignee(persistedUserTask.getAssignee())
-            .candidateUsers(persistedUserTask.getCandidateUsersList())
-            .candidateGroups(persistedUserTask.getCandidateGroupsList())
-            .build();
-
-    final var userTaskUpdateRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER_TASK)
-            .permissionType(PermissionType.UPDATE)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(userTaskKey)
-            .resourceProperties(userTaskProperties)
-            .build();
-    final var userTaskClaimRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER_TASK)
-            .permissionType(PermissionType.CLAIM)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(userTaskKey)
-            .resourceProperties(userTaskProperties)
-            .build();
-
     return authCheckBehavior
         .isAnyAuthorizedOrInternalCommand(
-            processDefinitionUpdateUserTaskRequest, userTaskUpdateRequest, userTaskClaimRequest)
+            buildProcessDefinitionUpdateUserTaskRequest(command, persistedUserTask),
+            buildUserTaskRequest(command, persistedUserTask, PermissionType.UPDATE),
+            buildUserTaskRequest(command, persistedUserTask, PermissionType.CLAIM))
         .map(ignored -> persistedUserTask);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -9,13 +9,10 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -57,24 +54,6 @@ public class UserTaskCommandPreconditionChecker {
     }
 
     return Either.right(persistedUserTask);
-  }
-
-  // Temporary method to be used until all `UserTaskCommandProcessors` are migrated to provide
-  // their own authorization checks
-  protected Either<Rejection, UserTaskRecord> checkProcessDefinitionUpdateUserTaskAuth(
-      final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .permissionType(PermissionType.UPDATE_USER_TASK)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(persistedUserTask.getBpmnProcessId())
-            .build();
-
-    return authCheckBehavior
-        .isAuthorizedOrInternalCommand(authRequest)
-        .map(ignored -> persistedUserTask);
   }
 
   protected Either<Rejection, UserTaskRecord> checkLifecycleState(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -19,8 +19,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.BiFunction;
 
 public class UserTaskCommandPreconditionChecker {
 
@@ -32,9 +30,6 @@ public class UserTaskCommandPreconditionChecker {
   private final List<LifecycleState> validLifecycleStates;
   private final String intent;
   private final AuthorizationCheckBehavior authCheckBehavior;
-  private final BiFunction<
-          TypedRecord<UserTaskRecord>, UserTaskRecord, Either<Rejection, UserTaskRecord>>
-      additionalChecks;
   private final UserTaskState userTaskState;
 
   public UserTaskCommandPreconditionChecker(
@@ -42,21 +37,9 @@ public class UserTaskCommandPreconditionChecker {
       final String intent,
       final UserTaskState userTaskState,
       final AuthorizationCheckBehavior authCheckBehavior) {
-    this(validLifecycleStates, intent, null, userTaskState, authCheckBehavior);
-  }
-
-  public UserTaskCommandPreconditionChecker(
-      final List<LifecycleState> validLifecycleStates,
-      final String intent,
-      final BiFunction<
-              TypedRecord<UserTaskRecord>, UserTaskRecord, Either<Rejection, UserTaskRecord>>
-          additionalChecks,
-      final UserTaskState userTaskState,
-      final AuthorizationCheckBehavior authCheckBehavior) {
     this.validLifecycleStates = validLifecycleStates;
     this.intent = intent;
     this.authCheckBehavior = authCheckBehavior;
-    this.additionalChecks = additionalChecks;
     this.userTaskState = userTaskState;
   }
 
@@ -106,16 +89,5 @@ public class UserTaskCommandPreconditionChecker {
     }
 
     return Either.right(persistedUserTask);
-  }
-
-  // Hook for additional checks in subclasses, currently used only by UserTaskClaimProcessor, it
-  // will be removed once in the next commit, so the UserTaskClaimProcessor will perform custom
-  // checks on its own
-  protected Either<Rejection, UserTaskRecord> applyAdditionalChecksIfPresent(
-      final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
-    return Optional.ofNullable(additionalChecks)
-        .map(checks -> checks.apply(command, persistedUserTask))
-        .filter(Either::isLeft)
-        .orElse(Either.right(persistedUserTask));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -7,12 +7,13 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -27,7 +28,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -122,45 +122,11 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
 
   private Either<Rejection, UserTaskRecord> checkAuthorization(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
-    final var processDefinitionUpdateUserTaskRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .permissionType(PermissionType.UPDATE_USER_TASK)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(persistedUserTask.getBpmnProcessId())
-            .build();
-
-    final var userTaskKey = String.valueOf(persistedUserTask.getUserTaskKey());
-    final var userTaskProperties =
-        UserTaskAuthorizationProperties.builder()
-            .assignee(persistedUserTask.getAssignee())
-            .candidateUsers(persistedUserTask.getCandidateUsersList())
-            .candidateGroups(persistedUserTask.getCandidateGroupsList())
-            .build();
-
-    final var userTaskUpdateRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER_TASK)
-            .permissionType(PermissionType.UPDATE)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(userTaskKey)
-            .resourceProperties(userTaskProperties)
-            .build();
-    final var userTaskCompleteRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER_TASK)
-            .permissionType(PermissionType.COMPLETE)
-            .tenantId(persistedUserTask.getTenantId())
-            .addResourceId(userTaskKey)
-            .resourceProperties(userTaskProperties)
-            .build();
-
     return authCheckBehavior
         .isAnyAuthorizedOrInternalCommand(
-            processDefinitionUpdateUserTaskRequest, userTaskUpdateRequest, userTaskCompleteRequest)
+            buildProcessDefinitionUpdateUserTaskRequest(command, persistedUserTask),
+            buildUserTaskRequest(command, persistedUserTask, PermissionType.UPDATE),
+            buildUserTaskRequest(command, persistedUserTask, PermissionType.COMPLETE))
         .map(ignored -> persistedUserTask);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -24,6 +26,8 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -42,6 +46,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final VariableBehavior variableBehavior;
   private final AsyncRequestBehavior asyncRequestBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
   private final UserTaskCommandPreconditionChecker commandChecker;
 
   public UserTaskUpdateProcessor(
@@ -55,6 +60,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
     asyncRequestState = state.getAsyncRequestState();
     this.variableBehavior = variableBehavior;
     this.asyncRequestBehavior = asyncRequestBehavior;
+    this.authCheckBehavior = authCheckBehavior;
     responseWriter = writers.response();
     commandChecker =
         new UserTaskCommandPreconditionChecker(
@@ -171,7 +177,34 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
 
   private Either<Rejection, UserTaskRecord> checkAuthorization(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
-    return commandChecker.checkProcessDefinitionUpdateUserTaskAuth(command, persistedUserTask);
+    final var processDefinitionUpdateUserTaskRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.UPDATE_USER_TASK)
+            .tenantId(persistedUserTask.getTenantId())
+            .addResourceId(persistedUserTask.getBpmnProcessId())
+            .build();
+
+    final var userTaskUpdateRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.USER_TASK)
+            .permissionType(PermissionType.UPDATE)
+            .tenantId(persistedUserTask.getTenantId())
+            .addResourceId(String.valueOf(persistedUserTask.getUserTaskKey()))
+            .resourceProperties(
+                UserTaskAuthorizationProperties.builder()
+                    .assignee(persistedUserTask.getAssignee())
+                    .candidateUsers(persistedUserTask.getCandidateUsersList())
+                    .candidateGroups(persistedUserTask.getCandidateGroupsList())
+                    .build())
+            .build();
+
+    return authCheckBehavior
+        .isAnyAuthorizedOrInternalCommand(
+            processDefinitionUpdateUserTaskRequest, userTaskUpdateRequest)
+        .map(ignored -> persistedUserTask);
   }
 
   private void mergeVariables(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AuthorizationHelper.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AuthorizationHelper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+
+/**
+ * Test utility for configuring authorization permissions in user task authorization tests.
+ *
+ * <p>Provides a convenient wrapper around {@link EngineRule#authorization()} to assign permissions
+ * for specific users, resources, and scopes used in user task scenarios.
+ */
+public final class AuthorizationHelper {
+
+  private final EngineRule engine;
+
+  public AuthorizationHelper(final EngineRule engine) {
+    this.engine = engine;
+  }
+
+  public void addPermissionsToUser(
+      final String assignToPermissionUsername,
+      final String adminUsername,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final AuthorizationScope authorizationScope) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(assignToPermissionUsername)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(authorizationScope.getMatcher())
+        .withResourceId(authorizationScope.getResourceId())
+        .withResourcePropertyName(authorizationScope.getResourcePropertyName())
+        .create(adminUsername);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -7,30 +7,38 @@
  */
 package io.camunda.zeebe.engine.processing.usertask;
 
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_ASSIGNEE;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_GROUPS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class UserTaskAssignAuthorizationTest {
+
   public static final String USER_TASK_ID = "userTask";
   private static final String PROCESS_ID = "processId";
   private static final ConfiguredUser DEFAULT_USER =
@@ -53,26 +61,17 @@ public class UserTaskAssignAuthorizationTest {
                       .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+  private AuthorizationHelper authorizationHelper;
 
   @Before
   public void before() {
-    engine
-        .deployment()
-        .withXmlResource(
-            "process.bpmn",
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .userTask(USER_TASK_ID)
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy(DEFAULT_USER.getUsername());
+    authorizationHelper = new AuthorizationHelper(engine);
   }
 
   @Test
   public void shouldBeAuthorizedToAssignUserTaskWithDefaultUser() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
 
     // when
     engine
@@ -90,16 +89,214 @@ public class UserTaskAssignAuthorizationTest {
   }
 
   @Test
-  public void shouldBeAuthorizedToAssignUserTaskWithUser() {
+  public void shouldBeAuthorizedToAssignUserTaskWithProcessDefinitionUpdateUserTaskPermission() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
     final var user = createUser();
-    addPermissionsToUser(
-        user,
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
-        AuthorizationResourceMatcher.ID,
-        PROCESS_ID);
+        AuthorizationScope.id(PROCESS_ID));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee("assignee")
+        .assign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToAssignUserTaskWithUserTaskUpdateWildcardPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.WILDCARD);
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee("assignee")
+        .assign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToAssignUserTaskWithUserTaskUpdateResourceIdPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.id(String.valueOf(userTaskKey)));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee("assignee")
+        .assign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToAssignUserTaskWithUserTaskUpdateAssigneePropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(process(t -> t.zeebeAssignee(user.getUsername())));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_ASSIGNEE));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee("newAssignee")
+        .assign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToUnassignUserTaskWithUserTaskUpdateAssigneePropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(process(t -> t.zeebeAssignee(user.getUsername())));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_ASSIGNEE));
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).unassign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToAssignUserTaskWithUserTaskUpdateCandidateUsersPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(
+            process(
+                t ->
+                    t.zeebeCandidateUsers(
+                        "bilbo, thorin, %s, frodo".formatted(user.getUsername()))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_USERS));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee("assignee")
+        .assign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToUnassignUserTaskWithUserTaskUpdateCandidateUsersPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(
+            process(
+                t -> t.zeebeCandidateUsers("dragons, balrogs, %s".formatted(user.getUsername()))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_USERS));
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).unassign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToAssignUserTaskWithUserTaskUpdateCandidateGroupsPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var groupId = createGroupWithUser(user);
+    final var processInstanceKey =
+        createProcessInstance(
+            process(t -> t.zeebeCandidateGroups("men, %s, ents".formatted(groupId))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_GROUPS));
 
     // when
     engine
@@ -119,8 +316,9 @@ public class UserTaskAssignAuthorizationTest {
   @Test
   public void shouldBeUnauthorizedToAssignUserTaskIfNoPermissions() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
     final var user = createUser();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
 
     // when
     final var rejection =
@@ -135,8 +333,10 @@ public class UserTaskAssignAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
-                .formatted(PROCESS_ID));
+            """
+                Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'; \
+                and Insufficient permissions to perform operation 'UPDATE' on resource 'USER_TASK', required resource identifiers are one of '[*, %s]'"""
+                .formatted(PROCESS_ID, userTaskKey));
   }
 
   private UserRecordValue createUser() {
@@ -150,25 +350,43 @@ public class UserTaskAssignAuthorizationTest {
         .getValue();
   }
 
-  private void addPermissionsToUser(
-      final UserRecordValue user,
-      final AuthorizationResourceType authorization,
-      final PermissionType permissionType,
-      final AuthorizationResourceMatcher matcher,
-      final String resourceId) {
-    engine
-        .authorization()
-        .newAuthorization()
-        .withPermissions(permissionType)
-        .withOwnerId(user.getUsername())
-        .withOwnerType(AuthorizationOwnerType.USER)
-        .withResourceType(authorization)
-        .withResourceMatcher(matcher)
-        .withResourceId(resourceId)
-        .create(DEFAULT_USER.getUsername());
+  private long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .getFirst()
+        .getKey();
   }
 
-  private long createProcessInstance() {
+  private String createGroupWithUser(final UserRecordValue user) {
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var groupName = UUID.randomUUID().toString();
+    engine.group().newGroup(groupId).withName(groupName).create();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
+    return groupId;
+  }
+
+  private long createProcessInstance(final BpmnModelInstance process) {
+    engine.deployment().withXmlResource("process.bpmn", process).deploy(DEFAULT_USER.getUsername());
     return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+
+  private static BpmnModelInstance process() {
+    return process(b -> {});
+  }
+
+  private static BpmnModelInstance process(final Consumer<UserTaskBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask(USER_TASK_ID)
+            .zeebeUserTask();
+    consumer.accept(builder);
+    return builder.endEvent().done();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -7,24 +7,31 @@
  */
 package io.camunda.zeebe.engine.processing.usertask;
 
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_ASSIGNEE;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_CANDIDATE_GROUPS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_CANDIDATE_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,25 +62,17 @@ public class UserTaskClaimAuthorizationTest {
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
+  private AuthorizationHelper authorizationHelper;
+
   @Before
   public void before() {
-    engine
-        .deployment()
-        .withXmlResource(
-            "process.bpmn",
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .userTask(USER_TASK_ID)
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy(DEFAULT_USER.getUsername());
+    authorizationHelper = new AuthorizationHelper(engine);
   }
 
   @Test
   public void shouldBeAuthorizedToClaimUserTaskWithDefaultUser() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
 
     // when
     engine
@@ -91,22 +90,310 @@ public class UserTaskClaimAuthorizationTest {
   }
 
   @Test
-  public void shouldBeAuthorizedToClaimUserTaskWithUser() {
+  public void shouldBeAuthorizedToClaimUserTaskWithProcessDefinitionUpdateUserTaskPermission() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
     final var user = createUser();
-    addPermissionsToUser(
-        user,
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
-        AuthorizationResourceMatcher.ID,
-        PROCESS_ID);
+        AuthorizationScope.id(PROCESS_ID));
 
     // when
     engine
         .userTask()
         .ofInstance(processInstanceKey)
-        .withAssignee("assignee")
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskUpdateWildcardPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.WILDCARD);
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskUpdateResourceIdPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.id(String.valueOf(userTaskKey)));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskUpdateAssigneePropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(process(t -> t.zeebeAssignee(user.getUsername())));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_ASSIGNEE));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToClaimUserTaskWithUserTaskUpdateCandidateUsersPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(
+            process(
+                t -> t.zeebeCandidateUsers("elrond, %s, legolas".formatted(user.getUsername()))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_USERS));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToClaimUserTaskWithUserTaskUpdateCandidateGroupsPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var groupId = createGroupWithUser(user);
+    final var processInstanceKey =
+        createProcessInstance(
+            process(t -> t.zeebeCandidateGroups("dwarves, %s".formatted(groupId))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_GROUPS));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimWildcardPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.CLAIM,
+        AuthorizationScope.WILDCARD);
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimResourceIdPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.CLAIM,
+        AuthorizationScope.id(String.valueOf(userTaskKey)));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimAssigneePropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(process(t -> t.zeebeAssignee(user.getUsername())));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.CLAIM,
+        AuthorizationScope.property(PROP_ASSIGNEE));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimCandidateUsersPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(
+            process(
+                t -> t.zeebeCandidateUsers("faramir, %s, boromir".formatted(user.getUsername()))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.CLAIM,
+        AuthorizationScope.property(PROP_CANDIDATE_USERS));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
+        .claim(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimCandidateGroupsPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var groupId = createGroupWithUser(user);
+    final var processInstanceKey =
+        createProcessInstance(
+            process(t -> t.zeebeCandidateGroups("%s, orcs, trolls".formatted(groupId))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.CLAIM,
+        AuthorizationScope.property(PROP_CANDIDATE_GROUPS));
+
+    // when
+    engine
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee(user.getUsername())
         .claim(user.getUsername());
 
     // then
@@ -120,7 +407,8 @@ public class UserTaskClaimAuthorizationTest {
   @Test
   public void shouldBeUnauthorizedToClaimUserTaskIfNoPermissions() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
     final var user = createUser();
 
     // when
@@ -136,8 +424,11 @@ public class UserTaskClaimAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
-                .formatted(PROCESS_ID));
+            """
+                Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'; \
+                and Insufficient permissions to perform operation 'UPDATE' on resource 'USER_TASK', required resource identifiers are one of '[*, %s]'; \
+                and Insufficient permissions to perform operation 'CLAIM' on resource 'USER_TASK', required resource identifiers are one of '[*, %s]'"""
+                .formatted(PROCESS_ID, userTaskKey, userTaskKey));
   }
 
   private UserRecordValue createUser() {
@@ -151,25 +442,43 @@ public class UserTaskClaimAuthorizationTest {
         .getValue();
   }
 
-  private void addPermissionsToUser(
-      final UserRecordValue user,
-      final AuthorizationResourceType authorization,
-      final PermissionType permissionType,
-      final AuthorizationResourceMatcher matcher,
-      final String resourceId) {
+  private String createGroupWithUser(final UserRecordValue user) {
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var groupName = UUID.randomUUID().toString();
+    engine.group().newGroup(groupId).withName(groupName).create();
     engine
-        .authorization()
-        .newAuthorization()
-        .withPermissions(permissionType)
-        .withOwnerId(user.getUsername())
-        .withOwnerType(AuthorizationOwnerType.USER)
-        .withResourceType(authorization)
-        .withResourceMatcher(matcher)
-        .withResourceId(resourceId)
-        .create(DEFAULT_USER.getUsername());
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
+    return groupId;
   }
 
-  private long createProcessInstance() {
+  private long createProcessInstance(final BpmnModelInstance process) {
+    engine.deployment().withXmlResource("process.bpmn", process).deploy(DEFAULT_USER.getUsername());
     return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+
+  private long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .getFirst()
+        .getKey();
+  }
+
+  private static BpmnModelInstance process() {
+    return process(b -> {});
+  }
+
+  private static BpmnModelInstance process(final Consumer<UserTaskBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask(USER_TASK_ID)
+            .zeebeUserTask();
+    consumer.accept(builder);
+    return builder.endEvent().done();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.usertask;
 
-import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_ASSIGNEE;
-import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_CANDIDATE_GROUPS;
-import static io.camunda.zeebe.engine.processing.identity.authorization.property.evaluator.UserTaskPropertyAuthorizationEvaluator.PROP_CANDIDATE_USERS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_ASSIGNEE;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_GROUPS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
@@ -375,7 +375,8 @@ public class UserTaskClaimAuthorizationTest {
   }
 
   @Test
-  public void shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimCandidateGroupsPropertyPermission() {
+  public void
+      shouldBeAuthorizedToClaimUserTaskWithUserTaskClaimCandidateGroupsPropertyPermission() {
     // given
     final var user = createUser();
     final var groupId = createGroupWithUser(user);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -7,24 +7,31 @@
  */
 package io.camunda.zeebe.engine.processing.usertask;
 
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_ASSIGNEE;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_GROUPS;
+import static io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties.PROP_CANDIDATE_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,26 +61,17 @@ public class UserTaskUpdateAuthorizationTest {
                       .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+  private AuthorizationHelper authorizationHelper;
 
   @Before
   public void before() {
-    engine
-        .deployment()
-        .withXmlResource(
-            "process.bpmn",
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .userTask(USER_TASK_ID)
-                .zeebeUserTask()
-                .endEvent()
-                .done())
-        .deploy(DEFAULT_USER.getUsername());
+    authorizationHelper = new AuthorizationHelper(engine);
   }
 
   @Test
   public void shouldBeAuthorizedToUpdateUserTaskWithDefaultUser() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
 
     // when
     engine.userTask().ofInstance(processInstanceKey).update(DEFAULT_USER.getUsername());
@@ -87,16 +85,143 @@ public class UserTaskUpdateAuthorizationTest {
   }
 
   @Test
-  public void shouldBeAuthorizedToUpdateUserTaskWithUser() {
+  public void shouldBeAuthorizedToUpdateUserTaskWithUserTaskUpdateWildcardPermission() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
     final var user = createUser();
-    addPermissionsToUser(
-        user,
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.WILDCARD);
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).update(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToUpdateUserTaskWithProcessDefinitionUpdateUserTaskPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
-        AuthorizationResourceMatcher.ID,
-        PROCESS_ID);
+        AuthorizationScope.id(PROCESS_ID));
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).update(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToUpdateUserTaskWithUserTaskUpdateResourceIdPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var user = createUser();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.id(String.valueOf(userTaskKey)));
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).update(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToUpdateUserTaskWithUserTaskUpdateAssigneePropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(process(t -> t.zeebeAssignee(user.getUsername())));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_ASSIGNEE));
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).update(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToUpdateUserTaskWithUserTaskUpdateCandidateUsersPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var processInstanceKey =
+        createProcessInstance(
+            process(
+                t ->
+                    t.zeebeCandidateUsers(
+                        "bilbo, thorin, %s, frodo".formatted(user.getUsername()))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_USERS));
+
+    // when
+    engine.userTask().ofInstance(processInstanceKey).update(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void
+      shouldBeAuthorizedToUpdateUserTaskWithUserTaskUpdateCandidateGroupsPropertyPermission() {
+    // given
+    final var user = createUser();
+    final var groupId = createGroupWithUser(user);
+    final var processInstanceKey =
+        createProcessInstance(
+            process(t -> t.zeebeCandidateGroups("men, %s, ents".formatted(groupId))));
+    authorizationHelper.addPermissionsToUser(
+        user.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.USER_TASK,
+        PermissionType.UPDATE,
+        AuthorizationScope.property(PROP_CANDIDATE_GROUPS));
 
     // when
     engine.userTask().ofInstance(processInstanceKey).update(user.getUsername());
@@ -112,8 +237,9 @@ public class UserTaskUpdateAuthorizationTest {
   @Test
   public void shouldBeUnauthorizedToUpdateUserTaskIfNoPermissions() {
     // given
-    final var processInstanceKey = createProcessInstance();
+    final var processInstanceKey = createProcessInstance(process());
     final var user = createUser();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
 
     // when
     final var rejection =
@@ -127,8 +253,18 @@ public class UserTaskUpdateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
-                .formatted(PROCESS_ID));
+            """
+                Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'; \
+                and Insufficient permissions to perform operation 'UPDATE' on resource 'USER_TASK', required resource identifiers are one of '[*, %s]'"""
+                .formatted(PROCESS_ID, userTaskKey));
+  }
+
+  private long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .getFirst()
+        .getKey();
   }
 
   private UserRecordValue createUser() {
@@ -142,25 +278,35 @@ public class UserTaskUpdateAuthorizationTest {
         .getValue();
   }
 
-  private void addPermissionsToUser(
-      final UserRecordValue user,
-      final AuthorizationResourceType authorization,
-      final PermissionType permissionType,
-      final AuthorizationResourceMatcher matcher,
-      final String resourceId) {
+  private String createGroupWithUser(final UserRecordValue user) {
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var groupName = UUID.randomUUID().toString();
+    engine.group().newGroup(groupId).withName(groupName).create();
     engine
-        .authorization()
-        .newAuthorization()
-        .withPermissions(permissionType)
-        .withOwnerId(user.getUsername())
-        .withOwnerType(AuthorizationOwnerType.USER)
-        .withResourceType(authorization)
-        .withResourceMatcher(matcher)
-        .withResourceId(resourceId)
-        .create(DEFAULT_USER.getUsername());
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
+    return groupId;
   }
 
-  private long createProcessInstance() {
+  private long createProcessInstance(final BpmnModelInstance process) {
+    engine.deployment().withXmlResource("process.bpmn", process).deploy(DEFAULT_USER.getUsername());
     return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+
+  private static BpmnModelInstance process() {
+    return process(b -> {});
+  }
+
+  private static BpmnModelInstance process(final Consumer<UserTaskBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask(USER_TASK_ID)
+            .zeebeUserTask();
+    consumer.accept(builder);
+    return builder.endEvent().done();
   }
 }


### PR DESCRIPTION
## Description

This PR implements operation-specific authorization checks for user task operations in the Engine, enabling fine-grained permission control for task assignment/claiming, updating, and completion. 

### Changes

#### Authorization logic for user task operations

Each user task operation now supports a composite authorization model where users can be authorized via **either** of the following permission paths:

| Operation | Required permission (any of) |
|-----------|------------------------------|
| **Update** | `PROCESS_DEFINITION[UPDATE_USER_TASK](wildcard or id: processDefinition)` **OR** `USER_TASK[UPDATE](wildcard or id: userTaskKey or properties:  assignee, candidateGroups, candidateUsers)` |
| **Complete** | `PROCESS_DEFINITION[UPDATE_USER_TASK](wildcard or id: processDefinition)` **OR** `USER_TASK[UPDATE](...)` **OR** `USER_TASK[COMPLETE](wildcard or id: userTaskKey or properties: assignee, candidateGroups, candidateUsers)` |
| **Assign/Reassign/Unassign** | `PROCESS_DEFINITION[UPDATE_USER_TASK](rwildcard or id: processDefinition)` **OR** `USER_TASK[UPDATE](wildcard or id: userTaskKey or properties: assignee, candidateGroups, candidateUsers)` |
| **Claim** | `PROCESS_DEFINITION[UPDATE_USER_TASK](wildcard or id: processDefinition)` **OR** `USER_TASK[UPDATE](...)` **OR** `USER_TASK[CLAIM](wildcard or id: userTaskKey or properties: assignee, candidateGroups, candidateUsers)` |
| **Self-Unassignment** | Same as Assign **OR** `USER_TASK[CLAIM](wildcard or id: userTaskKey or properties: assignee)` (only when user is currently assigned to the current task) |

#### Key implementation details

1. **Updated user task comman processors**:
   - `UserTaskAssignProcessor` - Implements assign/unassign authorization with special handling for self-unassignment via `CLAIM` permission
   - `UserTaskClaimProcessor` - Supports `UPDATE` or `CLAIM` permissions
   - `UserTaskCompleteProcessor` - Supports `UPDATE` or `COMPLETE` permissions
   - `UserTaskUpdateProcessor` - Supports `UPDATE` permission

2. **New `UserTaskAuthorizationHelper`**:  A utility class that builds common authorization requests for user task operations, supporting: 
   - `PROCESS_DEFINITION[UPDATE_USER_TASK]` permission checks
   - `USER_TASK` permission checks with property-based scopes (assignee, candidateUsers, candidateGroups)

3. **Refactored `UserTaskCommandPreconditionChecker`**: Separated concerns by exposing `checkUserTaskExists()` and `checkLifecycleState()` methods, allowing processors to inject authorization checks between these validations

4. **Updated ArchUnit tests**: Added support for `isAnyAuthorized` and `isAnyAuthorizedOrInternalCommand` methods, removed `UserTaskCommandPreconditionChecker` delegation

### Special cases

- **Self-Unassignment**: Users with only `USER_TASK[CLAIM]` permission can unassign tasks **only if they are currently assigned** to that task.  This prevents users from unassigning others' tasks with just `CLAIM` permission.

### Testing
Added comprehensive authorization test coverage for all user task operations across multiple permission scopes: 
- Wildcard scope (`*`)
- Resource ID scope (userTaskKey)
- Property-based scopes (assignee, candidateUsers, candidateGroups)

## Related issues

closes #42410, #40115
