### PR TITLE
test: migrate batchMoveModification.spec tp OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -20,6 +20,7 @@ import {OperateFiltersPanelPage} from '@pages/OperateFiltersPanelPage';
 import {OperateDashboardPage} from '@pages/OperateDashboardPage';
 import {OperateDiagramPage} from '@pages/OperateDiagramPage';
 import {OperateProcessMigrationModePage} from '@pages/OperateProcessMigrationModePage';
+import {OperateProcessModificationModePage} from '@pages/OperateProcessModificationModePage';
 import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
@@ -56,6 +57,7 @@ type PlaywrightFixtures = {
   operateDashboardPage: OperateDashboardPage;
   operateDiagramPage: OperateDiagramPage;
   operateProcessMigrationModePage: OperateProcessMigrationModePage;
+  operateProcessModificationModePage: OperateProcessModificationModePage;
   operateOperationPanelPage: OperateOperationPanelPage;
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
@@ -96,6 +98,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateProcessMigrationModePage: async ({page}, use) => {
     await use(new OperateProcessMigrationModePage(page));
+  },
+  operateProcessModificationModePage: async ({page}, use) => {
+    await use(new OperateProcessModificationModePage(page));
   },
   loginPage: async ({page}, use) => {
     await use(new LoginPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -11,6 +11,7 @@ import {Page, Locator} from '@playwright/test';
 export class OperateDashboardPage {
   private page: Page;
   readonly metricPanel: Locator;
+  readonly runningInstancesText: Locator;
   readonly totalInstancesLink: Locator;
   readonly activeInstancesLink: Locator;
   readonly incidentInstancesLink: Locator;
@@ -35,6 +36,9 @@ export class OperateDashboardPage {
   constructor(page: Page) {
     this.page = page;
     this.metricPanel = page.getByTestId('metric-panel');
+    this.runningInstancesText = page.getByText(
+      /running process instances in total/i,
+    );
     this.totalInstancesLink = page.getByTestId('total-instances-link');
     this.activeInstancesLink = page.getByTestId('active-instances-link');
     this.incidentInstancesLink = page.getByTestId('incident-instances-link');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -11,6 +11,7 @@ import {Page, Locator} from '@playwright/test';
 class OperateHomePage {
   private page: Page;
   readonly operateBanner: Locator;
+  readonly dashboardLink: Locator;
   readonly processesTab: Locator;
   readonly decisionsTab: Locator;
   readonly informationDialog: Locator;
@@ -22,6 +23,7 @@ class OperateHomePage {
   constructor(page: Page) {
     this.page = page;
     this.operateBanner = page.getByRole('link', {name: 'Camunda logo Operate'});
+    this.dashboardLink = page.getByRole('link', {name: 'Dashboard'});
     this.processesTab = page.getByRole('link', {name: 'Processes'}).first();
     this.decisionsTab = page.getByRole('link', {name: 'Decisions'});
     this.informationDialog = page.getByRole('button', {
@@ -38,6 +40,10 @@ class OperateHomePage {
 
   async clickProcessesTab(): Promise<void> {
     await this.processesTab.click();
+  }
+
+  async clickDashboardLink(): Promise<void> {
+    await this.dashboardLink.click();
   }
 
   async clickDecisionsTab(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -98,6 +98,13 @@ export class OperateOperationPanelPage {
       .filter({hasText: `${successCount} ${operationText} succeeded`});
   }
 
+  getModificationOperationEntry(successCount: number): Locator {
+    const operationText = successCount === 1 ? 'operation' : 'operations';
+    return this.getAllOperationEntries()
+      .filter({hasText: 'Modify'})
+      .filter({hasText: `${successCount} ${operationText} succeeded`});
+  }
+
   getRetryOperationEntry(successCount: number): Locator {
     const retryText = successCount === 1 ? 'retry' : 'retries';
     return this.getAllOperationEntries()
@@ -136,5 +143,16 @@ export class OperateOperationPanelPage {
         'Progress bar did not appear or disappeared too quickly - operation likely completed fast',
       );
     }
+  }
+
+  async collapseOperationsPanel(): Promise<void> {
+    const isVisible = await this.operationsPanel.isVisible();
+    if (isVisible) {
+      await this.collapseButton.click();
+    }
+  }
+
+  get operationsList(): Locator {
+    return this.operationList;
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessModificationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessModificationModePage.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+
+export class OperateProcessModificationModePage {
+  private page: Page;
+  readonly moveButton: Locator;
+  readonly moveModificationModal: {
+    continueButton: Locator;
+  };
+  readonly undoButton: Locator;
+  readonly applyModificationButton: Locator;
+  readonly applyModificationsModal: {
+    title: Locator;
+    applyButton: Locator;
+  };
+  readonly exitModificationModeModal: {
+    dialog: Locator;
+    cancelButton: Locator;
+    exitButton: Locator;
+    subtitle: Locator;
+  };
+  readonly batchModificationModeText: Locator;
+  readonly modificationNotification: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.moveButton = page.getByRole('button', {name: 'Move', exact: true});
+
+    this.moveModificationModal = {
+      continueButton: page
+        .getByRole('dialog')
+        .getByRole('button', {name: /continue/i}),
+    };
+
+    this.undoButton = page.getByRole('button', {name: /undo/i});
+
+    this.applyModificationButton = page.getByRole('button', {
+      name: /apply modification/i,
+    });
+
+    this.applyModificationsModal = {
+      title: page.getByRole('heading', {name: /apply modifications/i}),
+      applyButton: page.getByRole('button', {name: /^apply$/i}),
+    };
+
+    this.exitModificationModeModal = {
+      dialog: page.getByRole('dialog', {
+        name: /exit batch modification mode/i,
+      }),
+      cancelButton: page
+        .getByRole('dialog', {name: /exit batch modification mode/i})
+        .getByRole('button', {name: /cancel/i}),
+      exitButton: page
+        .getByRole('dialog', {name: /exit batch modification mode/i})
+        .getByRole('button', {name: /exit/i}),
+      subtitle: page
+        .getByRole('dialog', {name: /exit batch modification mode/i})
+        .getByText(/about to discard all added modifications/i),
+    };
+
+    this.batchModificationModeText = page.getByText('Batch Modification Mode', {
+      exact: true,
+    });
+
+    this.modificationNotification = page.locator(
+      '.cds--inline-notification__subtitle',
+    );
+  }
+
+  async clickMoveButton(): Promise<void> {
+    await this.moveButton.click();
+  }
+
+  async confirmMoveModification(): Promise<void> {
+    await this.moveModificationModal.continueButton.click();
+  }
+
+  async clickUndoButton(): Promise<void> {
+    await this.undoButton.click();
+  }
+
+  async clickApplyModificationButton(): Promise<void> {
+    await this.applyModificationButton.click();
+  }
+
+  async confirmApplyModifications(): Promise<void> {
+    await this.applyModificationsModal.applyButton.click();
+  }
+
+  async cancelExitModificationMode(): Promise<void> {
+    await this.exitModificationModeModal.cancelButton.click();
+  }
+
+  async confirmExitModificationMode(): Promise<void> {
+    await this.exitModificationModeModal.exitButton.click();
+  }
+
+  async expectModificationNotification(
+    instanceCount: number,
+    sourceFlowNode: string,
+    targetFlowNode: string,
+  ): Promise<void> {
+    await expect(
+      this.modificationNotification.filter({
+        hasText: 'Modification scheduled',
+      }),
+    ).toBeVisible({timeout: 30000});
+
+    await expect(this.modificationNotification).toContainText(
+      `Move ${instanceCount} instances`,
+    );
+    await expect(this.modificationNotification).toContainText(sourceFlowNode);
+    await expect(this.modificationNotification).toContainText(targetFlowNode);
+  }
+
+  async startBatchMoveModification(): Promise<void> {
+    await this.clickMoveButton();
+    await this.confirmMoveModification();
+    await expect(this.batchModificationModeText).toBeVisible();
+  }
+
+  async applyAndConfirmModification(): Promise<void> {
+    await expect(this.applyModificationButton).toBeVisible();
+    await this.clickApplyModificationButton();
+    await expect(this.applyModificationsModal.title).toBeVisible();
+    await this.confirmApplyModifications();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -427,6 +427,14 @@ class OperateProcessesPage {
   async clickViewParentInstanceFromList(): Promise<void> {
     await this.viewParentInstanceLinkInList.click();
   }
+
+  getNthProcessInstanceCheckbox(index: number): Locator {
+    return this.page
+      .getByTestId('data-list')
+      .getByRole('row')
+      .nth(index + 1) // +1 to skip header row
+      .getByRole('checkbox');
+  }
 }
 
 export {OperateProcessesPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
@@ -40,6 +40,36 @@ export async function hideModificationHelperModal(page: Page): Promise<void> {
   });
 }
 
+export async function gotoProcessesPage(
+  page: Page,
+  options?: {
+    searchParams?: {
+      active?: string;
+      ids?: string;
+      process?: string;
+      version?: string;
+      flowNodeId?: string;
+    };
+  },
+): Promise<void> {
+  const baseUrl = `${process.env.CORE_APPLICATION_URL}/operate/processes`;
+  const searchParams = new URLSearchParams();
+
+  if (options?.searchParams) {
+    Object.entries(options.searchParams).forEach(([key, value]) => {
+      if (value) {
+        searchParams.append(key, value);
+      }
+    });
+  }
+
+  const url = searchParams.toString()
+    ? `${baseUrl}?${searchParams.toString()}`
+    : baseUrl;
+
+  await page.goto(url);
+}
+
 export async function validateURL(page: Page, URL: RegExp): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises, playwright/missing-playwright-await
   expect(page).toHaveURL(URL);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessBatchMod_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessBatchMod_v_1.bpmn
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="orderProcessBatchMod" name="Order process (Batch Modification)" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Order received">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
+    <bpmn:serviceTask id="checkPayment" name="Check payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="checkPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="shipArticles" name="Ship Articles">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="shipArticles" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="EndEvent_042s0oc" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
+      <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:serviceTask id="requestForPayment" name="Request for payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="requestPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessBatchMod">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="156" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="138" />
+        <di:waypoint x="300" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+        <dc:Bounds x="300" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
+        <dc:Bounds x="633" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="792" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
+        <di:waypoint x="733" y="138" />
+        <di:waypoint x="792" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="469" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="460" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
+        <di:waypoint x="400" y="138" />
+        <di:waypoint x="469" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="54.5" y="227" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="444" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
+        <di:waypoint x="494" y="163" />
+        <di:waypoint x="494" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="188" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
+        <di:waypoint x="444" y="300" />
+        <di:waypoint x="350" y="300" />
+        <di:waypoint x="350" y="178" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="389" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
+        <di:waypoint x="519" y="138" />
+        <di:waypoint x="633" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="566" y="117" width="21" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from '@fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {
+  navigateToApp,
+  hideModificationHelperModal,
+  gotoProcessesPage,
+} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let processInstances: ProcessInstance[];
+
+const NUM_PROCESS_INSTANCES = 10;
+const NUM_SELECTED_PROCESS_INSTANCES = 4;
+
+test.beforeAll(async () => {
+  await deploy(['./resources/orderProcessBatchMod_v_1.bpmn']);
+
+  processInstances = await createInstances(
+    'orderProcessBatchMod',
+    1,
+    NUM_PROCESS_INSTANCES,
+  );
+
+  await sleep(2000);
+});
+
+test.describe('Process Instance Batch Modification', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await hideModificationHelperModal(page);
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Move Operation', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateOperationPanelPage,
+    operateDiagramPage,
+    operateProcessModificationModePage,
+  }) => {
+    const processInstanceKeys = processInstances.map(
+      (instance) => instance.processInstanceKey,
+    );
+
+    await test.step('Navigate to processes page with filters', async () => {
+      await gotoProcessesPage(page, {
+        searchParams: {
+          active: 'true',
+          process: 'orderProcessBatchMod',
+          version: '1',
+          flowNodeId: 'checkPayment',
+        },
+      });
+    });
+
+    await test.step('Verify correct number of instances displayed', async () => {
+      await expect(
+        page.getByText(`${NUM_PROCESS_INSTANCES} results`),
+      ).toBeVisible();
+    });
+
+    await test.step('Select 4 process instances for move modification', async () => {
+      await operateProcessesPage.selectProcessInstances(
+        NUM_SELECTED_PROCESS_INSTANCES,
+      );
+    });
+
+    await test.step('Start move modification', async () => {
+      await operateProcessModificationModePage.startBatchMoveModification();
+    });
+
+    await test.step('Select target flow node', async () => {
+      await operateDiagramPage.clickFlowNode('shipArticles');
+
+      await operateProcessModificationModePage.expectModificationNotification(
+        NUM_SELECTED_PROCESS_INSTANCES,
+        'Check payment',
+        'Ship Articles',
+      );
+    });
+
+    await test.step('Test undo functionality', async () => {
+      await operateProcessModificationModePage.clickUndoButton();
+
+      await expect(
+        operateProcessModificationModePage.modificationNotification.filter({
+          hasText: 'Modification scheduled',
+        }),
+      ).toBeHidden();
+
+      await expect(
+        operateProcessModificationModePage.batchModificationModeText,
+      ).toBeVisible();
+      await expect(
+        operateProcessModificationModePage.applyModificationButton,
+      ).toBeDisabled();
+    });
+
+    await test.step('Re-select target flow node and apply modification', async () => {
+      await operateDiagramPage.clickFlowNode('shipArticles');
+
+      await operateProcessModificationModePage.expectModificationNotification(
+        NUM_SELECTED_PROCESS_INSTANCES,
+        'Check payment',
+        'Ship Articles',
+      );
+
+      await operateProcessModificationModePage.applyAndConfirmModification();
+    });
+
+    await test.step('Verify operation is created and completed', async () => {
+      await expect(operateOperationPanelPage.operationsList).toBeVisible();
+      const operationEntry =
+        operateOperationPanelPage.getModificationOperationEntry(4);
+
+      await expect(operationEntry).toBeVisible({timeout: 120000});
+
+      await operateOperationPanelPage.clickOperationLink(operationEntry);
+    });
+
+    await test.step('Filter and verify modified instances', async () => {
+      await operateFiltersPanelPage.selectProcess(
+        'Order process (Batch Modification)',
+      );
+      await operateFiltersPanelPage.selectVersion('1');
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        processInstanceKeys.join(','),
+      );
+
+      await expect(
+        page.getByText(`${NUM_SELECTED_PROCESS_INSTANCES} results`),
+      ).toBeVisible();
+    });
+
+    await test.step('Wait for modification to complete and verify flow nodes', async () => {
+      await operateOperationPanelPage.waitForOperationToComplete();
+
+      await page.reload();
+
+      await expect(
+        operateDiagramPage.diagram.getByTestId(
+          'state-overlay-checkPayment-canceled',
+        ),
+      ).toHaveText(NUM_SELECTED_PROCESS_INSTANCES.toString());
+
+      await expect(
+        operateDiagramPage.diagram.getByTestId(
+          'state-overlay-shipArticles-active',
+        ),
+      ).toHaveText(NUM_SELECTED_PROCESS_INSTANCES.toString());
+    });
+  });
+
+  test('Exit Modal', async ({
+    page,
+    operateProcessesPage,
+    operateDiagramPage,
+    operateProcessModificationModePage,
+    operateHomePage,
+    operateDashboardPage,
+  }) => {
+    await test.step('Navigate to processes page and select instance', async () => {
+      await gotoProcessesPage(page, {
+        searchParams: {
+          active: 'true',
+          process: 'orderProcessBatchMod',
+          version: '1',
+          flowNodeId: 'checkPayment',
+        },
+      });
+      await operateProcessesPage.selectProcessInstances(1);
+    });
+
+    await test.step('Enter batch modification mode', async () => {
+      await operateProcessModificationModePage.startBatchMoveModification();
+
+      await operateDiagramPage.clickFlowNode('shipArticles');
+    });
+
+    await test.step('Test navigation interruption and modal', async () => {
+      await operateHomePage.clickDashboardLink();
+
+      await expect(
+        operateProcessModificationModePage.exitModificationModeModal.dialog,
+      ).toBeVisible();
+      await expect(
+        operateProcessModificationModePage.exitModificationModeModal.subtitle,
+      ).toBeVisible();
+    });
+
+    await test.step('Test modal cancellation', async () => {
+      await operateProcessModificationModePage.cancelExitModificationMode();
+      await expect(
+        operateProcessModificationModePage.exitModificationModeModal.dialog,
+      ).toBeHidden();
+      await expect(
+        operateProcessModificationModePage.batchModificationModeText,
+      ).toBeVisible();
+    });
+
+    await test.step('Test modal confirmation and exit', async () => {
+      await operateHomePage.clickDashboardLink();
+
+      await operateProcessModificationModePage.confirmExitModificationMode();
+
+      await expect(
+        operateProcessModificationModePage.batchModificationModeText,
+      ).toBeHidden();
+
+      await expect(operateDashboardPage.runningInstancesText).toBeVisible();
+
+      await page.goBack();
+
+      await expect(
+        operateProcessModificationModePage.batchModificationModeText,
+      ).toBeHidden();
+    });
+  });
+});


### PR DESCRIPTION
## Description
Migrates batch move modification test to OC E2E suite with improved Page Object Model implementation.

### Changes

**Tests:**
- Move Operation: End-to-end batch move userflow validation
- Exit Modal: Navigation interruption and exit confirmation


🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20460018115)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/34094
