### PR TITLE
feat: Upgrade OS Java Client to v3.4.0

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -455,7 +455,6 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="Python">
-      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="RIGHT_MARGIN" value="80" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <indentOptions>

--- a/load-tests/secondary-storage-values-opensearch.yaml
+++ b/load-tests/secondary-storage-values-opensearch.yaml
@@ -28,6 +28,10 @@ extraEnvs:
 
 opensearchJavaOpts: "-Xms1024m -Xmx1024m"
 
+sysctlInit:
+  enabled: true
+sysctlVmMaxMapCount: 262144
+
 resources:
   requests:
     cpu: 3

--- a/operate/common/src/main/java/io/camunda/operate/util/CollectionUtil.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/CollectionUtil.java
@@ -26,26 +26,29 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.opensearch.client.opensearch._types.FieldValue;
 
 public abstract class CollectionUtil {
 
-  public static <K, V> V getOrDefaultForNullValue(Map<K, V> map, K key, V defaultValue) {
+  public static <K, V> V getOrDefaultForNullValue(
+      final Map<K, V> map, final K key, final V defaultValue) {
     final V value = map.get(key);
     return value == null ? defaultValue : value;
   }
 
-  public static <K, T> T getOrDefaultFromMap(Map<K, T> map, K key, T defaultValue) {
+  public static <K, T> T getOrDefaultFromMap(
+      final Map<K, T> map, final K key, final T defaultValue) {
     return key == null ? defaultValue : map.getOrDefault(key, defaultValue);
   }
 
-  public static <T> T firstOrDefault(List<T> list, T defaultValue) {
+  public static <T> T firstOrDefault(final List<T> list, final T defaultValue) {
     return list.isEmpty() ? defaultValue : list.get(0);
   }
 
   @SafeVarargs
-  public static <T> List<T> throwAwayNullElements(T... array) {
+  public static <T> List<T> throwAwayNullElements(final T... array) {
     final List<T> listOfNotNulls = new ArrayList<>();
-    for (T o : array) {
+    for (final T o : array) {
       if (o != null) {
         listOfNotNulls.add(o);
       }
@@ -53,28 +56,29 @@ public abstract class CollectionUtil {
     return listOfNotNulls;
   }
 
-  public static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+  public static <T> Predicate<T> distinctByKey(final Function<? super T, ?> keyExtractor) {
     final Set<Object> seen = ConcurrentHashMap.newKeySet();
     return t -> seen.add(keyExtractor.apply(t));
   }
 
-  public static <T> List<T> emptyListWhenNull(List<T> aList) {
+  public static <T> List<T> emptyListWhenNull(final List<T> aList) {
     return aList == null ? Collections.emptyList() : aList;
   }
 
-  public static <T> List<T> withoutNulls(Collection<T> aCollection) {
+  public static <T> List<T> withoutNulls(final Collection<T> aCollection) {
     if (aCollection != null) {
       return filter(aCollection, Objects::nonNull);
     }
     return Collections.emptyList();
   }
 
-  public static <T, S> Map<T, List<S>> addToMap(Map<T, List<S>> map, T key, S value) {
+  public static <T, S> Map<T, List<S>> addToMap(
+      final Map<T, List<S>> map, final T key, final S value) {
     map.computeIfAbsent(key, k -> new ArrayList<S>()).add(value);
     return map;
   }
 
-  public static Map<String, Object> asMap(Object... keyValuePairs) {
+  public static Map<String, Object> asMap(final Object... keyValuePairs) {
     if (keyValuePairs == null || keyValuePairs.length % 2 != 0) {
       throw new OperateRuntimeException("keyValuePairs should not be null and has a even length.");
     }
@@ -85,49 +89,55 @@ public abstract class CollectionUtil {
     return result;
   }
 
-  public static <S, T> List<T> map(Collection<S> sourceList, Function<? super S, T> mapper) {
+  public static <S, T> List<T> map(
+      final Collection<S> sourceList, final Function<? super S, T> mapper) {
     return map(sourceList.stream(), mapper);
   }
 
-  public static <S, T> List<T> map(S[] sourceArray, Function<S, T> mapper) {
+  public static <S, T> List<T> map(final S[] sourceArray, final Function<S, T> mapper) {
     return map(Arrays.stream(sourceArray).parallel(), mapper);
   }
 
-  public static <S, T> List<T> map(Stream<S> sequenceStream, Function<? super S, T> mapper) {
+  public static <S, T> List<T> map(
+      final Stream<S> sequenceStream, final Function<? super S, T> mapper) {
     return sequenceStream.map(mapper).collect(Collectors.toList());
   }
 
-  public static <T> List<T> filter(Collection<T> collection, Predicate<T> predicate) {
+  public static <T> List<T> filter(final Collection<T> collection, final Predicate<T> predicate) {
     return filter(collection.stream(), predicate);
   }
 
-  public static <T> List<T> filter(Stream<T> filterStream, Predicate<T> predicate) {
+  public static <T> List<T> filter(final Stream<T> filterStream, final Predicate<T> predicate) {
     return filterStream.filter(predicate).collect(Collectors.toList());
   }
 
-  public static List<String> toSafeListOfStrings(Collection<?> aCollection) {
+  public static List<String> toSafeListOfStrings(final Collection<?> aCollection) {
     return map(withoutNulls(aCollection), Object::toString);
   }
 
-  public static String[] toSafeArrayOfStrings(Collection<?> aCollection) {
+  public static String[] toSafeArrayOfStrings(final Collection<?> aCollection) {
     return toSafeListOfStrings(aCollection).toArray(new String[] {});
   }
 
-  public static List<String> toSafeListOfStrings(Object... objects) {
+  public static List<String> toSafeListOfStrings(final Object... objects) {
     return toSafeListOfStrings(Arrays.asList(objects));
   }
 
-  public static List<Long> toSafeListOfLongs(Collection<String> aCollection) {
+  public static List<Long> toSafeListOfLongs(final Collection<String> aCollection) {
     return map(withoutNulls(aCollection), STRING_TO_LONG);
   }
 
-  public static <T> void addNotNull(Collection<T> collection, T object) {
+  public static List<FieldValue> toSafeListOfOSFieldValues(final Object... objects) {
+    return toSafeListOfStrings(Arrays.asList(objects)).stream().map(FieldValue::of).toList();
+  }
+
+  public static <T> void addNotNull(final Collection<T> collection, final T object) {
     if (collection != null && object != null) {
       collection.add(object);
     }
   }
 
-  public static List<Integer> fromTo(int from, int to) {
+  public static List<Integer> fromTo(final int from, final int to) {
     final List<Integer> result = new ArrayList<>();
     for (int i = from; i <= to; i++) {
       result.add(i);
@@ -135,15 +145,15 @@ public abstract class CollectionUtil {
     return result;
   }
 
-  public static boolean isNotEmpty(Collection<?> aCollection) {
+  public static boolean isNotEmpty(final Collection<?> aCollection) {
     return aCollection != null && !aCollection.isEmpty();
   }
 
-  public static boolean isEmpty(Collection<?> aCollection) {
+  public static boolean isEmpty(final Collection<?> aCollection) {
     return aCollection == null || aCollection.isEmpty();
   }
 
-  public static boolean isEmpty(Object... objects) {
+  public static boolean isEmpty(final Object... objects) {
     return objects == null || objects.length == 0;
   }
 
@@ -154,7 +164,8 @@ public abstract class CollectionUtil {
    * @param <E>
    * @return
    */
-  public static <E> List<E> splitAndGetSublist(List<E> list, int subsetCount, int subsetId) {
+  public static <E> List<E> splitAndGetSublist(
+      final List<E> list, final int subsetCount, final int subsetId) {
     if (subsetId >= subsetCount) {
       return new ArrayList<>();
     }
@@ -170,12 +181,12 @@ public abstract class CollectionUtil {
     return new ArrayList<>(list.subList(start, end));
   }
 
-  public static <T> T chooseOne(List<T> items) {
+  public static <T> T chooseOne(final List<T> items) {
     return items.get(new Random().nextInt(items.size()));
   }
 
-  public static <T> boolean allElementsAreOfType(Class clazz, T... array) {
-    for (T element : array) {
+  public static <T> boolean allElementsAreOfType(final Class clazz, final T... array) {
+    for (final T element : array) {
       if (!clazz.isInstance(element)) {
         return false;
       }
@@ -183,14 +194,14 @@ public abstract class CollectionUtil {
     return true;
   }
 
-  public static long countNonNullObjects(Object... objects) {
+  public static long countNonNullObjects(final Object... objects) {
     return Arrays.stream(objects).filter(Objects::nonNull).count();
   }
 
   public static <T> List<T> reversedView(final List<T> list) {
     return new AbstractList<T>() {
       @Override
-      public T get(int index) {
+      public T get(final int index) {
         return list.get(list.size() - 1 - index);
       }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchDecisionStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchDecisionStore.java
@@ -40,14 +40,14 @@ public class OpensearchDecisionStore implements DecisionStore {
   @Autowired private BeanFactory beanFactory;
 
   @Override
-  public Optional<Long> getDistinctCountFor(String fieldName) {
+  public Optional<Long> getDistinctCountFor(final String fieldName) {
     final var indexAlias = decisionIndex.getAlias();
     final var searchRequestBuilder =
         searchRequestBuilder(indexAlias)
             .query(matchAll())
             .size(0)
             .aggregations(
-                DISTINCT_FIELD_COUNTS, cardinalityAggregation(fieldName, 1_000)._toAggregation());
+                DISTINCT_FIELD_COUNTS, cardinalityAggregation(fieldName, 1_000).toAggregation());
 
     try {
       final var searchResponse =
@@ -55,7 +55,7 @@ public class OpensearchDecisionStore implements DecisionStore {
 
       return Optional.of(
           searchResponse.aggregations().get(DISTINCT_FIELD_COUNTS).cardinality().value());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error(
           String.format(
               "Error in distinct count for field %s in index alias %s.", fieldName, indexAlias),
@@ -70,7 +70,8 @@ public class OpensearchDecisionStore implements DecisionStore {
   }
 
   @Override
-  public long deleteDocuments(String indexName, String idField, String id) throws IOException {
+  public long deleteDocuments(final String indexName, final String idField, final String id)
+      throws IOException {
     return withIOException(
         () -> richOpenSearchClient.doc().delete(indexName, idField, id).deleted());
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchIncidentStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchIncidentStore.java
@@ -30,8 +30,6 @@ import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -44,8 +42,8 @@ public class OpensearchIncidentStore implements IncidentStore {
       TermQuery.of(
               q ->
                   q.field(IncidentTemplate.STATE).value(FieldValue.of(IncidentState.ACTIVE.name())))
-          ._toQuery();
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchIncidentStore.class);
+          .toQuery();
+
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
   @Autowired private IncidentTemplate incidentTemplate;
@@ -82,7 +80,7 @@ public class OpensearchIncidentStore implements IncidentStore {
                             IncidentTemplate.ERROR_TYPE,
                             ErrorType.values().length,
                             Map.of("_key", SortOrder.Asc))
-                        ._toAggregation()));
+                        .toAggregation()));
 
     final OpenSearchDocumentOperations.AggregatedResult<IncidentEntity> result =
         richOpenSearchClient.doc().scrollValuesAndAggregations(request, IncidentEntity.class);

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetricsStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetricsStore.java
@@ -84,7 +84,7 @@ public class OpensearchMetricsStore implements MetricsStore {
     final var searchRequestBuilder =
         searchRequestBuilder(metricTemplate.getFullQualifiedName())
             .query(query)
-            .aggregations(PROCESS_INSTANCES_AGG_NAME, sumAggregation(EVENT_VALUE)._toAggregation());
+            .aggregations(PROCESS_INSTANCES_AGG_NAME, sumAggregation(EVENT_VALUE).toAggregation());
 
     return searchWithSumAggregation(searchRequestBuilder, PROCESS_INSTANCES_AGG_NAME);
   }
@@ -100,8 +100,7 @@ public class OpensearchMetricsStore implements MetricsStore {
     final var searchRequestBuilder =
         searchRequestBuilder(metricTemplate.getFullQualifiedName())
             .query(query)
-            .aggregations(
-                DECISION_INSTANCES_AGG_NAME, sumAggregation(EVENT_VALUE)._toAggregation());
+            .aggregations(DECISION_INSTANCES_AGG_NAME, sumAggregation(EVENT_VALUE).toAggregation());
 
     return searchWithSumAggregation(searchRequestBuilder, DECISION_INSTANCES_AGG_NAME);
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -71,7 +71,7 @@ public class OpensearchProcessStore implements ProcessStore {
         searchRequestBuilder(processIndex.getAlias())
             .query(matchAll())
             .aggregations(
-                DISTINCT_FIELD_COUNTS, cardinalityAggregation(fieldName, 1_000)._toAggregation())
+                DISTINCT_FIELD_COUNTS, cardinalityAggregation(fieldName, 1_000).toAggregation())
             .size(0);
 
     try {
@@ -228,7 +228,7 @@ public class OpensearchProcessStore implements ProcessStore {
                         Map.of(
                             "incidents", incidentsQuery,
                             "running", runningQuery))
-                    ._toAggregation());
+                    .toAggregation());
 
     final Map<String, FiltersBucket> buckets =
         richOpenSearchClient

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/OpenSearchOperation.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/OpenSearchOperation.java
@@ -16,30 +16,30 @@ import org.opensearch.client.util.ObjectBuilderBase;
 import org.slf4j.Logger;
 
 public class OpenSearchOperation {
-  public static final int QUERY_MAX_SIZE = 10000;
   protected Logger logger;
 
-  public OpenSearchOperation(Logger logger) {
+  public OpenSearchOperation(final Logger logger) {
     this.logger = logger;
   }
 
-  protected String getIndex(ObjectBuilderBase builder) {
+  protected String getIndex(final ObjectBuilderBase builder) {
     try {
       final Field indexField = builder.getClass().getDeclaredField("index");
       indexField.setAccessible(true);
       return indexField.get(builder).toString();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       logger.error(String.format("Failed to get index from %s", builder.getClass().getName()));
       return "FAILED_INDEX";
     }
   }
 
-  protected <R> R safe(ExceptionSupplier<R> supplier, Function<Exception, String> errorMessage) {
+  protected <R> R safe(
+      final ExceptionSupplier<R> supplier, final Function<Exception, String> errorMessage) {
     try {
       return supplier.get();
-    } catch (OpenSearchException e) {
+    } catch (final OpenSearchException e) {
       throw e;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message = errorMessage.apply(e);
       logger.error(message, e);
       throw new OperateRuntimeException(message, e);

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchClusterOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchClusterOperations.java
@@ -13,11 +13,11 @@ import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.client.opensearch.cluster.HealthResponse;
-import org.opensearch.client.opensearch.nodes.Stats;
+import org.opensearch.client.opensearch.nodes.stats.Stats;
 import org.slf4j.Logger;
 
 public class OpenSearchClusterOperations extends OpenSearchSyncOperation {
-  public OpenSearchClusterOperations(Logger logger, OpenSearchClient openSearchClient) {
+  public OpenSearchClusterOperations(final Logger logger, final OpenSearchClient openSearchClient) {
     super(logger, openSearchClient);
   }
 
@@ -27,7 +27,7 @@ public class OpenSearchClusterOperations extends OpenSearchSyncOperation {
           openSearchClient.cluster().health(h -> h.timeout(t -> t.time("5s")));
       final HealthStatus status = response.status();
       return !response.timedOut() && !status.equals(HealthStatus.Red);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       logger.error(
           String.format(
               "Couldn't connect to OpenSearch due to %s. Return unhealthy state.", e.getMessage()),

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchRetryOperation.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchRetryOperation.java
@@ -11,16 +11,12 @@ import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.store.opensearch.client.OpenSearchFailedShardsException;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.function.CheckedSupplier;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch.tasks.GetTasksResponse;
-import org.opensearch.client.opensearch.tasks.Info;
 import org.slf4j.Logger;
 
 public abstract class OpenSearchRetryOperation extends OpenSearchSyncOperation {
@@ -94,13 +90,5 @@ public abstract class OpenSearchRetryOperation extends OpenSearchSyncOperation {
               + " seconds waiting.",
           e);
     }
-  }
-
-  protected GetTasksResponse task(final String id) throws IOException {
-    return openSearchClient.tasks().get(t -> t.taskId(id));
-  }
-
-  protected Map<String, Info> tasksWithActions(final List<String> actions) throws IOException {
-    return openSearchClient.tasks().list(l -> l.actions(actions)).tasks();
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/QueryDSL.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/QueryDSL.java
@@ -14,8 +14,10 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.BuiltinScriptLanguage;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -38,7 +40,8 @@ import org.opensearch.client.opensearch._types.query_dsl.WildcardQuery;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
 
 public interface QueryDSL {
-  String DEFAULT_SCRIPT_LANG = "painless";
+  ScriptLanguage DEFAULT_SCRIPT_LANG =
+      ScriptLanguage.builder().builtin(BuiltinScriptLanguage.Painless).build();
 
   private static <A> List<A> nonNull(final A[] items) {
     return nonNull(Arrays.asList(items));
@@ -54,11 +57,11 @@ public interface QueryDSL {
   }
 
   static Query and(final Query... queries) {
-    return BoolQuery.of(q -> q.must(nonNull(queries)))._toQuery();
+    return BoolQuery.of(q -> q.must(nonNull(queries))).toQuery();
   }
 
   static Query and(final List<Query> queries) {
-    return BoolQuery.of(q -> q.must(nonNull(queries)))._toQuery();
+    return BoolQuery.of(q -> q.must(nonNull(queries))).toQuery();
   }
 
   static Query withTenantCheck(final Query query) {
@@ -77,40 +80,40 @@ public interface QueryDSL {
   }
 
   static Query constantScore(final Query query) {
-    return ConstantScoreQuery.of(q -> q.filter(query))._toQuery();
+    return ConstantScoreQuery.of(q -> q.filter(query)).toQuery();
   }
 
   static Query exists(final String field) {
-    return ExistsQuery.of(q -> q.field(field))._toQuery();
+    return ExistsQuery.of(q -> q.field(field)).toQuery();
   }
 
   static <A> Query gt(final String field, final A gt) {
-    return RangeQuery.of(q -> q.field(field).gt(json(gt)))._toQuery();
+    return RangeQuery.of(q -> q.field(field).gt(json(gt))).toQuery();
   }
 
   static <A> Query gteLte(final String field, final A gte, final A lte) {
-    return RangeQuery.of(q -> q.field(field).gte(json(gte)).lte(json(lte)))._toQuery();
+    return RangeQuery.of(q -> q.field(field).gte(json(gte)).lte(json(lte))).toQuery();
   }
 
   static <A> Query gtLte(final String field, final A gt, final A lte) {
-    return RangeQuery.of(q -> q.field(field).gt(json(gt)).lte(json(lte)))._toQuery();
+    return RangeQuery.of(q -> q.field(field).gt(json(gt)).lte(json(lte))).toQuery();
   }
 
   static <A> Query gteLt(final String field, final A gte, final A lt) {
-    return RangeQuery.of(q -> q.field(field).gte(json(gte)).lt(json(lt)))._toQuery();
+    return RangeQuery.of(q -> q.field(field).gte(json(gte)).lt(json(lt))).toQuery();
   }
 
   static Query hasChildQuery(final String type, final Query query) {
     return HasChildQuery.of(q -> q.query(query).type(type).scoreMode(ChildScoreMode.None))
-        ._toQuery();
+        .toQuery();
   }
 
   static Query ids(final List<String> ids) {
-    return IdsQuery.of(q -> q.values(nonNull(ids)))._toQuery();
+    return IdsQuery.of(q -> q.values(nonNull(ids))).toQuery();
   }
 
   static Query ids(final Collection<String> ids) {
-    return IdsQuery.of(q -> q.values(ids.stream().toList()))._toQuery();
+    return IdsQuery.of(q -> q.values(ids.stream().toList())).toQuery();
   }
 
   static Query ids(final String... ids) {
@@ -133,11 +136,11 @@ public interface QueryDSL {
       final String field, final Collection<A> values, final Function<A, FieldValue> toFieldValue) {
     final List<FieldValue> fieldValues = values.stream().map(toFieldValue).toList();
     return TermsQuery.of(q -> q.field(field).terms(TermsQueryField.of(f -> f.value(fieldValues))))
-        ._toQuery();
+        .toQuery();
   }
 
   static <A> Query lte(final String field, final A lte) {
-    return RangeQuery.of(q -> q.field(field).lte(json(lte)))._toQuery();
+    return RangeQuery.of(q -> q.field(field).lte(json(lte))).toQuery();
   }
 
   static <A> Query match(
@@ -150,7 +153,7 @@ public interface QueryDSL {
         .query(toFieldValue.apply(value))
         .operator(operator)
         .build()
-        ._toQuery();
+        .toQuery();
   }
 
   static Query match(final String field, final String value, final Operator operator) {
@@ -158,23 +161,23 @@ public interface QueryDSL {
   }
 
   static Query matchAll() {
-    return new MatchAllQuery.Builder().build()._toQuery();
+    return new MatchAllQuery.Builder().build().toQuery();
   }
 
   static Query matchNone() {
-    return new MatchNoneQuery.Builder().build()._toQuery();
+    return new MatchNoneQuery.Builder().build().toQuery();
   }
 
   static Query not(final Query... queries) {
-    return BoolQuery.of(q -> q.mustNot(nonNull(queries)))._toQuery();
+    return BoolQuery.of(q -> q.mustNot(nonNull(queries))).toQuery();
   }
 
   static Query or(final Query... queries) {
-    return BoolQuery.of(q -> q.should(nonNull(queries)))._toQuery();
+    return BoolQuery.of(q -> q.should(nonNull(queries))).toQuery();
   }
 
   static Query prefix(final String field, final String value) {
-    return PrefixQuery.of(q -> q.field(field).value(value))._toQuery();
+    return PrefixQuery.of(q -> q.field(field).value(value)).toQuery();
   }
 
   static SortOrder reverseOrder(final SortOrder sortOrder) {
@@ -253,11 +256,11 @@ public interface QueryDSL {
 
   static <A> Query term(
       final String field, final A value, final Function<A, FieldValue> toFieldValue) {
-    return TermQuery.of(q -> q.field(field).value(toFieldValue.apply(value)))._toQuery();
+    return TermQuery.of(q -> q.field(field).value(toFieldValue.apply(value))).toQuery();
   }
 
   static Query wildcardQuery(final String field, final String value) {
-    return WildcardQuery.of(q -> q.field(field).value(value))._toQuery();
+    return WildcardQuery.of(q -> q.field(field).value(value)).toQuery();
   }
 
   static Query matchDateQuery(
@@ -267,6 +270,6 @@ public interface QueryDSL {
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math
     return RangeQuery.of(
             q -> q.field(name).gte(json(dateAsString)).lte(json(dateAsString)).format(dateFormat))
-        ._toQuery();
+        .toQuery();
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeStatisticsDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeStatisticsDao.java
@@ -68,7 +68,7 @@ public class OpensearchFlowNodeStatisticsDao implements FlowNodeStatisticsDao {
                 aggregationDSLWrapper.withSubaggregations(
                     aggregationDSLWrapper.termAggregation(FLOW_NODE_ID, TERMS_AGG_SIZE),
                     Map.of(
-                        COUNT_INCIDENT, queryDSLWrapper.term(INCIDENT, true)._toAggregation(),
+                        COUNT_INCIDENT, queryDSLWrapper.term(INCIDENT, true).toAggregation(),
                         COUNT_CANCELED,
                             queryDSLWrapper
                                 .and(
@@ -76,7 +76,7 @@ public class OpensearchFlowNodeStatisticsDao implements FlowNodeStatisticsDao {
                                         queryDSLWrapper.term(
                                             TYPE, FlowNodeType.MULTI_INSTANCE_BODY.name())),
                                     queryDSLWrapper.term(STATE, TERMINATED.name()))
-                                ._toAggregation(),
+                                .toAggregation(),
                         COUNT_COMPLETED,
                             queryDSLWrapper
                                 .and(
@@ -84,7 +84,7 @@ public class OpensearchFlowNodeStatisticsDao implements FlowNodeStatisticsDao {
                                         queryDSLWrapper.term(
                                             TYPE, FlowNodeType.MULTI_INSTANCE_BODY.name())),
                                     queryDSLWrapper.term(STATE, COMPLETED.name()))
-                                ._toAggregation(),
+                                .toAggregation(),
                         COUNT_ACTIVE,
                             queryDSLWrapper
                                 .and(
@@ -93,7 +93,7 @@ public class OpensearchFlowNodeStatisticsDao implements FlowNodeStatisticsDao {
                                             TYPE, FlowNodeType.MULTI_INSTANCE_BODY.name())),
                                     queryDSLWrapper.term(STATE, ACTIVE.name()),
                                     queryDSLWrapper.term(INCIDENT, false))
-                                ._toAggregation())))
+                                .toAggregation())))
             .size(0);
 
     return richOpenSearchClient

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
@@ -17,6 +17,7 @@ import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -96,7 +97,7 @@ public abstract class OpensearchSearchableDao<T, R> {
   protected void buildPaging(final Query<T> query, final SearchRequest.Builder request) {
     final Object[] searchAfter = query.getSearchAfter();
     if (searchAfter != null) {
-      request.searchAfter(CollectionUtil.toSafeListOfStrings(searchAfter));
+      request.searchAfter(CollectionUtil.toSafeListOfOSFieldValues(searchAfter));
     }
     request.size(query.getSize());
   }
@@ -114,12 +115,13 @@ public abstract class OpensearchSearchableDao<T, R> {
               .filter(Objects::nonNull)
               .toList();
 
-      final List<String> sortValues = hits.get(hits.size() - 1).sort();
+      final String[] sortValues =
+          hits.getLast().sort().stream().map(FieldValue::_toJsonString).toArray(String[]::new);
 
       return new Results<T>()
           .setTotal(results.total().value())
           .setItems(items)
-          .setSortValues(sortValues.toArray());
+          .setSortValues(sortValues);
     } else {
       return new Results<T>().setTotal(results.total().value());
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
@@ -265,7 +265,7 @@ public class OpenSearchQueryHelper {
       }
       rangeQueryBuilder.format(operateProperties.getOpensearch().getOsDateFormat());
 
-      return rangeQueryBuilder.build()._toQuery();
+      return rangeQueryBuilder.build().toQuery();
     }
     return null;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchBatchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchBatchOperationReader.java
@@ -13,19 +13,18 @@ import static io.camunda.operate.store.opensearch.dsl.QueryDSL.sortOptions;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.stringTerms;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 import static io.camunda.operate.util.CollectionUtil.reversedView;
-import static io.camunda.operate.util.ConversionUtils.toStringArray;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.ID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.reader.BatchOperationReader;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.util.Arrays;
 import java.util.List;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
@@ -100,7 +99,7 @@ public class OpensearchBatchOperationReader implements BatchOperationReader {
             .size(batchOperationRequestDto.getPageSize());
 
     if (querySearchAfter != null) {
-      searchRequestBuilder.searchAfter(Arrays.asList(toStringArray(querySearchAfter)));
+      searchRequestBuilder.searchAfter(CollectionUtil.toSafeListOfOSFieldValues(querySearchAfter));
     }
 
     return searchRequestBuilder;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionInstanceReader.java
@@ -9,7 +9,6 @@ package io.camunda.operate.webapp.opensearch.reader;
 
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
-import static io.camunda.operate.util.CollectionUtil.toSafeListOfStrings;
 import static io.camunda.operate.webapp.rest.dto.dmn.list.DecisionInstanceListRequestDto.SORT_BY_PROCESS_INSTANCE_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.*;
 import static io.camunda.webapps.schema.entities.dmn.DecisionInstanceState.EVALUATED;
@@ -268,7 +267,7 @@ public class OpensearchDecisionInstanceReader implements DecisionInstanceReader 
                 q.format(operateProperties.getOpensearch().getDateFormat());
                 return q;
               });
-      return query._toQuery();
+      return query.toQuery();
     }
     return null;
   }
@@ -343,7 +342,7 @@ public class OpensearchDecisionInstanceReader implements DecisionInstanceReader 
 
     searchRequest.sort(sort2).sort(sort3).size(request.getPageSize());
     if (querySearchAfter != null) {
-      searchRequest.searchAfter(toSafeListOfStrings(querySearchAfter));
+      searchRequest.searchAfter(CollectionUtil.toSafeListOfOSFieldValues(querySearchAfter));
     }
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchDecisionReader.java
@@ -102,7 +102,7 @@ public class OpensearchDecisionReader implements DecisionReader {
                                         sourceFields,
                                         TOPHITS_AGG_SIZE,
                                         sortOptions(DecisionIndex.VERSION, SortOrder.Desc))
-                                    ._toAggregation())))));
+                                    .toAggregation())))));
 
     final Map<String, List<DecisionDefinitionEntity>> result = new HashMap<>();
     final var response = richOpenSearchClient.doc().search(aggregationsRequest, Object.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
@@ -41,6 +41,7 @@ import io.camunda.operate.cache.ProcessCache;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
+import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.data.IncidentDataHolder;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
@@ -67,6 +68,7 @@ import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,7 +76,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch._types.aggregations.*;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -146,20 +147,19 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
                         latestFlowNodeAggName,
                         topHitsAggregation(
                                 List.of(STATE, TREE_PATH), 1, sortOptions(START_DATE, Desc))
-                            ._toAggregation()))));
+                            .toAggregation()))));
 
     final Aggregation finishedFlowNodesAggs =
         withSubaggregations(
             term(STATE, COMPLETED.name()),
             Map.of(
                 FINISHED_FLOW_NODES_BUCKETS_AGG_NAME,
-                termAggregation(FLOW_NODE_ID, TERMS_AGG_SIZE)._toAggregation()));
+                termAggregation(FLOW_NODE_ID, TERMS_AGG_SIZE).toAggregation()));
 
     final Aggregation incidentsAggs =
         withSubaggregations(
             term(INCIDENT, true),
-            Map.of(
-                AGG_INCIDENT_PATHS, termAggregation(TREE_PATH, TERMS_AGG_SIZE)._toAggregation()));
+            Map.of(AGG_INCIDENT_PATHS, termAggregation(TREE_PATH, TERMS_AGG_SIZE).toAggregation()));
 
     final var searchRequestBuilder =
         searchRequestBuilder(flowNodeInstanceTemplate)
@@ -321,7 +321,7 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
 
     final Aggregation runningParentsAgg =
         and(not(exists(END_DATE)), prefix(TREE_PATH, parentTreePath), term(LEVEL, level - 1))
-            ._toAggregation();
+            .toAggregation();
 
     final Query postFilter = and(term(LEVEL, level), prefix(TREE_PATH, parentTreePath), idsQuery);
 
@@ -391,25 +391,24 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
             || request.getSearchAfterOrEqual() != null
             || (request.getSearchBefore() == null && request.getSearchBeforeOrEqual() == null);
 
-    final Function<Object[], List<String>> toStrings =
-        objects -> Arrays.stream(objects).map(Object::toString).toList();
-
     if (directSorting) { // this sorting is also the default one for 1st page
       searchRequestBuilder.sort(sortOptions(START_DATE, Asc), sortOptions(ID, Asc));
       if (request.getSearchAfter() != null) {
-        searchRequestBuilder.searchAfter(toStrings.apply(request.getSearchAfter(objectMapper)));
+        searchRequestBuilder.searchAfter(
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchAfter(objectMapper)));
       } else if (request.getSearchAfterOrEqual() != null) {
         searchRequestBuilder.searchAfter(
-            toStrings.apply(request.getSearchAfterOrEqual(objectMapper)));
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchAfterOrEqual(objectMapper)));
       }
     } else { // searchBefore != null
       // reverse sorting
       searchRequestBuilder.sort(sortOptions(START_DATE, Desc), sortOptions(ID, Desc));
       if (request.getSearchBefore() != null) {
-        searchRequestBuilder.searchAfter(toStrings.apply(request.getSearchBefore(objectMapper)));
+        searchRequestBuilder.searchAfter(
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchBefore(objectMapper)));
       } else if (request.getSearchBeforeOrEqual() != null) {
         searchRequestBuilder.searchAfter(
-            toStrings.apply(request.getSearchBeforeOrEqual(objectMapper)));
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchBeforeOrEqual(objectMapper)));
       }
     }
   }
@@ -458,7 +457,7 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
             .query(withTenantCheck(term(PROCESS_INSTANCE_KEY, processInstanceId)))
             .size(0)
             .aggregations(
-                NUMBER_OF_INCIDENTS_FOR_TREE_PATH, filtersAggregation(filters)._toAggregation());
+                NUMBER_OF_INCIDENTS_FOR_TREE_PATH, filtersAggregation(filters).toAggregation());
 
     final Map<String, Long> flowNodeIdIncidents =
         richOpenSearchClient
@@ -633,7 +632,7 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
   private LongTermsBucket getBucketFromLevel(
       final Buckets<LongTermsBucket> buckets, final int level) {
     return buckets.array().stream()
-        .filter(b -> Integer.valueOf(b.key()).intValue() == level)
+        .filter(d -> d.key().signed().intValue() == level)
         .findFirst()
         .get();
   }
@@ -813,7 +812,7 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
         termAggregation(LEVEL, TERMS_AGG_SIZE, Map.of("_key", Asc)), // upper level first
         Map.of(
             LEVELS_TOP_HITS_AGG_NAME,
-            topHitsAggregation(1)._toAggregation()) // select one instance per each level
+            topHitsAggregation(1).toAggregation()) // select one instance per each level
         );
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
@@ -68,8 +68,6 @@ import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListViewReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListViewReader.java
@@ -220,7 +220,7 @@ public class OpensearchListViewReader implements ListViewReader {
     }
     searchRequest.size(request.getPageSize());
     if (querySearchAfter != null) {
-      searchRequest.searchAfter(CollectionUtil.toSafeListOfStrings(querySearchAfter));
+      searchRequest.searchAfter(CollectionUtil.toSafeListOfOSFieldValues(querySearchAfter));
     }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
@@ -132,7 +132,7 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
     }
 
     if (querySearchAfter != null) {
-      searchSourceBuilder.searchAfter(CollectionUtil.toSafeListOfStrings(querySearchAfter));
+      searchSourceBuilder.searchAfter(CollectionUtil.toSafeListOfOSFieldValues(querySearchAfter));
     }
 
     searchSourceBuilder

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
@@ -249,7 +249,7 @@ public class OpensearchOperationReader extends OpensearchAbstractReader implemen
                             BatchOperationTemplate.FAILED_OPERATIONS_COUNT, failedOperationQuery,
                             BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
                                 completedOperationQuery))
-                    ._toAggregation());
+                    .toAggregation());
     return searchRequestBuilder;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchVariableReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchVariableReader.java
@@ -9,7 +9,6 @@ package io.camunda.operate.webapp.opensearch.reader;
 
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
-import static io.camunda.operate.util.CollectionUtil.toSafeListOfStrings;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.FULL_VALUE;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.NAME;
 
@@ -17,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.reader.VariableReader;
 import io.camunda.operate.webapp.rest.dto.VariableDto;
@@ -225,19 +225,22 @@ public class OpensearchVariableReader implements VariableReader {
     if (directSorting) { // this sorting is also the default one for 1st page
       searchRequest.sort(sortOptions(NAME, SortOrder.Asc));
       if (request.getSearchAfter() != null) {
-        searchRequest.searchAfter(toSafeListOfStrings(request.getSearchAfter(objectMapper)));
+        searchRequest.searchAfter(
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchAfter(objectMapper)));
       } else if (request.getSearchAfterOrEqual() != null) {
-        searchRequest.searchAfter(toSafeListOfStrings(request.getSearchAfterOrEqual(objectMapper)));
+        searchRequest.searchAfter(
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchAfterOrEqual(objectMapper)));
       }
       searchRequest.size(request.getPageSize());
     } else { // searchBefore != null
       // reverse sorting
       searchRequest.sort(sortOptions(NAME, SortOrder.Desc));
       if (request.getSearchBefore() != null) {
-        searchRequest.searchAfter(toSafeListOfStrings(request.getSearchBefore(objectMapper)));
+        searchRequest.searchAfter(
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchBefore(objectMapper)));
       } else if (request.getSearchBeforeOrEqual() != null) {
         searchRequest.searchAfter(
-            toSafeListOfStrings(request.getSearchBeforeOrEqual(objectMapper)));
+            CollectionUtil.toSafeListOfOSFieldValues(request.getSearchBeforeOrEqual(objectMapper)));
       }
       searchRequest.size(request.getPageSize() + 1);
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregator.java
@@ -114,6 +114,6 @@ public class OpensearchDataAggregator extends DataAggregator {
                                 failedOperationQuery,
                                 BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
                                 completedOperationQuery))
-                        ._toAggregation())));
+                        .toAggregation())));
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -149,7 +150,7 @@ public class OpensearchSearchableDaoTest {
     final Hit<Object> validHit = Mockito.mock(Hit.class);
 
     when(validHit.source()).thenReturn(new Object());
-    when(validHit.sort()).thenReturn(Collections.singletonList("sortVal"));
+    when(validHit.sort()).thenReturn(Collections.singletonList(FieldValue.of("sortVal")));
     when(mockHitsMetadata.hits()).thenReturn(Collections.singletonList(validHit));
     when(mockHitsMetadata.total()).thenReturn(mockTotalHits);
     when(mockTotalHits.value()).thenReturn(1L);

--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -158,13 +158,6 @@ public abstract class AbstractCCSMIT extends AbstractIT {
     return embeddedOptimizeExtension.getConfigurationService().getConfiguredZeebe().getName();
   }
 
-  protected void waitUntilMinimumDataExportedCount(
-      final int minExportedEventCount,
-      final String indexName,
-      final TermsQueryContainer boolQueryBuilder) {
-    waitUntilMinimumDataExportedCount(minExportedEventCount, indexName, boolQueryBuilder, 15);
-  }
-
   protected void waitUntilMinimumProcessInstanceEventsExportedCount(
       final int minExportedEventCount) {
     waitUntilMinimumDataExportedCount(
@@ -188,7 +181,7 @@ public abstract class AbstractCCSMIT extends AbstractIT {
 
   protected void waitUntilRecordMatchingQueryExported(
       final long minRecordCount, final String indexName, final TermsQueryContainer boolQuery) {
-    waitUntilMinimumDataExportedCount(minRecordCount, indexName, boolQuery, 10);
+    waitUntilMinimumDataExportedCount(minRecordCount, indexName, boolQuery);
   }
 
   protected void waitUntilInstanceRecordWithElementIdExported(final String instanceElementId) {
@@ -271,21 +264,18 @@ public abstract class AbstractCCSMIT extends AbstractIT {
   }
 
   protected void waitUntilMinimumDataExportedCount(
-      final long minimumCount,
-      final String indexName,
-      final TermsQueryContainer queryContainer,
-      final long countTimeoutInSeconds) {
+      final long minimumCount, final String indexName, final TermsQueryContainer queryContainer) {
     final String expectedIndex = zeebeExtension.getZeebeRecordPrefix() + "-" + indexName;
     Awaitility.given()
         .ignoreExceptions()
-        .timeout(30, TimeUnit.SECONDS)
+        .timeout(60, TimeUnit.SECONDS)
         .untilAsserted(
             () ->
                 assertThat(databaseIntegrationTestExtension.zeebeIndexExists(expectedIndex))
                     .isTrue());
     Awaitility.given()
         .ignoreExceptions()
-        .timeout(countTimeoutInSeconds, TimeUnit.SECONDS)
+        .timeout(60, TimeUnit.SECONDS)
         .untilAsserted(
             () ->
                 assertThat(
@@ -406,6 +396,6 @@ public abstract class AbstractCCSMIT extends AbstractIT {
         elementType.name());
     query.addTermQuery(ZeebeProcessInstanceRecordDto.Fields.intent, intent.name().toUpperCase());
     waitUntilMinimumDataExportedCount(
-        1, DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, query, 10);
+        1, DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, query);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
@@ -702,7 +702,7 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
     final Aggregation subAggregation =
         AggregationDSL.valueCountAggregation(
                 String.join(".", FLOW_NODE_INSTANCES, ProcessInstanceIndex.FLOW_NODE_INSTANCE_ID))
-            ._toAggregation();
+            .toAggregation();
     final NestedAggregation termsAgg =
         new NestedAggregation.Builder().path(FLOW_NODE_INSTANCES).build();
     final Aggregation agg =
@@ -728,7 +728,7 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
             .aggregations()
             .get(FLOW_NODE_INSTANCES + FREQUENCY_AGGREGATION)
             .valueCount();
-    return (long) countAggregator.value();
+    return Math.round(countAggregator.value());
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/AssigneeAndCandidateGroupsReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/AssigneeAndCandidateGroupsReaderOS.java
@@ -116,7 +116,7 @@ public class AssigneeAndCandidateGroupsReaderOS implements AssigneeAndCandidateG
     final Aggregation userTasksAgg =
         AggregationDSL.withSubaggregations(
             nestedAgg,
-            Collections.singletonMap(COMPOSITE_AGG, assigneeCompositeAgg._toAggregation()));
+            Collections.singletonMap(COMPOSITE_AGG, assigneeCompositeAgg.toAggregation()));
 
     final List<String> termsBatch = new ArrayList<>();
     final OpenSearchCompositeAggregationScroller compositeAggregationScroller =
@@ -128,7 +128,7 @@ public class AssigneeAndCandidateGroupsReaderOS implements AssigneeAndCandidateG
             .size(0)
             .setPathToAggregation(NESTED_USER_TASKS_AGG, COMPOSITE_AGG)
             .setCompositeBucketConsumer(
-                bucket -> termsBatch.add((bucket.key()).get(TERMS_AGG).to(String.class)));
+                bucket -> termsBatch.add((bucket.key()).get(TERMS_AGG).stringValue()));
     boolean hasPage;
     do {
       hasPage = compositeAggregationScroller.consumePage();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/BackupReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/BackupReaderOS.java
@@ -118,7 +118,7 @@ public class BackupReaderOS extends AbstractBackupReader {
   }
 
   private static SnapshotInfoDto toSnapshotInfoDto(final SnapshotInfo snapshotInfo) {
-    final long startTimeMillis = Long.parseLong(snapshotInfo.startTimeInMillis());
+    final long startTimeMillis = snapshotInfo.startTimeInMillis();
     final List<String> shardFailures =
         snapshotInfo.shards().failures().stream().map(ShardFailure::toString).toList();
     return new SnapshotInfoDto(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionInstanceReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionInstanceReaderOS.java
@@ -59,7 +59,7 @@ public class DefinitionInstanceReaderOS extends DefinitionInstanceReader {
     final String defKeyAggName = "definitionKeyAggregation";
     final Aggregation definitionKeyAgg =
         termAggregation(resolveDefinitionKeyFieldForType(type), MAX_RESPONSE_SIZE_LIMIT)
-            ._toAggregation();
+            .toAggregation();
     final SearchRequest.Builder requestBuilder =
         new SearchRequest.Builder()
             .index(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/DefinitionReaderOS.java
@@ -220,7 +220,7 @@ public class DefinitionReaderOS implements DefinitionReader {
                     .toQuery())
             .size(0)
             .aggregations(
-                Collections.singletonMap(ENGINE_AGGREGATION, enginesAggregation._toAggregation()));
+                Collections.singletonMap(ENGINE_AGGREGATION, enginesAggregation.toAggregation()));
 
     final String errorMessage =
         String.format(
@@ -288,8 +288,8 @@ public class DefinitionReaderOS implements DefinitionReader {
         Aggregation.of(
             a ->
                 a.composite(keyAndTypeAndTenantAggregation)
-                    .aggregations(NAME_AGGREGATION, nameAggregation._toAggregation())
-                    .aggregations(ENGINE_AGGREGATION, enginesAggregation._toAggregation()));
+                    .aggregations(NAME_AGGREGATION, nameAggregation.toAggregation())
+                    .aggregations(ENGINE_AGGREGATION, enginesAggregation.toAggregation()));
 
     final Map<String, List<CompositeBucket>> keyAndTypeAggBucketsByTenantId = new HashMap<>();
 
@@ -304,7 +304,7 @@ public class DefinitionReaderOS implements DefinitionReader {
         .setPathToAggregation(DEFINITION_KEY_AND_TYPE_AND_TENANT_AGGREGATION)
         .setCompositeBucketConsumer(
             bucket -> {
-              final String tenantId = (bucket.key()).get(TENANT_AGGREGATION).to(String.class);
+              final String tenantId = (bucket.key()).get(TENANT_AGGREGATION).stringValue();
               if (!keyAndTypeAggBucketsByTenantId.containsKey(tenantId)) {
                 keyAndTypeAggBucketsByTenantId.put(tenantId, new ArrayList<>());
               }
@@ -323,9 +323,9 @@ public class DefinitionReaderOS implements DefinitionReader {
                   .map(
                       parsedBucket -> {
                         final String indexAliasName =
-                            parsedBucket.key().get(DEFINITION_TYPE_AGGREGATION).to(String.class);
+                            parsedBucket.key().get(DEFINITION_TYPE_AGGREGATION).stringValue();
                         final String definitionKey =
-                            parsedBucket.key().get(DEFINITION_KEY_AGGREGATION).to(String.class);
+                            parsedBucket.key().get(DEFINITION_KEY_AGGREGATION).stringValue();
                         final String definitionName =
                             parsedBucket
                                 .aggregations()
@@ -430,7 +430,7 @@ public class DefinitionReaderOS implements DefinitionReader {
                     AggregationDSL.withSubaggregations(
                         versionAggregation,
                         Collections.singletonMap(
-                            VERSION_TAG_AGGREGATION, versionTagAggregation._toAggregation()))))
+                            VERSION_TAG_AGGREGATION, versionTagAggregation.toAggregation()))))
             .size(0);
 
     final String errorMessage =
@@ -645,10 +645,10 @@ public class DefinitionReaderOS implements DefinitionReader {
 
     subAggregations.put(
         "versionForSorting",
-        AggregationBuilders.min().script(numericVersionScript).build()._toAggregation());
+        AggregationBuilders.min().script(numericVersionScript).build().toAggregation());
 
     subAggregations.put(
-        "topHits", AggregationDSL.topHitsAggregation(1)._toAggregation() // Use size=1
+        "topHits", AggregationDSL.topHitsAggregation(1).toAggregation() // Use size=1
         );
 
     final Aggregation definitionAgg =
@@ -711,7 +711,7 @@ public class DefinitionReaderOS implements DefinitionReader {
                 AggregationBuilders.min()
                     .script(createDefaultScript("Integer.parseInt(doc['version'].value)"))
                     .build()
-                    ._toAggregation()));
+                    .toAggregation()));
 
     // 2.3 group by engine
     final TermsAggregation enginesAggregation =
@@ -745,9 +745,9 @@ public class DefinitionReaderOS implements DefinitionReader {
 
     final Aggregation.Builder complexKeyAndTypeAggregationBuilder =
         new Aggregation.Builder()
-            .aggregations(TENANT_AGGREGATION, tenantsAggregation._toAggregation())
+            .aggregations(TENANT_AGGREGATION, tenantsAggregation.toAggregation())
             .aggregations(NAME_AGGREGATION, nameAggregationSub)
-            .aggregations(ENGINE_AGGREGATION, enginesAggregation._toAggregation());
+            .aggregations(ENGINE_AGGREGATION, enginesAggregation.toAggregation());
 
     final List<CompositeBucket> keyAndTypeAggBuckets =
         performSearchAndCollectAllKeyAndTypeBuckets(
@@ -761,9 +761,9 @@ public class DefinitionReaderOS implements DefinitionReader {
         .map(
             keyAndTypeAgg -> {
               final String indexAliasName =
-                  keyAndTypeAgg.key().get(DEFINITION_TYPE_AGGREGATION).to(String.class);
+                  keyAndTypeAgg.key().get(DEFINITION_TYPE_AGGREGATION).stringValue();
               final String definitionKey =
-                  keyAndTypeAgg.key().get(DEFINITION_KEY_AGGREGATION).to(String.class);
+                  keyAndTypeAgg.key().get(DEFINITION_KEY_AGGREGATION).stringValue();
               final StringTermsAggregate tenantResult =
                   keyAndTypeAgg.aggregations().get(TENANT_AGGREGATION).sterms();
               final StringTermsAggregate nameResult =
@@ -841,9 +841,9 @@ public class DefinitionReaderOS implements DefinitionReader {
     while (!keyAndTypeAggregationResult.buckets().array().isEmpty()) {
       keyAndTypeAggBuckets.addAll(keyAndTypeAggregationResult.buckets().array());
 
-      final Map<String, String> keysToTypes =
+      final Map<String, FieldValue> keysToTypes =
           keyAndTypeAggregationResult.afterKey().entrySet().stream()
-              .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().to(String.class)));
+              .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()));
 
       final Aggregation.Builder keyTypeAggregationTempBuilder =
           new Aggregation.Builder().aggregations(keyTypeAggregation.aggregations());

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/EntitiesReaderOS.java
@@ -180,7 +180,7 @@ public class EntitiesReaderOS implements EntitiesReader {
             .map(
                 collectionId -> {
                   final Aggregation termsAggregation =
-                      new TermsAggregation.Builder().field(INDEX_FIELD).build()._toAggregation();
+                      new TermsAggregation.Builder().field(INDEX_FIELD).build().toAggregation();
                   final Aggregation aggregation =
                       new Aggregation.Builder()
                           .filter(term(COLLECTION_ID, collectionId))

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ProcessDefinitionReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ProcessDefinitionReaderOS.java
@@ -81,7 +81,7 @@ public class ProcessDefinitionReaderOS implements ProcessDefinitionReader {
                 new TermsAggregation.Builder()
                     .field(ProcessDefinitionIndex.PROCESS_DEFINITION_KEY)
                     .build()
-                    ._toAggregation())
+                    .toAggregation())
             .source(new SourceConfig.Builder().fetch(false).build());
 
     final String errorMessage = "Was not able to fetch non-onboarded process definition keys.";

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/AvgAggregationOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/AvgAggregationOS.java
@@ -40,6 +40,6 @@ public class AvgAggregationOS extends AggregationStrategyOS {
     final AverageAggregation.Builder builder = new AverageAggregation.Builder().script(script);
     AggregationResultMappingUtil.firstField(fields).ifPresent(builder::field);
     return Pair.of(
-        createAggregationName(customIdentifier, AVG_AGGREGATION), builder.build()._toAggregation());
+        createAggregationName(customIdentifier, AVG_AGGREGATION), builder.build().toAggregation());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/MaxAggregationOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/MaxAggregationOS.java
@@ -40,6 +40,6 @@ public class MaxAggregationOS extends AggregationStrategyOS {
     final MaxAggregation.Builder builder = new MaxAggregation.Builder().script(script);
     AggregationResultMappingUtil.firstField(fields).ifPresent(builder::field);
     return Pair.of(
-        createAggregationName(customIdentifier, MAX_AGGREGATION), builder.build()._toAggregation());
+        createAggregationName(customIdentifier, MAX_AGGREGATION), builder.build().toAggregation());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/MinAggregationOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/MinAggregationOS.java
@@ -40,6 +40,6 @@ public class MinAggregationOS extends AggregationStrategyOS {
     final MinAggregation.Builder builder = new MinAggregation.Builder().script(script);
     AggregationResultMappingUtil.firstField(fields).ifPresent(builder::field);
     return Pair.of(
-        createAggregationName(customIdentifier, MIN_AGGREGATION), builder.build()._toAggregation());
+        createAggregationName(customIdentifier, MIN_AGGREGATION), builder.build().toAggregation());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/PercentileAggregationOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/PercentileAggregationOS.java
@@ -58,7 +58,7 @@ public class PercentileAggregationOS extends AggregationStrategyOS {
     return Pair.of(
         createAggregationName(
             customIdentifier, String.valueOf(percentileValue), PERCENTILE_AGGREGATION),
-        builder.build()._toAggregation());
+        builder.build().toAggregation());
   }
 
   private Double mapToDoubleOrNull(
@@ -66,7 +66,7 @@ public class PercentileAggregationOS extends AggregationStrategyOS {
     final Double percentile =
         Optional.ofNullable(aggregation.values())
             .filter(h -> h.keyed().get(Double.toString(percentileValue)) != null)
-            .map(h -> Double.parseDouble(h.keyed().get(Double.toString(percentileValue))))
+            .map(h -> h.keyed().get(Double.toString(percentileValue)).to(Double.class))
             .orElse(null);
     return percentile == null || Double.isNaN(percentile) || Double.isInfinite(percentile)
         ? null

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/SumAggregationOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/aggregations/SumAggregationOS.java
@@ -40,6 +40,6 @@ public class SumAggregationOS extends AggregationStrategyOS {
     final SumAggregation.Builder builder = new SumAggregation.Builder().script(script);
     AggregationResultMappingUtil.firstField(fields).ifPresent(builder::field);
     return Pair.of(
-        createAggregationName(customIdentifier, SUM_AGGREGATION), builder.build()._toAggregation());
+        createAggregationName(customIdentifier, SUM_AGGREGATION), builder.build().toAggregation());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/ProcessDistributedByVariableInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/distributedby/process/ProcessDistributedByVariableInterpreterOS.java
@@ -154,7 +154,7 @@ public class ProcessDistributedByVariableInterpreterOS
                 variableSubAggregation.get().getKey(),
                 variableSubAggregation.get().getValue(),
                 FILTERED_INSTANCE_COUNT_AGGREGATION,
-                new ReverseNestedAggregation.Builder().build()._toAggregation()));
+                new ReverseNestedAggregation.Builder().build().toAggregation()));
     final Aggregation nestedVariableAggregation =
         withSubaggregations(
             new Builder().path(VARIABLES).build(),

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/util/ProcessPartQueryUtilOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/util/ProcessPartQueryUtilOS.java
@@ -89,7 +89,7 @@ public final class ProcessPartQueryUtilOS extends AbstractProcessPartQueryUtil {
               .reduceScript(getReduceScript())
               .params(params)
               .build()
-              ._toAggregation();
+              .toAggregation();
         };
 
     final Map<String, Aggregation> aggregations =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/ProcessViewRawDataInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/ProcessViewRawDataInterpreterOS.java
@@ -224,7 +224,7 @@ public class ProcessViewRawDataInterpreterOS extends AbstractProcessViewRawDataI
           if (sorting.isPresent()
               && sorting.get().getBy().isPresent()
               && ProcessInstanceIndex.DURATION.equals(sorting.get().getBy().get())) {
-            processInstance.setDuration(Math.round(Double.parseDouble(hit.sort().get(0))));
+            processInstance.setDuration(Math.round(hit.sort().getFirst().doubleValue()));
           } else {
             final long currentTime = this.<Long>getField(hit, CURRENT_TIME);
             processInstance.setDuration(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/service/DateAggregationServiceOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/service/DateAggregationServiceOS.java
@@ -164,7 +164,8 @@ public class DateAggregationServiceOS extends DateAggregationService {
   private Map<String, Map<String, Aggregate>> multiBucketAggregation(final Aggregate aggregate) {
     if (aggregate.isDateHistogram()) {
       return aggregate.dateHistogram().buckets().array().stream()
-          .collect(Collectors.toMap(DateHistogramBucket::key, DateHistogramBucket::aggregations));
+          .collect(
+              Collectors.toMap(b -> String.valueOf(b.key()), DateHistogramBucket::aggregations));
     } else if (aggregate.isDateRange()) {
       return aggregate.dateRange().buckets().array().stream()
           .collect(Collectors.toMap(RangeBucket::key, RangeBucket::aggregations));

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/service/MinMaxStatsServiceOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/service/MinMaxStatsServiceOS.java
@@ -148,7 +148,7 @@ public class MinMaxStatsServiceOS extends AbstractMinMaxStatsService {
     final Pair<String, Aggregation> basicAggregation =
         Pair.of(
             STATS_AGGREGATION_FIRST_FIELD,
-            new StatsAggregation.Builder().script(script).build()._toAggregation());
+            new StatsAggregation.Builder().script(script).build().toAggregation());
 
     final Pair<String, Aggregation> aggregation =
         filterQuery == null
@@ -312,7 +312,7 @@ public class MinMaxStatsServiceOS extends AbstractMinMaxStatsService {
     if (format != null) {
       builder.format(format);
     }
-    return builder.build()._toAggregation();
+    return builder.build().toAggregation();
   }
 
   private MinMaxStatDto mapCrossFieldStatAggregationsToStatDto(final SearchResponse<?> response) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/AlertWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/AlertWriterOS.java
@@ -94,7 +94,7 @@ public class AlertWriterOS implements AlertWriter {
               return errorMessage + e.getMessage();
             });
 
-    if (response.shards().failed().intValue() > 0) {
+    if (response.shards().failed() > 0) {
       final String errorMessage =
           format(
               "Was not able to update alert with id [%s] and name [%s]. Error during the update in Opensearch.",

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/CollectionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/CollectionWriterOS.java
@@ -83,7 +83,7 @@ public class CollectionWriterOS implements CollectionWriter {
             id, collection.getName());
     final UpdateResponse updateResponse = osClient.update(request, errorMessage);
 
-    if (updateResponse.shards().failed().intValue() > 0) {
+    if (updateResponse.shards().failed() > 0) {
       LOG.error(
           "Was not able to update collection with id [{}] and name [{}].",
           id,
@@ -346,7 +346,7 @@ public class CollectionWriterOS implements CollectionWriter {
 
     final UpdateResponse updateResponse = osClient.update(request, errorMessage);
 
-    if (updateResponse.shards().failed().intValue() > 0) {
+    if (updateResponse.shards().failed() > 0) {
       final String message = String.format(errorMessage, collectionId);
       LOG.error(message, collectionId);
       throw new OptimizeRuntimeException(message);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/DashboardWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/DashboardWriterOS.java
@@ -140,7 +140,7 @@ public class DashboardWriterOS implements DashboardWriter {
 
     final UpdateResponse<Void> updateResponse = osClient.update(request, errorMessage);
 
-    if (updateResponse.shards().failed().intValue() > 0) {
+    if (updateResponse.shards().failed() > 0) {
       LOG.error(
           "Was not able to update dashboard with id [{}] and name [{}].", id, dashboard.getName());
       throw new OptimizeRuntimeException("Was not able to update dashboard!");

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
@@ -385,7 +385,7 @@ public class ReportWriterOS implements ReportWriter {
 
     final UpdateResponse<ReportDefinitionUpdateDto> updateResponse =
         osClient.update(request, errorMessage);
-    if (updateResponse.shards().failed().intValue() > 0) {
+    if (updateResponse.shards().failed() > 0) {
       LOG.error(
           "Was not able to update report with id [{}] and name [{}].",
           updatedReport.getId(),

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/VariableRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/VariableRepositoryOS.java
@@ -478,7 +478,7 @@ public class VariableRepositoryOS implements VariableRepository {
         AggregationDSL.withSubaggregations(
             nestedAgg,
             Collections.singletonMap(
-                VAR_NAME_AND_TYPE_COMPOSITE_AGG, varNameAndTypeAgg._toAggregation()));
+                VAR_NAME_AND_TYPE_COMPOSITE_AGG, varNameAndTypeAgg.toAggregation()));
 
     final List<String> indicesToTarget =
         processDefinitionKeysToTarget.stream()
@@ -507,9 +507,9 @@ public class VariableRepositoryOS implements VariableRepository {
       final Map<String, DefinitionVariableLabelsDto> definitionLabelsByKey) {
     final String processDefinitionKey =
         extractProcessDefinitionKeyFromIndexName(
-            (bucket.key().get(INDEX_AGGREGATION).to(String.class)));
-    final String variableName = bucket.key().get(NAME_AGGREGATION).to(String.class);
-    final String variableType = bucket.key().get(TYPE_AGGREGATION).to(String.class);
+            (bucket.key().get(INDEX_AGGREGATION).stringValue()));
+    final String variableName = bucket.key().get(NAME_AGGREGATION).stringValue();
+    final String variableType = bucket.key().get(TYPE_AGGREGATION).stringValue();
     return processVariableNameResponseDtoFrom(
         definitionLabelsByKey, processDefinitionKey, variableName, variableType);
   }
@@ -544,7 +544,7 @@ public class VariableRepositoryOS implements VariableRepository {
         if (valueBucket.keyAsString() != null) {
           allValues.add(valueBucket.keyAsString());
         } else {
-          allValues.add(String.valueOf(valueBucket.key()));
+          allValues.add(String.valueOf(valueBucket.key().signed()));
         }
       }
     }
@@ -565,7 +565,7 @@ public class VariableRepositoryOS implements VariableRepository {
             .build();
 
     filterForVariableWithGivenIdAndPrefix.aggregations(
-        Map.of(VALUE_AGGREGATION, collectAllVariableValues._toAggregation()));
+        Map.of(VALUE_AGGREGATION, collectAllVariableValues.toAggregation()));
 
     final NestedAggregation.Builder nestedAgg = new NestedAggregation.Builder().path(variablePath);
     final Aggregation finalAgg =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/os/AbstractZeebeRecordFetcherOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/os/AbstractZeebeRecordFetcherOS.java
@@ -70,9 +70,8 @@ public abstract class AbstractZeebeRecordFetcherOS<T> extends AbstractZeebeRecor
     final SearchResponse<T> searchResponse =
         osClient.getOpenSearchClient().search(builder.build(), getRecordDtoClass());
     if (!searchResponse.shards().failures().isEmpty()
-        || (searchResponse.shards().total().intValue()
-            > (searchResponse.shards().failures().size()
-                + searchResponse.shards().successful().intValue()))) {
+        || (searchResponse.shards().total()
+            > (searchResponse.shards().failures().size() + searchResponse.shards().successful()))) {
       throw new OptimizeRuntimeException("Not all shards could be searched successfully");
     }
     return searchResponse.hits().hits().stream().map(Hit::source).toList();

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -66,8 +66,6 @@
     <previous.optimize.elasticsearch.version>8.13.0</previous.optimize.elasticsearch.version>
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->
     <elasticsearch.log4j.version>2.24.2</elasticsearch.log4j.version>
-    <!-- OpenSearch-->
-    <opensearch.client.version>2.26.0</opensearch.client.version>
     <!-- The least supported opensearch version we should test against-->
     <opensearch.test.version>2.17.0</opensearch.test.version>
     <!-- the opensearch version of the previous Optimize version -->

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/os/index/UpdateLogEntryIndexOS.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/os/index/UpdateLogEntryIndexOS.java
@@ -18,6 +18,6 @@ public class UpdateLogEntryIndexOS extends UpdateLogEntryIndex<Builder> {
   @Override
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder contentBuilder) {
-    return contentBuilder.numberOfShards(Integer.toString(value));
+    return contentBuilder.numberOfShards(value);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/RenameFieldTestIndexOS.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/RenameFieldTestIndexOS.java
@@ -18,6 +18,6 @@ public class RenameFieldTestIndexOS extends RenameFieldTestIndex<Builder> {
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder indexSettingsBuilder)
       throws IOException {
-    return indexSettingsBuilder.numberOfShards(Integer.toString(value));
+    return indexSettingsBuilder.numberOfShards(value);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestIndexOS.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestIndexOS.java
@@ -22,6 +22,6 @@ public class UserTestIndexOS extends UserTestIndex<Builder> {
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder indexSettingsBuilder)
       throws IOException {
-    return indexSettingsBuilder.numberOfShards(Integer.toString(value));
+    return indexSettingsBuilder.numberOfShards(value);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestUpdatedMappingIndexOS.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestUpdatedMappingIndexOS.java
@@ -18,6 +18,6 @@ public class UserTestUpdatedMappingIndexOS extends UserTestUpdatedMappingIndex<B
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder indexSettingsBuilder)
       throws IOException {
-    return indexSettingsBuilder.numberOfShards(Integer.toString(value));
+    return indexSettingsBuilder.numberOfShards(value);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestWithTemplateIndexOS.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestWithTemplateIndexOS.java
@@ -20,6 +20,6 @@ public class UserTestWithTemplateIndexOS extends UserTestWithTemplateIndex<Build
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder indexSettingsBuilder)
       throws IOException {
-    return indexSettingsBuilder.numberOfShards(Integer.toString(value));
+    return indexSettingsBuilder.numberOfShards(value);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestWithTemplateUpdatedMappingIndexOS.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/UserTestWithTemplateUpdatedMappingIndexOS.java
@@ -19,6 +19,6 @@ public class UserTestWithTemplateUpdatedMappingIndexOS
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder indexSettingsBuilder)
       throws IOException {
-    return indexSettingsBuilder.numberOfShards(Integer.toString(value));
+    return indexSettingsBuilder.numberOfShards(value);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/VariableUpdateInstanceIndexOldOS.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/indices/VariableUpdateInstanceIndexOldOS.java
@@ -16,6 +16,6 @@ public class VariableUpdateInstanceIndexOldOS extends VariableUpdateInstanceInde
   @Override
   public Builder addStaticSetting(
       final String key, final int value, final Builder indexSettingsBuilder) throws IOException {
-    return indexSettingsBuilder.numberOfShards(Integer.toString(value));
+    return indexSettingsBuilder.numberOfShards(value);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchUtil.java
@@ -19,7 +19,7 @@ public final class OptimizeOpenSearchUtil {
   public static IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder contentBuilder) {
     if (NUMBER_OF_SHARDS_SETTING.equalsIgnoreCase(key)) {
-      return contentBuilder.numberOfShards(Integer.toString(value));
+      return contentBuilder.numberOfShards(value);
     } else {
       throw new NotSupportedException(
           "Cannot set property "

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/dsl/QueryDSL.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/dsl/QueryDSL.java
@@ -16,9 +16,11 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.BuiltinScriptLanguage;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.ScriptField;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery.Builder;
@@ -40,7 +42,8 @@ import org.opensearch.client.opensearch.core.search.SourceConfig;
 
 public interface QueryDSL {
 
-  String DEFAULT_SCRIPT_LANG = "painless";
+  ScriptLanguage DEFAULT_SCRIPT_LANG =
+      ScriptLanguage.builder().builtin(BuiltinScriptLanguage.Painless).build();
 
   private static <A> List<A> nonNull(final A[] items) {
     return nonNull(Arrays.asList(items));

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.ShardFailure;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
@@ -376,10 +377,11 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
 
   public long deleteByQuery(final Query query, final boolean refresh, final String... indexes) {
     final List<String> listIndexes = List.of(indexes);
+    final Refresh refreshPolicy = refresh ? Refresh.True : Refresh.False;
     final DeleteByQueryRequest request =
         applyIndexPrefix(deleteByQueryRequestBuilder(listIndexes))
             .query(query)
-            .refresh(refresh)
+            .refresh(refreshPolicy)
             .build();
     final DeleteByQueryResponse response;
     Long status;
@@ -407,7 +409,7 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
     final UpdateByQueryRequest request =
         applyIndexPrefix(updateByQueryRequestBuilder(List.of(index)))
             .query(query)
-            .refresh(true)
+            .refresh(Refresh.True)
             .script(script)
             .build();
     final UpdateByQueryResponse response;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchTaskOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchTaskOperations.java
@@ -9,12 +9,11 @@ package io.camunda.optimize.service.db.os.client.sync;
 
 import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
-import org.opensearch.client.opensearch.tasks.Info;
+import org.opensearch.client.opensearch.tasks.TaskInfo;
 
 public class OpenSearchTaskOperations extends OpenSearchRetryOperation {
 
@@ -33,7 +32,7 @@ public class OpenSearchTaskOperations extends OpenSearchRetryOperation {
   }
 
   @Override
-  public Map<String, Info> tasksWithActions(final List<String> actions) {
+  public List<TaskInfo> tasksWithActions(final List<String> actions) {
     return safe(
         () -> super.tasksWithActions(actions),
         e ->

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchIndexSettingsBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchIndexSettingsBuilder.java
@@ -35,7 +35,7 @@ import org.opensearch.client.opensearch._types.analysis.TruncateTokenFilter;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettingsAnalysis;
 import org.opensearch.client.opensearch.indices.IndexSettingsMapping;
-import org.opensearch.client.opensearch.indices.IndexSettingsMappingLimit;
+import org.opensearch.client.opensearch.indices.IndexSettingsMappingLimitNestedObjects;
 import org.springframework.context.annotation.Conditional;
 
 @Conditional(OpenSearchCondition.class)
@@ -76,12 +76,11 @@ public class OpenSearchIndexSettingsBuilder {
             new Time.Builder()
                 .time(configurationService.getOpenSearchConfiguration().getRefreshInterval())
                 .build())
-        .numberOfReplicas(
-            String.valueOf(configurationService.getOpenSearchConfiguration().getNumberOfReplicas()))
+        .numberOfReplicas(configurationService.getOpenSearchConfiguration().getNumberOfReplicas())
         .mapping(
             new IndexSettingsMapping.Builder()
                 .nestedObjects(
-                    new IndexSettingsMappingLimit.Builder()
+                    new IndexSettingsMappingLimitNestedObjects.Builder()
                         .limit(
                             (long)
                                 configurationService
@@ -131,7 +130,7 @@ public class OpenSearchIndexSettingsBuilder {
                                     TokenChar.Punctuation,
                                     TokenChar.Symbol))
                             .build()
-                            ._toTokenizerDefinition())
+                            .toTokenizerDefinition())
                     .build())
             .filter(
                 IS_PRESENT_FILTER,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/InstantPreviewDashboardMetadataIndexOS.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/InstantPreviewDashboardMetadataIndexOS.java
@@ -20,7 +20,7 @@ public class InstantPreviewDashboardMetadataIndexOS
   public IndexSettings.Builder addStaticSetting(
       final String key, final int value, final IndexSettings.Builder contentBuilder) {
     if (NUMBER_OF_SHARDS_SETTING.equalsIgnoreCase(key)) {
-      return contentBuilder.numberOfShards(Integer.toString(value));
+      return contentBuilder.numberOfShards(value);
     } else {
       throw new NotSupportedException(
           "Cannot set property "

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,7 @@
     <version.netty>4.2.9.Final</version.netty>
     <version.objenesis>3.5</version.objenesis>
     <version.opensearch>2.17.0</version.opensearch>
-    <version.opensearch-java>2.26.0</version.opensearch-java>
+    <version.opensearch-java>3.4.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.1.0</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.33.4</version.protobuf>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -392,8 +392,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.opensearch.client</groupId>
-      <artifactId>opensearch-rest-client</artifactId>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -486,8 +486,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
               utils.new SchemaSettingsAppender(templateFile)
-                  .withNumberOfReplicas(settings.getNumberOfReplicas())
-                  .withNumberOfShards(settings.getNumberOfShards())
+                  .withNumberOfReplicas(settings.getNumberOfReplicas().toString())
+                  .withNumberOfShards(settings.getNumberOfShards().toString())
                   .withRefreshInterval(settings.getRefreshInterval())
                   .build());
       return PutIndexTemplateRequest.of(
@@ -519,8 +519,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var currentTemplate = getIndexTemplateState(indexTemplateDescriptor);
       final var configuredSettings =
           utils.new SchemaSettingsAppender(templateFile)
-              .withNumberOfShards(indexConfiguration.getNumberOfShards())
-              .withNumberOfReplicas(indexConfiguration.getNumberOfReplicas())
+              .withNumberOfShards(indexConfiguration.getNumberOfShards().toString())
+              .withNumberOfReplicas(indexConfiguration.getNumberOfReplicas().toString())
               .withRefreshInterval(indexConfiguration.getRefreshInterval());
       final var configuredPriority =
           convertValue(indexConfiguration.getTemplatePriority(), Long::valueOf);
@@ -595,8 +595,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
               utils.new SchemaSettingsAppender(templateFile)
-                  .withNumberOfReplicas(settings.getNumberOfReplicas())
-                  .withNumberOfShards(settings.getNumberOfShards())
+                  .withNumberOfReplicas(settings.getNumberOfReplicas().toString())
+                  .withNumberOfShards(settings.getNumberOfShards().toString())
                   .withRefreshInterval(settings.getRefreshInterval())
                   .build());
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -48,6 +48,9 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.HealthStatus;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.Slices;
+import org.opensearch.client.opensearch._types.SlicesCalculation;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch.cluster.HealthResponse;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
@@ -60,10 +63,10 @@ import org.opensearch.client.opensearch.generic.Request;
 import org.opensearch.client.opensearch.generic.Requests;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+import org.opensearch.client.opensearch.indices.IndexTemplate;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
-import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplate;
 import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem;
 import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplateMapping;
 import org.slf4j.LoggerFactory;
@@ -74,7 +77,8 @@ public class OpensearchEngineClient implements SearchEngineClient {
       new SuppressLogger(LoggerFactory.getLogger(OpensearchEngineClient.class));
   private static final String OPERATE_DELETE_ARCHIVED_POLICY =
       "/schema/opensearch/create/policy/operate_delete_archived_indices.json";
-  private static final long AUTO_SLICES = 0; // see OS docs; 0 means auto
+  private static final Slices AUTO_SLICES =
+      Slices.builder().calculation(SlicesCalculation.Auto).build();
   private final ObjectReader objectReader;
   private final ObjectWriter objectWriter;
   private final OpenSearchClient client;
@@ -308,7 +312,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
             .conflicts(Conflicts.Proceed)
             .index(indexName)
             .query(q -> q.matchAll(m -> m))
-            .refresh(true)
+            .refresh(Refresh.True)
             .build();
     try {
       client.indices().refresh(r -> r.index(indexName));

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -72,13 +72,13 @@ public class SearchEngineClientUtils {
           (Map<String, Object>) settingsBlock.computeIfAbsent("index", k -> new HashMap<>());
     }
 
-    public SchemaSettingsAppender withNumberOfShards(final int numberOfShards) {
-      indexBlock.put("number_of_shards", String.valueOf(numberOfShards));
+    public SchemaSettingsAppender withNumberOfShards(final Object numberOfShards) {
+      indexBlock.put("number_of_shards", numberOfShards);
       return this;
     }
 
-    public SchemaSettingsAppender withNumberOfReplicas(final int numberOfReplicas) {
-      indexBlock.put("number_of_replicas", String.valueOf(numberOfReplicas));
+    public SchemaSettingsAppender withNumberOfReplicas(final Object numberOfReplicas) {
+      indexBlock.put("number_of_replicas", numberOfReplicas);
       return this;
     }
 

--- a/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
@@ -83,9 +83,9 @@ public class OpensearchEngineClientIT {
 
     assertThat(index.aliases().keySet()).isEqualTo(Set.of(descriptor.getAlias()));
     assertThat(index.settings().index().numberOfReplicas())
-        .isEqualTo(indexSettings.getNumberOfReplicas().toString());
+        .isEqualTo(indexSettings.getNumberOfReplicas());
     assertThat(index.settings().index().numberOfShards())
-        .isEqualTo(indexSettings.getNumberOfShards().toString());
+        .isEqualTo(indexSettings.getNumberOfShards());
   }
 
   @Test
@@ -108,20 +108,12 @@ public class OpensearchEngineClientIT {
     assertThat(createdTemplate.size()).isEqualTo(1);
 
     final var indexSettings =
-        createdTemplate
-            .getFirst()
-            .indexTemplate()
-            .template()
-            .settings()
-            .get("index")
-            .toJson()
-            .asJsonObject();
+        createdTemplate.getFirst().indexTemplate().template().settings().index();
 
-    assertThat(indexSettings.getString("number_of_shards"))
-        .isEqualTo(expectedIndexSettings.getNumberOfShards().toString());
-    assertThat(indexSettings.getString("number_of_replicas"))
-        .isEqualTo(expectedIndexSettings.getNumberOfReplicas().toString());
-    assertThat(indexSettings.getString("refresh_interval")).isEqualTo("2s");
+    assertThat(indexSettings.numberOfShards()).isEqualTo(expectedIndexSettings.getNumberOfShards());
+    assertThat(indexSettings.numberOfReplicas())
+        .isEqualTo(expectedIndexSettings.getNumberOfReplicas());
+    assertThat(indexSettings.refreshInterval().time()).isEqualTo("2s");
 
     SchemaTestUtil.validateMappings(
         createdTemplate.getFirst().indexTemplate().template().mappings(),
@@ -510,9 +502,9 @@ public class OpensearchEngineClientIT {
     assertThat(index.mappings().meta().get("test_key").to(String.class)).isEqualTo("test_value");
     assertThat(index.aliases().keySet()).isEqualTo(Set.of(descriptor.getAlias()));
     assertThat(index.settings().index().numberOfReplicas())
-        .isEqualTo(indexSettings.getNumberOfReplicas().toString());
+        .isEqualTo(indexSettings.getNumberOfReplicas());
     assertThat(index.settings().index().numberOfShards())
-        .isEqualTo(indexSettings.getNumberOfShards().toString());
+        .isEqualTo(indexSettings.getNumberOfShards());
   }
 
   @Test
@@ -546,9 +538,9 @@ public class OpensearchEngineClientIT {
     assertThat(index.mappings().meta().get("int_key").to(Integer.class)).isEqualTo(42);
     assertThat(index.aliases().keySet()).isEqualTo(Set.of(descriptor.getAlias()));
     assertThat(index.settings().index().numberOfReplicas())
-        .isEqualTo(indexSettings.getNumberOfReplicas().toString());
+        .isEqualTo(indexSettings.getNumberOfReplicas());
     assertThat(index.settings().index().numberOfShards())
-        .isEqualTo(indexSettings.getNumberOfShards().toString());
+        .isEqualTo(indexSettings.getNumberOfShards());
   }
 
   private String getPolicyMinAge(final String policyName) throws IOException {

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchQueryHitTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchQueryHitTransformer.java
@@ -22,7 +22,7 @@ public final class SearchQueryHitTransformer<T>
   }
 
   @Override
-  public SearchQueryHit<T> apply(Hit<T> value) {
+  public SearchQueryHit<T> apply(final Hit<T> value) {
     final var sortValues = toArray(value.sort());
     return new SearchQueryHit.Builder<T>()
         .id(value.id())

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/AggregationCursorTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/AggregationCursorTransformer.java
@@ -14,17 +14,16 @@ import java.util.stream.Stream;
 import org.opensearch.client.opensearch._types.FieldValue;
 
 public class AggregationCursorTransformer
-    implements SearchTransfomer<Object[], Map<String, String>> {
+    implements SearchTransfomer<Object[], Map<String, FieldValue>> {
 
   @Override
-  public Map<String, String> apply(final Object[] value) {
+  public Map<String, FieldValue> apply(final Object[] value) {
     return Stream.of(value)
         .filter(item -> item instanceof Map<?, ?>)
         .flatMap(item -> ((Map<?, ?>) item).entrySet().stream())
         .collect(
             Collectors.toMap(
-                entry -> entry.getKey().toString(),
-                entry -> toFieldValue(entry.getValue()).stringValue()));
+                entry -> entry.getKey().toString(), entry -> toFieldValue(entry.getValue())));
   }
 
   public static FieldValue toFieldValue(final Object value) {

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
 import io.camunda.search.os.transformers.OpensearchTransformers;
 import java.util.Optional;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
 import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregation;
@@ -36,7 +37,9 @@ public final class SearchCardinalityAggregationTransformer
                           b.inline(
                               f -> {
                                 f.source(script);
-                                Optional.ofNullable(value.lang()).ifPresent(f::lang);
+                                Optional.ofNullable(value.lang())
+                                    .map(d -> ScriptLanguage.builder().custom(d).build())
+                                    .ifPresent(f::lang);
                                 return f;
                               });
                           return b;

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchTermsAggregatorTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchTermsAggregatorTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.search.sort.SortOption.FieldSorting;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
@@ -45,6 +46,7 @@ public final class SearchTermsAggregatorTransformer
                             in -> {
                               final var inline = in.source(script);
                               return Optional.ofNullable(value.lang())
+                                  .map(lang -> ScriptLanguage.builder().custom(lang).build())
                                   .map(inline::lang)
                                   .orElse(inline);
                             })));

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/QueryTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/QueryTransformer.java
@@ -32,7 +32,7 @@ public final class QueryTransformer extends OpensearchTransformer<SearchQuery, Q
     final var queryOptionCls = queryOption.getClass();
     final var transformer = getQueryOptionTransformer(queryOptionCls);
     final var transformedQueryOption = transformer.apply(queryOption);
-    final var query = transformedQueryOption._toQuery();
+    final var query = transformedQueryOption.toQuery();
 
     return query;
   }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchQueryHitTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchQueryHitTransformer.java
@@ -11,17 +11,18 @@ import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.os.transformers.OpensearchTransformer;
 import io.camunda.search.os.transformers.OpensearchTransformers;
 import java.util.List;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.core.search.Hit;
 
 public final class SearchQueryHitTransformer<T>
     extends OpensearchTransformer<Hit<T>, SearchQueryHit<T>> {
 
-  public SearchQueryHitTransformer(OpensearchTransformers transformers) {
+  public SearchQueryHitTransformer(final OpensearchTransformers transformers) {
     super(transformers);
   }
 
   @Override
-  public SearchQueryHit<T> apply(Hit<T> value) {
+  public SearchQueryHit<T> apply(final Hit<T> value) {
     final var sortValues = toArray(value.sort());
     return new SearchQueryHit.Builder<T>()
         .id(value.id())
@@ -35,9 +36,9 @@ public final class SearchQueryHitTransformer<T>
         .build();
   }
 
-  private Object[] toArray(final List<String> values) {
+  private Object[] toArray(final List<FieldValue> values) {
     if (values != null && !values.isEmpty()) {
-      return values.toArray();
+      return values.stream().map(FieldValue::_get).map(String::valueOf).toArray();
     } else {
       return null;
     }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchRequestTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchRequestTransformer.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
@@ -101,8 +102,8 @@ public final class SearchRequestTransformer
     return values.stream().map(sortTransformer::apply).collect(Collectors.toList());
   }
 
-  private List<String> of(final Object[] values) {
-    return Arrays.asList(values).stream().map(Object::toString).collect(Collectors.toList());
+  private List<FieldValue> of(final Object[] values) {
+    return Arrays.stream(values).map(Object::toString).map(FieldValue::of).toList();
   }
 
   private SourceConfig of(final SearchSourceConfig value) {

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/AggregationResultTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/AggregationResultTransformerTest.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jackson.JacksonJsonpParser;
+import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeBucket;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -191,7 +191,7 @@ public class AggregationResultTransformerTest {
         .map(
             processId ->
                 CompositeBucket.of(
-                    cb -> cb.key(Map.of("bpmnProcessId", JsonData.of(processId))).docCount(90)))
+                    cb -> cb.key(Map.of("bpmnProcessId", FieldValue.of(processId))).docCount(90)))
         .collect(Collectors.toList());
   }
 }

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/TermQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/TermQueryTransformerTest.java
@@ -67,7 +67,7 @@ public class TermQueryTransformerTest {
                 .caseInsensitive(true) // if not null it will be set
                 .build()
                 .toSearchQuery(),
-            "{'term':{'foo':{'value':'string','case_insensitive':true}}}"),
+            "{'term':{'foo':{'case_insensitive':true,'value':'string'}}}"),
         Arguments.arguments(
             SearchQueryBuilders.term()
                 .field("foo")
@@ -75,7 +75,7 @@ public class TermQueryTransformerTest {
                 .caseInsensitive(false)
                 .build()
                 .toSearchQuery(),
-            "{'term':{'foo':{'value':'string','case_insensitive':false}}}"),
+            "{'term':{'foo':{'case_insensitive':false,'value':'string'}}}"),
         Arguments.arguments(
             SearchQueryBuilders.term()
                 .field("foo")

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -215,9 +215,7 @@ public class SearchClientAdapter {
                   c.index(indexName)
                       .settings(
                           settings ->
-                              settings
-                                  .numberOfShards("1")
-                                  .numberOfReplicas(String.valueOf(numberOfReplicas))));
+                              settings.numberOfShards(1).numberOfReplicas(numberOfReplicas)));
     }
   }
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/util/CollectionUtil.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/util/CollectionUtil.java
@@ -23,18 +23,20 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.opensearch.client.opensearch._types.FieldValue;
 
 public abstract class CollectionUtil {
 
-  public static <K, V> V getOrDefaultForNullValue(Map<K, V> map, K key, V defaultValue) {
+  public static <K, V> V getOrDefaultForNullValue(
+      final Map<K, V> map, final K key, final V defaultValue) {
     final V value = map.get(key);
     return value == null ? defaultValue : value;
   }
 
   @SafeVarargs
-  public static <T> List<T> throwAwayNullElements(T... array) {
+  public static <T> List<T> throwAwayNullElements(final T... array) {
     final List<T> listOfNotNulls = new ArrayList<>();
-    for (T o : array) {
+    for (final T o : array) {
       if (o != null) {
         listOfNotNulls.add(o);
       }
@@ -42,24 +44,25 @@ public abstract class CollectionUtil {
     return listOfNotNulls;
   }
 
-  public static <T> List<T> emptyListWhenNull(List<T> aList) {
+  public static <T> List<T> emptyListWhenNull(final List<T> aList) {
     return aList == null ? Collections.emptyList() : aList;
   }
 
   @SuppressWarnings("unchecked")
-  public static <T> List<T> withoutNulls(Collection<T> aCollection) {
+  public static <T> List<T> withoutNulls(final Collection<T> aCollection) {
     if (aCollection != null) {
       return filter(aCollection, obj -> obj != null);
     }
     return Collections.EMPTY_LIST;
   }
 
-  public static <T, S> Map<T, List<S>> addToMap(Map<T, List<S>> map, T key, S value) {
+  public static <T, S> Map<T, List<S>> addToMap(
+      final Map<T, List<S>> map, final T key, final S value) {
     map.computeIfAbsent(key, k -> new ArrayList<S>()).add(value);
     return map;
   }
 
-  public static Map<String, Object> asMap(Object... keyValuePairs) {
+  public static Map<String, Object> asMap(final Object... keyValuePairs) {
     if (keyValuePairs == null || keyValuePairs.length % 2 != 0) {
       throw new TasklistRuntimeException("keyValuePairs should not be null and has a even length.");
     }
@@ -71,57 +74,62 @@ public abstract class CollectionUtil {
   }
 
   // We need this because map::getOrDefault throws an exception for null keys :-(
-  public static <K, T> T getOrDefaultFromMap(Map<K, T> map, K key, T defaultValue) {
+  public static <K, T> T getOrDefaultFromMap(
+      final Map<K, T> map, final K key, final T defaultValue) {
     return key == null ? defaultValue : map.getOrDefault(key, defaultValue);
   }
 
-  public static <T> T firstOrDefault(List<T> list, T defaultValue) {
+  public static <T> T firstOrDefault(final List<T> list, final T defaultValue) {
     return list.isEmpty() ? defaultValue : list.get(0);
   }
 
-  public static <S, T> List<T> map(Collection<S> sourceList, Function<S, T> mapper) {
+  public static <S, T> List<T> map(final Collection<S> sourceList, final Function<S, T> mapper) {
     return map(sourceList.stream(), mapper);
   }
 
-  public static <S, T> List<T> map(S[] sourceArray, Function<S, T> mapper) {
+  public static <S, T> List<T> map(final S[] sourceArray, final Function<S, T> mapper) {
     return map(Arrays.stream(sourceArray).parallel(), mapper);
   }
 
-  public static <S, T> List<T> map(Stream<S> sequenceStream, Function<S, T> mapper) {
+  public static <S, T> List<T> map(final Stream<S> sequenceStream, final Function<S, T> mapper) {
     return sequenceStream.map(mapper).collect(Collectors.toList());
   }
 
-  public static <T> List<T> filter(Collection<T> collection, Predicate<T> predicate) {
+  public static <T> List<T> filter(final Collection<T> collection, final Predicate<T> predicate) {
     return filter(collection.stream(), predicate);
   }
 
-  public static <T> List<T> filter(Stream<T> filterStream, Predicate<T> predicate) {
+  public static <T> List<T> filter(final Stream<T> filterStream, final Predicate<T> predicate) {
     return filterStream.filter(predicate).collect(Collectors.toList());
   }
 
-  public static List<String> toSafeListOfStrings(Collection<?> aCollection) {
+  public static List<String> toSafeListOfStrings(final Collection<?> aCollection) {
     return map(withoutNulls(aCollection), obj -> obj.toString());
   }
 
-  public static String[] toSafeArrayOfStrings(Collection<?> aCollection) {
+  public static String[] toSafeArrayOfStrings(final Collection<?> aCollection) {
     return toSafeListOfStrings(aCollection).toArray(new String[] {});
   }
 
-  public static List<String> toSafeListOfStrings(Object... objects) {
+  public static List<String> toSafeListOfStrings(final Object... objects) {
     return toSafeListOfStrings(Arrays.asList(objects));
   }
 
-  public static List<Long> toSafeListOfLongs(Collection<String> aCollection) {
+  public static List<Long> toSafeListOfLongs(final Collection<String> aCollection) {
     return map(withoutNulls(aCollection), STRING_TO_LONG);
   }
 
-  public static <T> void addNotNull(Collection<T> collection, T object) {
+  public static List<FieldValue> toSafeListOfOSFieldValues(final Object... objects) {
+    return toSafeListOfStrings(Arrays.asList(objects)).stream().map(FieldValue::of).toList();
+  }
+
+  public static <T> void addNotNull(final Collection<T> collection, final T object) {
     if (collection != null && object != null) {
       collection.add(object);
     }
   }
 
-  public static List<Integer> fromTo(int from, int to) {
+  public static List<Integer> fromTo(final int from, final int to) {
     final List<Integer> result = new ArrayList<>();
     for (int i = from; i <= to; i++) {
       result.add(i);
@@ -129,14 +137,15 @@ public abstract class CollectionUtil {
     return result;
   }
 
-  public static boolean isNotEmpty(Collection<?> aCollection) {
+  public static boolean isNotEmpty(final Collection<?> aCollection) {
     return aCollection != null && !aCollection.isEmpty();
   }
 
   /**
    * @param subsetId starts from 0
    */
-  public static <E> List<E> splitAndGetSublist(List<E> list, int subsetCount, int subsetId) {
+  public static <E> List<E> splitAndGetSublist(
+      final List<E> list, final int subsetCount, final int subsetId) {
     if (subsetId >= subsetCount) {
       return new ArrayList<>();
     }
@@ -152,12 +161,12 @@ public abstract class CollectionUtil {
     return new ArrayList<>(list.subList(start, end));
   }
 
-  public static <T> T chooseOne(List<T> items) {
+  public static <T> T chooseOne(final List<T> items) {
     return items.get(new Random().nextInt(items.size()));
   }
 
-  public static <T> boolean allElementsAreOfType(Class clazz, T... array) {
-    for (T element : array) {
+  public static <T> boolean allElementsAreOfType(final Class clazz, final T... array) {
+    for (final T element : array) {
       if (!clazz.isInstance(element)) {
         return false;
       }
@@ -169,7 +178,7 @@ public abstract class CollectionUtil {
     return Arrays.stream(items).map(String::valueOf).toArray(String[]::new);
   }
 
-  public static long countNonNullObjects(Object... objects) {
+  public static long countNonNullObjects(final Object... objects) {
     return Arrays.stream(objects).filter(Objects::nonNull).count();
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -375,7 +375,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
                     s -> s.field(f -> f.field(ProcessIndex.VERSION).order(SortOrder.Desc))))
             .size(1)
             .build()
-            ._toAggregation();
+            .toAggregation();
 
     final SearchRequest.Builder searchRequest =
         new SearchRequest.Builder().index(processIndex.getAlias()).query(query).size(0);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -129,7 +129,7 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
       }
 
       final List<LongTermsBucket> buckets = aggregate.lterms().buckets().array();
-      return buckets.stream().map(l -> Long.valueOf(l.key())).collect(Collectors.toSet());
+      return buckets.stream().map(l -> l.key().signed()).collect(Collectors.toSet());
     } catch (final IOException | OpenSearchException e) {
       LOGGER.error(
           "Error while retrieving assigned users between dates from index: " + template, e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -29,6 +29,7 @@ import io.camunda.tasklist.store.TaskStore;
 import io.camunda.tasklist.store.VariableStore;
 import io.camunda.tasklist.store.util.TaskVariableSearchUtil;
 import io.camunda.tasklist.tenant.TenantAwareOpenSearchClient;
+import io.camunda.tasklist.util.CollectionUtil;
 import io.camunda.tasklist.util.OpenSearchUtil;
 import io.camunda.tasklist.util.OpenSearchUtil.QueryType;
 import io.camunda.tasklist.views.TaskSearchView;
@@ -442,7 +443,10 @@ public class TaskStoreOpenSearch implements TaskStore {
 
   private List<TaskSearchView> mapTasksFromEntity(final SearchResponse<TaskEntity> response) {
     return response.hits().hits().stream()
-        .map(sh -> TaskSearchView.createFrom(sh.source(), sh.sort().toArray(new String[0])))
+        .map(
+            sh ->
+                TaskSearchView.createFrom(
+                    sh.source(), sh.sort().stream().map(FieldValue::_get).toArray()))
         .toList();
   }
 
@@ -827,7 +831,7 @@ public class TaskStoreOpenSearch implements TaskStore {
       searchRequestBuilder.size(query.getPageSize());
     }
     if (querySearchAfter != null) {
-      searchRequestBuilder.searchAfter(Arrays.stream(querySearchAfter).toList());
+      searchRequestBuilder.searchAfter(CollectionUtil.toSafeListOfOSFieldValues(querySearchAfter));
     }
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
@@ -81,7 +81,7 @@ public abstract class OpenSearchUtil {
       final var query = queryBuilder.build();
 
       if (query instanceof final QueryVariant qv) {
-        boolQ.must(qv._toQuery());
+        boolQ.must(qv.toQuery());
       } else if (query instanceof final Query q) {
         boolQ.must(q);
       } else {
@@ -96,7 +96,7 @@ public abstract class OpenSearchUtil {
         new BoolQuery.Builder()
             .must(must -> must.matchNone(none -> none.queryName("matchNone")))
             .build();
-    return boolQuery._toQuery();
+    return boolQuery.toQuery();
   }
 
   public static Query joinWithAnd(final Query... queries) {
@@ -109,7 +109,7 @@ public abstract class OpenSearchUtil {
       final var query = queryBuilder;
 
       if (query instanceof final QueryVariant qv) {
-        boolQ.must(qv._toQuery());
+        boolQ.must(qv.toQuery());
       } else {
         boolQ.must(query);
       }
@@ -360,7 +360,7 @@ public abstract class OpenSearchUtil {
   /**
    * Helper method to scroll in chunks. This is useful when you have a large number of ids and want
    * to avoid sending them all at once to OpenSearch to not hit the max allowed terms limit {@link
-   * #DEFAULT_MAX_TERMS_COUNT}
+   * io.camunda.tasklist.property.OpenSearchProperties#DEFAULT_MAX_TERMS_COUNT}
    */
   public static <T, ID> List<T> scrollInChunks(
       final List<ID> ids,

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearchTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.store.opensearch;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.queries.TaskQuery;
+import io.camunda.tasklist.tenant.TenantAwareOpenSearchClient;
+import io.camunda.tasklist.views.TaskSearchView;
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskStoreOpenSearchTest {
+
+  @Captor private ArgumentCaptor<SearchRequest.Builder> searchRequestCaptor;
+
+  @Mock private TenantAwareOpenSearchClient tenantAwareClient;
+
+  @Spy private final TaskTemplate taskTemplate = new TaskTemplate("test", true);
+
+  @InjectMocks private TaskStoreOpenSearch instance;
+
+  @ParameterizedTest
+  @CsvSource({
+    "CREATED,test-tasklist-task-,_",
+    "COMPLETED,test-tasklist-task-,_alias",
+    "CANCELED,test-tasklist-task-,_alias"
+  })
+  void getTasksForDifferentStates(
+      final TaskState taskState, final String expectedIndexPrefix, final String expectedIndexSuffix)
+      throws Exception {
+    // Given
+    final TaskQuery taskQuery = new TaskQuery().setPageSize(50).setState(taskState);
+
+    final SearchResponse mockedResponse = mock();
+    when(tenantAwareClient.search(searchRequestCaptor.capture(), any(Class.class)))
+        .thenReturn(mockedResponse);
+
+    final Hit mockedHit = mock();
+    when(mockedHit.source()).thenReturn(getTaskEntity(taskState));
+
+    final HitsMetadata mockedHits = mock();
+    when(mockedResponse.hits()).thenReturn(mockedHits);
+    when(mockedHits.hits()).thenReturn(List.of(mockedHit));
+
+    // When
+    final List<TaskSearchView> result = instance.getTasks(taskQuery);
+
+    // Then
+    final SearchRequest searchRequest = searchRequestCaptor.getValue().build();
+    assertThat(searchRequest.index())
+        .singleElement(as(STRING))
+        .satisfies(
+            index -> {
+              assertThat(index).startsWith(expectedIndexPrefix);
+              assertThat(index).endsWith(expectedIndexSuffix);
+            });
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getImplementation()).isEqualTo(TaskImplementation.JOB_WORKER);
+    verify(tenantAwareClient).search(searchRequestCaptor.capture(), eq(TaskEntity.class));
+  }
+
+  @Test
+  void queryTasksWithProvidedTenantIds() throws IOException, IOException {
+    final TaskQuery taskQuery =
+        new TaskQuery()
+            .setTenantIds(new String[] {"tenant_a", "tenant_b"})
+            .setPageSize(50)
+            .setState(TaskState.CREATED);
+
+    final SearchResponse mockedResponse = mock();
+    when(tenantAwareClient.searchByTenantIds(
+            any(), eq(TaskEntity.class), eq(Set.of("tenant_a", "tenant_b"))))
+        .thenReturn(mockedResponse);
+
+    final Hit mockedHit = mock();
+    when(mockedHit.source()).thenReturn(getTaskEntity(TaskState.CREATED));
+
+    final HitsMetadata mockedHits = mock();
+    when(mockedHits.hits()).thenReturn(List.of(mockedHit));
+    when(mockedResponse.hits()).thenReturn(mockedHits);
+
+    // When
+    final List<TaskSearchView> result = instance.getTasks(taskQuery);
+
+    // Then
+    verify(tenantAwareClient, never()).search(any(), any(Class.class));
+    assertThat(result).hasSize(1);
+  }
+
+  private static TaskEntity getTaskEntity(final TaskState taskState) {
+    final TaskEntity taskEntity = new TaskEntity();
+    taskEntity.setId("123456789");
+    taskEntity.setKey(123456789L);
+    taskEntity.setPartitionId(2);
+    taskEntity.setBpmnProcessId("bigFormProcess");
+    taskEntity.setProcessDefinitionId("00000000000");
+    taskEntity.setFlowNodeBpmnId("Activity_0aaaaa");
+    taskEntity.setFlowNodeInstanceId("11111111111");
+    taskEntity.setProcessInstanceId("2222222222");
+    taskEntity.setCreationTime(OffsetDateTime.parse("2023-01-01T00:00:02.523+02:00"));
+    taskEntity.setCompletionTime(null);
+    taskEntity.setState(taskState);
+    taskEntity.setAssignee(null);
+    taskEntity.setCandidateGroups(null);
+    taskEntity.setFormKey("camunda-forms:bpmn:userTaskForm_1111111");
+    taskEntity.setImplementation(TaskImplementation.JOB_WORKER);
+    return taskEntity;
+  }
+}

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearchTest.java
@@ -96,10 +96,10 @@ class VariableStoreOpenSearchTest {
     final var filters = capturedSearchRequest.query().constantScore().filter().bool().must();
     assertThat(filters).hasSize(2);
     assertThat(filters.getFirst().terms().field()).isEqualTo(FlowNodeInstanceTemplate.SCOPE_KEY);
-    assertThat(filters.getFirst().terms().terms().value().stream().map(FieldValue::_get))
+    assertThat(filters.getFirst().terms().terms().value().stream().map(FieldValue::_toJsonString))
         .isEqualTo(List.of("flowNodeId1"));
     assertThat(filters.getLast().terms().field()).isEqualTo(VariableTemplate.NAME);
-    assertThat(filters.getLast().terms().terms().value().stream().map(FieldValue::_get))
+    assertThat(filters.getLast().terms().terms().value().stream().map(FieldValue::_toJsonString))
         .isEqualTo(varNames);
     assertThat(capturedSearchRequest.size()).isEqualTo(200);
     assertThat(result).isEmpty();

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/BackupRestoreDataGeneratorOpenSearch.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/BackupRestoreDataGeneratorOpenSearch.java
@@ -12,8 +12,11 @@ import io.camunda.tasklist.qa.backup.BackupRestoreTestContext;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.BuiltinScriptLanguage;
 import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery.Builder;
 import org.opensearch.client.opensearch.indices.RefreshRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,12 +54,17 @@ public class BackupRestoreDataGeneratorOpenSearch extends AbstractBackupRestoreD
       openSearchClient.updateByQuery(
           qr ->
               qr.index(getMainIndexNameFor(TaskTemplate.INDEX_NAME))
-                  .query(new MatchAllQuery.Builder().build()._toQuery())
+                  .query(new Builder().build().toQuery())
                   .script(
                       s ->
                           s.inline(
-                              is -> is.lang("painless").source("ctx._source.assignee = 'demo'")))
-                  .refresh(true));
+                              is ->
+                                  is.lang(
+                                          ScriptLanguage.builder()
+                                              .builtin(BuiltinScriptLanguage.Painless)
+                                              .build())
+                                      .source("ctx._source.assignee = 'demo'")))
+                  .refresh(Refresh.True));
     } catch (final OpenSearchException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -34,7 +34,7 @@ import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.client.opensearch.indices.FlushRequest;
-import org.opensearch.client.opensearch.nodes.Stats;
+import org.opensearch.client.opensearch.nodes.stats.Stats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/OpenSearchTenantCheckApplierTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/OpenSearchTenantCheckApplierTest.java
@@ -55,7 +55,7 @@ public class OpenSearchTenantCheckApplierTest {
     assertThat(sr.query().bool().must()).hasSize(2);
     assertThat(sr.query().bool().must().get(0).terms().field()).isEqualTo("tenantId");
     assertThat(sr.query().bool().must().get(0).terms().terms().value())
-        .map(FieldValue::stringValue)
+        .map(FieldValue::_toJsonString)
         .containsExactly("TenantA", "TenantB");
     assertThat(sr.query().bool().must().get(1).term().value().stringValue()).isEqualTo("value");
     assertThat(sr.query().bool().must().get(1).term().field()).isEqualTo("field");
@@ -112,7 +112,7 @@ public class OpenSearchTenantCheckApplierTest {
     assertThat(sr.query().bool().must()).hasSize(2);
     assertThat(sr.query().bool().must().get(0).terms().field()).isEqualTo("tenantId");
     assertThat(sr.query().bool().must().get(0).terms().terms().value())
-        .map(FieldValue::stringValue)
+        .map(FieldValue::_toJsonString)
         .containsExactly("TenantA");
     assertThat(sr.query().bool().must().get(1).term().value().stringValue()).isEqualTo("value");
     assertThat(sr.query().bool().must().get(1).term().field()).isEqualTo("field");

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpenSearchSnapshotInfo.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpenSearchSnapshotInfo.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.backup.repository.opensearch;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
 import org.opensearch.client.opensearch.snapshot.SnapshotShardFailure;
@@ -97,14 +98,8 @@ public class OpenSearchSnapshotInfo {
         .setSnapshot(snapshotInfo.snapshot())
         .setUuid(snapshotInfo.uuid())
         .setState(SnapshotState.valueOf(snapshotInfo.state()))
-        .setStartTimeInMillis(
-            snapshotInfo.startTimeInMillis() != null
-                ? Long.parseLong(snapshotInfo.startTimeInMillis())
-                : 0L)
-        .setEndTimeInMillis(
-            snapshotInfo.endTimeInMillis() != null
-                ? Long.parseLong(snapshotInfo.endTimeInMillis())
-                : 0)
+        .setStartTimeInMillis(Optional.ofNullable(snapshotInfo.startTimeInMillis()).orElse(0L))
+        .setEndTimeInMillis(Optional.ofNullable(snapshotInfo.endTimeInMillis()).orElse(0L))
         .setMetadata(snapshotInfo.metadata())
         .setFailures(snapshotInfo.failures());
   }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -94,7 +94,7 @@ class OpensearchBackupRepositoryTest {
                     defaultFields(bi, metadata)
                         .snapshot("test-snapshot")
                         .state(SnapshotState.IN_PROGRESS.name())
-                        .startTimeInMillis("23")));
+                        .startTimeInMillis(23L)));
     final var response = GetSnapshotResponse.of(b -> defaultFields(b).snapshots(snapshotInfos));
 
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any())).thenReturn(response);
@@ -206,9 +206,8 @@ class OpensearchBackupRepositoryTest {
                                             .snapshot("snapshot")
                                             .state(SnapshotState.SUCCESS.name())
                                             .startTimeInMillis(
-                                                Long.toString(
-                                                    now - (incompleteCheckTimeoutLength / 2)))
-                                            .endTimeInMillis(Long.toString(now)))))));
+                                                now - (incompleteCheckTimeoutLength / 2))
+                                            .endTimeInMillis(now))))));
 
     final var response = repository.getBackupState("repo", 5L);
 
@@ -235,9 +234,9 @@ class OpensearchBackupRepositoryTest {
                     defaultFields(bi, new Metadata(5L, "1", 1, 3))
                         .snapshot("snapshot")
                         .state(SnapshotState.SUCCESS.name())
-                        .startTimeInMillis(Long.toString(endtime - 20))
+                        .startTimeInMillis(endtime - 20)
                         // end time was double the timeout from now
-                        .endTimeInMillis(Long.toString(endtime))));
+                        .endTimeInMillis(endtime)));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
         .thenReturn(GetSnapshotResponse.of(b -> defaultFields(b).snapshots(snapshotInfos)));
 
@@ -321,16 +320,16 @@ class OpensearchBackupRepositoryTest {
                 defaultFields(bi, new Metadata(5L, "1", 1, 3))
                     .uuid("uuid")
                     .state(SnapshotState.SUCCESS.name())
-                    .startTimeInMillis(Long.toString(timeoutTime - 50))
-                    .endTimeInMillis(Long.toString(timeoutTime - 40)));
+                    .startTimeInMillis(timeoutTime - 50)
+                    .endTimeInMillis(timeoutTime - 40));
     final var lastSnapshotInfo =
         SnapshotInfo.of(
             bi ->
                 defaultFields(bi, new Metadata(5L, "1", 2, 3))
                     .uuid("uuid")
                     .state(SnapshotState.SUCCESS.name())
-                    .startTimeInMillis(Long.toString(timeoutTime - 30))
-                    .endTimeInMillis(Long.toString(timeoutTime - 20)));
+                    .startTimeInMillis(timeoutTime - 30)
+                    .endTimeInMillis(timeoutTime - 20));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
         .thenReturn(
             GetSnapshotResponse.of(
@@ -350,8 +349,8 @@ class OpensearchBackupRepositoryTest {
                 defaultFields(bi, new Metadata(5L, "1", 1, 3))
                     .uuid("uuid")
                     .state(SnapshotState.SUCCESS.name())
-                    .startTimeInMillis(Long.toString(now - incompleteCheckTimeoutLength))
-                    .endTimeInMillis(Long.toString(now - 20)));
+                    .startTimeInMillis(now - incompleteCheckTimeoutLength)
+                    .endTimeInMillis(now - 20));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
         .thenReturn(
             GetSnapshotResponse.of(b -> defaultFields(b).snapshots(List.of(firstSnapshotInfo))));
@@ -368,7 +367,7 @@ class OpensearchBackupRepositoryTest {
                 defaultFields(bi)
                     .uuid("uuid")
                     .state(SnapshotState.PARTIAL.name())
-                    .startTimeInMillis(Long.toString(Instant.now().toEpochMilli())));
+                    .startTimeInMillis(Instant.now().toEpochMilli()));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
         .thenReturn(
             GetSnapshotResponse.of(b -> defaultFields(b).snapshots(List.of(firstSnapshotInfo))));
@@ -385,14 +384,14 @@ class OpensearchBackupRepositoryTest {
                 defaultFields(bi, new Metadata(5L, "1", 1, 2))
                     .uuid("uuid")
                     .state(SnapshotState.SUCCESS.name())
-                    .startTimeInMillis(Long.toString(Instant.now().toEpochMilli())));
+                    .startTimeInMillis(Instant.now().toEpochMilli()));
     final var lastSnapshotInfo =
         SnapshotInfo.of(
             bi ->
                 defaultFields(bi, new Metadata(5L, "1", 2, 2))
                     .uuid("uuid")
                     .state(SnapshotState.SUCCESS.name())
-                    .startTimeInMillis(Long.toString(Instant.now().toEpochMilli())));
+                    .startTimeInMillis(Instant.now().toEpochMilli()));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
         .thenReturn(
             GetSnapshotResponse.of(
@@ -410,7 +409,7 @@ class OpensearchBackupRepositoryTest {
                 defaultFields(bi)
                     .uuid("uuid")
                     .state(SnapshotState.FAILED.name())
-                    .startTimeInMillis(Long.toString(Instant.now().toEpochMilli())));
+                    .startTimeInMillis(Instant.now().toEpochMilli()));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
         .thenReturn(
             GetSnapshotResponse.of(b -> defaultFields(b).snapshots(List.of(firstSnapshotInfo))));

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
@@ -25,6 +25,7 @@
       },
       "join": {
         "type": "join",
+        "eager_global_ordinals": true,
         "relations": {
           "group": ["member"]
         }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
@@ -25,6 +25,7 @@
       },
       "join": {
         "type": "join",
+        "eager_global_ordinals": true,
         "relations": {
           "role": ["member"]
         }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
@@ -25,6 +25,7 @@
       },
       "join": {
         "type": "join",
+        "eager_global_ordinals": true,
         "relations": {
           "tenant": ["member"]
         }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
@@ -48,7 +48,8 @@
 			},
 			"joinRelation": {
 				"type": "join",
-				"relations": {
+        "eager_global_ordinals": true,
+        "relations": {
 					"processInstance": [
 						"activity",
 						"variable"

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
@@ -4,6 +4,7 @@
     "properties": {
       "join": {
         "type": "join",
+        "eager_global_ordinals": true,
         "relations": {
           "task": [
             "localVariable"

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -243,14 +243,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.opensearch.client</groupId>
-      <artifactId>opensearch-rest-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -45,6 +45,8 @@ import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Slices;
+import org.opensearch.client.opensearch._types.SlicesCalculation;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery.Builder;
@@ -66,7 +68,8 @@ import org.slf4j.Logger;
 public final class OpenSearchArchiverRepository extends OpensearchRepository
     implements ArchiverRepository {
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
-  private static final long AUTO_SLICES = 0; // see OS docs; 0 means auto
+  private static final Slices AUTO_SLICES =
+      Slices.builder().calculation(SlicesCalculation.Auto).build();
 
   private final int partitionId;
   private final HistoryConfiguration config;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -29,8 +29,10 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.BuiltinScriptLanguage;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
@@ -177,7 +179,7 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
                             + "ctx._source.operationsFinishedCount = params.operationsFinishedCount;"
                             + "ctx._source.operationsCompletedCount = params.operationsCompletedCount;"
                             + "ctx._source.operationsFailedCount = params.operationsFailedCount;")
-                    .lang("painless")
+                    .lang(ScriptLanguage.builder().builtin(BuiltinScriptLanguage.Painless).build())
                     .params(parameters))
         .build();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
@@ -12,10 +12,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.BuiltinScriptLanguage;
 import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.ScriptLanguage;
 
 public class OpensearchScriptBuilder {
-  public static final String DEFAULT_SCRIPT_LANG = "painless";
+  public static final ScriptLanguage DEFAULT_SCRIPT_LANG =
+      ScriptLanguage.builder().builtin(BuiltinScriptLanguage.Painless).build();
 
   public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
     Objects.requireNonNull(parameters, "Script Parameters must not be null");

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -230,6 +235,7 @@
         <configuration>
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>org.apache.httpcomponents.core5:httpcore5</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- This dependency is indirectly used by the awssk auth plugin. It requires these


### PR DESCRIPTION
## Description

This will update the OpenSearch Java client version from `v2.26.0` to `v3.4.0`.

This upgrade requires addressing breaking API changes, updates to functionality (such as including eager ordinals in the OS ISM response, #26085), and updating tests and integration tests accordingly.

Because these modules are used as shared dependencies, the full upgrade must be completed in a single step rather than split between `zeebe/operate/tasklist` and `optimize` as previously planned.


## Checklist

- [ ] Ensure all tests pass

## Related issues

Closes to #40597, #26085, #40602
