### PR TITLE
[CPT] fix: Complete a multiple instance user task without waiting

### DIFF
--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestCompletionApiIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestCompletionApiIT.java
@@ -333,8 +333,6 @@ public class CamundaProcessTestCompletionApiIT {
 
     // When: complete both user tasks
     processTestContext.completeUserTask(UserTaskSelectors.byElementId(elementId));
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElement(elementId, 1);
-
     processTestContext.completeUserTask(UserTaskSelectors.byElementId(elementId));
 
     // Then: both user tasks are completed (3 elements = 2 user tasks + multi-instance body)

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestCompletionApiIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestCompletionApiIT.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.HashMap;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @CamundaProcessTest
@@ -157,21 +156,6 @@ public class CamundaProcessTestCompletionApiIT {
     final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
     final ProcessInstanceEvent processInstanceEvent =
         client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-
-    // When
-    processTestContext.completeUserTask("user-task-1");
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-  }
-
-  @Test
-  void shouldCompleteUserTaskWithVariables() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
     final Map<String, Object> variables = new HashMap<>();
     variables.put("abc", 123);
 
@@ -199,119 +183,6 @@ public class CamundaProcessTestCompletionApiIT {
     // Then
     assertThatProcessInstance(processInstanceEvent).isCompleted();
     assertThatProcessInstance(processInstanceEvent).hasVariables(variables);
-  }
-
-  @Test
-  void shouldCompleteUserTaskByTaskName() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-
-    // When
-    processTestContext.completeUserTask(UserTaskSelectors.byTaskName("user-task"));
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-  }
-
-  @Test
-  void shouldCompleteUserTaskByTaskNameWithVariable() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-    final Map<String, Object> variables = new HashMap<>();
-    variables.put("abc", 123);
-
-    // When
-    processTestContext.completeUserTask(UserTaskSelectors.byTaskName("user-task"), variables);
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-    assertThatProcessInstance(processInstanceEvent).hasVariables(variables);
-  }
-
-  @Test
-  void shouldCompleteUserTaskByElementId() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-
-    // When
-    processTestContext.completeUserTask(UserTaskSelectors.byElementId("user-task-1"));
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-  }
-
-  @Test
-  void shouldCompleteUserTaskByElementIdWithVariables() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-    final Map<String, Object> variables = new HashMap<>();
-    variables.put("abc", 123);
-
-    // When
-    processTestContext.completeUserTask(UserTaskSelectors.byElementId("user-task-1"), variables);
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-    assertThatProcessInstance(processInstanceEvent).hasVariables(variables);
-  }
-
-  @Test
-  void shouldCompleteUserTaskBySelector() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-
-    // When
-    processTestContext.completeUserTask(t -> t.getName().equals("user-task"));
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-  }
-
-  @Test
-  void shouldCompleteUserTaskBySelectorWithVariables() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-    final Map<String, Object> variables = new HashMap<>();
-    variables.put("abc", 123);
-
-    // When
-    processTestContext.completeUserTask(t -> t.getName().equals("user-task"), variables);
-
-    // Then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
-    assertThatProcessInstance(processInstanceEvent).hasVariables(variables);
-  }
-
-  @Test
-  void shouldGiveHelpfulErrorMessageWhenCompleteUserTaskFails() {
-    // Given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
-
-    // When
-    Assertions.assertThatThrownBy(
-            () ->
-                processTestContext.completeUserTask(UserTaskSelectors.byElementId("unknown-task")))
-        .hasMessage(
-            "Expected to complete user task [elementId: unknown-task] but no user task is available.");
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.extensions;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.CompleteUserTaskResponse;
+import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.assertions.UserTaskSelectors;
+import io.camunda.process.test.impl.client.CamundaManagementClient;
+import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
+import io.camunda.process.test.utils.DevAwaitBehavior;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CompleteUserTaskTest {
+
+  private static final Long USER_TASK_KEY = 100L;
+  private static final String USER_TASK_ELEMENT_ID = "task1";
+
+  @Mock private CamundaProcessTestRuntime camundaProcessTestRuntime;
+  @Mock private Consumer<AutoCloseable> clientCreationCallback;
+  @Mock private CamundaManagementClient camundaManagementClient;
+  @Mock private JsonMapper jsonMapper;
+  @Mock private io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper;
+
+  @Mock private CamundaClientBuilderFactory camundaClientBuilderFactory;
+  @Mock private CamundaClientBuilder camundaClientBuilder;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
+  @Mock private UserTask userTask;
+
+  @Captor private ArgumentCaptor<Consumer<UserTaskFilter>> userTaskFilterCaptor;
+  @Mock private UserTaskFilter userTaskFilter;
+
+  private CamundaProcessTestContext camundaProcessTestContext;
+
+  @BeforeEach
+  void configureMocks() {
+    when(camundaProcessTestRuntime.getCamundaClientBuilderFactory())
+        .thenReturn(camundaClientBuilderFactory);
+    when(camundaClientBuilderFactory.get()).thenReturn(camundaClientBuilder);
+    when(camundaClientBuilder.build()).thenReturn(camundaClient);
+  }
+
+  @Nested
+  class HappyCases {
+
+    @BeforeEach
+    void setup() {
+      camundaProcessTestContext =
+          new CamundaProcessTestContextImpl(
+              camundaProcessTestRuntime,
+              clientCreationCallback,
+              camundaManagementClient,
+              DevAwaitBehavior.expectSuccess(),
+              jsonMapper,
+              zeebeJsonMapper);
+
+      when(camundaClient
+              .newUserTaskSearchRequest()
+              .filter(userTaskFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(userTask));
+
+      when(userTask.getUserTaskKey()).thenReturn(USER_TASK_KEY);
+      when(userTask.getElementId()).thenReturn(USER_TASK_ELEMENT_ID);
+    }
+
+    @Test
+    void shouldCompleteUserTask() {
+      // when
+      camundaProcessTestContext.completeUserTask(USER_TASK_ELEMENT_ID);
+
+      // then
+      verify(
+              camundaClient
+                  .newCompleteUserTaskCommand(USER_TASK_KEY)
+                  .variables(Collections.emptyMap()))
+          .send();
+    }
+
+    @Test
+    void shouldCompleteUserTaskWithVariables() {
+      // given
+      final Map<String, Object> variables = Collections.singletonMap("result", "okay");
+
+      // when
+      camundaProcessTestContext.completeUserTask(USER_TASK_ELEMENT_ID, variables);
+
+      // then
+      verify(camundaClient.newCompleteUserTaskCommand(USER_TASK_KEY).variables(variables)).send();
+    }
+
+    @Test
+    void shouldSearchByElementId() {
+      // when
+      camundaProcessTestContext.completeUserTask(USER_TASK_ELEMENT_ID);
+
+      // then
+      userTaskFilterCaptor.getValue().accept(userTaskFilter);
+      verify(userTaskFilter).elementId(USER_TASK_ELEMENT_ID);
+      verify(userTaskFilter).state(UserTaskState.CREATED);
+
+      verifyNoMoreInteractions(userTaskFilter);
+    }
+
+    @Test
+    void shouldSearchBySelector() {
+      // when
+      camundaProcessTestContext.completeUserTask(
+          UserTaskSelectors.byElementId(USER_TASK_ELEMENT_ID));
+
+      // then
+      userTaskFilterCaptor.getValue().accept(userTaskFilter);
+      verify(userTaskFilter).elementId(USER_TASK_ELEMENT_ID);
+      verify(userTaskFilter).state(UserTaskState.CREATED);
+
+      verifyNoMoreInteractions(userTaskFilter);
+    }
+
+    @Test
+    void shouldAwaitUntilUserTaskIsPresent() {
+      // given
+      when(camundaClient
+              .newUserTaskSearchRequest()
+              .filter(userTaskFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.singletonList(userTask));
+
+      clearInvocations(camundaClient);
+
+      // when
+      camundaProcessTestContext.completeUserTask(USER_TASK_ELEMENT_ID);
+
+      // then
+      verify(camundaClient, times(2)).newUserTaskSearchRequest();
+    }
+
+    @Test
+    void shouldRetryCompletion() {
+      // given
+      when(camundaClient
+              .newCompleteUserTaskCommand(USER_TASK_KEY)
+              .variables(Collections.emptyMap())
+              .send()
+              .join())
+          .thenThrow(new ClientException("expected"))
+          .thenReturn(mock(CompleteUserTaskResponse.class));
+
+      clearInvocations(camundaClient);
+
+      // when
+      camundaProcessTestContext.completeUserTask(USER_TASK_ELEMENT_ID);
+
+      // then
+      verify(camundaClient, times(2)).newCompleteUserTaskCommand(USER_TASK_KEY);
+    }
+  }
+
+  @Nested
+  class FailureCases {
+
+    @BeforeEach
+    void setup() {
+      camundaProcessTestContext =
+          new CamundaProcessTestContextImpl(
+              camundaProcessTestRuntime,
+              clientCreationCallback,
+              camundaManagementClient,
+              DevAwaitBehavior.expectFailure(),
+              jsonMapper,
+              zeebeJsonMapper);
+    }
+
+    @Test
+    void shouldFailIfNoUserTaskIsPresent() {
+      // given
+      when(camundaClient
+              .newUserTaskSearchRequest()
+              .filter(userTaskFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      // when/then
+      assertThatThrownBy(() -> camundaProcessTestContext.completeUserTask(USER_TASK_ELEMENT_ID))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining(
+              "Expected to complete user task [elementId: %s] but no user task is available.",
+              USER_TASK_ELEMENT_ID);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR wraps the user task completion in an await block to retry a failed completion, for example, caused by the eventual consistency of the search API. As a result, a user can complete multiple user tasks without waiting until the previous completion is materialized in the search API.

This PR contains new unit tests for the user task completion that replaces some slow integration tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42929
