### PR TITLE
Reject batch operation execution execute command in failure cases

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
@@ -125,7 +125,7 @@ public final class BatchOperationExecutionExecuteProcessor
 
     // if suspended, skip execution and stop the EXECUTE-loop
     if (batchOperation.isSuspended()) {
-      final var message = "Batch operation `%d` is suspended.".formatted(batchKey);
+      final var message = "Batch operation '%d' is suspended.".formatted(batchKey);
       LOGGER.info(message);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, message);
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -74,6 +76,7 @@ public final class BatchOperationExecutionExecuteProcessor
 
   private final TypedCommandWriter commandWriter;
   private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final BatchOperationState batchOperationState;
   private final KeyGenerator keyGenerator;
@@ -90,6 +93,7 @@ public final class BatchOperationExecutionExecuteProcessor
       final BatchOperationMetrics metrics) {
     commandWriter = writers.command();
     stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
     batchOperationState = processingState.getBatchOperationState();
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.keyGenerator = keyGenerator;
@@ -113,13 +117,17 @@ public final class BatchOperationExecutionExecuteProcessor
 
     final var batchOperation = getBatchOperation(batchKey);
     if (batchOperation == null) {
-      LOGGER.debug("No batch operation found for key '{}'.", batchKey);
+      final var message = "No batch operation found for key '%d'.".formatted(batchKey);
+      LOGGER.debug(message);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, message);
       return;
     }
 
     // if suspended, skip execution and stop the EXECUTE-loop
     if (batchOperation.isSuspended()) {
-      LOGGER.info("Batch operation {} is suspended.", batchOperation.getKey());
+      final var message = "Batch operation `%d` is suspended.".formatted(batchKey);
+      LOGGER.info(message);
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, message);
       return;
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/LifecycleBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/LifecycleBatchOperationTest.java
@@ -87,7 +87,8 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
         .batchOperation()
         .newExecution()
         .withBatchOperationKey(batchOperationKey)
-        .executeWithoutExpectation();
+        .expectRejection()
+        .execute();
 
     // then we have a suspended event
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -212,9 +212,26 @@ public final class BatchOperationClient {
 
   public static class BatchOperationExecutionClient {
 
+    private static final Function<Long, Record<BatchOperationExecutionRecordValue>>
+        SUCCESS_EXPECTATION =
+            (position) ->
+                RecordingExporter.batchOperationExecutionRecords(
+                        BatchOperationExecutionIntent.EXECUTED)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+    private static final Function<Long, Record<BatchOperationExecutionRecordValue>>
+        REJECTION_EXPECTATION =
+            (position) ->
+                RecordingExporter.batchOperationExecutionRecords(
+                        BatchOperationExecutionIntent.EXECUTE)
+                    .onlyCommandRejections()
+                    .withSourceRecordPosition(position)
+                    .getFirst();
     private final CommandWriter writer;
     private final BatchOperationExecutionRecord batchOperationExecutionRecord;
     private int partition = DEFAULT_PARTITION;
+    private Function<Long, Record<BatchOperationExecutionRecordValue>> expectation =
+        SUCCESS_EXPECTATION;
 
     public BatchOperationExecutionClient(final CommandWriter writer) {
       this.writer = writer;
@@ -228,6 +245,11 @@ public final class BatchOperationClient {
 
     public BatchOperationExecutionClient onPartition(final int partition) {
       this.partition = partition;
+      return this;
+    }
+
+    public BatchOperationExecutionClient expectRejection() {
+      expectation = REJECTION_EXPECTATION;
       return this;
     }
 
@@ -246,28 +268,7 @@ public final class BatchOperationClient {
                       .authorizations(authorizations)
                       .requestId(new Random().nextLong())
                       .requestStreamId(new Random().nextInt()));
-      return RecordingExporter.batchOperationExecutionRecords()
-          .withIntent(BatchOperationExecutionIntent.EXECUTED)
-          .withSourceRecordPosition(position)
-          .withPartitionId(partition)
-          .getFirst();
-    }
-
-    public void executeWithoutExpectation() {
-      executeWithoutExpectation(
-          AuthorizationUtil.getAuthInfoWithClaim(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
-    }
-
-    public void executeWithoutExpectation(final AuthInfo authorizations) {
-      final long position =
-          writer.writeCommandOnPartition(
-              partition,
-              r ->
-                  r.intent(BatchOperationExecutionIntent.EXECUTE)
-                      .event(batchOperationExecutionRecord)
-                      .authorizations(authorizations)
-                      .requestId(new Random().nextLong())
-                      .requestStreamId(new Random().nextInt()));
+      return expectation.apply(position);
     }
   }
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -640,7 +641,7 @@ public final class RecordingExporter implements Exporter {
   }
 
   public static BatchOperationExecutionRecordStream batchOperationExecutionRecords(
-      final BatchOperationIntent intent) {
+      final BatchOperationExecutionIntent intent) {
     return batchOperationExecutionRecords().withIntent(intent);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

There is cases in this processor where no followup record is written to the log. So there's no events, commands or rejection written.
This is a problem as during replay we determine if a command is processed by seeing if there's any followup records written. As a result it can happen that the same executet command is processed twice.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43197 
