### PR TITLE
Decision instances search API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mammalAnimalProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mammalAnimalProcess.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="f728e02" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="mammalAnimalProcess" name="mammalAnimalProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0nl8alw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0nl8alw" sourceRef="StartEvent_1" targetRef="isMammal" />
+    <bpmn:businessRuleTask id="isMammal" name="Decide if animal is a mammal">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="IsMammal" resultVariable="isMammal" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0nl8alw</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lj77p3</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:exclusiveGateway id="Gateway_11cuamg" name="Is a mammal?">
+      <bpmn:incoming>Flow_0lj77p3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1t0rucw</bpmn:outgoing>
+      <bpmn:outgoing>Flow_12vtfp3</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0lj77p3" sourceRef="isMammal" targetRef="Gateway_11cuamg" />
+    <bpmn:endEvent id="Event_1c4jkn4" name="A mammal end">
+      <bpmn:incoming>Flow_1t0rucw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1t0rucw" name="yes" sourceRef="Gateway_11cuamg" targetRef="Event_1c4jkn4">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isMammal</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0xrkaq6" name="Not a mammal end">
+      <bpmn:incoming>Flow_12vtfp3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12vtfp3" name="no" sourceRef="Gateway_11cuamg" targetRef="Event_0xrkaq6">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(isMammal)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mammalAnimalProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03rn0cw_di" bpmnElement="isMammal">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_11cuamg_di" bpmnElement="Gateway_11cuamg" isMarkerVisible="true">
+        <dc:Bounds x="395" y="93" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="455" y="111" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1c4jkn4_di" bpmnElement="Event_1c4jkn4">
+        <dc:Bounds x="502" y="32" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="484" y="75" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xrkaq6_di" bpmnElement="Event_0xrkaq6">
+        <dc:Bounds x="502" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="485" y="195" width="72" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nl8alw_di" bpmnElement="Flow_0nl8alw">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lj77p3_di" bpmnElement="Flow_0lj77p3">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="395" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t0rucw_di" bpmnElement="Flow_1t0rucw">
+        <di:waypoint x="420" y="93" />
+        <di:waypoint x="420" y="50" />
+        <di:waypoint x="502" y="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="391" y="63" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12vtfp3_di" bpmnElement="Flow_12vtfp3">
+        <di:waypoint x="420" y="143" />
+        <di:waypoint x="420" y="170" />
+        <di:waypoint x="502" y="170" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="429" y="154" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
@@ -1,0 +1,354 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertStatusCode,
+  assertRequiredFields,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {createMammalProcessInstanceAndDeployMammalDecision, DecisionInstance} from '@requestHelpers';
+import {validateResponse} from '../../../../json-body-assertions';
+import {decisionInstanceRequiredFields} from 'utils/beans/requestBeans';
+
+const DECISION_INSTANCES_SEARCH_ENDPOINT = '/decision-instances/search';
+
+test.describe.parallel('Search Decision Instances API Tests', () => {
+  let decisionInstances: DecisionInstance[] = [];
+  let processInstanceKey: string;
+
+  test.beforeAll(async ({request}) => {
+    const result =
+      await createMammalProcessInstanceAndDeployMammalDecision(request);
+    processInstanceKey = result.instance.processInstanceKey;
+    decisionInstances = result.decisions;
+  });
+
+
+  test.afterAll(async ({request}) => {
+    // Cleanup all created decision instances
+    for (const decisionInstance of decisionInstances) {
+      try {
+        await request.delete(buildUrl(`/decisions/${decisionInstance.decisionEvaluationInstanceKey}`));
+        console.log(`Cleaned up decision instance: ${decisionInstance.decisionEvaluationInstanceKey}`);
+      } catch (error) {
+        console.warn(
+          `Failed to cleanup decision instance ${decisionInstance.decisionEvaluationInstanceKey}:`,
+          error,
+        );
+      }
+    }
+  });
+  test('Search decision instances - multiple results - success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      for (const element of body.items) {
+        assertRequiredFields(element, decisionInstanceRequiredFields);
+      }
+      expect(body.items.length).toBeGreaterThanOrEqual(3);
+      expect(Array.isArray(body.items)).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision instances different filters - success', async ({
+    request,
+  }) => {
+    await test.step('Filter By state', async () => {
+      const stateToSearch = 'EVALUATED';
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                state: stateToSearch,
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        for (const element of body.items) {
+          assertRequiredFields(element, decisionInstanceRequiredFields);
+        }
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.state).toBe('EVALUATED');
+        });
+        expect(body.items.length).toBeGreaterThanOrEqual(3);
+        expect(Array.isArray(body.items)).toBe(true);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Filter By decisionEvaluationInstanceKey', async () => {
+      const decisionEvaluationInstanceKeyToSearch =
+        decisionInstances[1].decisionEvaluationInstanceKey;
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                decisionEvaluationInstanceKey:
+                  decisionEvaluationInstanceKeyToSearch,
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        for (const element of body.items) {
+          assertRequiredFields(element, decisionInstanceRequiredFields);
+        }
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.decisionEvaluationInstanceKey).toBe(
+            decisionEvaluationInstanceKeyToSearch,
+          );
+        });
+        expect(body.items.length).toBeGreaterThanOrEqual(1);
+        expect(Array.isArray(body.items)).toBe(true);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Filter By processInstanceKey', async () => {
+      const processInstanceKeyToSearch = processInstanceKey;
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: processInstanceKeyToSearch,
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        expect(body.items.length).toEqual(3);
+        for (const element of body.items) {
+          assertRequiredFields(element, decisionInstanceRequiredFields);
+        }
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.processInstanceKey).toBe(processInstanceKey);
+        });
+        expect(Array.isArray(body.items)).toBe(true);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Filter By decisionDefinitionID', async () => {
+      const decisionDefinitionIdToSearch =
+        decisionInstances[1].decisionDefinitionId;
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                decisionDefinitionId: decisionDefinitionIdToSearch,
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        expect(body.items.length).toBeGreaterThanOrEqual(1);
+        for (const element of body.items) {
+          assertRequiredFields(element, decisionInstanceRequiredFields);
+        }
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.decisionDefinitionId).toBe(decisionDefinitionIdToSearch);
+        });
+        expect(Array.isArray(body.items)).toBe(true);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Search decision by multiple filters: processInstanceKey and decisionDefinitionId', async ({
+    request,
+  }) => {
+    const processInstanceKeyToSearch = processInstanceKey;
+    const decisionDefinitionIdToSearch =
+      decisionInstances[1].decisionDefinitionId;
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: processInstanceKeyToSearch,
+              decisionDefinitionId: decisionDefinitionIdToSearch,
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      for (const element of body.items) {
+        assertRequiredFields(element, decisionInstanceRequiredFields);
+      }
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      expect(body.items[0].decisionDefinitionId).toBe(
+        decisionDefinitionIdToSearch,
+      );
+      expect(body.items[0].processInstanceKey).toBe(processInstanceKeyToSearch);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision instances - empty result', async ({request}) => {
+    const someNotExistingProcessInstanceKey = '99999999999999999';
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: someNotExistingProcessInstanceKey,
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      expect(body.items.length).toEqual(0);
+      expect(body.page.totalItems).toEqual(0);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision instances - invalid request - bad request', async ({
+    request,
+  }) => {
+    const someRandomFilterValue = 'meow';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              randomNotExistingFieldName: someRandomFilterValue,
+            },
+          },
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        'Request property [filter.randomNotExistingFieldName] cannot be parsed',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision requirements - unauthorized request', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
@@ -33,21 +33,6 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
     decisionInstances = result.decisions;
   });
 
