### PR TITLE
POC for Keycloak redirect

### DIFF
--- a/identity/client/src/utility/auth/index.ts
+++ b/identity/client/src/utility/auth/index.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getBaseUrl, getLoginApiUrl, getLogoutApiUrl } from "src/configuration";
+import { getLoginApiUrl, getLogoutApiUrl } from "src/configuration";
 
 let loggedIn = false;
 
@@ -63,10 +63,30 @@ export function logout(): Promise<void> {
   })
     .then((response: Response) => {
       if (response.status < 400) {
-        window.location.href = `${getBaseUrl()}/`;
+        // redirect to Keycloak logout endpoint
+        // hardcoding post_logout_redirect_uri and client_id for now
+        window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:8080/identity&client_id=orchestration-cluster`;
+        // window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout`;
       }
     })
     .catch((e) => {
       console.log(e);
     });
 }
+
+// export function logout(): Promise<void> {
+//   const data = new FormData();
+//   return fetch(getLogoutApiUrl(), {
+//     method: "post",
+//     body: data,
+//   })
+//     .then(() => {
+//       window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout`;
+//       /*if (response.status < 400) {
+//         window.location.href = `${getBaseUrl()}/`;
+//       }*/
+//     })
+//     .catch((e) => {
+//       console.log(e);
+//     });
+// }

--- a/operate/client/src/modules/stores/authentication.ts
+++ b/operate/client/src/modules/stores/authentication.ts
@@ -80,7 +80,10 @@ class Authentication {
 
     storeStateLocally({wasReloaded: true});
 
-    window.location.reload();
+    // redirect to Keycloak logout endpoint
+    // hardcoding post_logout_redirect_uri and client_id for now
+    window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:8080/operate&client_id=orchestration-cluster`;
+    // window.location.reload();
   };
 
   handleLogout = async () => {


### PR DESCRIPTION
## Description
This is a simple POC and investigation on how Keycloak end session redirect works.

In this POC:
- On Identity and Operate Logout:
  - clear Camunda session as before
  - redirect to Keycloak logout endpoint to clear IdP session are well
  - pass hardcoded (for now) `post_logout_redirect_uri `and `client_id` for redirect after logout

Keycloak logout endpoint is hardcoded to: `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout`

`post_logout_redirect_uri `and `client_id` are passed as parameters: 
`?post_logout_redirect_uri=http://localhost:8080/operate&client_id=orchestration-cluster`

In Keycloak:
- Front-channel logout URL is set to `http://localhost:8080/logout` <img width="1165" height="308" alt="Screenshot 2025-12-24 at 13 35 31" src="https://github.com/user-attachments/assets/ad054f28-4d5c-4807-af51-6ea74ea88861" />
- This is not needed if logout is performed from Camunda as we kill the local Camunda session before the redirect.
- This might be needed in case IdP logout is performed from the third party app and the user wants to terminate Camunda session as well, but this is up to the user to configure it.

Testing:
- Run local Camunda with Keycloak
- Login to Identity or Operate
- Click the logout button: <img width="896" height="656" alt="Screenshot 2025-12-24 at 13 32 47" src="https://github.com/user-attachments/assets/28f94fb5-3b8d-4bee-904f-395f213dbbd1" />
- Confirm the logout 
- You'll be redirected to the sign in screen: <img width="954" height="682" alt="Screenshot 2025-12-24 at 13 32 52" src="https://github.com/user-attachments/assets/fa323ee1-dcad-4aca-9872-b3f4d8ab7d37" />

Next steps:
- Understand `logout` for each component (each component seems to have slightly different approach)
- Understand how do we read `well-known/openid-configuration`
- Replace hardcoded URLs with values coming from configuration or from dedicated property `endSessionEndpoint`
- Investigate remaining IdP providers on how do they implement redirect after logout

@npepinpe you've mentioned you had a PoC. Was it a different approach?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to [#2991](https://github.com/camunda/product-hub/issues/2991)
relates to #43407 
