### PR TITLE
ci: restore threadcount but limit max memory allocated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,8 @@ jobs:
       - name: Maven Run Test (Zeebe)
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
+        # Maintain the forkCount * JVM heap size ( -Xmx ) to not exceed ~50% of the available memory
+        # on the runner.
         shell: bash
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
           -D forkCount=7
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
-          -D argLine="-Xmx4g"
+          -D argLine="@{argLine} -Xmx4g"
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,9 +381,10 @@ jobs:
         shell: bash
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
+          -D forkCount=7
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
-          -D junitThreadCount=8
+          -D junitThreadCount=16
+          -D argLine="-Xmx4g"
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Restore fork & threadcount for the `Zeebe Unit / *` test suite  but limit JVM heap accessible memory per thread. Surefire seems to be allocating a lot of memory with the increased number of tests in the `camunda-exporter` module, causing the JVM to crash due to OOM. 


<img width="1006" height="274" alt="image" src="https://github.com/user-attachments/assets/46fd4363-0c24-413e-af00-970ebc57fdda" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
Ref incident: [#inc-4147-zeebe-unit-exporter](https://camunda.slack.com/archives/C0A5574TRNG)
closes #