-
-  test.afterAll(async ({request}) => {
-    // Cleanup all created decision instances
-    for (const decisionInstance of decisionInstances) {
-      try {
-        await request.delete(buildUrl(`/decisions/${decisionInstance.decisionEvaluationInstanceKey}`));
-        console.log(`Cleaned up decision instance: ${decisionInstance.decisionEvaluationInstanceKey}`);
-      } catch (error) {
-        console.warn(
-          `Failed to cleanup decision instance ${decisionInstance.decisionEvaluationInstanceKey}:`,
-          error,
-        );
-      }
-    }
-  });
   test('Search decision instances - multiple results - success', async ({
     request,
   }) => {
@@ -335,7 +320,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search decision requirements - unauthorized request', async ({
+  test('Search decision instances - unauthorized request', async ({
     request,
   }) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
@@ -64,161 +64,163 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search decision instances different filters - success', async ({
+  test('Search decision instances - filter by state', async ({request}) => {
+    const stateToSearch = 'EVALUATED';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              state: stateToSearch,
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      for (const element of body.items) {
+        assertRequiredFields(element, decisionInstanceRequiredFields);
+      }
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.state).toBe('EVALUATED');
+      });
+      expect(body.items.length).toBeGreaterThanOrEqual(3);
+      expect(Array.isArray(body.items)).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search decision instances - filter by decisionEvaluationInstanceKey', async ({
     request,
   }) => {
-    await test.step('Filter By state', async () => {
-      const stateToSearch = 'EVALUATED';
-      await expect(async () => {
-        const res = await request.post(
-          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                state: stateToSearch,
-              },
+    const decisionEvaluationInstanceKeyToSearch =
+      decisionInstances[1].decisionEvaluationInstanceKey;
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              decisionEvaluationInstanceKey:
+                decisionEvaluationInstanceKeyToSearch,
             },
           },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      for (const element of body.items) {
+        assertRequiredFields(element, decisionInstanceRequiredFields);
+      }
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.decisionEvaluationInstanceKey).toBe(
+          decisionEvaluationInstanceKeyToSearch,
         );
+      });
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      expect(Array.isArray(body.items)).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
 
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-
-        const body = await res.json();
-        for (const element of body.items) {
-          assertRequiredFields(element, decisionInstanceRequiredFields);
-        }
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.state).toBe('EVALUATED');
-        });
-        expect(body.items.length).toBeGreaterThanOrEqual(3);
-        expect(Array.isArray(body.items)).toBe(true);
-      }).toPass(defaultAssertionOptions);
-    });
-
-    await test.step('Filter By decisionEvaluationInstanceKey', async () => {
-      const decisionEvaluationInstanceKeyToSearch =
-        decisionInstances[1].decisionEvaluationInstanceKey;
-      await expect(async () => {
-        const res = await request.post(
-          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                decisionEvaluationInstanceKey:
-                  decisionEvaluationInstanceKeyToSearch,
-              },
+  test('Search decision instances - filter by processInstanceKey', async ({
+    request,
+  }) => {
+    const processInstanceKeyToSearch = processInstanceKey;
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: processInstanceKeyToSearch,
             },
           },
-        );
+        },
+      );
 
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-        const body = await res.json();
-        for (const element of body.items) {
-          assertRequiredFields(element, decisionInstanceRequiredFields);
-        }
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.decisionEvaluationInstanceKey).toBe(
-            decisionEvaluationInstanceKeyToSearch,
-          );
-        });
-        expect(body.items.length).toBeGreaterThanOrEqual(1);
-        expect(Array.isArray(body.items)).toBe(true);
-      }).toPass(defaultAssertionOptions);
-    });
+      const body = await res.json();
+      expect(body.items.length).toEqual(3);
+      for (const element of body.items) {
+        assertRequiredFields(element, decisionInstanceRequiredFields);
+      }
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.processInstanceKey).toBe(processInstanceKey);
+      });
+      expect(Array.isArray(body.items)).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
 
