### PR TITLE
[Backport main] Clock API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -68,7 +68,16 @@ const normalProjects = [
   {
     name: 'api-tests',
     testMatch: ['tests/api/**/*.spec.ts'],
+    testIgnore: ['tests/api/v2/clock/*.spec.ts'],
     use: devices['Desktop Chrome'],
+    teardown: 'clock-api-tests'
+  },
+  {
+    name: 'clock-api-tests',
+    testMatch: ['tests/api/v2/clock/*.spec.ts'],
+    use: devices['Desktop Chrome'],
+    workers: 1,
+    fullyParallel: false,
   },
   {
     name: 'chromium',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/clock_api_test_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/clock_api_test_process.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="c11cfbc" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="clockApiTestProcess" name="clock_api_test_process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0ipyxw2</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_144oc1f">
+      <bpmn:incoming>Flow_0ipyxw2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ipyxw2" sourceRef="StartEvent_1" targetRef="Event_144oc1f" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="clockApiTestProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_144oc1f_di" bpmnElement="Event_144oc1f">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ipyxw2_di" bpmnElement="Flow_0ipyxw2">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertStatusCode,
+  buildUrl,
+  jsonHeaders,
+  assertBadRequest
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
+import { defaultAssertionOptions } from 'utils/constants';
+
+
+test.describe('Pin Clock API Tests', () => {
+  test.beforeAll(async ({ request }) => {
+    await deploy(['./resources/clock_api_test_process.bpmn']);
+    const res = await request.post(
+        buildUrl(
+            '/clock/reset',
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertStatusCode(res, 204);
+  });
+
+  test.afterAll(async ({ request }) => {
+    const res = await request.post(
+        buildUrl(
+            '/clock/reset',
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+  });
+
+test('Pin clock to a fixed instant', async ({ request }) => {
+    const timestamp = Date.parse('2025-01-01T00:00:00Z');
+
+    await test.step('Pin clock to fixed instant and verify', async () => {
+        const pin = await request.put(
+            buildUrl('/clock'),
+            {
+                data: { timestamp },
+                headers: jsonHeaders(),
+            },
+        );
+
+        await assertStatusCode(pin, 204);
+    });
+    
+    await test.step('Create process instances and verify start and end dates', async () => {
+        const instance = await createSingleInstance('clockApiTestProcess', 1);
+        const processInstanceKeyToGet = instance.processInstanceKey;
+
+        await expect(async () => {
+            const res = await request.get(
+            buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+            {
+                headers: jsonHeaders(),
+            },
+            );
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+            {
+                path: '/process-instances/{processInstanceKey}',
+                method: 'GET',
+                status: '200',
+            },
+            res,
+            );
+            
+            const body = await res.json();
+            expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+            expect(body.state).toBe('COMPLETED');
+            const startDate = body.startDate;
+            const endDate = body.endDate;
+            expect(new Date(startDate).getTime()).toBe(timestamp);
+            expect(new Date(endDate).getTime()).toBe(timestamp);
+        }).toPass(defaultAssertionOptions);   
+    });
+
+    await test.step('Reset clock', async () => {
+      const res = await request.post(
+        buildUrl(
+            '/clock/reset',
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+    });
+  });
+
+  test('Pin clock - bad request', async ({ request }) => {
+    const someInvalidData = 'meow';
+    const pin = await request.put(
+            buildUrl('/clock'),
+            {
+                data: { timestamp: someInvalidData },
+                headers: jsonHeaders(),
+            },
+        );
+
+        await assertBadRequest(
+        pin,
+        "Request property [timestamp] cannot be parsed",
+      );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-pin-api.spec.ts
@@ -11,116 +11,91 @@ import {
   assertStatusCode,
   buildUrl,
   jsonHeaders,
-  assertBadRequest
+  assertBadRequest,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  createSingleInstance,
-  deploy,
-} from '../../../../utils/zeebeClient';
-import { defaultAssertionOptions } from 'utils/constants';
-
+import {createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {defaultAssertionOptions} from 'utils/constants';
 
 test.describe('Pin Clock API Tests', () => {
-  test.beforeAll(async ({ request }) => {
+  test.beforeAll(async ({request}) => {
     await deploy(['./resources/clock_api_test_process.bpmn']);
-    const res = await request.post(
-        buildUrl(
-            '/clock/reset',
-        ),
-        {
-          headers: jsonHeaders(),
-        },
-      );
+    const res = await request.post(buildUrl('/clock/reset'), {
+      headers: jsonHeaders(),
+    });
 
-      await assertStatusCode(res, 204);
+    await assertStatusCode(res, 204);
   });
 
-  test.afterAll(async ({ request }) => {
-    const res = await request.post(
-        buildUrl(
-            '/clock/reset',
-        ),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-      await assertStatusCode(res, 204);
+  test.afterAll(async ({request}) => {
+    const res = await request.post(buildUrl('/clock/reset'), {
+      headers: jsonHeaders(),
+    });
+    await assertStatusCode(res, 204);
   });
 
-test('Pin clock to a fixed instant', async ({ request }) => {
+  test('Pin clock to a fixed instant', async ({request}) => {
     const timestamp = Date.parse('2025-01-01T00:00:00Z');
 
     await test.step('Pin clock to fixed instant and verify', async () => {
-        const pin = await request.put(
-            buildUrl('/clock'),
-            {
-                data: { timestamp },
-                headers: jsonHeaders(),
-            },
+      const pin = await request.put(buildUrl('/clock'), {
+        data: {timestamp},
+        headers: jsonHeaders(),
+      });
+
+      await assertStatusCode(pin, 204);
+    });
+
+    await test.step('Create process instances and verify start and end dates', async () => {
+      const instance = await createSingleInstance('clockApiTestProcess', 1);
+      const processInstanceKeyToGet = instance.processInstanceKey;
+
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+          {
+            headers: jsonHeaders(),
+          },
         );
 
-        await assertStatusCode(pin, 204);
-    });
-    
-    await test.step('Create process instances and verify start and end dates', async () => {
-        const instance = await createSingleInstance('clockApiTestProcess', 1);
-        const processInstanceKeyToGet = instance.processInstanceKey;
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
 
-        await expect(async () => {
-            const res = await request.get(
-            buildUrl(`/process-instances/${processInstanceKeyToGet}`),
-            {
-                headers: jsonHeaders(),
-            },
-            );
-
-            await assertStatusCode(res, 200);
-            await validateResponse(
-            {
-                path: '/process-instances/{processInstanceKey}',
-                method: 'GET',
-                status: '200',
-            },
-            res,
-            );
-            
-            const body = await res.json();
-            expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
-            expect(body.state).toBe('COMPLETED');
-            const startDate = body.startDate;
-            const endDate = body.endDate;
-            expect(new Date(startDate).getTime()).toBe(timestamp);
-            expect(new Date(endDate).getTime()).toBe(timestamp);
-        }).toPass(defaultAssertionOptions);   
+        const body = await res.json();
+        expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+        expect(body.state).toBe('COMPLETED');
+        const startDate = body.startDate;
+        const endDate = body.endDate;
+        expect(new Date(startDate).getTime()).toBe(timestamp);
+        expect(new Date(endDate).getTime()).toBe(timestamp);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Reset clock', async () => {
-      const res = await request.post(
-        buildUrl(
-            '/clock/reset',
-        ),
-        {
-          headers: jsonHeaders(),
-        },
-      );
+      const res = await request.post(buildUrl('/clock/reset'), {
+        headers: jsonHeaders(),
+      });
       await assertStatusCode(res, 204);
     });
   });
 
-  test('Pin clock - bad request', async ({ request }) => {
+  test('Pin clock - bad request', async ({request}) => {
     const someInvalidData = 'meow';
-    const pin = await request.put(
-            buildUrl('/clock'),
-            {
-                data: { timestamp: someInvalidData },
-                headers: jsonHeaders(),
-            },
-        );
+    const pin = await request.put(buildUrl('/clock'), {
+      data: {timestamp: someInvalidData},
+      headers: jsonHeaders(),
+    });
 
-        await assertBadRequest(
-        pin,
-        "Request property [timestamp] cannot be parsed",
-      );
+    await assertBadRequest(
+      pin,
+      'Request property [timestamp] cannot be parsed',
+    );
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
@@ -53,7 +53,6 @@ test.describe('Reset Clock API Tests', () => {
       const serverTimeMs = new Date(res.startDate).getTime();
       const nowMs = Date.now();
       const diff = Math.abs(serverTimeMs - nowMs);
-      console.log('Diff: ', diff);
       expect(diff).toBeLessThanOrEqual(MAX_DRIFT);
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
@@ -7,128 +7,106 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {
-  assertStatusCode,
-  buildUrl,
-  jsonHeaders,
-} from '../../../../utils/http';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  createSingleInstance,
-  deploy,
-} from '../../../../utils/zeebeClient';
-import { defaultAssertionOptions } from 'utils/constants';
-
+import {createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {defaultAssertionOptions} from 'utils/constants';
 
 test.describe('Reset Clock API Tests', () => {
   const timestamp = Date.parse('2025-01-01T00:00:00Z');
-  test.beforeAll(async ({ request }) => {
+  test.beforeAll(async ({request}) => {
     await deploy(['./resources/clock_api_test_process.bpmn']);
 
     await test.step('Pin clock to fixed instant and verify', async () => {
-        const pin = await request.put(
-            buildUrl('/clock'),
-            {
-                data: { timestamp },
-                headers: jsonHeaders(),
-            },
+      const pin = await request.put(buildUrl('/clock'), {
+        data: {timestamp},
+        headers: jsonHeaders(),
+      });
+
+      await assertStatusCode(pin, 204);
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    const res = await request.post(buildUrl('/clock/reset'), {
+      headers: jsonHeaders(),
+    });
+    await assertStatusCode(res, 204);
+  });
+
+  test('Reset clock', async ({request}) => {
+    await test.step('Create process instances and verify pinned start and end dates', async () => {
+      const instance = await createSingleInstance('clockApiTestProcess', 1);
+      const processInstanceKeyToGet = instance.processInstanceKey;
+
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+          {
+            headers: jsonHeaders(),
+          },
         );
 
-        await assertStatusCode(pin, 204);
-    });
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
 
-  });
-
-  test.afterAll(async ({ request }) => {
-    const res = await request.post(
-        buildUrl(
-            '/clock/reset',
-        ),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-      await assertStatusCode(res, 204);
-  });
-
-test('Reset clock', async ({ request }) => {
-    await test.step('Create process instances and verify pinned start and end dates', async () => {
-        const instance = await createSingleInstance('clockApiTestProcess', 1);
-        const processInstanceKeyToGet = instance.processInstanceKey;
-
-        await expect(async () => {
-            const res = await request.get(
-            buildUrl(`/process-instances/${processInstanceKeyToGet}`),
-            {
-                headers: jsonHeaders(),
-            },
-            );
-
-            await assertStatusCode(res, 200);
-            await validateResponse(
-            {
-                path: '/process-instances/{processInstanceKey}',
-                method: 'GET',
-                status: '200',
-            },
-            res,
-            );
-            
-            const body = await res.json();
-            expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
-            expect(body.state).toBe('COMPLETED');
-            const startDate = body.startDate;
-            const endDate = body.endDate;
-            expect(new Date(startDate).getTime()).toBe(timestamp);
-            expect(new Date(endDate).getTime()).toBe(timestamp);
-        }).toPass(defaultAssertionOptions);   
+        const body = await res.json();
+        expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+        expect(body.state).toBe('COMPLETED');
+        const startDate = body.startDate;
+        const endDate = body.endDate;
+        expect(new Date(startDate).getTime()).toBe(timestamp);
+        expect(new Date(endDate).getTime()).toBe(timestamp);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Reset clock', async () => {
-      const res = await request.post(
-        buildUrl(
-            '/clock/reset',
-        ),
-        {
-          headers: jsonHeaders(),
-        },
-      );
+      const res = await request.post(buildUrl('/clock/reset'), {
+        headers: jsonHeaders(),
+      });
       await assertStatusCode(res, 204);
     });
 
     await test.step('Create process instances and verify updated start and end dates', async () => {
-        const instance = await createSingleInstance('clockApiTestProcess', 1);
-        const processInstanceKeyToGet = instance.processInstanceKey;
+      const instance = await createSingleInstance('clockApiTestProcess', 1);
+      const processInstanceKeyToGet = instance.processInstanceKey;
 
-        await expect(async () => {
-            const res = await request.get(
-            buildUrl(`/process-instances/${processInstanceKeyToGet}`),
-            {
-                headers: jsonHeaders(),
-            },
-            );
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
 
-            await assertStatusCode(res, 200);
-            await validateResponse(
-            {
-                path: '/process-instances/{processInstanceKey}',
-                method: 'GET',
-                status: '200',
-            },
-            res,
-            );
-            
-            const body = await res.json();
-            expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
-            expect(body.state).toBe('COMPLETED');
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
 
-            const MAX_DRIFT = 60_000;
-            const serverTimeMs = new Date(body.startDate).getTime();
-            const nowMs = Date.now();
-            const diff = Math.abs(serverTimeMs - nowMs);
-            console.log('Diff: ', diff);
-            expect(diff).toBeLessThanOrEqual(MAX_DRIFT);
-        }).toPass(defaultAssertionOptions);   
+        const body = await res.json();
+        expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+        expect(body.state).toBe('COMPLETED');
+
+        const MAX_DRIFT = 60_000;
+        const serverTimeMs = new Date(body.startDate).getTime();
+        const nowMs = Date.now();
+        const diff = Math.abs(serverTimeMs - nowMs);
+        console.log('Diff: ', diff);
+        expect(diff).toBeLessThanOrEqual(MAX_DRIFT);
+      }).toPass(defaultAssertionOptions);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertStatusCode,
+  buildUrl,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
+import { defaultAssertionOptions } from 'utils/constants';
+
+
+test.describe('Reset Clock API Tests', () => {
+  const timestamp = Date.parse('2025-01-01T00:00:00Z');
+  test.beforeAll(async ({ request }) => {
+    await deploy(['./resources/clock_api_test_process.bpmn']);
+
+    await test.step('Pin clock to fixed instant and verify', async () => {
+        const pin = await request.put(
+            buildUrl('/clock'),
+            {
+                data: { timestamp },
+                headers: jsonHeaders(),
+            },
+        );
+
+        await assertStatusCode(pin, 204);
+    });
+
+  });
+
+  test.afterAll(async ({ request }) => {
+    const res = await request.post(
+        buildUrl(
+            '/clock/reset',
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+  });
+
+test('Reset clock', async ({ request }) => {
+    await test.step('Create process instances and verify pinned start and end dates', async () => {
+        const instance = await createSingleInstance('clockApiTestProcess', 1);
+        const processInstanceKeyToGet = instance.processInstanceKey;
+
+        await expect(async () => {
+            const res = await request.get(
+            buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+            {
+                headers: jsonHeaders(),
+            },
+            );
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+            {
+                path: '/process-instances/{processInstanceKey}',
+                method: 'GET',
+                status: '200',
+            },
+            res,
+            );
+            
+            const body = await res.json();
+            expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+            expect(body.state).toBe('COMPLETED');
+            const startDate = body.startDate;
+            const endDate = body.endDate;
+            expect(new Date(startDate).getTime()).toBe(timestamp);
+            expect(new Date(endDate).getTime()).toBe(timestamp);
+        }).toPass(defaultAssertionOptions);   
+    });
+
+    await test.step('Reset clock', async () => {
+      const res = await request.post(
+        buildUrl(
+            '/clock/reset',
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 204);
+    });
+
+    await test.step('Create process instances and verify updated start and end dates', async () => {
+        const instance = await createSingleInstance('clockApiTestProcess', 1);
+        const processInstanceKeyToGet = instance.processInstanceKey;
+
+        await expect(async () => {
+            const res = await request.get(
+            buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+            {
+                headers: jsonHeaders(),
+            },
+            );
+
+            await assertStatusCode(res, 200);
+            await validateResponse(
+            {
+                path: '/process-instances/{processInstanceKey}',
+                method: 'GET',
+                status: '200',
+            },
+            res,
+            );
+            
+            const body = await res.json();
+            expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+            expect(body.state).toBe('COMPLETED');
+
+            const MAX_DRIFT = 60_000;
+            const serverTimeMs = new Date(body.startDate).getTime();
+            const nowMs = Date.now();
+            const diff = Math.abs(serverTimeMs - nowMs);
+            console.log('Diff: ', diff);
+            expect(diff).toBeLessThanOrEqual(MAX_DRIFT);
+        }).toPass(defaultAssertionOptions);   
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/clock-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/clock-requestHelpers.ts
@@ -15,8 +15,9 @@ import {createSingleInstance} from '../zeebeClient';
 
 export async function createProcessInstanceAndRetrieveTimeStamp(
   request: APIRequestContext,
+  processDefinitionId: string,
 ) {
-  const instance = await createSingleInstance('clockApiTestProcess', 1);
+  const instance = await createSingleInstance(processDefinitionId, 1);
   const processInstanceKeyToGet = instance.processInstanceKey;
   let startDate = '';
   let endDate = '';
@@ -41,6 +42,7 @@ export async function createProcessInstanceAndRetrieveTimeStamp(
 
     const body = await res.json();
     expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+    expect(body.processDefinitionId).toBe(instance.processDefinitionId);
     expect(body.state).toBe('COMPLETED');
     startDate = body.startDate;
     endDate = body.endDate;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/clock-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/clock-requestHelpers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {APIRequestContext} from 'playwright-core';
+import {expect} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {defaultAssertionOptions} from '../constants';
+import {validateResponse} from '../../json-body-assertions';
+import {createSingleInstance} from '../zeebeClient';
+
+export async function createProcessInstanceAndRetrieveTimeStamp(
+  request: APIRequestContext,
+) {
+  const instance = await createSingleInstance('clockApiTestProcess', 1);
+  const processInstanceKeyToGet = instance.processInstanceKey;
+  let startDate = '';
+  let endDate = '';
+
+  await expect(async () => {
+    const res = await request.get(
+      buildUrl(`/process-instances/${processInstanceKeyToGet}`),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/process-instances/{processInstanceKey}',
+        method: 'GET',
+        status: '200',
+      },
+      res,
+    );
+
+    const body = await res.json();
+    expect(body.processInstanceKey).toBe(processInstanceKeyToGet);
+    expect(body.state).toBe('COMPLETED');
+    startDate = body.startDate;
+    endDate = body.endDate;
+  }).toPass(defaultAssertionOptions);
+
+  return {startDate: startDate, endDate: endDate};
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -64,3 +64,4 @@ export {
   createMammalProcessInstanceAndDeployMammalDecision,
   type DecisionInstance,
 } from './decision-instance-requestHelpers';
+export {createProcessInstanceAndRetrieveTimeStamp} from './clock-requestHelpers';


### PR DESCRIPTION
## Description
Backport of #43239 to `main`.

relates to #37204

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/20572936210)