### PR TITLE
[Backport stable/8.8] perf: flush after filling a new segment with zeroes

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -79,6 +79,7 @@ public interface SegmentAllocator {
         final FileChannel channel, final FileDescriptor fileDescriptor, final long segmentSize)
         throws IOException {
       IoUtil.fill(channel, 0, segmentSize, (byte) 0);
+      channel.force(true);
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #43147 to `stable/8.8`.

relates to 