-    await test.step('Filter By processInstanceKey', async () => {
-      const processInstanceKeyToSearch = processInstanceKey;
-      await expect(async () => {
-        const res = await request.post(
-          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processInstanceKey: processInstanceKeyToSearch,
-              },
+  test('Search decision instances - filter by decisionDefinitionId', async ({
+    request,
+  }) => {
+    const decisionDefinitionIdToSearch =
+      decisionInstances[1].decisionDefinitionId;
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              decisionDefinitionId: decisionDefinitionIdToSearch,
             },
           },
-        );
+        },
+      );
 
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: DECISION_INSTANCES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-        const body = await res.json();
-        expect(body.items.length).toEqual(3);
-        for (const element of body.items) {
-          assertRequiredFields(element, decisionInstanceRequiredFields);
-        }
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.processInstanceKey).toBe(processInstanceKey);
-        });
-        expect(Array.isArray(body.items)).toBe(true);
-      }).toPass(defaultAssertionOptions);
-    });
-
-    await test.step('Filter By decisionDefinitionID', async () => {
-      const decisionDefinitionIdToSearch =
-        decisionInstances[1].decisionDefinitionId;
-      await expect(async () => {
-        const res = await request.post(
-          buildUrl(DECISION_INSTANCES_SEARCH_ENDPOINT, {}),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                decisionDefinitionId: decisionDefinitionIdToSearch,
-              },
-            },
-          },
-        );
-
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: DECISION_INSTANCES_SEARCH_ENDPOINT,
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-
-        const body = await res.json();
-        expect(body.items.length).toBeGreaterThanOrEqual(1);
-        for (const element of body.items) {
-          assertRequiredFields(element, decisionInstanceRequiredFields);
-        }
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.decisionDefinitionId).toBe(decisionDefinitionIdToSearch);
-        });
-        expect(Array.isArray(body.items)).toBe(true);
-      }).toPass(defaultAssertionOptions);
-    });
+      const body = await res.json();
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      for (const element of body.items) {
+        assertRequiredFields(element, decisionInstanceRequiredFields);
+      }
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.decisionDefinitionId).toBe(decisionDefinitionIdToSearch);
+      });
+      expect(Array.isArray(body.items)).toBe(true);
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Search decision by multiple filters: processInstanceKey and decisionDefinitionId', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -114,30 +114,144 @@ test.describe('Element Instance Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  filterCases(resourceId).forEach(({filterKey, filterValue, expectedTotal}) => {
-    test(`Search Element Instances - Filter by ${filterKey} - Success`, async ({
+  // filterCases(resourceId).forEach(({filterKey, filterValue, expectedTotal}) => {
+  //   test(`Search Element Instances - Filter by ${filterKey} - Success`, async ({
+  //     request,
+  //   }) => {
+  //     await expect(async () => {
+  //       const filter: Record<string, unknown> = {};
+  //       const {key, value} = createFilter(filterKey, filterValue, state);
+  //       filter[key] = value;
+  //       const res = await request.post(buildUrl('/element-instances/search'), {
+  //         headers: jsonHeaders(),
+  //         data: {
+  //           filter: filter,
+  //         },
+  //       });
+  //       await assertStatusCode(res, 200);
+  //       const body = await res.json();
+  //       expect(body.page.totalItems).toBe(expectedTotal);
+  //       expect(body.items.length).toBe(expectedTotal);
+  //       for (const item of body.items) {
+  //         expect(item[key]).toBe(value);
+  //       }
+  //     }).toPass(defaultAssertionOptions);
+  //   });
+  // });
+
+  test(`Search Element Instances - Filter by differetnt filters - Success`, async ({
       request,
     }) => {
-      await expect(async () => {
-        const filter: Record<string, unknown> = {};
-        const {key, value} = createFilter(filterKey, filterValue, state);
-        filter[key] = value;
+      await test.step('Filter By processDefinitionId', async () => {
+        const processDefinitionIdToSearch = resourceId;
+        const expectedTotal = 2;
+        await expect(async () => {
         const res = await request.post(buildUrl('/element-instances/search'), {
           headers: jsonHeaders(),
           data: {
-            filter: filter,
+            filter: {
+              processDefinitionId: processDefinitionIdToSearch,
+            },
           },
         });
         await assertStatusCode(res, 200);
         const body = await res.json();
         expect(body.page.totalItems).toBe(expectedTotal);
         expect(body.items.length).toBe(expectedTotal);
-        for (const item of body.items) {
-          expect(item[key]).toBe(value);
-        }
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.processDefinitionId).toBe(processDefinitionIdToSearch);
+        });
       }).toPass(defaultAssertionOptions);
+      });
+
+      await test.step('Filter By elementName', async () => {
+        const elementNameToSearch = 'Decision If Human Needed';
+        const expectedTotal = 1;
+        await expect(async () => {
+        const res = await request.post(buildUrl('/element-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              elementName: elementNameToSearch,
+            },
+          },
+        });
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBe(expectedTotal);
+        expect(body.items.length).toBe(expectedTotal);
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.elementName).toBe(elementNameToSearch);
+        });
+      }).toPass(defaultAssertionOptions);
+      });
+
+      await test.step('Filter By type', async () => {
+        const typeToSearch = 'EXCLUSIVE_GATEWAY';
+        const expectedTotal = 1;
+        await expect(async () => {
+        const res = await request.post(buildUrl('/element-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              type: typeToSearch,
+            },
+          },
+        });
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(expectedTotal);
+        expect(body.items.length).toBeGreaterThanOrEqual(expectedTotal);
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.type).toBe(typeToSearch);
+        });
+      }).toPass(defaultAssertionOptions);
+      });
+
+      await test.step('Filter By processDefinitionKey', async () => {
+        const processDefinitionKeyToSearch = state.processDefinitionKey as string;
+        const expectedTotal = 2;
+        await expect(async () => {
+        const res = await request.post(buildUrl('/element-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionKey: processDefinitionKeyToSearch,
+            },
+          },
+        });
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBe(expectedTotal);
+        expect(body.items.length).toBe(expectedTotal);
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.processDefinitionKey).toBe(processDefinitionKeyToSearch);
+        });
+      }).toPass(defaultAssertionOptions);
+      });
+
+      await test.step('Filter By processInstanceKey', async () => {
+        const processInstanceKeyToSearch = state.processInstanceKey as string;
+        const expectedTotal = 2;
+        await expect(async () => {
+        const res = await request.post(buildUrl('/element-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: processInstanceKeyToSearch,
+            },
+          },
+        });
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBe(expectedTotal);
+        expect(body.items.length).toBe(expectedTotal);
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.processInstanceKey).toBe(processInstanceKeyToSearch);
+        });
+      }).toPass(defaultAssertionOptions);
+      });
     });
