### PR TITLE
fix: correct order of rdbms table names

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -40,6 +40,7 @@ public final class RdbmsTableNames {
           "FORM",
           "GROUP_MEMBER",
           "GROUP_",
+          "HISTORY_DELETION",
           "INCIDENT",
           "JOB",
           "MAPPING_RULES",
@@ -57,8 +58,7 @@ public final class RdbmsTableNames {
           "USER_TASK_TAG",
           "USER_TASK",
           "USER_",
-          "VARIABLE",
-          "HISTORY_DELETION");
+          "VARIABLE");
 
   private RdbmsTableNames() {
     // Utility class - prevent instantiation


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Similar to the change in [this PR](https://github.com/camunda/camunda/pull/41264), the table names are again in the incorrect order. This PR corrects the ordering

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43261 
