### PR TITLE
feat: Add option to configure platform helm values in load test via GHA

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -31,7 +31,7 @@ on:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       platform-helm-values:
-        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
         type: string
         default: ""
         required: false
@@ -78,7 +78,7 @@ on:
         type: string
         required: false
       platform-helm-values:
-        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
         type: string
         default: ""
         required: false

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,6 +30,10 @@ on:
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
+      platform-helm-values:
+        description: 'Additional Camunda Platform Helm values file URL to use for deployment'
+        type: string
+        required: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
         type: boolean

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,7 +30,7 @@ on:
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
-      platform-test-load:
+      platform-test-value:
         description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         required: false
       stable-vms:
@@ -75,7 +75,7 @@ on:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         type: string
         required: false
-      platform-test-load:
+      platform-test-value:
         description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         required: false

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -31,7 +31,7 @@ on:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       platform-helm-values:
-        description: 'Specifies which platform test components to deploy. For example, `resources` can be modified as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         default: ""
         required: false
@@ -78,7 +78,7 @@ on:
         type: string
         required: false
       platform-helm-values:
-        description: 'Specifies which platform test components to deploy. For example, `resources` can be modified as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         default: ""
         required: false
@@ -294,7 +294,7 @@ jobs:
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
             additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=gcr.io --set orchestration.image.repository=zeebe-io/zeebe --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}" \
-            additional_load_test_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }} ${{ inputs.load-test-load }}"
+            additional_load_test_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }} ${{ inputs.load-test-load }} ${{ inputs.platform-helm-values }}"
       - name: Summarize platform deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,9 +30,8 @@ on:
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
-      platform-helm-values:
-        description: 'Additional Camunda Platform Helm values file URL to use for deployment'
-        type: string
+      platform-test-load:
+        description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         required: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
@@ -74,6 +73,10 @@ on:
         required: false
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
+        type: string
+        required: false
+      platform-test-load:
+        description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         required: false
       publish:

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -293,8 +293,8 @@ jobs:
           cd load-tests/setup/${{ inputs.name }}
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
-            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=gcr.io --set orchestration.image.repository=zeebe-io/zeebe --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}" \
-            additional_load_test_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }} ${{ inputs.load-test-load }} ${{ inputs.platform-helm-values }}"
+            additional_platform_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} --set orchestration.image.registry=gcr.io --set orchestration.image.repository=zeebe-io/zeebe --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.platform-helm-values }}" \
+            additional_load_test_configuration="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }} ${{ inputs.load-test-load }}"
       - name: Summarize platform deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -79,6 +79,7 @@ on:
         description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         required: false
+        default: ""
       publish:
         description: 'Where to publish the results, can be "slack" or "comment"'
         default: ""

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,8 +30,9 @@ on:
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
-      platform-test-value:
-        description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+      platform-helm-value:
+        description: 'Specifies which platform test components to deploy. For example, `resources` can be modified as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        type: string
         required: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
@@ -75,8 +76,8 @@ on:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         type: string
         required: false
-      platform-test-value:
-        description: 'Specifies which platform test components to deploy. For example, `resources` can be modify as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+      platform-helm-value:
+        description: 'Specifies which platform test components to deploy. For example, `resources` can be modified as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         required: false
         default: ""

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,9 +30,10 @@ on:
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
-      platform-helm-value:
+      platform-helm-values:
         description: 'Specifies which platform test components to deploy. For example, `resources` can be modified as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
+        default: ""
         required: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
@@ -76,11 +77,11 @@ on:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         type: string
         required: false
-      platform-helm-value:
+      platform-helm-values:
         description: 'Specifies which platform test components to deploy. For example, `resources` can be modified as per the requirement. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
-        required: false
         default: ""
+        required: false
       publish:
         description: 'Where to publish the results, can be "slack" or "comment"'
         default: ""


### PR DESCRIPTION
This pull request introduces a small enhancement to the workflow configuration by adding a new optional input parameter. This change increases flexibility for deployments by allowing users to specify additional Helm values.

## Description
* Workflow configuration enhancement:
  * [`.github/workflows/camunda-load-test.yml`](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R33-R36): Added a new optional input parameter `platform-helm-values` that allows specifying an additional Camunda Platform Helm values.
  * Ran Workflow: https://github.com/camunda/camunda/actions/runs/20909100097


## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41844