-  });
 
   test(`Search Element Instances - Multiple Filters`, async ({request}) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -112,119 +112,123 @@ test.describe('Element Instance Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test(`Search Element Instances - Filter by different filters - Success`, async ({
-      request,
-    }) => {
-      await test.step('Filter By processDefinitionId', async () => {
-        const processDefinitionIdToSearch = resourceId;
-        const expectedTotal = 2;
-        await expect(async () => {
-        const res = await request.post(buildUrl('/element-instances/search'), {
-          headers: jsonHeaders(),
-          data: {
-            filter: {
-              processDefinitionId: processDefinitionIdToSearch,
-            },
+  test('Search Element Instances - filter by processDefinitionId', async ({
+    request,
+  }) => {
+    const processDefinitionIdToSearch = resourceId;
+    const expectedTotal = 2;
+    await expect(async () => {
+      const res = await request.post(buildUrl('/element-instances/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processDefinitionId: processDefinitionIdToSearch,
           },
-        });
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        expect(body.page.totalItems).toBe(expectedTotal);
-        expect(body.items.length).toBe(expectedTotal);
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.processDefinitionId).toBe(processDefinitionIdToSearch);
-        });
-      }).toPass(defaultAssertionOptions);
+        },
       });
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(expectedTotal);
+      expect(body.items.length).toBe(expectedTotal);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.processDefinitionId).toBe(processDefinitionIdToSearch);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
-      await test.step('Filter By elementName', async () => {
-        const elementNameToSearch = 'Decision If Human Needed';
-        const expectedTotal = 1;
-        await expect(async () => {
-        const res = await request.post(buildUrl('/element-instances/search'), {
-          headers: jsonHeaders(),
-          data: {
-            filter: {
-              elementName: elementNameToSearch,
-            },
+  test('Search Element Instances - filter by elementName', async ({
+    request,
+  }) => {
+    const elementNameToSearch = 'Decision If Human Needed';
+    const expectedTotal = 1;
+    await expect(async () => {
+      const res = await request.post(buildUrl('/element-instances/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            elementName: elementNameToSearch,
           },
-        });
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        expect(body.page.totalItems).toBe(expectedTotal);
-        expect(body.items.length).toBe(expectedTotal);
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.elementName).toBe(elementNameToSearch);
-        });
-      }).toPass(defaultAssertionOptions);
+        },
       });
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(expectedTotal);
+      expect(body.items.length).toBe(expectedTotal);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.elementName).toBe(elementNameToSearch);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
-      await test.step('Filter By type', async () => {
-        const typeToSearch = 'EXCLUSIVE_GATEWAY';
-        const expectedTotal = 1;
-        await expect(async () => {
-        const res = await request.post(buildUrl('/element-instances/search'), {
-          headers: jsonHeaders(),
-          data: {
-            filter: {
-              type: typeToSearch,
-            },
+  test('Search Element Instances - filter by type', async ({request}) => {
+    const typeToSearch = 'EXCLUSIVE_GATEWAY';
+    const expectedTotal = 1;
+    await expect(async () => {
+      const res = await request.post(buildUrl('/element-instances/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            type: typeToSearch,
           },
-        });
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        expect(body.page.totalItems).toBeGreaterThanOrEqual(expectedTotal);
-        expect(body.items.length).toBeGreaterThanOrEqual(expectedTotal);
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.type).toBe(typeToSearch);
-        });
-      }).toPass(defaultAssertionOptions);
+        },
       });
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(expectedTotal);
+      expect(body.items.length).toBeGreaterThanOrEqual(expectedTotal);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.type).toBe(typeToSearch);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
-      await test.step('Filter By processDefinitionKey', async () => {
-        const processDefinitionKeyToSearch = state.processDefinitionKey as string;
-        const expectedTotal = 2;
-        await expect(async () => {
-        const res = await request.post(buildUrl('/element-instances/search'), {
-          headers: jsonHeaders(),
-          data: {
-            filter: {
-              processDefinitionKey: processDefinitionKeyToSearch,
-            },
+  test('Search Element Instances - filter by processDefinitionKey', async ({
+    request,
+  }) => {
+    const processDefinitionKeyToSearch = state.processDefinitionKey as string;
+    const expectedTotal = 2;
+    await expect(async () => {
+      const res = await request.post(buildUrl('/element-instances/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processDefinitionKey: processDefinitionKeyToSearch,
           },
-        });
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        expect(body.page.totalItems).toBe(expectedTotal);
-        expect(body.items.length).toBe(expectedTotal);
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.processDefinitionKey).toBe(processDefinitionKeyToSearch);
-        });
-      }).toPass(defaultAssertionOptions);
+        },
       });
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(expectedTotal);
+      expect(body.items.length).toBe(expectedTotal);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.processDefinitionKey).toBe(processDefinitionKeyToSearch);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
-      await test.step('Filter By processInstanceKey', async () => {
-        const processInstanceKeyToSearch = state.processInstanceKey as string;
-        const expectedTotal = 2;
-        await expect(async () => {
-        const res = await request.post(buildUrl('/element-instances/search'), {
-          headers: jsonHeaders(),
-          data: {
-            filter: {
-              processInstanceKey: processInstanceKeyToSearch,
-            },
+  test('Search Element Instances - filter by processInstanceKey', async ({
+    request,
+  }) => {
+    const processInstanceKeyToSearch = state.processInstanceKey as string;
+    const expectedTotal = 2;
+    await expect(async () => {
+      const res = await request.post(buildUrl('/element-instances/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: processInstanceKeyToSearch,
           },
-        });
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        expect(body.page.totalItems).toBe(expectedTotal);
-        expect(body.items.length).toBe(expectedTotal);
-        body.items.forEach((item: Record<string, unknown>) => {
-          expect(item.processInstanceKey).toBe(processInstanceKeyToSearch);
-        });
-      }).toPass(defaultAssertionOptions);
+        },
       });
-    });
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(expectedTotal);
+      expect(body.items.length).toBe(expectedTotal);
+      body.items.forEach((item: Record<string, unknown>) => {
+        expect(item.processInstanceKey).toBe(processInstanceKeyToSearch);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
 
   test(`Search Element Instances - Multiple Filters`, async ({request}) => {
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -21,8 +21,6 @@ import {
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import {createFilter} from '@requestHelpers';
-import {filterCases} from '../../../../utils/beans/element-instance-requestBeans';
 
 /*
  * Test Suite for Element Instance Search API
@@ -114,32 +112,7 @@ test.describe('Element Instance Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  // filterCases(resourceId).forEach(({filterKey, filterValue, expectedTotal}) => {
-  //   test(`Search Element Instances - Filter by ${filterKey} - Success`, async ({
-  //     request,
-  //   }) => {
-  //     await expect(async () => {
-  //       const filter: Record<string, unknown> = {};
-  //       const {key, value} = createFilter(filterKey, filterValue, state);
-  //       filter[key] = value;
-  //       const res = await request.post(buildUrl('/element-instances/search'), {
-  //         headers: jsonHeaders(),
-  //         data: {
-  //           filter: filter,
-  //         },
-  //       });
-  //       await assertStatusCode(res, 200);
-  //       const body = await res.json();
-  //       expect(body.page.totalItems).toBe(expectedTotal);
-  //       expect(body.items.length).toBe(expectedTotal);
-  //       for (const item of body.items) {
-  //         expect(item[key]).toBe(value);
-  //       }
-  //     }).toPass(defaultAssertionOptions);
-  //   });
-  // });
-
-  test(`Search Element Instances - Filter by differetnt filters - Success`, async ({
+  test(`Search Element Instances - Filter by different filters - Success`, async ({
       request,
     }) => {
       await test.step('Filter By processDefinitionId', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/element-instance-requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/element-instance-requestBeans.ts
@@ -6,34 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export const filterCases = (resourceId: string) => [
-  {
-    filterKey: 'processDefinitionId',
-    filterValue: resourceId,
-    expectedTotal: 2,
-  },
-  {
-    filterKey: 'elementName',
-    filterValue: 'Decision If Human Needed',
-    expectedTotal: 1,
-  },
-  {
-    filterKey: 'type',
-    filterValue: 'EXCLUSIVE_GATEWAY',
-    expectedTotal: 1,
-  },
-  {
-    filterKey: 'processDefinitionKey',
-    filterValue: '',
-    expectedTotal: 2,
-  },
-  {
-    filterKey: 'processInstanceKey',
-    filterValue: '',
-    expectedTotal: 2,
-  },
-];
-
 export const EXPECTED_ELEMENT_INSTANCE_GET_SUCCESS = (
   processInstanceKey: string,
   elementInstanceKey: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -131,6 +131,22 @@ export const decisionRequirementRequiredFields: string[] = [
   'decisionRequirementsKey',
   'resourceName',
 ];
+export const decisionInstanceRequiredFields: string[] = [
+  'decisionEvaluationInstanceKey',
+  'state',
+  'evaluationDate',
+  'decisionDefinitionId',
+  'decisionDefinitionName',
+  'decisionDefinitionVersion',
+  'decisionDefinitionType',
+  'result',
+  'tenantId',
+  'decisionEvaluationKey',
+  'processDefinitionKey',
+  'processInstanceKey',
+  'decisionDefinitionKey',
+  'elementInstanceKey',
+];
 export const evaluateDecisionRequiredFields: string[] = [
   'decisionDefinitionId',
   'decisionDefinitionName',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-instance-requestHelpers.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect} from '@playwright/test';
+import {createSingleInstance, deploy} from '../zeebeClient';
+import {validateResponse} from '../../json-body-assertions';
+import {
+  assertStatusCode,
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+} from 'utils/http';
+import {defaultAssertionOptions} from '../constants';
+import {decisionInstanceRequiredFields} from 'utils/beans/requestBeans';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+export interface DecisionInstance {
+  decisionEvaluationInstanceKey: string;
+  state: 'EVALUATED' | 'FAILED' | 'UNSPECIFIED' | 'UNKNOWN';
+  evaluationDate: string;
+  decisionDefinitionId: string;
+  decisionDefinitionName: string;
+  decisionDefinitionVersion: number;
+  decisionDefinitionType:
+    | 'DECISION_TABLE'
+    | 'LITERAL_EXPRESSION'
+    | 'UNSPECIFIED'
+    | 'UNKNOWN';
+  result: string;
+  tenantId: string;
+  decisionEvaluationKey: string;
+  processDefinitionKey: string;
+  processInstanceKey: string;
+  decisionDefinitionKey: string;
+  elementInstanceKey: string;
+}
+
+export async function searchDecisionInstancesByProcessInstanceKey(
+  processInstanceKey: string,
+  request: APIRequestContext,
+) {
+  const foundDecisionInstances: DecisionInstance[] = [];
+
+  await waitForAssertion({
+    assertion: async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/decision-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            page: {
+              from: 0,
+              limit: 10,
+            },
+            filter: {
+              processInstanceKey: processInstanceKey,
+            },
+          },
+        });
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/decision-instances/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        body.items.forEach((item: Record<string, unknown>) => {
+          expect(item.state).toEqual('EVALUATED');
+        });
+        expect(body.items.length).toBeGreaterThan(0);
+        for (const element of body.items) {
+          assertRequiredFields(element, decisionInstanceRequiredFields);
+          foundDecisionInstances.push(element as DecisionInstance);
+        }
+      }).toPass(defaultAssertionOptions);
+    },
+    onFailure: async () => {},
+    maxRetries: 10,
+  });
+  return foundDecisionInstances;
+}
+
+export async function createMammalProcessInstanceAndDeployMammalDecision(
+  request: APIRequestContext,
+) {
+  await deploy([
+    './resources/mammalAnimalProcess.bpmn',
+    './resources/isMammal_.dmn',
+  ]);
+  const instance = await createSingleInstance('mammalAnimalProcess', 1, {
+    hasHairOrFur: true,
+    warmBlooded: true,
+    givesMilk: true,
+  });
+  const decisions: DecisionInstance[] =
+    await searchDecisionInstancesByProcessInstanceKey(
+      instance.processInstanceKey.toString(),
+      request,
+    );
+  return {
+    decisions: decisions,
+    instance: instance,
+  };
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/decision-instance-requestHelpers.ts
@@ -103,7 +103,7 @@ export async function createMammalProcessInstanceAndDeployMammalDecision(
   });
   const decisions: DecisionInstance[] =
     await searchDecisionInstancesByProcessInstanceKey(
-      instance.processInstanceKey.toString(),
+      instance.processInstanceKey,
       request,
     );
   return {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
@@ -12,21 +12,6 @@ import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
 import {expect} from '@playwright/test';
 import {SearchElementInstancesResponse} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 
-export function createFilter(
-  filterKey: string,
-  filterValue: string,
-  state: Record<string, unknown>,
-): {key: string; value: unknown} {
-  if (filterValue === '') {
-    if (filterKey === 'processDefinitionKey')
-      // Use value from state
-      return {key: filterKey, value: state.processDefinitionKey};
-    else if (filterKey === 'processInstanceKey')
-      return {key: filterKey, value: state.processInstanceKey};
-    else throw new Error('Unsupported filter key for empty value');
-  } else return {key: filterKey, value: filterValue};
-}
-
 export async function searchActiveElementInstance(
   request: APIRequestContext,
   processInstanceKey: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -52,3 +52,7 @@ export {
   deployMammalDecisionAndStoreResponse,
   deployTwoSimpleDecisionsAndStoreResponse,
 } from './decision-requirement-requestHelper';
+export {
+  createMammalProcessInstanceAndDeployMammalDecision,
+  type DecisionInstance,
+} from './decision-instance-requestHelpers';


### PR DESCRIPTION
## Description

This PR covers Decision instances search API happy path test:

- Search decision by multiple filters: processInstanceKey and decisionDefinitionId
- Search decision instances - multiple results - success
- Search decision instances - empty result
- Search decision instances different filters - success

and unhappy path:

- Search decision instances - invalid request - bad request
- Search decision requirements - unauthorized request

Also it changes Element instance search API test for filtered request - separate one generic test into test for each filter as separate test step.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

In Backport will be required to adjust required fields for API response (there is one additional field)
## Related issues

related #37204

## On demand workflow
[isn't 100% green](https://github.com/camunda/camunda/actions/runs/20458414363/job/58785617025) but the test failing also [fails](https://github.com/camunda/camunda/actions/runs/20453847621) on stable/8.8 
