### PR TITLE
fix: Add process name to UserTask interface

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
@@ -49,6 +49,9 @@ public interface UserTask {
   /** BPMN process id of the process associated with this task */
   String getBpmnProcessId();
 
+  /** Name of the process definition */
+  String getProcessName();
+
   /** Key of the process definition */
   Long getProcessDefinitionKey();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
@@ -36,6 +36,7 @@ public class UserTaskImpl implements UserTask {
   private final List<String> candidateGroup;
   private final List<String> candidateUser;
   private final String bpmnProcessId;
+  private final String processName;
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
   private final Long formKey;
@@ -60,6 +61,7 @@ public class UserTaskImpl implements UserTask {
     candidateGroup = item.getCandidateGroups();
     candidateUser = item.getCandidateUsers();
     bpmnProcessId = item.getProcessDefinitionId();
+    processName = item.getProcessName();
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     formKey = ParseUtil.parseLongOrNull(item.getFormKey());
@@ -118,6 +120,11 @@ public class UserTaskImpl implements UserTask {
   @Override
   public String getBpmnProcessId() {
     return bpmnProcessId;
+  }
+
+  @Override
+  public String getProcessName() {
+    return processName;
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR adds the `processName` property to the UserTask interface of the Java Client SDK

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/42857

duplicate of https://github.com/camunda/camunda/pull/42858
