### PR TITLE
S3 backup store RFC339 timestamps

### DIFF
--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.s3;
 
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -75,7 +77,10 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  */
 public final class S3BackupStore implements BackupStore {
   static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new Jdk8Module()).registerModule(new JavaTimeModule());
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(new JavaTimeModule())
+          .disable(WRITE_DATES_AS_TIMESTAMPS);
   static final String SNAPSHOT_PREFIX = "snapshot/";
   static final String SEGMENTS_PREFIX = "segments/";
   static final String MANIFEST_OBJECT_KEY = "manifest.json";

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.s3;
 
+import static io.camunda.zeebe.backup.s3.S3BackupStore.MAPPER;
+
 import io.camunda.zeebe.backup.s3.manifest.CompletedBackupManifest;
 import io.camunda.zeebe.backup.s3.manifest.FailedBackupManifest;
 import io.camunda.zeebe.backup.s3.manifest.InProgressBackupManifest;
@@ -19,7 +21,7 @@ final class ManifestCompatabilityTest {
   @Test
   void shouldParseCompletedManifestFromPreviousVersion() throws IOException {
     // given
-    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+    final var objectReader = MAPPER.readerFor(ValidBackupManifest.class);
 
     // when
     final var manifest =
@@ -39,7 +41,7 @@ final class ManifestCompatabilityTest {
   @Test
   void shouldParseCompletedManifestWithoutFilesFromPreviousVersion() throws IOException {
     // given
-    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+    final var objectReader = MAPPER.readerFor(ValidBackupManifest.class);
 
     // when
     final var manifest =
@@ -57,7 +59,7 @@ final class ManifestCompatabilityTest {
   @Test
   void shouldParseInProgressManifestFromPreviousVersion() throws IOException {
     // given
-    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+    final var objectReader = MAPPER.readerFor(ValidBackupManifest.class);
 
     // when
     final var manifest =
@@ -75,7 +77,7 @@ final class ManifestCompatabilityTest {
   @Test
   void shouldParseFailedManifestFromPreviousVersion() throws IOException {
     // given
-    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+    final var objectReader = MAPPER.readerFor(ValidBackupManifest.class);
 
     // when
     final var manifest =
@@ -88,5 +90,84 @@ final class ManifestCompatabilityTest {
     Assertions.assertThat(manifest.snapshotFiles()).isNotNull();
     Assertions.assertThat(manifest.segmentFiles().files()).isNotEmpty();
     Assertions.assertThat(manifest.snapshotFiles().files()).isNotEmpty();
+  }
+
+  @Test
+  void shouldParseManifestWithBigDecimalDateFormat() throws IOException {
+    // given
+    // Date format: epoch.nanoseconds (1668519689.290560717 = 2022-11-15T13:41:29.290560717Z)
+    final var json =
+        """
+        {
+           "statusCode": "completed",
+           "id": { "nodeId": 0, "partitionId": 1, "checkpointId": 1668519689 },
+           "descriptor": { "checkpointPosition": 2641349, "numberOfPartitions": 3, "brokerVersion": "8.9.0-SNAPSHOT" },
+           "createdAt":"1668519689.290560717",
+           "modifiedAt":"1668519689.290560717"
+         }
+        """;
+
+    // when
+    final var manifest = MAPPER.readValue(json, CompletedBackupManifest.class);
+
+    // then
+    Assertions.assertThat(manifest.createdAt()).isNotNull();
+    final var createdAtUtc = manifest.createdAt().atZone(java.time.ZoneOffset.UTC);
+    Assertions.assertThat(createdAtUtc.getYear()).isEqualTo(2022);
+    Assertions.assertThat(createdAtUtc.getMonthValue()).isEqualTo(11);
+    Assertions.assertThat(createdAtUtc.getDayOfMonth()).isEqualTo(15);
+    Assertions.assertThat(createdAtUtc.getHour()).isEqualTo(13);
+    Assertions.assertThat(createdAtUtc.getMinute()).isEqualTo(41);
+    Assertions.assertThat(createdAtUtc.getSecond()).isEqualTo(29);
+    Assertions.assertThat(manifest.createdAt().getNano()).isEqualTo(290560717);
+
+    Assertions.assertThat(manifest.modifiedAt()).isNotNull();
+    final var modifiedAtUtc = manifest.modifiedAt().atZone(java.time.ZoneOffset.UTC);
+    Assertions.assertThat(modifiedAtUtc.getYear()).isEqualTo(2022);
+    Assertions.assertThat(modifiedAtUtc.getMonthValue()).isEqualTo(11);
+    Assertions.assertThat(modifiedAtUtc.getDayOfMonth()).isEqualTo(15);
+    Assertions.assertThat(modifiedAtUtc.getHour()).isEqualTo(13);
+    Assertions.assertThat(modifiedAtUtc.getMinute()).isEqualTo(41);
+    Assertions.assertThat(modifiedAtUtc.getSecond()).isEqualTo(29);
+    Assertions.assertThat(manifest.modifiedAt().getNano()).isEqualTo(290560717);
+  }
+
+  @Test
+  void shouldParseManifestWitRFCDateFormat() throws IOException {
+    // given
+    final var json =
+        """
+        {
+           "statusCode": "completed",
+           "id": { "nodeId": 0, "partitionId": 1, "checkpointId": 1668519689 },
+           "descriptor": { "checkpointPosition": 2641349, "numberOfPartitions": 3, "brokerVersion": "8.9.0-SNAPSHOT" },
+           "createdAt":"2025-12-22T20:12:33.641444035Z",
+           "modifiedAt":"2025-12-22T20:12:33.641444035Z"
+         }
+        """;
+
+    // when
+    final var manifest = MAPPER.readValue(json, CompletedBackupManifest.class);
+
+    // then
+    Assertions.assertThat(manifest.createdAt()).isNotNull();
+    final var createdAtUtc = manifest.createdAt().atZone(java.time.ZoneOffset.UTC);
+    Assertions.assertThat(createdAtUtc.getYear()).isEqualTo(2025);
+    Assertions.assertThat(createdAtUtc.getMonthValue()).isEqualTo(12);
+    Assertions.assertThat(createdAtUtc.getDayOfMonth()).isEqualTo(22);
+    Assertions.assertThat(createdAtUtc.getHour()).isEqualTo(20);
+    Assertions.assertThat(createdAtUtc.getMinute()).isEqualTo(12);
+    Assertions.assertThat(createdAtUtc.getSecond()).isEqualTo(33);
+    Assertions.assertThat(manifest.createdAt().getNano()).isEqualTo(641444035);
+
+    Assertions.assertThat(manifest.modifiedAt()).isNotNull();
+    final var modifiedAtUtc = manifest.modifiedAt().atZone(java.time.ZoneOffset.UTC);
+    Assertions.assertThat(modifiedAtUtc.getYear()).isEqualTo(2025);
+    Assertions.assertThat(modifiedAtUtc.getMonthValue()).isEqualTo(12);
+    Assertions.assertThat(modifiedAtUtc.getDayOfMonth()).isEqualTo(22);
+    Assertions.assertThat(modifiedAtUtc.getHour()).isEqualTo(20);
+    Assertions.assertThat(modifiedAtUtc.getMinute()).isEqualTo(12);
+    Assertions.assertThat(modifiedAtUtc.getSecond()).isEqualTo(33);
+    Assertions.assertThat(manifest.modifiedAt().getNano()).isEqualTo(641444035);
   }
 }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
@@ -133,7 +133,7 @@ final class ManifestCompatabilityTest {
   }
 
   @Test
-  void shouldParseManifestWitRFCDateFormat() throws IOException {
+  void shouldParseManifestWithRFCDateFormat() throws IOException {
     // given
     final var json =
         """


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Use RFC339 format in S3 Manifest's created/modifiedAt fields, same as already done for other backup stores.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40777
