### PR TITLE
Make history deletion schedulers configurable

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -25,6 +25,9 @@ public class Data {
   /** This section allows to configure the audit log setup. */
   @NestedConfigurationProperty private AuditLog auditLog = new AuditLog();
 
+  /** This section allows to configure the history deletion setup. */
+  @NestedConfigurationProperty private HistoryDeletion historyDeletion = new HistoryDeletion();
+
   /** This section allows to configure primary Zeebe's data storage. */
   @NestedConfigurationProperty private PrimaryStorage primaryStorage = new PrimaryStorage();
 
@@ -43,6 +46,14 @@ public class Data {
 
   public void setAuditLog(final AuditLog auditLog) {
     this.auditLog = auditLog;
+  }
+
+  public HistoryDeletion getHistoryDeletion() {
+    return historyDeletion;
+  }
+
+  public void setHistoryDeletion(final HistoryDeletion historyDeletion) {
+    this.historyDeletion = historyDeletion;
   }
 
   public Duration getSnapshotPeriod() {

--- a/configuration/src/main/java/io/camunda/configuration/HistoryDeletion.java
+++ b/configuration/src/main/java/io/camunda/configuration/HistoryDeletion.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import java.time.Duration;
+
+/** Configuration for history deletion. */
+public class HistoryDeletion {
+
+  private Duration delayBetweenRuns = Duration.ofSeconds(1);
+  private Duration maxDelayBetweenRuns = Duration.ofMinutes(5);
+  private int queueBatchSize = 100;
+  private int dependentRowLimit = 10000;
+
+  public Duration getDelayBetweenRuns() {
+    return delayBetweenRuns;
+  }
+
+  public void setDelayBetweenRuns(final Duration delayBetweenRuns) {
+    this.delayBetweenRuns = delayBetweenRuns;
+  }
+
+  public Duration getMaxDelayBetweenRuns() {
+    return maxDelayBetweenRuns;
+  }
+
+  public void setMaxDelayBetweenRuns(final Duration maxDelayBetweenRuns) {
+    this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+  }
+
+  public int getQueueBatchSize() {
+    return queueBatchSize;
+  }
+
+  public void setQueueBatchSize(final int queueBatchSize) {
+    this.queueBatchSize = queueBatchSize;
+  }
+
+  public int getDependentRowLimit() {
+    return dependentRowLimit;
+  }
+
+  public void setDependentRowLimit(final int dependentRowLimit) {
+    this.dependentRowLimit = dependentRowLimit;
+  }
+
+  /** Converts this configuration to an {@link HistoryDeletionConfiguration} for the exporter. */
+  public HistoryDeletionConfiguration toConfiguration() {
+    final HistoryDeletionConfiguration historyDeletionConfiguration =
+        new HistoryDeletionConfiguration();
+    historyDeletionConfiguration.setDelayBetweenRuns(delayBetweenRuns);
+    historyDeletionConfiguration.setMaxDelayBetweenRuns(maxDelayBetweenRuns);
+    historyDeletionConfiguration.setQueueBatchSize(queueBatchSize);
+    historyDeletionConfiguration.setDependentRowLimit(dependentRowLimit);
+    return historyDeletionConfiguration;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/HistoryDeletion.java
+++ b/configuration/src/main/java/io/camunda/configuration/HistoryDeletion.java
@@ -13,10 +13,15 @@ import java.time.Duration;
 /** Configuration for history deletion. */
 public class HistoryDeletion {
 
-  private Duration delayBetweenRuns = Duration.ofSeconds(1);
-  private Duration maxDelayBetweenRuns = Duration.ofMinutes(5);
-  private int queueBatchSize = 100;
-  private int dependentRowLimit = 10000;
+  private static final Duration DEFAULT_DELAY_BETWEEN_RUNS = Duration.ofSeconds(1);
+  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofMinutes(5);
+  private static final int DEFAULT_QUEUE_BATCH_SIZE = 100;
+  private static final int DEFAULT_DEPENDENT_ROW_LIMIT = 10000;
+
+  private Duration delayBetweenRuns = DEFAULT_DELAY_BETWEEN_RUNS;
+  private Duration maxDelayBetweenRuns = DEFAULT_MAX_DELAY_BETWEEN_RUNS;
+  private int queueBatchSize = DEFAULT_QUEUE_BATCH_SIZE;
+  private int dependentRowLimit = DEFAULT_DEPENDENT_ROW_LIMIT;
 
   public Duration getDelayBetweenRuns() {
     return delayBetweenRuns;

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -767,8 +767,8 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateCamundaExporter(final BrokerBasedProperties override) {
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+    final Data data = unifiedConfiguration.getCamunda().getData();
+    final SecondaryStorage secondaryStorage = data.getSecondaryStorage();
 
     if (!secondaryStorage.getAutoconfigureCamundaExporter()) {
       LOGGER.debug("Skipping autoconfiguration of the (default) exporter 'camundaexporter'");
@@ -777,12 +777,8 @@ public class BrokerBasedPropertiesOverride {
 
     final DocumentBasedSecondaryStorageDatabase database;
     switch (secondaryStorage.getType()) {
-      case elasticsearch ->
-          database =
-              unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getElasticsearch();
-      case opensearch ->
-          database =
-              unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getOpensearch();
+      case elasticsearch -> database = secondaryStorage.getElasticsearch();
+      case opensearch -> database = secondaryStorage.getOpensearch();
       default -> {
         // RDBMS and NONE are not supported.
         return;
@@ -910,16 +906,18 @@ public class BrokerBasedPropertiesOverride {
     setArg(args, "bulk.size", database.getBulk().getSize());
     setArg(args, "bulk.memoryLimit", database.getBulk().getMemoryLimit().toMegabytes());
 
-    final var auditLog = unifiedConfiguration.getCamunda().getData().getAuditLog();
+    final var auditLog = data.getAuditLog();
+    final var historyDeletion = data.getHistoryDeletion();
     exporter.setArgs(
         ExporterConfiguration.of(io.camunda.exporter.config.ExporterConfiguration.class, args)
             .apply(config -> config.setAuditLog(auditLog.toConfiguration()))
+            .apply(config -> config.setHistoryDeletion(historyDeletion.toConfiguration()))
             .toArgs());
   }
 
   private void populateRdbmsExporter(final BrokerBasedProperties override) {
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+    final Data data = unifiedConfiguration.getCamunda().getData();
+    final SecondaryStorage secondaryStorage = data.getSecondaryStorage();
 
     final Rdbms database = secondaryStorage.getRdbms();
 
@@ -993,10 +991,12 @@ public class BrokerBasedPropertiesOverride {
     setArgIfNotNull(
         args, "batchOperationItemInsertBlockSize", database.getBatchOperationItemInsertBlockSize());
 
-    final var auditLog = unifiedConfiguration.getCamunda().getData().getAuditLog();
+    final var auditLog = data.getAuditLog();
+    final var historyDeletion = data.getHistoryDeletion();
     exporter.setArgs(
         ExporterConfiguration.of(io.camunda.exporter.rdbms.ExporterConfiguration.class, args)
             .apply(config -> config.setAuditLog(auditLog.toConfiguration()))
+            .apply(config -> config.setHistoryDeletion(historyDeletion.toConfiguration()))
             .toArgs());
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/HistoryDeletionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryDeletionTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class HistoryDeletionTest {
+
+  @Test
+  void shouldHaveDefaults() {
+    final HistoryDeletion historyDeletion = new HistoryDeletion();
+
+    assertThat(historyDeletion.getDelayBetweenRuns())
+        .as("Default delayBetweenRuns should be 1 second")
+        .isEqualTo(Duration.ofSeconds(1));
+    assertThat(historyDeletion.getMaxDelayBetweenRuns())
+        .as("Default maxDelayBetweenRuns should be 5 minutes")
+        .isEqualTo(Duration.ofMinutes(5));
+    assertThat(historyDeletion.getQueueBatchSize())
+        .as("Default queueBatchSize should be 100")
+        .isEqualTo(100);
+    assertThat(historyDeletion.getDependentRowLimit())
+        .as("Default dependentRowLimit should be 10000")
+        .isEqualTo(10000);
+  }
+
+  @Test
+  void shouldConvertToHistoryDeletionConfiguration() {
+    final HistoryDeletion historyDeletion = new HistoryDeletion();
+
+    // mutate values to ensure mapping works for non-defaults
+    historyDeletion.setDelayBetweenRuns(Duration.ofSeconds(3));
+    historyDeletion.setMaxDelayBetweenRuns(Duration.ofMinutes(2));
+    historyDeletion.setQueueBatchSize(250);
+    historyDeletion.setDependentRowLimit(5000);
+
+    final HistoryDeletionConfiguration config = historyDeletion.toConfiguration();
+
+    assertThat(config.getDelayBetweenRuns())
+        .as("Converted delayBetweenRuns should match")
+        .isEqualTo(historyDeletion.getDelayBetweenRuns());
+    assertThat(config.getMaxDelayBetweenRuns())
+        .as("Converted maxDelayBetweenRuns should match")
+        .isEqualTo(historyDeletion.getMaxDelayBetweenRuns());
+    assertThat(config.getQueueBatchSize())
+        .as("Converted queueBatchSize should match")
+        .isEqualTo(historyDeletion.getQueueBatchSize());
+    assertThat(config.getDependentRowLimit())
+        .as("Converted dependentRowLimit should match")
+        .isEqualTo(historyDeletion.getDependentRowLimit());
+  }
+
+  @Nested
+  @ActiveProfiles({"broker"})
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+        "camunda.data.history-deletion.delay-between-runs=PT2S",
+        "camunda.data.history-deletion.max-delay-between-runs=PT10M",
+        "camunda.data.history-deletion.queue-batch-size=200",
+        "camunda.data.history-deletion.dependent-row-limit=5000"
+      })
+  class RDBMSExporterTest {
+    @Test
+    void shouldPopulateWithHistoryDeletion(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getRdbmsExporter();
+
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getHistoryDeletion().getDelayBetweenRuns())
+          .isEqualTo(Duration.ofSeconds(2));
+      assertThat(config.getHistoryDeletion().getMaxDelayBetweenRuns())
+          .isEqualTo(Duration.ofMinutes(10));
+      assertThat(config.getHistoryDeletion().getQueueBatchSize()).isEqualTo(200);
+      assertThat(config.getHistoryDeletion().getDependentRowLimit()).isEqualTo(5000);
+    }
+  }
+
+  @Nested
+  @ActiveProfiles({"broker"})
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.history-deletion.delay-between-runs=PT3S",
+        "camunda.data.history-deletion.max-delay-between-runs=PT15M",
+        "camunda.data.history-deletion.queue-batch-size=150",
+      })
+  class CamundaExporterTest {
+    @Test
+    void shouldPopulateWithHistoryDeletion(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getCamundaExporter();
+
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getHistoryDeletion().getDelayBetweenRuns())
+          .isEqualTo(Duration.ofSeconds(3));
+      assertThat(config.getHistoryDeletion().getMaxDelayBetweenRuns())
+          .isEqualTo(Duration.ofMinutes(15));
+      assertThat(config.getHistoryDeletion().getQueueBatchSize()).isEqualTo(150);
+      assertThat(config.getHistoryDeletion().getDependentRowLimit()).isEqualTo(10000);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -217,4 +217,10 @@ public record RdbmsWriterConfig(
       }
     }
   }
+
+  public record HistoryDeletionConfig(
+      Duration delayBetweenRuns,
+      Duration maxDelayBetweenRuns,
+      int queueBatchSize,
+      int dependentRowLimit) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write.service;
 
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
@@ -25,27 +26,30 @@ public class HistoryDeletionService {
 
   private final RdbmsWriters rdbmsWriters;
   private final HistoryDeletionDbReader historyDeletionDbReader;
-  private final Duration minimumDeletionInterval = Duration.ofSeconds(1);
-  private final Duration maximumDeletionInterval = Duration.ofMinutes(5);
-  private Duration currentDeletionInterval = minimumDeletionInterval;
+  private final HistoryDeletionConfig config;
+  private Duration currentDeletionInterval;
 
   public HistoryDeletionService(
-      final RdbmsWriters rdbmsWriters, final HistoryDeletionDbReader historyDeletionDbReader) {
+      final RdbmsWriters rdbmsWriters,
+      final HistoryDeletionDbReader historyDeletionDbReader,
+      final HistoryDeletionConfig config) {
     this.rdbmsWriters = rdbmsWriters;
     this.historyDeletionDbReader = historyDeletionDbReader;
+    this.config = config;
+    this.currentDeletionInterval = config.delayBetweenRuns();
   }
 
   public Duration deleteHistory(final int partitionId) {
-    final var batch = historyDeletionDbReader.getNextBatch(partitionId, 100);
+    final var batch = historyDeletionDbReader.getNextBatch(partitionId, config.queueBatchSize());
     LOG.trace("Deleting historic data for entities: {}", batch);
 
     final var deletedProcessInstances = deleteProcessInstances(batch);
     final var deletedResourceCount = deleteFromHistoryDeletionTable(deletedProcessInstances);
 
     if (deletedResourceCount > 0) {
-      return minimumDeletionInterval;
-    } else if (currentDeletionInterval.compareTo(maximumDeletionInterval) >= 0) {
-      return maximumDeletionInterval;
+      return config.delayBetweenRuns();
+    } else if (currentDeletionInterval.compareTo(config.maxDelayBetweenRuns()) >= 0) {
+      return config.maxDelayBetweenRuns();
     } else {
       currentDeletionInterval = currentDeletionInterval.multipliedBy(2);
       return currentDeletionInterval;
@@ -71,7 +75,7 @@ public class HistoryDeletionService {
         rdbmsWriters.getProcessInstanceDependantWriters().stream()
             .allMatch(
                 dependant -> {
-                  final var limit = 10000; // TODO make limit configurable
+                  final var limit = config.dependentRowLimit();
                   final var deletedRows =
                       dependant.deleteProcessInstanceRelatedData(processInstanceKeys, limit);
                   return deletedRows < limit;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
@@ -40,7 +41,10 @@ public class HistoryDeletionServiceTest {
     rdbmsWritersMock = mock(RdbmsWriters.class, Answers.RETURNS_DEEP_STUBS);
     historyDeletionDbReaderMock = mock(HistoryDeletionDbReader.class);
     historyDeletionService =
-        new HistoryDeletionService(rdbmsWritersMock, historyDeletionDbReaderMock);
+        new HistoryDeletionService(
+            rdbmsWritersMock,
+            historyDeletionDbReaderMock,
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000));
   }
 
   @Test

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.historydeletion;
+
+import java.time.Duration;
+
+public final class HistoryDeletionConfiguration {
+
+  private Duration delayBetweenRuns = Duration.ofSeconds(1);
+  private Duration maxDelayBetweenRuns = Duration.ofMinutes(5);
+  private int queueBatchSize = 100;
+  private int dependentRowLimit = 10000;
+
+  public Duration getDelayBetweenRuns() {
+    return delayBetweenRuns;
+  }
+
+  public void setDelayBetweenRuns(final Duration delayBetweenRuns) {
+    this.delayBetweenRuns = delayBetweenRuns;
+  }
+
+  public Duration getMaxDelayBetweenRuns() {
+    return maxDelayBetweenRuns;
+  }
+
+  public void setMaxDelayBetweenRuns(final Duration maxDelayBetweenRuns) {
+    this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+  }
+
+  public int getQueueBatchSize() {
+    return queueBatchSize;
+  }
+
+  public void setQueueBatchSize(final int queueBatchSize) {
+    this.queueBatchSize = queueBatchSize;
+  }
+
+  public int getDependentRowLimit() {
+    return dependentRowLimit;
+  }
+
+  public void setDependentRowLimit(final int dependentRowLimit) {
+    this.dependentRowLimit = dependentRowLimit;
+  }
+
+  @Override
+  public String toString() {
+    return "HistoryDeletionConfiguration{"
+        + "delayBetweenRuns="
+        + delayBetweenRuns
+        + ", maxDelayBetweenRuns="
+        + maxDelayBetweenRuns
+        + ", queueBatchSize="
+        + queueBatchSize
+        + ", dependentRowLimit="
+        + dependentRowLimit
+        + '}';
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfiguration.java
@@ -11,10 +11,15 @@ import java.time.Duration;
 
 public final class HistoryDeletionConfiguration {
 
-  private Duration delayBetweenRuns = Duration.ofSeconds(1);
-  private Duration maxDelayBetweenRuns = Duration.ofMinutes(5);
-  private int queueBatchSize = 100;
-  private int dependentRowLimit = 10000;
+  private static final Duration DEFAULT_DELAY_BETWEEN_RUNS = Duration.ofSeconds(1);
+  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofMinutes(5);
+  private static final int DEFAULT_QUEUE_BATCH_SIZE = 100;
+  private static final int DEFAULT_DEPENDENT_ROW_LIMIT = 10000;
+
+  private Duration delayBetweenRuns = DEFAULT_DELAY_BETWEEN_RUNS;
+  private Duration maxDelayBetweenRuns = DEFAULT_MAX_DELAY_BETWEEN_RUNS;
+  private int queueBatchSize = DEFAULT_QUEUE_BATCH_SIZE;
+  private int dependentRowLimit = DEFAULT_DEPENDENT_ROW_LIMIT;
 
   public Duration getDelayBetweenRuns() {
     return delayBetweenRuns;

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfigurationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.historydeletion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class HistoryDeletionConfigurationTest {
+
+  @Test
+  void shouldHaveDefaultDelayBetweenRuns() {
+    final var config = new HistoryDeletionConfiguration();
+
+    assertThat(config.getDelayBetweenRuns()).isEqualTo(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldSetDelayBetweenRuns() {
+    final var config = new HistoryDeletionConfiguration();
+    config.setDelayBetweenRuns(Duration.ofMillis(2500));
+
+    assertThat(config.getDelayBetweenRuns()).isEqualTo(Duration.ofMillis(2500));
+  }
+
+  @Test
+  void shouldHaveDefaultMaxDelayBetweenRuns() {
+    final var config = new HistoryDeletionConfiguration();
+
+    assertThat(config.getMaxDelayBetweenRuns()).isEqualTo(Duration.ofMinutes(5));
+  }
+
+  @Test
+  void shouldSetMaxDelayBetweenRuns() {
+    final var config = new HistoryDeletionConfiguration();
+    config.setMaxDelayBetweenRuns(Duration.ofMillis(5000));
+
+    assertThat(config.getMaxDelayBetweenRuns()).isEqualTo(Duration.ofMillis(5000));
+  }
+
+  @Test
+  void shouldHaveDefaultBatchSize() {
+    final var config = new HistoryDeletionConfiguration();
+
+    assertThat(config.getQueueBatchSize()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldSetBatchSize() {
+    final var config = new HistoryDeletionConfiguration();
+    config.setQueueBatchSize(500);
+
+    assertThat(config.getQueueBatchSize()).isEqualTo(500);
+  }
+
+  @Test
+  void shouldHaveDefaultDependentRowLimit() {
+    final var config = new HistoryDeletionConfiguration();
+
+    assertThat(config.getDependentRowLimit()).isEqualTo(10000);
+  }
+
+  @Test
+  void shouldSetDependentRowLimit() {
+    final var config = new HistoryDeletionConfiguration();
+    config.setDependentRowLimit(5000);
+
+    assertThat(config.getDependentRowLimit()).isEqualTo(5000);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
+import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 
 public class ExporterConfiguration {
 
@@ -26,6 +27,7 @@ public class ExporterConfiguration {
   private IncidentNotifierConfiguration notifier = new IncidentNotifierConfiguration();
   private BatchOperationConfiguration batchOperation = new BatchOperationConfiguration();
   private AuditLogConfiguration auditLog = new AuditLogConfiguration();
+  private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
   private boolean createSchema = true;
 
   public AuditLogConfiguration getAuditLog() {
@@ -34,6 +36,14 @@ public class ExporterConfiguration {
 
   public void setAuditLog(final AuditLogConfiguration auditLog) {
     this.auditLog = auditLog;
+  }
+
+  public HistoryDeletionConfiguration getHistoryDeletion() {
+    return historyDeletion;
+  }
+
+  public void setHistoryDeletion(final HistoryDeletionConfiguration historyDeletion) {
+    this.historyDeletion = historyDeletion;
   }
 
   public ConnectConfiguration getConnect() {
@@ -159,6 +169,8 @@ public class ExporterConfiguration {
         + batchOperation
         + ", auditLog="
         + auditLog
+        + ", historyDeletion="
+        + historyDeletion
         + '}';
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -266,13 +266,13 @@ public final class BackgroundTaskManagerFactory {
   private OpenSearchHistoryDeletionRepository createHistoryDeletionRepository(
       final OpenSearchAsyncClient asyncClient) {
     return new OpenSearchHistoryDeletionRepository(
-        resourceProvider, asyncClient, executor, logger, partitionId);
+        resourceProvider, asyncClient, executor, logger, partitionId, config.getHistoryDeletion());
   }
 
   private ElasticsearchHistoryDeletionRepository createHistoryDeletionRepository(
       final ElasticsearchAsyncClient asyncClient) {
     return new ElasticsearchHistoryDeletionRepository(
-        resourceProvider, asyncClient, executor, logger, partitionId);
+        resourceProvider, asyncClient, executor, logger, partitionId, config.getHistoryDeletion());
   }
 
   private ReschedulingTask buildRolloverPeriodJob() {
@@ -415,8 +415,14 @@ public final class BackgroundTaskManagerFactory {
   }
 
   private ReschedulingTask buildHistoryDeletionTask(final BackgroundTask task) {
-    // TODO make hardcoded values configurable
-    return new ReschedulingTask(task, 1, 1000, 60000, executor, logger);
+    final var historyDeletion = config.getHistoryDeletion();
+    return new ReschedulingTask(
+        task,
+        1,
+        historyDeletion.getDelayBetweenRuns().toMillis(),
+        historyDeletion.getMaxDelayBetweenRuns().toMillis(),
+        executor,
+        logger);
   }
 
   private ScheduledThreadPoolExecutor buildExecutor() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
@@ -39,7 +39,8 @@ public class ElasticsearchHistoryDeletionRepositoryIT extends HistoryDeletionRep
         client,
         Runnable::run,
         LOGGER,
-        partitionId);
+        partitionId,
+        config.getHistoryDeletion());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
@@ -33,7 +33,8 @@ public class OpenSearchHistoryDeletionIT extends HistoryDeletionRepositoryIT {
         client,
         Runnable::run,
         LOGGER,
-        partitionId);
+        partitionId,
+        config.getHistoryDeletion());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryConfig;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
+import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +23,7 @@ public class ExporterConfiguration {
 
   // AuditLog
   private AuditLogConfiguration auditLog = new AuditLogConfiguration();
+  private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
   private Duration flushInterval = DEFAULT_FLUSH_INTERVAL;
   private int queueSize = RdbmsWriterConfig.DEFAULT_QUEUE_SIZE;
   private int queueMemoryLimit = RdbmsWriterConfig.DEFAULT_QUEUE_MEMORY_LIMIT;
@@ -42,6 +44,14 @@ public class ExporterConfiguration {
 
   public void setAuditLog(final AuditLogConfiguration auditLog) {
     this.auditLog = auditLog;
+  }
+
+  public HistoryDeletionConfiguration getHistoryDeletion() {
+    return historyDeletion;
+  }
+
+  public void setHistoryDeletion(final HistoryDeletionConfiguration historyDeletion) {
+    this.historyDeletion = historyDeletion;
   }
 
   public Duration getFlushInterval() {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.rdbms;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
@@ -149,7 +150,14 @@ public class RdbmsExporterWrapper implements Exporter {
     final var historyCleanupService = new HistoryCleanupService(rdbmsWriterConfig, rdbmsWriters);
     builder.historyCleanupService(historyCleanupService);
     final var historyDeletionService =
-        new HistoryDeletionService(rdbmsWriters, rdbmsService.getHistoryDeletionDbReader());
+        new HistoryDeletionService(
+            rdbmsWriters,
+            rdbmsService.getHistoryDeletionDbReader(),
+            new HistoryDeletionConfig(
+                config.getHistoryDeletion().getDelayBetweenRuns(),
+                config.getHistoryDeletion().getMaxDelayBetweenRuns(),
+                config.getHistoryDeletion().getQueueBatchSize(),
+                config.getHistoryDeletion().getDependentRowLimit()));
     builder.historyDeletionService(historyDeletionService);
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);


### PR DESCRIPTION
## Description

Add configuration for history deletion:
- Unified Configuration: `camunda.data.history-deletion`
- propagate to Common Exporter Configuration
  - Camunda Exporter (ES/OS)
  - RDBMS Exporter

Use these configurable values in Repository (ES/OS) and in Service (RDBMS).

### Note
Used `ExponentialBackoff` to calculate next job delay

## Related issues

closes #42386
