### PR TITLE
Fix group and tenant audit logs

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 
 public class GroupAuditLogTransformer implements AuditLogTransformer<GroupRecordValue> {
@@ -14,5 +16,10 @@ public class GroupAuditLogTransformer implements AuditLogTransformer<GroupRecord
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.GROUP_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
+    log.setEntityKey(record.getValue().getGroupId());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 
 public class GroupEntityAuditLogTransformer implements AuditLogTransformer<GroupRecordValue> {
@@ -14,5 +16,10 @@ public class GroupEntityAuditLogTransformer implements AuditLogTransformer<Group
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.GROUP_ENTITY_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
+    log.setEntityKey(record.getValue().getGroupId());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 
 public class TenantAuditLogTransformer implements AuditLogTransformer<TenantRecordValue> {
@@ -14,5 +16,10 @@ public class TenantAuditLogTransformer implements AuditLogTransformer<TenantReco
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.TENANT_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
+    log.setEntityKey(record.getValue().getTenantId());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 
 public class TenantEntityAuditLogTransformer implements AuditLogTransformer<TenantRecordValue> {
@@ -14,5 +16,10 @@ public class TenantEntityAuditLogTransformer implements AuditLogTransformer<Tena
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.TENANT_ENTITY_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
+    log.setEntityKey(record.getValue().getTenantId());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogHandlerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogHandlerTest.java
@@ -14,40 +14,41 @@ import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
-import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class TenantEntityAuditLogHandlerTest {
+class GroupAuditLogHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final TenantEntityAuditLogTransformer transformer = new TenantEntityAuditLogTransformer();
+  private final GroupAuditLogTransformer transformer = new GroupAuditLogTransformer();
 
   public static Stream<Arguments> getIntentMappings() {
     return Stream.of(
-        Arguments.of(TenantIntent.ENTITY_ADDED, AuditLogOperationType.ASSIGN),
-        Arguments.of(TenantIntent.ENTITY_REMOVED, AuditLogOperationType.UNASSIGN));
+        Arguments.of(GroupIntent.CREATED, AuditLogOperationType.CREATE),
+        Arguments.of(GroupIntent.UPDATED, AuditLogOperationType.UPDATE),
+        Arguments.of(GroupIntent.DELETED, AuditLogOperationType.DELETE));
   }
 
   @MethodSource("getIntentMappings")
   @ParameterizedTest
-  void shouldTransformTenantEntityRecord(
-      final TenantIntent intent, final AuditLogOperationType operationType) {
+  void shouldTransformGroupRecord(
+      final GroupIntent intent, final AuditLogOperationType operationType) {
     // given
-    final TenantRecordValue recordValue =
-        ImmutableTenantRecordValue.builder()
-            .from(factory.generateObject(TenantRecordValue.class))
-            .withTenantId("test-tenant")
-            .withTenantKey(456L)
+    final GroupRecordValue recordValue =
+        ImmutableGroupRecordValue.builder()
+            .from(factory.generateObject(GroupRecordValue.class))
+            .withGroupId("test-group")
+            .withGroupKey(789L)
             .build();
 
-    final Record<TenantRecordValue> record =
-        factory.generateRecord(ValueType.TENANT, r -> r.withIntent(intent).withValue(recordValue));
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(ValueType.GROUP, r -> r.withIntent(intent).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -56,6 +57,6 @@ class TenantEntityAuditLogHandlerTest {
     // then
     final AuditLogInfo auditLogInfo = AuditLogInfo.of(record);
     assertThat(auditLogInfo.operationType()).isEqualTo(operationType);
-    assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
+    assertThat(entity.getEntityKey()).isEqualTo("test-group");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogHandlerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogHandlerTest.java
@@ -14,40 +14,40 @@ import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
-import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class TenantEntityAuditLogHandlerTest {
+class GroupEntityAuditLogHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final TenantEntityAuditLogTransformer transformer = new TenantEntityAuditLogTransformer();
+  private final GroupEntityAuditLogTransformer transformer = new GroupEntityAuditLogTransformer();
 
   public static Stream<Arguments> getIntentMappings() {
     return Stream.of(
-        Arguments.of(TenantIntent.ENTITY_ADDED, AuditLogOperationType.ASSIGN),
-        Arguments.of(TenantIntent.ENTITY_REMOVED, AuditLogOperationType.UNASSIGN));
+        Arguments.of(GroupIntent.ENTITY_ADDED, AuditLogOperationType.ASSIGN),
+        Arguments.of(GroupIntent.ENTITY_REMOVED, AuditLogOperationType.UNASSIGN));
   }
 
   @MethodSource("getIntentMappings")
   @ParameterizedTest
-  void shouldTransformTenantEntityRecord(
-      final TenantIntent intent, final AuditLogOperationType operationType) {
+  void shouldTransformGroupEntityRecord(
+      final GroupIntent intent, final AuditLogOperationType operationType) {
     // given
-    final TenantRecordValue recordValue =
-        ImmutableTenantRecordValue.builder()
-            .from(factory.generateObject(TenantRecordValue.class))
-            .withTenantId("test-tenant")
-            .withTenantKey(456L)
+    final GroupRecordValue recordValue =
+        ImmutableGroupRecordValue.builder()
+            .from(factory.generateObject(GroupRecordValue.class))
+            .withGroupId("test-group")
+            .withGroupKey(789L)
             .build();
 
-    final Record<TenantRecordValue> record =
-        factory.generateRecord(ValueType.TENANT, r -> r.withIntent(intent).withValue(recordValue));
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(ValueType.GROUP, r -> r.withIntent(intent).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -56,6 +56,6 @@ class TenantEntityAuditLogHandlerTest {
     // then
     final AuditLogInfo auditLogInfo = AuditLogInfo.of(record);
     assertThat(auditLogInfo.operationType()).isEqualTo(operationType);
-    assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
+    assertThat(entity.getEntityKey()).isEqualTo("test-group");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogHandlerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogHandlerTest.java
@@ -57,5 +57,6 @@ class TenantAuditLogHandlerTest {
     // then
     final AuditLogInfo auditLogInfo = AuditLogInfo.of(record);
     assertThat(auditLogInfo.operationType()).isEqualTo(operationType);
+    assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Include the group and tenant IDs in related audit log entries and add acceptance tests for these logs.

This PR also expands the Java client with an `entityKey` filter to allow us finer-grained filtering through the Java client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43249
