### PR TITLE
fix: pass ArgoCD labels as separate --label arguments for preview envs

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -354,7 +354,7 @@ camunda-platform:
       clusters:
         - id: "default-cluster"
           name: "Default Cluster"
-          version: "8.8.0"
+          version: "8.9.0"
           authentication: "BEARER_TOKEN"
           authorizations:
             enabled: true

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -380,10 +380,10 @@ camunda-platform:
       #   repository: camunda/web-modeler-webapp
       resources:
         limits:
-          cpu: 100m
-          memory: 256Mi
+          cpu: 500m
+          memory: 1Gi
         requests:
-          cpu: 40m
+          cpu: 100m
           memory: 256Mi
       nodeSelector:
         cloud.google.com/gke-nodepool: previews

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -15,8 +15,9 @@ on:
         type: string
       labels:
         description: |
-          Additional ArgoCD app labels (comma or newline-separated key=value pairs)
-          e.g., "preview=smoke-test,repo=camunda/camunda"
+          Additional ArgoCD app labels (comma or newline-separated key=value pairs).
+          Values must be valid Kubernetes labels: alphanumeric, '-', '_', '.' only (no '/').
+          e.g., "preview=smoke-test,repo=camunda_camunda"
         required: false
         type: string
         default: ''
@@ -173,8 +174,8 @@ jobs:
     - name: Determine Argocd Arguments for c8sm
       shell: bash
       run: |
-        # Normalize labels: support both newline and comma separation
-        labels_normalized=$(echo "${labels}" | tr '\n' ',' | sed 's/,,*/,/g' | sed 's/^,//;s/,$//')
+        # Convert comma/newline-separated labels to multiple --label arguments
+        label_args=$(echo "${labels}" | tr ',' '\n' | sed '/^$/d; s/^/--label /' | tr '\n' ' ')
         echo "argocd_arguments=--dest-namespace ${app_name} \
           --file .ci/preview-environments/argo/c8sm.yml \
           --helm-set global.preview.git.branch=${revision} \
@@ -184,7 +185,7 @@ jobs:
           --name ${app_name} \
           --revision ${revision} \
           --helm-set git.branch=${revision} \
-          --upsert ${labels_normalized:+--label ${labels_normalized}}" >> "$GITHUB_ENV"
+          --upsert ${label_args}" >> "$GITHUB_ENV"
       env:
         docker_tag: pr-${{ github.event.pull_request.head.sha || github.sha }}
         labels: ${{ inputs.labels }}

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -71,7 +71,7 @@ jobs:
         github-token: ${{ github.token }}
         label-selector: |
           preview=smoke-test
-          repo=camunda/camunda
+          repo=camunda_camunda
         min-age: 12h
 
     - name: Observe build status

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -25,7 +25,7 @@ jobs:
       app-name: smoke-${{ github.run_number }}
       labels: |
         preview=smoke-test
-        repo=camunda/camunda
+        repo=camunda_camunda
 
   teardown-smoke-test:
     name: Teardown Smoke Test Preview Environment


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/719.

Fix [ArgoCD label arguments format](https://github.com/camunda/camunda/actions/runs/20438512216/job/58726947404). ArgoCD CLI expects each label as a separate `--label key=value` argument when creating a new app, not a comma-separated string.

Test: https://github.com/camunda/camunda/actions/runs/20463570232

This PR adds two addition fixes:
- [fix: increase resource requests and limits for modeler/webapp pods in preview envs](https://github.com/camunda/camunda/pull/43210/commits/b1d8e4c7e917f0ca95588b8d47dd12ed7b9ad0bc) (fix OOMKill observed when executing [SM-8.9/smoke-tests.spec.ts](https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/tests/SM-8.9/smoke-tests.spec.ts))
- [fix: set default-cluster version to 8.9.0 for modeler/restapi in preview envs](https://github.com/camunda/camunda/pull/43210/commits/33bd1adc491fa790a1a9288444375107055959fa)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
