### PR TITLE
fix: slack notification

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
           echo "Base branch: ${{ needs.validate-release.outputs.base }}"
-    
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.validate-release.outputs.base }}
@@ -104,22 +104,22 @@ jobs:
             echo "Updating separate service images (zeebe, tasklist, operate)"
             # Update zeebe image
             sed -i.bak "s|image: camunda/zeebe:.*|image: camunda/zeebe:$release_version|g" "$compose_file"
-            # Update tasklist image  
+            # Update tasklist image
             sed -i.bak2 "s|image: camunda/tasklist:.*|image: camunda/tasklist:$release_version|g" "$compose_file"
             # Update operate image
             sed -i.bak3 "s|image: camunda/operate:.*|image: camunda/operate:$release_version|g" "$compose_file"
-            
+
             echo "Updated docker-compose.yml with separate services:"
             grep -E "image: camunda/(zeebe|tasklist|operate):" "$compose_file"
           else
             echo "Updating unified camunda service image"
             # Replace the camunda image tag in docker-compose.yml
             sed -i.bak "s|image: camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
-            
+
             echo "Updated docker-compose.yml with unified service:"
             grep "image: camunda/camunda:" "$compose_file"
           fi
-      
+
       - name: Set NON_STANDALONE variable
         shell: bash
         run: |
@@ -253,10 +253,10 @@ jobs:
             export CORE_APPLICATION_URL="http://localhost:8080"
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
           fi
-          
+
           echo "Running API tests"
           npm run test -- --project=api-tests
-          
+
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
       - name: Publish test results to TestRail
@@ -329,18 +329,18 @@ jobs:
             echo "Updating separate service images (zeebe, tasklist, operate)"
             # Update zeebe image
             sed -i.bak "s|image: camunda/zeebe:.*|image: camunda/zeebe:$release_version|g" "$compose_file"
-            # Update tasklist image  
+            # Update tasklist image
             sed -i.bak2 "s|image: camunda/tasklist:.*|image: camunda/tasklist:$release_version|g" "$compose_file"
             # Update operate image
             sed -i.bak3 "s|image: camunda/operate:.*|image: camunda/operate:$release_version|g" "$compose_file"
-            
+
             echo "Updated docker-compose.yml with separate services:"
             grep -E "image: camunda/(zeebe|tasklist|operate):" "$compose_file"
           else
             echo "Updating unified camunda service image"
             # Replace the camunda image tag in docker-compose.yml
             sed -i.bak "s|image: camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
-            
+
             echo "Updated docker-compose.yml with unified service:"
             grep "image: camunda/camunda:" "$compose_file"
           fi
@@ -480,7 +480,7 @@ jobs:
             export CORE_APPLICATION_URL="http://localhost:8080"
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
             TEST_ARGS=(--project=chromium)
-            
+
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
               echo "Running V2 mode tests"
               if [[ "${{ needs.validate-release.outputs.base }}" == "stable/8.8" ]]; then
@@ -563,7 +563,7 @@ jobs:
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
 
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@5ae53f9ab3a0882dc89dbfe38e3ae46fd88ea91a
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

closes #43243 

<!-- Describe the goal and purpose of this PR. -->

We did not get a Slack notification in the mono repo release process, which affected the 8.9 release candidate. 
- Failed run result was not to the channel [here](https://github.com/camunda/camunda/actions/runs/20441221790). 

After the fix,
- Triggered run: https://github.com/camunda/camunda/actions/runs/20461659904
- Slack message: https://camunda.slack.com/archives/C06UWQNCU7M/p1766496579217109

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
