### PR TITLE
test: retries to reduce flakiness

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -7,6 +7,7 @@
  */
 
 import {Page, Locator, expect} from '@playwright/test';
+import {waitForAssertion} from '../utils/waitForAssertion';
 
 type OptionalFilter =
   | 'Variable'
@@ -165,8 +166,16 @@ export class OperateFiltersPanelPage {
   }
 
   async selectProcess(option: string) {
-    await this.processNameFilter.click();
-    await this.getOptionByName(option).click();
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.processNameFilter).toBeVisible();
+        await this.processNameFilter.click();
+        await this.getOptionByName(option).click();
+      },
+      onFailure: async () => {
+        await this.page.reload();
+      },
+    });
   }
 
   async selectVersion(option: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -170,6 +170,7 @@ export class OperateFiltersPanelPage {
       assertion: async () => {
         await expect(this.processNameFilter).toBeVisible();
         await this.processNameFilter.click();
+        await this.processNameFilter.clear();
         await this.getOptionByName(option).click();
       },
       onFailure: async () => {
@@ -179,8 +180,15 @@ export class OperateFiltersPanelPage {
   }
 
   async selectVersion(option: string) {
-    await this.processVersionFilter.click();
-    await this.getOptionByName(option).click();
+    await waitForAssertion({
+      assertion: async () => {
+        await this.processVersionFilter.click();
+        await this.getOptionByName(option).click();
+      },
+      onFailure: async () => {
+        await this.page.reload();
+      },
+    });
   }
 
   async selectFlowNode(option: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -119,9 +119,11 @@ export class OperateOperationPanelPage {
   }
 
   async clickOperationLink(operationEntry: Locator): Promise<void> {
-    await OperateOperationPanelPage.getOperationID(operationEntry).click({
-      timeout: 30000,
-    });
+    await OperateOperationPanelPage.getOperationID(operationEntry)
+      .first()
+      .click({
+        timeout: 30000,
+      });
   }
 
   async expandOperationsPanel(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -7,6 +7,7 @@
  */
 
 import {Page, Locator, expect} from '@playwright/test';
+import {sleep} from "../utils/sleep";
 
 export class OperateProcessMigrationModePage {
   private page: Page;
@@ -93,6 +94,7 @@ export class OperateProcessMigrationModePage {
   }
 
   async completeProcessInstanceMigration(): Promise<void> {
+    await sleep(200);
     await this.clickNextButton();
     await this.clickConfirmButton();
     await this.fillMigrationConfirmation('MIGRATE');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -72,6 +72,8 @@ export class OperateProcessMigrationModePage {
   }
 
   async clickMigrationConfirmationButton(): Promise<void> {
+    await expect(this.migrationConfirmationButton).toBeVisible();
+    await expect(this.migrationConfirmationButton).toBeEnabled();
     await this.migrationConfirmationButton.click();
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -361,6 +361,7 @@ class OperateProcessesPage {
 
           // Wait for the element to be attached and stable
           await checkbox.waitFor({state: 'attached', timeout: 5000});
+          await sleep(200);
           if (!(await checkbox.isChecked())) {
             await checkbox.click({timeout: 10000});
           }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -145,16 +145,8 @@ test.describe('Child Process Instance Migration', () => {
       await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
         parentInstanceKey,
       );
-
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(page.getByText('1 result')).toBeVisible({
-            timeout: 30000,
-          });
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
+      await expect(page.getByText('1 result')).toBeVisible({
+        timeout: 30000,
       });
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -8,15 +8,19 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createInstances} from 'utils/zeebeClient';
+import {
+  deploy,
+  createInstances,
+  cancelProcessInstance,
+} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessDeployment = {
+  version: number;
   readonly bpmnProcessId: string;
-  readonly version: number;
   readonly processDefinitionKey: string;
 };
 
@@ -58,13 +62,18 @@ test.beforeAll(async () => {
     (instance) => instance.processInstanceKey,
   );
 
-  await deploy(['./resources/childProcess_v_2.bpmn']);
+  const v2Deployment = await deploy(['./resources/childProcess_v_2.bpmn']);
 
   const childProcessV2: ProcessDeployment = {
     bpmnProcessId: 'childProcess',
-    version: 2,
+    version: v2Deployment.processes[0].processDefinitionVersion,
     processDefinitionKey: '',
   };
+
+  for (const key of parentInstances) {
+    parentProcess.version = key.processDefinitionVersion;
+  }
+  childProcessV1.version = childProcessV2.version - 1;
 
   testProcesses = {
     parentProcess,
@@ -89,6 +98,10 @@ test.describe('Child Process Instance Migration', () => {
   test.afterEach(async ({page}, testInfo) => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
+    for (const key of testProcesses.parentProcessInstanceKeys) {
+      console.log('cancelling process instance with key:', key);
+      await cancelProcessInstance(key);
+    }
   });
 
   test('Migrate Child Process Instances', async ({
@@ -105,6 +118,8 @@ test.describe('Child Process Instance Migration', () => {
     const targetVersion = testProcesses.childProcessV2.version.toString();
     const targetBpmnProcessId = testProcesses.childProcessV2.bpmnProcessId;
     const parentInstanceKey = testProcesses.parentProcessInstanceKeys[0]!;
+    console.log('Source Version:', sourceVersion);
+    console.log('Target Version:', targetVersion);
 
     await test.step('Navigate to parent process instance and view called child processes', async () => {
       await operateFiltersPanelPage.selectProcess(
@@ -185,17 +200,11 @@ test.describe('Child Process Instance Migration', () => {
 
       await operateOperationPanelPage.waitForOperationToComplete();
 
+      await sleep(500);
       const operationEntry =
         operateOperationPanelPage.getMigrationOperationEntry(1);
 
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operationEntry.first()).toBeVisible({timeout: 60000});
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
+      await expect(operationEntry.last()).toBeVisible({timeout: 120000});
 
       await operateOperationPanelPage.clickOperationLink(operationEntry);
     });
@@ -203,7 +212,7 @@ test.describe('Child Process Instance Migration', () => {
     await test.step('Verify 1 instance migrated to target version', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText('1 result')).toBeVisible({
+          await expect(page.getByText('1 result').first()).toBeVisible({
             timeout: 30000,
           });
         },
@@ -211,10 +220,16 @@ test.describe('Child Process Instance Migration', () => {
           await page.reload();
         },
       });
-
-      await expect(
-        operateProcessesPage.getVersionCells(targetVersion),
-      ).toHaveCount(1, {timeout: 30000});
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.getVersionCells(targetVersion),
+          ).toHaveCount(1, {timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
 
       await expect(
         operateProcessesPage.getParentInstanceCell(parentInstanceKey),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -188,7 +188,14 @@ test.describe('Child Process Instance Migration', () => {
       const operationEntry =
         operateOperationPanelPage.getMigrationOperationEntry(1);
 
-      await expect(operationEntry).toBeVisible({timeout: 120000});
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operationEntry.first()).toBeVisible({timeout: 60000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
 
       await operateOperationPanelPage.clickOperationLink(operationEntry);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -157,7 +157,9 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Expect all incidents resolved', async () => {
-      await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+      await expect(operateProcessInstancePage.incidentsBanner).toBeHidden({
+        timeout: 15000,
+      });
       await expect(operateProcessInstancePage.incidentsTable).toBeHidden();
       await expect(operateProcessInstancePage.completedIcon).toBeVisible();
     });


### PR DESCRIPTION
## Description

- The migration notification and the operation ID were used for the child migration tests. This might make the tests flaky if there are earlier operations present. Also, we started the test with versions 1 and 2, but on retry the versions are incremented to 2 and 3, so we couldn’t find the processes during the retry. I used the process ID, version, and parent process to select the process after migration.

- Increased timeout from 10 seconds to 15 seconds for incidents. 

Successful run [here](https://github.com/camunda/camunda/actions/runs/20466147486) 
<img src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzEzcTdxOWJyM3Q1dHh6cTk3cXVucjV3ZXNnZGN4bWd6eGViZzJ6dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/j0vs5H7Kcz3Pm9LRDa/giphy.gif" width="50" />

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
