### PR TITLE
feat: add ES/OS implementation for the parent endpoint.

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.columns.IncidentProcessInstanceStatisticsByErrorSearchColumn;
+import io.camunda.search.clients.reader.IncidentProcessInstanceStatisticsByErrorReader;
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+
+public class IncidentProcessInstanceStatisticsByErrorDbReader
+    extends AbstractEntityReader<IncidentProcessInstanceStatisticsByErrorEntity>
+    implements IncidentProcessInstanceStatisticsByErrorReader {
+
+  // TODO: implement aggregation logic for rdbms reader - #42652
+  public IncidentProcessInstanceStatisticsByErrorDbReader(final IncidentMapper incidentMapper) {
+    super(IncidentProcessInstanceStatisticsByErrorSearchColumn.values());
+  }
+
+  @Override
+  public SearchQueryResult<IncidentProcessInstanceStatisticsByErrorEntity> aggregate(
+      final IncidentProcessInstanceStatisticsByErrorQuery query,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return SearchQueryResult.empty();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/IncidentProcessInstanceStatisticsByErrorSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/IncidentProcessInstanceStatisticsByErrorSearchColumn.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+
+public enum IncidentProcessInstanceStatisticsByErrorSearchColumn
+    implements SearchColumn<IncidentProcessInstanceStatisticsByErrorEntity> {
+  ERROR_HASH_CODE("errorHashCode"),
+  ERROR_MESSAGE("errorMessage"),
+  ACTIVE_INSTANCES_WITH_ERROR_COUNT("activeInstancesWithErrorCount");
+
+  private final String property;
+
+  IncidentProcessInstanceStatisticsByErrorSearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<IncidentProcessInstanceStatisticsByErrorEntity> getEntityClass() {
+    return IncidentProcessInstanceStatisticsByErrorEntity.class;
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -27,6 +27,7 @@ import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.read.service.IncidentProcessInstanceStatisticsByErrorDbReader;
 import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
@@ -294,6 +295,12 @@ public class RdbmsConfiguration {
   public HistoryDeletionDbReader historyDeletionDbReader(
       final HistoryDeletionMapper historyDeletionMapper) {
     return new HistoryDeletionDbReader(historyDeletionMapper);
+  }
+
+  @Bean
+  public IncidentProcessInstanceStatisticsByErrorDbReader
+      incidentProcessInstanceStatisticsByErrorReader(final IncidentMapper incidentMapper) {
+    return new IncidentProcessInstanceStatisticsByErrorDbReader(incidentMapper);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -26,6 +26,7 @@ import io.camunda.search.clients.reader.FlowNodeInstanceReader;
 import io.camunda.search.clients.reader.FormReader;
 import io.camunda.search.clients.reader.GroupMemberReader;
 import io.camunda.search.clients.reader.GroupReader;
+import io.camunda.search.clients.reader.IncidentProcessInstanceStatisticsByErrorReader;
 import io.camunda.search.clients.reader.IncidentReader;
 import io.camunda.search.clients.reader.JobReader;
 import io.camunda.search.clients.reader.MappingRuleReader;
@@ -136,7 +137,9 @@ public class SearchClientConfiguration {
       final UserTaskReader userTaskReader,
       final VariableReader variableReader,
       final ClusterVariableReader clusterVariableReader,
-      final AuditLogReader auditLogReader) {
+      final AuditLogReader auditLogReader,
+      final IncidentProcessInstanceStatisticsByErrorReader
+          incidentProcessInstanceStatisticsByErrorReader) {
     return new SearchClientReaders(
         authorizationReader,
         batchOperationReader,
@@ -171,6 +174,7 @@ public class SearchClientConfiguration {
         userTaskReader,
         variableReader,
         clusterVariableReader,
-        auditLogReader);
+        auditLogReader,
+        incidentProcessInstanceStatisticsByErrorReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -38,6 +38,8 @@ import io.camunda.search.clients.reader.GroupMemberDocumentReader;
 import io.camunda.search.clients.reader.GroupMemberReader;
 import io.camunda.search.clients.reader.GroupReader;
 import io.camunda.search.clients.reader.IncidentDocumentReader;
+import io.camunda.search.clients.reader.IncidentProcessInstanceStatisticsByErrorDocumentReader;
+import io.camunda.search.clients.reader.IncidentProcessInstanceStatisticsByErrorReader;
 import io.camunda.search.clients.reader.IncidentReader;
 import io.camunda.search.clients.reader.JobDocumentReader;
 import io.camunda.search.clients.reader.JobReader;
@@ -389,5 +391,13 @@ public class SearchClientReaderConfiguration {
   public AuditLogReader auditLogReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
     return new AuditLogDocumentReader(executor, descriptors.get(AuditLogTemplate.class));
+  }
+
+  @Bean
+  public IncidentProcessInstanceStatisticsByErrorReader
+      incidentProcessInstanceStatisticsByErrorReader(
+          final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new IncidentProcessInstanceStatisticsByErrorDocumentReader(
+        executor, descriptors.get(IncidentTemplate.class)) {};
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.it.util.TestHelper.createTenant;
+import static io.camunda.it.util.TestHelper.deployResourceForTenant;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.client.api.statistics.response.IncidentProcessInstanceStatisticsByError;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+public class IncidentProcessInstanceStatisticsByErrorIT {
+
+  private static final String PASSWORD = "password";
+
+  private static final Permissions READ_PROCESS_DEFINITION_INSTANCES =
+      new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"));
+
+  private static final String USER_EMPTY = "user-empty";
+  private static final String USER_SINGLE_ERROR = "user-single-error";
+  private static final String USER_MULTI_ERROR = "user-multi-error";
+  private static final String USER_ACTIVE_ONLY = "user-active-only";
+  private static final String USER_ERROR_HASH_COLLISION = "user-error-hash-collision";
+  private static final String USER_NO_READ_PROCESS_INSTANCE = "user-no-read-process-instance";
+
+  private static final String TENANT_SINGLE_ERROR = "tenant-single-error";
+  private static final String TENANT_MULTI_ERROR = "tenant-multi-error";
+  private static final String TENANT_ACTIVE_ONLY = "tenant-active-only";
+  private static final String TENANT_ERROR_HASH_COLLISION = "tenant-error-hash-collision";
+  private static final String TENANT_NO_READ_PROCESS_INSTANCE = "tenant-no-read-process-instance";
+
+  private static final String ERROR_FAIL_1 = "error-fail-1";
+  private static final String ERROR_FAIL_2 = "error-fail-2";
+  private static final String ERROR_HASH_COLLISION_1 = "Ea";
+  private static final String ERROR_HASH_COLLISION_2 = "FB";
+
+  private static final String JOB_TYPE_1 = "jobType1";
+  private static final String JOB_TYPE_2 = "jobType2";
+
+  private static final String SIMPLE_PROCESS_1 = "simple-process-1";
+  private static final String SIMPLE_PROCESS_2 = "simple-process-2";
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication TEST_INSTANCE =
+      new TestCamundaApplication().withBasicAuth().withMultiTenancyEnabled();
+
+  @UserDefinition private static final TestUser U_EMPTY = testUser(USER_EMPTY);
+  @UserDefinition private static final TestUser U_SINGLE_ERROR = testUser(USER_SINGLE_ERROR);
+  @UserDefinition private static final TestUser U_MULTI_ERROR = testUser(USER_MULTI_ERROR);
+  @UserDefinition private static final TestUser U_ACTIVE_ONLY = testUser(USER_ACTIVE_ONLY);
+
+  @UserDefinition
+  private static final TestUser U_ERROR_HASH_COLLISION = testUser(USER_ERROR_HASH_COLLISION);
+
+  @UserDefinition
+  private static final TestUser U_NO_READ_PROCESS_INSTANCE =
+      new TestUser(USER_NO_READ_PROCESS_INSTANCE, PASSWORD, List.of());
+
+  private static CamundaClient adminClient;
+
+  private static TestUser testUser(final String userId) {
+    return new TestUser(userId, PASSWORD, List.of(READ_PROCESS_DEFINITION_INSTANCES));
+  }
+
+  @BeforeAll
+  public static void beforeAll(@Authenticated final CamundaClient adminClient) {
+    IncidentProcessInstanceStatisticsByErrorIT.adminClient = adminClient;
+  }
+
+  private static void ensureTenantExistsForUser(
+      final CamundaClient adminClient, final String tenantId, final String userId) {
+    createTenant(adminClient, tenantId, tenantId, userId);
+  }
+
+  @Test
+  void shouldReturnEmptyStatisticsWhenNoActiveIncidentsExist(
+      @Authenticated(USER_EMPTY) final CamundaClient userClient) {
+    // when
+    final var result =
+        userClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.page().totalItems()).isEqualTo(0);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+  }
+
+  @Test
+  void shouldReturnSingleErrorStatisticForMultipleFailingInstances(
+      @Authenticated(USER_SINGLE_ERROR) final CamundaClient userClient) {
+    // given
+    ensureTenantExistsForUser(adminClient, TENANT_SINGLE_ERROR, USER_SINGLE_ERROR);
+
+    final String processId = SIMPLE_PROCESS_1;
+    final BpmnModelInstance model = singleServiceTaskProcess(processId, JOB_TYPE_1);
+
+    final long processDefinitionKey =
+        deployAndWait(userClient, model, resourceName(processId), TENANT_SINGLE_ERROR);
+
+    final int numberOfInstances = 5;
+    final List<Long> processInstanceKeys =
+        createInstances(userClient, processDefinitionKey, TENANT_SINGLE_ERROR, numberOfInstances);
+
+    waitForProcessInstancesToStart(userClient, numberOfInstances);
+
+    waitForJobs(userClient, processInstanceKeys);
+
+    final List<Long> jobKeys = findJobKeysForInstances(userClient, processInstanceKeys, JOB_TYPE_1);
+
+    failJobs(userClient, jobKeys, ERROR_FAIL_1);
+
+    waitUntilIncidentsAreActive(userClient, numberOfInstances);
+
+    // when
+    final var result =
+        userClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+
+    // then
+    assertThat(result.page().totalItems()).isEqualTo(1);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+    assertThat(result.items()).hasSize(1);
+
+    assertThat(result.items())
+        .extracting(
+            IncidentProcessInstanceStatisticsByError::getErrorMessage,
+            IncidentProcessInstanceStatisticsByError::getActiveInstancesWithErrorCount)
+        .containsExactly(tuple(ERROR_FAIL_1, (long) numberOfInstances));
+  }
+
+  @Test
+  void shouldReturnMultipleErrorStatisticsForMultipleFailingInstances(
+      @Authenticated(USER_MULTI_ERROR) final CamundaClient userClient) {
+
+    // given
+    ensureTenantExistsForUser(adminClient, TENANT_MULTI_ERROR, USER_MULTI_ERROR);
+
+    final String process1Id = SIMPLE_PROCESS_1;
+    final String process2Id = SIMPLE_PROCESS_2;
+
+    final BpmnModelInstance model1 = singleServiceTaskProcess(process1Id, JOB_TYPE_1);
+    final BpmnModelInstance model2 = singleServiceTaskProcess(process2Id, JOB_TYPE_2);
+
+    final long processDefinitionKey1 =
+        deployAndWait(userClient, model1, resourceName(process1Id), TENANT_MULTI_ERROR);
+    final long processDefinitionKey2 =
+        deployAndWait(userClient, model2, resourceName(process2Id), TENANT_MULTI_ERROR);
+
+    final int numberOfInstancesPerError = 3;
+
+    final List<Long> process1InstanceKeys =
+        createInstances(
+            userClient, processDefinitionKey1, TENANT_MULTI_ERROR, numberOfInstancesPerError);
+    final List<Long> process2InstanceKeys =
+        createInstances(
+            userClient, processDefinitionKey2, TENANT_MULTI_ERROR, numberOfInstancesPerError);
+
+    waitForProcessInstancesToStart(userClient, numberOfInstancesPerError * 2);
+
+    waitForJobs(
+        userClient,
+        Stream.concat(process1InstanceKeys.stream(), process2InstanceKeys.stream()).toList());
+
+    final List<Long> jobKeys1 =
+        findJobKeysForInstances(userClient, process1InstanceKeys, JOB_TYPE_1);
+    final List<Long> jobKeys2 =
+        findJobKeysForInstances(userClient, process2InstanceKeys, JOB_TYPE_2);
+
+    failJobs(userClient, jobKeys1, ERROR_FAIL_1);
+    failJobs(userClient, jobKeys2, ERROR_FAIL_2);
+
+    waitUntilIncidentsAreActive(userClient, numberOfInstancesPerError * 2);
+
+    // when
+    final var result =
+        userClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+
+    // then
+    assertThat(result.page().totalItems()).isEqualTo(2);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+    assertThat(result.items()).hasSize(2);
+
+    assertThat(result.items())
+        .extracting(
+            IncidentProcessInstanceStatisticsByError::getErrorMessage,
+            IncidentProcessInstanceStatisticsByError::getActiveInstancesWithErrorCount)
+        .containsExactlyInAnyOrder(
+            tuple(ERROR_FAIL_1, (long) numberOfInstancesPerError),
+            tuple(ERROR_FAIL_2, (long) numberOfInstancesPerError));
+  }
+
+  @Test
+  void shouldReturnOnlyActiveIncidentsInStatistics(
+      @Authenticated(USER_ACTIVE_ONLY) final CamundaClient userClient) {
+
+    // given
+    ensureTenantExistsForUser(adminClient, TENANT_ACTIVE_ONLY, USER_ACTIVE_ONLY);
+
+    final String processId = SIMPLE_PROCESS_1;
+    final BpmnModelInstance model = singleServiceTaskProcess(processId, JOB_TYPE_1);
+
+    final long processDefinitionKey =
+        deployAndWait(userClient, model, resourceName(processId), TENANT_ACTIVE_ONLY);
+
+    final int totalInstances = 6;
+    final List<Long> processInstanceKeys =
+        createInstances(userClient, processDefinitionKey, TENANT_ACTIVE_ONLY, totalInstances);
+
+    waitForProcessInstancesToStart(userClient, totalInstances);
+
+    waitForJobs(userClient, processInstanceKeys);
+
+    final List<Long> instancesToFail = processInstanceKeys.subList(0, 4);
+    final List<Long> jobKeysToFail =
+        findJobKeysForInstances(userClient, instancesToFail, JOB_TYPE_1);
+
+    failJobs(userClient, jobKeysToFail, ERROR_FAIL_1);
+
+    waitUntilIncidentsAreActive(userClient, jobKeysToFail.size());
+
+    final List<Long> instancesToResolve = instancesToFail.subList(0, 2);
+    final List<Long> incidentKeysToResolve =
+        findIncidentKeysForInstances(userClient, instancesToResolve);
+
+    increaseRetries(userClient, jobKeysToFail);
+    resolveIncidents(userClient, incidentKeysToResolve);
+
+    waitUntilIncidentsAreResolved(userClient, 2);
+
+    // when
+    final var result =
+        userClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+
+    // then
+    assertThat(result.page().totalItems()).isEqualTo(1);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+    assertThat(result.items()).hasSize(1);
+
+    assertThat(result.items())
+        .extracting(IncidentProcessInstanceStatisticsByError::getErrorMessage)
+        .containsExactly(ERROR_FAIL_1);
+    assertThat(result.items())
+        .extracting(IncidentProcessInstanceStatisticsByError::getActiveInstancesWithErrorCount)
+        .containsExactly(2L);
+  }
+
+  @Test
+  void shouldReturnSeparateItemsWhenErrorHashCodeCollides(
+      @Authenticated(USER_ERROR_HASH_COLLISION) final CamundaClient userClient) {
+
+    // given
+    ensureTenantExistsForUser(adminClient, TENANT_ERROR_HASH_COLLISION, USER_ERROR_HASH_COLLISION);
+
+    final String processId = SIMPLE_PROCESS_1;
+    final BpmnModelInstance model1 = singleServiceTaskProcess(processId, JOB_TYPE_1);
+    final BpmnModelInstance model2 = singleServiceTaskProcess(processId, JOB_TYPE_2);
+
+    final long processDefinitionKey1 =
+        deployAndWait(userClient, model1, resourceName(processId), TENANT_ERROR_HASH_COLLISION);
+    final long processDefinitionKey2 =
+        deployAndWait(userClient, model2, resourceName(processId), TENANT_ERROR_HASH_COLLISION);
+
+    final int numberOfInstancesPerError = 4;
+
+    final List<Long> process1InstanceKeys =
+        createInstances(
+            userClient,
+            processDefinitionKey1,
+            TENANT_ERROR_HASH_COLLISION,
+            numberOfInstancesPerError);
+    final List<Long> process2InstanceKeys =
+        createInstances(
+            userClient,
+            processDefinitionKey2,
+            TENANT_ERROR_HASH_COLLISION,
+            numberOfInstancesPerError);
+
+    waitForProcessInstancesToStart(userClient, numberOfInstancesPerError * 2);
+    waitForJobs(
+        userClient,
+        Stream.concat(process1InstanceKeys.stream(), process2InstanceKeys.stream()).toList());
+
+    final List<Long> jobKeys1 =
+        findJobKeysForInstances(userClient, process1InstanceKeys, JOB_TYPE_1);
+    final List<Long> jobKeys2 =
+        findJobKeysForInstances(userClient, process2InstanceKeys, JOB_TYPE_2);
+
+    failJobs(userClient, jobKeys1, ERROR_HASH_COLLISION_1);
+    failJobs(userClient, jobKeys2, ERROR_HASH_COLLISION_2);
+
+    waitUntilIncidentsAreActive(userClient, numberOfInstancesPerError * 2);
+
+    // when
+    final var result =
+        userClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+
+    // then
+    assertThat(result.page().totalItems()).isEqualTo(2);
+    assertThat(result.page().hasMoreTotalItems()).isFalse();
+    assertThat(result.items()).hasSize(2);
+
+    final int sameHashCode = ERROR_HASH_COLLISION_1.hashCode();
+
+    assertThat(result.items())
+        .extracting(
+            IncidentProcessInstanceStatisticsByError::getErrorHashCode,
+            IncidentProcessInstanceStatisticsByError::getErrorMessage,
+            IncidentProcessInstanceStatisticsByError::getActiveInstancesWithErrorCount)
+        .containsExactlyInAnyOrder(
+            tuple(sameHashCode, ERROR_HASH_COLLISION_1, (long) numberOfInstancesPerError),
+            tuple(sameHashCode, ERROR_HASH_COLLISION_2, (long) numberOfInstancesPerError));
+  }
+
+  @Test
+  void shouldReturnNoStatisticsForUserWithoutReadProcessInstance(
+      @Authenticated(USER_NO_READ_PROCESS_INSTANCE) final CamundaClient userClient) {
+    // given
+    ensureTenantExistsForUser(adminClient, TENANT_NO_READ_PROCESS_INSTANCE, DEFAULT_USER_USERNAME);
+
+    final BpmnModelInstance process = singleServiceTaskProcess(SIMPLE_PROCESS_1, JOB_TYPE_1);
+
+    final long processDefinitionKey =
+        deployAndWait(
+            adminClient, process, resourceName(SIMPLE_PROCESS_1), TENANT_NO_READ_PROCESS_INSTANCE);
+
+    final List<Long> instanceKeys =
+        createInstances(adminClient, processDefinitionKey, TENANT_NO_READ_PROCESS_INSTANCE, 1);
+    waitForProcessInstancesToStart(adminClient, 1);
+
+    waitForJobs(adminClient, instanceKeys);
+
+    final List<Long> jobKeys = findJobKeysForInstances(adminClient, instanceKeys, JOB_TYPE_1);
+    failJobs(adminClient, jobKeys, ERROR_FAIL_1);
+    waitUntilIncidentsAreActive(adminClient, 1);
+
+    final var adminResult =
+        adminClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+    assertThat(adminResult.items()).isNotEmpty();
+
+    // when
+    final var result =
+        userClient.newIncidentProcessInstanceStatisticsByErrorRequest().send().join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  private static BpmnModelInstance singleServiceTaskProcess(
+      final String bpmnProcessId, final String jobType) {
+    return Bpmn.createExecutableProcess(bpmnProcessId)
+        .startEvent()
+        .serviceTask("serviceTask", t -> t.zeebeJobType(jobType))
+        .endEvent()
+        .done();
+  }
+
+  private static String resourceName(final String processId) {
+    return processId + ".bpmn";
+  }
+
+  private static long deployAndWait(
+      final CamundaClient client,
+      final BpmnModelInstance model,
+      final String resourceName,
+      final String tenantId) {
+    final long processDefinitionKey =
+        deployResourceForTenant(client, model, resourceName, tenantId)
+            .getProcesses()
+            .getFirst()
+            .getProcessDefinitionKey();
+    waitForProcessesToBeDeployed(client, f -> f.processDefinitionKey(processDefinitionKey), 1);
+    return processDefinitionKey;
+  }
+
+  private static List<Long> createInstances(
+      final CamundaClient client,
+      final long processDefinitionKey,
+      final String tenantId,
+      final int count) {
+    final List<Long> keys = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      keys.add(
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(tenantId)
+              .send()
+              .join()
+              .getProcessInstanceKey());
+    }
+    return keys;
+  }
+
+  private static List<Long> findJobKeysForInstances(
+      final CamundaClient client, final List<Long> processInstanceKeys, final String jobType) {
+    final List<Long> keys =
+        client
+            .newJobSearchRequest()
+            .filter(f -> f.processInstanceKey(ops -> ops.in(processInstanceKeys)).type(jobType))
+            .send()
+            .join()
+            .items()
+            .stream()
+            .map(Job::getJobKey)
+            .sorted(Comparator.naturalOrder())
+            .toList();
+    assertThat(keys).hasSize(processInstanceKeys.size());
+    return keys;
+  }
+
+  private static void failJobs(
+      final CamundaClient client, final List<Long> jobKeys, final String errorMessage) {
+    for (final Long jobKey : jobKeys) {
+      client.newFailCommand(jobKey).retries(0).errorMessage(errorMessage).send().join();
+    }
+  }
+
+  private static void increaseRetries(final CamundaClient client, final List<Long> jobKeys) {
+    for (final Long jobKey : jobKeys) {
+      client.newUpdateJobCommand(jobKey).updateRetries(1).send().join();
+    }
+  }
+
+  private static List<Long> findIncidentKeysForInstances(
+      final CamundaClient client, final List<Long> processInstanceKeys) {
+    return client
+        .newIncidentSearchRequest()
+        .filter(f -> f.processInstanceKey(ops -> ops.in(processInstanceKeys)))
+        .send()
+        .join()
+        .items()
+        .stream()
+        .map(Incident::getIncidentKey)
+        .sorted(Comparator.naturalOrder())
+        .toList();
+  }
+
+  private static void resolveIncidents(final CamundaClient client, final List<Long> incidentKeys) {
+    for (final Long incidentKey : incidentKeys) {
+      client.newResolveIncidentCommand(incidentKey).send().join();
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/IncidentProcessInstanceStatisticsByErrorDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/IncidentProcessInstanceStatisticsByErrorDocumentReader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class IncidentProcessInstanceStatisticsByErrorDocumentReader extends DocumentBasedReader
+    implements IncidentProcessInstanceStatisticsByErrorReader {
+
+  public IncidentProcessInstanceStatisticsByErrorDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<IncidentProcessInstanceStatisticsByErrorEntity> aggregate(
+      final IncidentProcessInstanceStatisticsByErrorQuery query,
+      final ResourceAccessChecks resourceAccessChecks) {
+
+    final var paginatedResult =
+        getSearchExecutor()
+            .aggregateWithQueryResult(
+                query,
+                IncidentProcessInstanceStatisticsByErrorAggregationResult.class,
+                resourceAccessChecks,
+                IncidentProcessInstanceStatisticsByErrorAggregationResult::items);
+
+    return new SearchQueryResult<>(
+        paginatedResult.total(),
+        paginatedResult.hasMoreTotalItems(),
+        paginatedResult.items(),
+        paginatedResult.startCursor(),
+        paginatedResult.endCursor());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers;
 
 import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation;
@@ -17,6 +18,7 @@ import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregatio
 import io.camunda.search.aggregation.UsageMetricsAggregation;
 import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
+import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResult;
@@ -30,6 +32,7 @@ import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.aggregation.AggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByErrorAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregationTransformer;
@@ -39,6 +42,7 @@ import io.camunda.search.clients.transformers.aggregation.ProcessInstanceFlowNod
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer;
@@ -189,6 +193,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
@@ -395,7 +400,8 @@ public final class ServiceTransformers {
             UserQuery.class,
             VariableQuery.class,
             ClusterVariableQuery.class,
-            AuditLogQuery.class)
+            AuditLogQuery.class,
+            IncidentProcessInstanceStatisticsByErrorQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -590,6 +596,9 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessDefinitionInstanceVersionStatisticsAggregation.class,
         new ProcessDefinitionInstanceVersionStatisticsAggregationTransformer());
+    mappers.put(
+        IncidentProcessInstanceStatisticsByErrorAggregation.class,
+        new IncidentProcessInstanceStatisticsByErrorAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -614,5 +623,8 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessDefinitionInstanceVersionStatisticsAggregationResult.class,
         new ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer());
+    mappers.put(
+        IncidentProcessInstanceStatisticsByErrorAggregationResult.class,
+        new IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/IncidentProcessInstanceStatisticsByErrorAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/IncidentProcessInstanceStatisticsByErrorAggregationTransformer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_ERROR_MESSAGE_SCRIPT;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_AFFECTED_INSTANCES;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_BY_ERROR;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_ERROR_HASH;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_SORT_AND_PAGE;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_TOTAL_ESTIMATE;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_SCRIPT_LANG;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_TOTAL_ESTIMATE_SCRIPT;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.bucketSort;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.ERROR_MSG_HASH;
+import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.PROCESS_INSTANCE_KEY;
+
+import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class IncidentProcessInstanceStatisticsByErrorAggregationTransformer
+    implements AggregationTransformer<IncidentProcessInstanceStatisticsByErrorAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<IncidentProcessInstanceStatisticsByErrorAggregation, ServiceTransformers> value) {
+
+    final var aggregation = value.getLeft();
+
+    // Bucket by error message (hash collisions split into separate buckets)
+    final var byErrorAgg =
+        terms()
+            .name(AGGREGATION_NAME_BY_ERROR)
+            .script(AGGREGATION_ERROR_MESSAGE_SCRIPT)
+            .lang(AGGREGATION_SCRIPT_LANG)
+            .aggregations(
+                // read error hash per error-message bucket
+                terms().name(AGGREGATION_NAME_ERROR_HASH).field(ERROR_MSG_HASH).size(1).build(),
+                // count distinct affected process instances
+                cardinality()
+                    .name(AGGREGATION_NAME_AFFECTED_INSTANCES)
+                    .field(PROCESS_INSTANCE_KEY)
+                    .build(),
+                // sorting + pagination
+                bucketSort()
+                    .name(AGGREGATION_NAME_SORT_AND_PAGE)
+                    .sorting(toBucketSortSortings(aggregation))
+                    .from(aggregation.page() != null ? aggregation.page().from() : null)
+                    .size(aggregation.page() != null ? aggregation.page().size() : null)
+                    .build())
+            .build();
+
+    // Estimate total unique error entries (hash + message)
+    final var totalEstimateAgg =
+        cardinality()
+            .name(AGGREGATION_NAME_TOTAL_ESTIMATE)
+            .script(AGGREGATION_TOTAL_ESTIMATE_SCRIPT)
+            .lang(AGGREGATION_SCRIPT_LANG)
+            .build();
+
+    return List.of(byErrorAgg, totalEstimateAgg);
+  }
+
+  private static List<FieldSorting> toBucketSortSortings(
+      final IncidentProcessInstanceStatisticsByErrorAggregation aggregation) {
+    return aggregation.sort().getFieldSortings().stream()
+        .map(
+            ordering ->
+                new FieldSorting(
+                    IncidentProcessInstanceStatisticsByErrorAggregation.toBucketSortField(
+                        ordering.field()),
+                    ordering.order()))
+        .toList();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_AFFECTED_INSTANCES;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_BY_ERROR;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_ERROR_HASH;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_TOTAL_ESTIMATE;
+
+import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer
+    implements AggregationResultTransformer<
+        IncidentProcessInstanceStatisticsByErrorAggregationResult> {
+
+  public static final String NULL = "__NULL__";
+
+  @Override
+  public IncidentProcessInstanceStatisticsByErrorAggregationResult apply(
+      final Map<String, AggregationResult> value) {
+
+    final AggregationResult byErrorAgg = value.get(AGGREGATION_NAME_BY_ERROR);
+    final Map<String, AggregationResult> perErrorAggs =
+        byErrorAgg != null ? byErrorAgg.aggregations() : Map.of();
+
+    final List<IncidentProcessInstanceStatisticsByErrorEntity> items = new ArrayList<>();
+
+    for (Map.Entry<String, AggregationResult> entry : perErrorAggs.entrySet()) {
+      final String bucketKey = entry.getKey();
+      final AggregationResult bucketAgg = entry.getValue();
+      final Map<String, AggregationResult> subAggs =
+          bucketAgg != null ? bucketAgg.aggregations() : Map.of();
+
+      final String errorMessage = NULL.equals(bucketKey) ? null : bucketKey;
+
+      final AggregationResult errorHashAgg =
+          subAggs.getOrDefault(AGGREGATION_NAME_ERROR_HASH, AggregationResult.EMPTY);
+      final Map<String, AggregationResult> hashBuckets = errorHashAgg.aggregations();
+
+      if (hashBuckets == null || hashBuckets.isEmpty()) {
+        throw new IllegalStateException(
+            "Missing required error hash aggregation for bucket key: " + bucketKey);
+      }
+
+      final Integer parsedErrorHashKey =
+          hashBuckets.keySet().stream()
+              .filter(Objects::nonNull)
+              .map(
+                  IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer::tryParseInt)
+              .findFirst()
+              .orElse(null);
+
+      final int errorHash = resolveErrorHashCode(errorMessage, parsedErrorHashKey);
+
+      final long activeInstancesWithErrorCount =
+          subAggs
+              .getOrDefault(AGGREGATION_NAME_AFFECTED_INSTANCES, AggregationResult.EMPTY)
+              .docCount();
+
+      items.add(
+          new IncidentProcessInstanceStatisticsByErrorEntity(
+              errorHash, errorMessage, activeInstancesWithErrorCount));
+    }
+
+    final AggregationResult cardinalityAgg = value.get(AGGREGATION_NAME_TOTAL_ESTIMATE);
+    final int totalItems =
+        cardinalityAgg != null ? Math.toIntExact(cardinalityAgg.docCount()) : perErrorAggs.size();
+
+    return new IncidentProcessInstanceStatisticsByErrorAggregationResult(items, totalItems);
+  }
+
+  private static int tryParseInt(final String value) {
+    try {
+      return Integer.parseInt(value);
+    } catch (final NumberFormatException e) {
+      throw new IllegalStateException(
+          "Failed to parse error hash bucket key to integer: " + value, e);
+    }
+  }
+
+  private static int resolveErrorHashCode(
+      final String errorMessageBucketKey, final Integer errorHashBucketKey) {
+    if (errorHashBucketKey != null) {
+      return errorHashBucketKey;
+    }
+
+    if (errorMessageBucketKey != null) {
+      return errorMessageBucketKey.hashCode();
+    }
+
+    throw new IllegalStateException(
+        "Failed to resolve error hash code: both errorMessageBucketKey and errorHashBucketKey are null");
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/IncidentProcessInstanceStatisticsByErrorAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/IncidentProcessInstanceStatisticsByErrorAggregationTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_ERROR_MESSAGE_SCRIPT;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_AFFECTED_INSTANCES;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_BY_ERROR;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_ERROR_HASH;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_SORT_AND_PAGE;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_TOTAL_ESTIMATE;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_SCRIPT_LANG;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_TOTAL_ESTIMATE_SCRIPT;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.toBucketSortField;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.IncidentProcessInstanceStatisticsByErrorSort;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IncidentProcessInstanceStatisticsByErrorAggregationTransformerTest {
+
+  private final IncidentProcessInstanceStatisticsByErrorAggregationTransformer transformer =
+      new IncidentProcessInstanceStatisticsByErrorAggregationTransformer();
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  @Test
+  void shouldBuildExpectedAggregationTreeWithoutPaging() {
+    // given
+    final var aggregation =
+        new IncidentProcessInstanceStatisticsByErrorAggregation(
+            null,
+            IncidentProcessInstanceStatisticsByErrorSort.of(s -> s.errorMessage().asc()),
+            null);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(2);
+
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchTermsAggregator.class,
+            byErrorAgg -> {
+              assertThat(byErrorAgg.name()).isEqualTo(AGGREGATION_NAME_BY_ERROR);
+              assertThat(byErrorAgg.script()).isEqualTo(AGGREGATION_ERROR_MESSAGE_SCRIPT);
+              assertThat(byErrorAgg.lang()).isEqualTo(AGGREGATION_SCRIPT_LANG);
+
+              final var subAggs = byErrorAgg.aggregations();
+              assertThat(subAggs).hasSize(3);
+
+              assertThat(subAggs.get(0))
+                  .isInstanceOfSatisfying(
+                      SearchTermsAggregator.class,
+                      errorHashAgg -> {
+                        assertThat(errorHashAgg.name()).isEqualTo(AGGREGATION_NAME_ERROR_HASH);
+                        assertThat(errorHashAgg.field()).isEqualTo(IncidentTemplate.ERROR_MSG_HASH);
+                        assertThat(errorHashAgg.size()).isEqualTo(1);
+                      });
+
+              assertThat(subAggs.get(1))
+                  .isInstanceOfSatisfying(
+                      SearchCardinalityAggregator.class,
+                      affectedInstancesAgg -> {
+                        assertThat(affectedInstancesAgg.name())
+                            .isEqualTo(AGGREGATION_NAME_AFFECTED_INSTANCES);
+                        assertThat(affectedInstancesAgg.field())
+                            .isEqualTo(IncidentTemplate.PROCESS_INSTANCE_KEY);
+                      });
+
+              assertThat(subAggs.get(2))
+                  .isInstanceOfSatisfying(
+                      SearchBucketSortAggregator.class,
+                      bucketSortAgg -> {
+                        assertThat(bucketSortAgg.name()).isEqualTo(AGGREGATION_NAME_SORT_AND_PAGE);
+                        // no paging information
+                        assertThat(bucketSortAgg.from()).isNull();
+                        assertThat(bucketSortAgg.size()).isNull();
+
+                        assertThat(bucketSortAgg.sorting())
+                            .containsExactly(
+                                new FieldSorting(toBucketSortField("errorMessage"), SortOrder.ASC));
+                      });
+            });
+
+    assertThat(aggregations.get(1))
+        .isInstanceOfSatisfying(
+            SearchCardinalityAggregator.class,
+            totalEstimateAgg -> {
+              assertThat(totalEstimateAgg.name()).isEqualTo(AGGREGATION_NAME_TOTAL_ESTIMATE);
+              assertThat(totalEstimateAgg.script()).isEqualTo(AGGREGATION_TOTAL_ESTIMATE_SCRIPT);
+              assertThat(totalEstimateAgg.lang()).isEqualTo(AGGREGATION_SCRIPT_LANG);
+            });
+  }
+
+  @Test
+  void shouldApplyBucketSortPagingAndSorting() {
+    // given
+    final var from = 10;
+    final var size = 25;
+    final var sort =
+        IncidentProcessInstanceStatisticsByErrorSort.of(
+            s -> s.activeInstancesWithErrorCount().desc().errorMessage().asc());
+
+    final var aggregation =
+        new IncidentProcessInstanceStatisticsByErrorAggregation(
+            null,
+            sort,
+            new SearchQueryPage(
+                from, size, null, null, SearchQueryPage.SearchQueryResultType.PAGINATED));
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var byErrorAgg = (SearchTermsAggregator) aggregations.getFirst();
+    final List<SearchAggregator> subAggs = byErrorAgg.aggregations();
+
+    final var bucketSortAgg = (SearchBucketSortAggregator) subAggs.get(2);
+    assertThat(bucketSortAgg.name()).isEqualTo(AGGREGATION_NAME_SORT_AND_PAGE);
+    assertThat(bucketSortAgg.from()).isEqualTo(from);
+    assertThat(bucketSortAgg.size()).isEqualTo(size);
+
+    assertThat(bucketSortAgg.sorting())
+        .containsExactly(
+            new FieldSorting(toBucketSortField("activeInstancesWithErrorCount"), SortOrder.DESC),
+            new FieldSorting(toBucketSortField("errorMessage"), SortOrder.ASC));
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/IncidentProcessInstanceStatisticsByErrorAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/IncidentProcessInstanceStatisticsByErrorAggregationResultTransformerTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_AFFECTED_INSTANCES;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_BY_ERROR;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_ERROR_HASH;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_TOTAL_ESTIMATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class IncidentProcessInstanceStatisticsByErrorAggregationResultTransformerTest {
+
+  private final IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer transformer =
+      new IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer();
+
+  @Test
+  public void shouldReturnEmptyResultWhenByErrorAggregationMissing() {
+    // given
+    final Map<String, AggregationResult> input = Map.of();
+
+    // when
+    final IncidentProcessInstanceStatisticsByErrorAggregationResult result =
+        transformer.apply(input);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.totalItems()).isZero();
+  }
+
+  @Test
+  public void shouldTransformBucketsAndUseParsedErrorHashKey() {
+    // given
+    final Map<String, AggregationResult> perErrorBuckets =
+        new LinkedHashMap<>(
+            Map.of(
+                "Something failed", errorBucket("123", 5L), "Other error", errorBucket("456", 0L)));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.totalItems()).isEqualTo(2);
+    assertThat(result.items())
+        .containsExactlyInAnyOrder(
+            new IncidentProcessInstanceStatisticsByErrorEntity(123, "Something failed", 5L),
+            new IncidentProcessInstanceStatisticsByErrorEntity(456, "Other error", 0L));
+  }
+
+  @Test
+  public void shouldHandleNullErrorMessageBucketKey() {
+    // given
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of(
+            IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer.NULL,
+            errorBucket("999", 2L));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.totalItems()).isEqualTo(1);
+    assertThat(result.items())
+        .containsExactly(new IncidentProcessInstanceStatisticsByErrorEntity(999, null, 2L));
+  }
+
+  @Test
+  public void shouldDefaultAffectedInstancesToZeroWhenMissing() {
+    // given
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of("Missing affected instances", errorBucketWithOnlyHash("101"));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items())
+        .containsExactly(
+            new IncidentProcessInstanceStatisticsByErrorEntity(
+                101, "Missing affected instances", 0L));
+  }
+
+  @Test
+  public void shouldUseTotalEstimateWhenProvided() {
+    // given
+    final Map<String, AggregationResult> perErrorBuckets = Map.of("Error", errorBucket("1", 1L));
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_NAME_BY_ERROR,
+            agg(0L, perErrorBuckets),
+            AGGREGATION_NAME_TOTAL_ESTIMATE,
+            new AggregationResult(100L, Map.of()));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.totalItems()).isEqualTo(100);
+  }
+
+  @Test
+  public void shouldThrowWhenErrorHashAggregationMissing() {
+    // given
+    final Map<String, AggregationResult> bucketSubAggs =
+        Map.of(AGGREGATION_NAME_AFFECTED_INSTANCES, new AggregationResult(1L, Map.of()));
+
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of("Error", new AggregationResult(0L, bucketSubAggs));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when + then
+    assertThatThrownBy(() -> transformer.apply(input))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Missing required error hash aggregation");
+  }
+
+  @Test
+  public void shouldThrowWhenErrorHashAggregationIsEmpty() {
+    // given
+    final Map<String, AggregationResult> bucketSubAggs =
+        Map.of(
+            AGGREGATION_NAME_ERROR_HASH, new AggregationResult(0L, Map.of()),
+            AGGREGATION_NAME_AFFECTED_INSTANCES, new AggregationResult(1L, Map.of()));
+
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of("Error", new AggregationResult(0L, bucketSubAggs));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when + then
+    assertThatThrownBy(() -> transformer.apply(input))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Missing required error hash aggregation");
+  }
+
+  @Test
+  public void shouldThrowWhenHashBucketKeyIsNotAnInteger() {
+    // given
+    final Map<String, AggregationResult> hashBuckets =
+        Map.of("not-an-int", AggregationResult.EMPTY);
+
+    final Map<String, AggregationResult> bucketSubAggs =
+        Map.of(
+            AGGREGATION_NAME_ERROR_HASH,
+            agg(0L, hashBuckets),
+            AGGREGATION_NAME_AFFECTED_INSTANCES,
+            new AggregationResult(1L, Map.of()));
+
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of("Error", new AggregationResult(0L, bucketSubAggs));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when + then
+    assertThatThrownBy(() -> transformer.apply(input))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to parse error hash bucket key to integer");
+  }
+
+  @Test
+  public void shouldFallbackToErrorMessageHashCodeWhenAllHashBucketKeysNull() {
+    // given
+    final String errorMessage = "Some error";
+
+    final Map<String, AggregationResult> hashBuckets = new HashMap<>();
+    hashBuckets.put(null, AggregationResult.EMPTY);
+
+    final Map<String, AggregationResult> bucketSubAggs =
+        Map.of(
+            AGGREGATION_NAME_ERROR_HASH,
+            agg(0L, hashBuckets),
+            AGGREGATION_NAME_AFFECTED_INSTANCES,
+            new AggregationResult(3L, Map.of()));
+
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of(errorMessage, new AggregationResult(0L, bucketSubAggs));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items())
+        .containsExactly(
+            new IncidentProcessInstanceStatisticsByErrorEntity(
+                errorMessage.hashCode(), errorMessage, 3L));
+  }
+
+  @Test
+  public void shouldThrowWhenUnableToResolveErrorHashCode() {
+    // given
+    final Map<String, AggregationResult> hashBuckets = new HashMap<>();
+    hashBuckets.put(null, AggregationResult.EMPTY);
+
+    final Map<String, AggregationResult> bucketSubAggs =
+        Map.of(
+            AGGREGATION_NAME_ERROR_HASH,
+            agg(0L, hashBuckets),
+            AGGREGATION_NAME_AFFECTED_INSTANCES,
+            new AggregationResult(1L, Map.of()));
+
+    final Map<String, AggregationResult> perErrorBuckets =
+        Map.of(
+            IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer.NULL,
+            new AggregationResult(0L, bucketSubAggs));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_NAME_BY_ERROR, agg(0L, perErrorBuckets));
+
+    // when + then
+    assertThatThrownBy(() -> transformer.apply(input))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to resolve error hash code");
+  }
+
+  private static AggregationResult errorBucket(
+      final String errorHashBucketKey, final long affected) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_NAME_ERROR_HASH,
+            errorHashAgg(errorHashBucketKey),
+            AGGREGATION_NAME_AFFECTED_INSTANCES,
+            new AggregationResult(affected, Map.of()));
+
+    return new AggregationResult(0L, subAggs);
+  }
+
+  private static AggregationResult errorBucketWithOnlyHash(final String errorHashBucketKey) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(AGGREGATION_NAME_ERROR_HASH, errorHashAgg(errorHashBucketKey));
+    return new AggregationResult(0L, subAggs);
+  }
+
+  private static AggregationResult errorHashAgg(final String errorHashBucketKey) {
+    final Map<String, AggregationResult> hashBuckets =
+        Map.of(errorHashBucketKey, AggregationResult.EMPTY);
+    return agg(0L, hashBuckets);
+  }
+
+  private static AggregationResult agg(
+      final long docCount, final Map<String, AggregationResult> aggs) {
+    return new AggregationResult(docCount, aggs);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/IncidentProcessInstanceStatisticsByErrorQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/IncidentProcessInstanceStatisticsByErrorQueryTransformerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.query;
+
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_AFFECTED_INSTANCES;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_BY_ERROR;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_ERROR_HASH;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_SORT_AND_PAGE;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.AGGREGATION_NAME_TOTAL_ESTIMATE;
+import static io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation.toBucketSortField;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
+import io.camunda.search.query.TypedSearchAggregationQuery;
+import io.camunda.search.sort.IncidentProcessInstanceStatisticsByErrorSort;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class IncidentProcessInstanceStatisticsByErrorQueryTransformerTest {
+
+  public static final String TENANT_ID = "tenant-1";
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  protected <Q extends TypedSearchAggregationQuery> SearchQueryRequest transformQuery(
+      final Q query) {
+    final var transformer = transformers.getTypedSearchQueryTransformer(query.getClass());
+    return transformer.apply(query);
+  }
+
+  @Test
+  public void shouldQueryByProcessDefinitionKeyAndAggregation() {
+    // given
+    final var query =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(
+            q -> q.filter(f -> f.states(IncidentState.ACTIVE.name()).tenantIds(TENANT_ID)));
+
+    // when
+    final var searchRequest = transformQuery(query);
+
+    // then
+    assertThat(searchRequest.sort()).isNull();
+    assertThat(searchRequest.from()).isNull();
+    assertThat(searchRequest.size()).isZero();
+
+    final var queryVariant = searchRequest.query().queryOption();
+
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              final var must = boolQuery.must();
+              assertThat(must).hasSize(2);
+
+              assertThat(must.getFirst())
+                  .isInstanceOfSatisfying(
+                      SearchQuery.class,
+                      stateSearchQuery -> {
+                        final var stateQueryOption = stateSearchQuery.queryOption();
+                        assertThat(stateQueryOption)
+                            .isInstanceOfSatisfying(
+                                SearchTermQuery.class,
+                                stateTermQuery -> {
+                                  assertThat(stateTermQuery.field())
+                                      .isEqualTo(IncidentTemplate.STATE);
+                                  assertThat(stateTermQuery.value().stringValue())
+                                      .isEqualTo(IncidentState.ACTIVE.name());
+                                });
+                      });
+
+              assertThat(must.getLast())
+                  .isInstanceOfSatisfying(
+                      SearchQuery.class,
+                      tenantSearchQuery -> {
+                        final var tenantQueryOption = tenantSearchQuery.queryOption();
+                        assertThat(tenantQueryOption)
+                            .isInstanceOfSatisfying(
+                                SearchTermQuery.class,
+                                tenantTermQuery -> {
+                                  assertThat(tenantTermQuery.field())
+                                      .isEqualTo(IncidentTemplate.TENANT_ID);
+                                  assertThat(tenantTermQuery.value().stringValue())
+                                      .isEqualTo(TENANT_ID);
+                                });
+                      });
+
+              final var aggregations = searchRequest.aggregations();
+              assertThat(aggregations).hasSize(2);
+
+              assertThat(aggregations.getFirst())
+                  .isInstanceOfSatisfying(
+                      SearchTermsAggregator.class,
+                      byErrorAgg -> {
+                        assertThat(byErrorAgg.name()).isEqualTo(AGGREGATION_NAME_BY_ERROR);
+                        assertThat(byErrorAgg.script()).isNotNull();
+
+                        final var subAggs = byErrorAgg.aggregations();
+                        assertThat(subAggs).hasSize(3);
+
+                        assertThat(subAggs.get(0))
+                            .isInstanceOfSatisfying(
+                                SearchTermsAggregator.class,
+                                errorHashAgg -> {
+                                  assertThat(errorHashAgg.name())
+                                      .isEqualTo(AGGREGATION_NAME_ERROR_HASH);
+                                  assertThat(errorHashAgg.field())
+                                      .isEqualTo(IncidentTemplate.ERROR_MSG_HASH);
+                                });
+
+                        assertThat(subAggs.get(1))
+                            .isInstanceOfSatisfying(
+                                SearchCardinalityAggregator.class,
+                                affectedInstancesAgg -> {
+                                  assertThat(affectedInstancesAgg.name())
+                                      .isEqualTo(AGGREGATION_NAME_AFFECTED_INSTANCES);
+                                  assertThat(affectedInstancesAgg.field())
+                                      .isEqualTo(IncidentTemplate.PROCESS_INSTANCE_KEY);
+                                });
+
+                        assertThat(subAggs.get(2))
+                            .isInstanceOfSatisfying(
+                                SearchBucketSortAggregator.class,
+                                bucketSortAgg -> {
+                                  assertThat(bucketSortAgg.name())
+                                      .isEqualTo(AGGREGATION_NAME_SORT_AND_PAGE);
+                                  assertThat(bucketSortAgg.sorting()).isNotNull();
+                                  bucketSortAgg
+                                      .sorting()
+                                      .forEach(
+                                          s ->
+                                              assertThat(s.field())
+                                                  .isEqualTo(toBucketSortField(s.field())));
+                                });
+                      });
+
+              assertThat(aggregations.get(1))
+                  .isInstanceOfSatisfying(
+                      SearchCardinalityAggregator.class,
+                      totalEstimateAgg -> {
+                        assertThat(totalEstimateAgg.name())
+                            .isEqualTo(AGGREGATION_NAME_TOTAL_ESTIMATE);
+                        assertThat(totalEstimateAgg.script()).isNotNull();
+                      });
+            });
+  }
+
+  @Test
+  public void shouldApplyBucketSortPagingAndSorting() {
+    // given
+    final var from = 10;
+    final var size = 25;
+    final var sort =
+        IncidentProcessInstanceStatisticsByErrorSort.of(
+            s -> s.activeInstancesWithErrorCount().desc().errorMessage().asc());
+
+    final var query =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(
+            q ->
+                q.filter(FilterBuilders.incident(f -> f.tenantIds(TENANT_ID)))
+                    .sort(sort)
+                    .page(
+                        new SearchQueryPage(
+                            from, size, null, null, SearchQueryResultType.PAGINATED)));
+
+    // when
+    final var searchRequest = transformQuery(query);
+
+    // then
+    assertThat(searchRequest.size()).isZero();
+    assertThat(searchRequest.sort()).isNull();
+
+    final var aggregations = searchRequest.aggregations();
+    assertThat(aggregations).hasSize(2);
+
+    final var byErrorAgg = (SearchTermsAggregator) aggregations.getFirst();
+    final List<SearchAggregator> subAggs = byErrorAgg.aggregations();
+
+    final var bucketSortAgg = (SearchBucketSortAggregator) subAggs.get(2);
+    assertThat(bucketSortAgg.name()).isEqualTo(AGGREGATION_NAME_SORT_AND_PAGE);
+    assertThat(bucketSortAgg.from()).isEqualTo(from);
+    assertThat(bucketSortAgg.size()).isEqualTo(size);
+
+    assertThat(bucketSortAgg.sorting())
+        .containsExactly(
+            new FieldSorting(toBucketSortField("activeInstancesWithErrorCount"), SortOrder.DESC),
+            new FieldSorting(toBucketSortField("errorMessage"), SortOrder.ASC));
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/IncidentProcessInstanceStatisticsByErrorReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/IncidentProcessInstanceStatisticsByErrorReader.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
+
+public interface IncidentProcessInstanceStatisticsByErrorReader
+    extends SearchQueryStatisticsReader<
+        IncidentProcessInstanceStatisticsByErrorEntity,
+        IncidentProcessInstanceStatisticsByErrorQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -43,4 +43,6 @@ public record SearchClientReaders(
     UserTaskReader userTaskReader,
     VariableReader variableReader,
     ClusterVariableReader clusterVariableReader,
-    AuditLogReader auditLogReader) {}
+    AuditLogReader auditLogReader,
+    IncidentProcessInstanceStatisticsByErrorReader
+        incidentProcessInstanceStatisticsByErrorReader) {}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -287,10 +287,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<IncidentProcessInstanceStatisticsByErrorEntity>
       incidentProcessInstanceStatisticsByError(
           final IncidentProcessInstanceStatisticsByErrorQuery query) {
-    // TODO will be implemented by the following tasks:
-    // https://github.com/camunda/camunda/issues/42650
-    // https://github.com/camunda/camunda/issues/42652
-    return SearchQueryResult.empty();
+
+    return doSearchWithReader(readers.incidentProcessInstanceStatisticsByErrorReader(), query);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/IncidentProcessInstanceStatisticsByErrorAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/IncidentProcessInstanceStatisticsByErrorAggregation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+import io.camunda.search.sort.IncidentProcessInstanceStatisticsByErrorSort;
+
+public record IncidentProcessInstanceStatisticsByErrorAggregation(
+    IncidentFilter filter, IncidentProcessInstanceStatisticsByErrorSort sort, SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  public static final String AGGREGATION_NAME_BY_ERROR = "by_error";
+  public static final String AGGREGATION_NAME_AFFECTED_INSTANCES = "affected_instances";
+  public static final String AGGREGATION_NAME_SORT_AND_PAGE = "sort_and_page";
+  public static final String AGGREGATION_NAME_TOTAL_ESTIMATE = "total_estimate";
+  public static final String AGGREGATION_NAME_ERROR_HASH = "error_hash";
+  public static final String AGGREGATION_SCRIPT_LANG = "painless";
+
+  // Buckets by error message
+  public static final String AGGREGATION_ERROR_MESSAGE_SCRIPT =
+      """
+      def msg = params._source['errorMessage'];
+      return msg == null ? '__NULL__' : msg;
+      """;
+
+  // Used only to estimate total unique (hash + message) combinations.
+  public static final String AGGREGATION_TOTAL_ESTIMATE_SCRIPT =
+      """
+      def msg = params._source['errorMessage'];
+      def hash = params._source['errorMessageHash'];
+      return hash + '::' + (msg == null ? '__NULL__' : msg);
+      """;
+
+  public static final String SORT_FIELD_ACTIVE_INSTANCES_WITH_ERROR_COUNT =
+      "activeInstancesWithErrorCount";
+
+  public static String toBucketSortField(final String domainField) {
+    return switch (domainField) {
+      case SORT_FIELD_ACTIVE_INSTANCES_WITH_ERROR_COUNT -> AGGREGATION_NAME_AFFECTED_INSTANCES;
+      case "errorMessage" -> "_key";
+      default -> domainField;
+    };
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/IncidentProcessInstanceStatisticsByErrorAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/IncidentProcessInstanceStatisticsByErrorAggregationResult.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import java.util.List;
+
+public record IncidentProcessInstanceStatisticsByErrorAggregationResult(
+    List<IncidentProcessInstanceStatisticsByErrorEntity> items, int totalItems)
+    implements AggregationResultBase, HasTotalItems {}

--- a/search/search-domain/src/main/java/io/camunda/search/query/IncidentProcessInstanceStatisticsByErrorQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/IncidentProcessInstanceStatisticsByErrorQuery.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.query;
 
+import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -18,11 +19,19 @@ import java.util.function.Function;
 
 public record IncidentProcessInstanceStatisticsByErrorQuery(
     IncidentFilter filter, IncidentProcessInstanceStatisticsByErrorSort sort, SearchQueryPage page)
-    implements TypedSearchQuery<IncidentFilter, IncidentProcessInstanceStatisticsByErrorSort> {
+    implements TypedSearchAggregationQuery<
+        IncidentFilter,
+        IncidentProcessInstanceStatisticsByErrorSort,
+        IncidentProcessInstanceStatisticsByErrorAggregation> {
 
   public static IncidentProcessInstanceStatisticsByErrorQuery of(
       final Function<Builder, ObjectBuilder<IncidentProcessInstanceStatisticsByErrorQuery>> fn) {
     return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public IncidentProcessInstanceStatisticsByErrorAggregation aggregation() {
+    return new IncidentProcessInstanceStatisticsByErrorAggregation(filter, sort, page);
   }
 
   public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -13,8 +13,10 @@ import static io.camunda.service.authorization.Authorizations.INCIDENT_READ_AUTH
 
 import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
@@ -102,13 +104,19 @@ public class IncidentServices
   public SearchQueryResult<IncidentProcessInstanceStatisticsByErrorEntity>
       incidentProcessInstanceStatisticsByError(
           final IncidentProcessInstanceStatisticsByErrorQuery query) {
+    final var sanitizedQuery =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(
+            b ->
+                b.page(query.page())
+                    .sort(query.sort())
+                    .filter(FilterBuilders.incident(f -> f.states(IncidentState.ACTIVE.name()))));
     return executeSearchRequest(
         () ->
             incidentSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, INCIDENT_READ_AUTHORIZATION))
-                .incidentProcessInstanceStatisticsByError(query));
+                .incidentProcessInstanceStatisticsByError(sanitizedQuery));
   }
 
   public SearchQueryResult<IncidentProcessInstanceStatisticsByDefinitionEntity>

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -113,10 +113,20 @@ public final class IncidentServiceTest {
     // when
     final var searchQueryResult =
         services.incidentProcessInstanceStatisticsByError(
-            SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery().build());
+            SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery()
+                .filter(f -> f.states(IncidentState.ACTIVE.name()))
+                .build());
 
     // then
     assertThat(searchQueryResult.items()).contains(entity);
+    final var queryCaptor =
+        ArgumentCaptor.forClass(
+            io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery.class);
+    verify(client).incidentProcessInstanceStatisticsByError(queryCaptor.capture());
+
+    final var capturedQuery = queryCaptor.getValue();
+    final var filter = capturedQuery.filter();
+    assertThat(filter.stateOperations()).containsExactly(Operation.eq(IncidentState.ACTIVE.name()));
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +23,7 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity
 import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -157,5 +159,51 @@ public final class IncidentServiceTest {
 
     assertThat(filter.errorMessageHashOperations()).containsExactly(Operation.eq(errorHashCode));
     assertThat(filter.stateOperations()).containsExactly(Operation.eq(state));
+  }
+
+  @Test
+  public void shouldForceActiveStateForIncidentProcessInstanceStatisticsByError() {
+    // given
+    when(client.incidentProcessInstanceStatisticsByError(any()))
+        .thenReturn(
+            SearchQueryResult.of(
+                Instancio.create(IncidentProcessInstanceStatisticsByErrorEntity.class)));
+
+    final var initialQuery =
+        SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery()
+            .filter(f -> f.states(IncidentState.RESOLVED.name()))
+            .build();
+
+    // when
+    services.incidentProcessInstanceStatisticsByError(initialQuery);
+
+    // then
+    final var queryCaptor =
+        ArgumentCaptor.forClass(IncidentProcessInstanceStatisticsByErrorQuery.class);
+    verify(client).incidentProcessInstanceStatisticsByError(queryCaptor.capture());
+    final var filter = queryCaptor.getValue().filter();
+    assertThat(filter.stateOperations()).containsExactly(Operation.eq(IncidentState.ACTIVE.name()));
+  }
+
+  @Test
+  public void shouldApplyActiveStateWhenMissingForIncidentProcessInstanceStatisticsByError() {
+    // given
+    when(client.incidentProcessInstanceStatisticsByError(any()))
+        .thenReturn(
+            SearchQueryResult.of(
+                Instancio.create(IncidentProcessInstanceStatisticsByErrorEntity.class)));
+
+    final var initialQuery =
+        SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery().build();
+
+    // when
+    services.incidentProcessInstanceStatisticsByError(initialQuery);
+
+    // then
+    final var queryCaptor =
+        ArgumentCaptor.forClass(IncidentProcessInstanceStatisticsByErrorQuery.class);
+    verify(client, times(1)).incidentProcessInstanceStatisticsByError(queryCaptor.capture());
+    final var filter = queryCaptor.getValue().filter();
+    assertThat(filter.stateOperations()).containsExactly(Operation.eq(IncidentState.ACTIVE.name()));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -15,7 +15,6 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.*;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateDate;
 
-import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.FilterBase;
@@ -700,8 +699,7 @@ public final class SearchQueryRequestMapper {
                 .fromIncidentProcessInstanceStatisticsByErrorQuerySortRequest(request.getSort()),
             SortOptionBuilders::incidentProcessInstanceStatisticsByError,
             SearchQuerySortRequestMapper::applyIncidentProcessInstanceStatisticsByErrorSortField);
-    // Only ACTIVE incidents are considered for error statistics. This is hardcoded here.
-    final var filter = FilterBuilders.incident().states(IncidentState.ACTIVE.name()).build();
+    final var filter = FilterBuilders.incident().build();
     return buildSearchQuery(
         filter, sort, page, SearchQueryBuilders::incidentProcessInstanceStatisticsByErrorQuery);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -15,6 +15,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.*;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateDate;
 
+import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.filter.FilterBase;
@@ -699,7 +700,8 @@ public final class SearchQueryRequestMapper {
                 .fromIncidentProcessInstanceStatisticsByErrorQuerySortRequest(request.getSort()),
             SortOptionBuilders::incidentProcessInstanceStatisticsByError,
             SearchQuerySortRequestMapper::applyIncidentProcessInstanceStatisticsByErrorSortField);
-    final var filter = FilterBuilders.incident().build();
+    // Only ACTIVE incidents are considered for error statistics. This is hardcoded here.
+    final var filter = FilterBuilders.incident().states(IncidentState.ACTIVE.name()).build();
     return buildSearchQuery(
         filter, sort, page, SearchQueryBuilders::incidentProcessInstanceStatisticsByErrorQuery);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -422,6 +422,93 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldSortIncidentProcessInstanceStatisticsByError() {
+    // given
+    when(incidentServices.incidentProcessInstanceStatisticsByError(
+            any(IncidentProcessInstanceStatisticsByErrorQuery.class)))
+        .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_QUERY_RESULT);
+
+    final var request =
+        """
+        {
+          "sort": [
+            {
+              "field": "errorMessage",
+              "order": "asc"
+            },
+            {
+              "field": "activeInstancesWithErrorCount",
+              "order": "desc"
+            }
+          ]
+        }
+        """;
+
+    // when/then
+    webClient
+        .post()
+        .uri(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            EXPECTED_INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_RESPONSE,
+            JsonCompareMode.STRICT);
+
+    verify(incidentServices)
+        .incidentProcessInstanceStatisticsByError(
+            new IncidentProcessInstanceStatisticsByErrorQuery.Builder()
+                .filter(f -> f.states(IncidentState.ACTIVE.name()))
+                .sort(s -> s.errorMessage().asc().activeInstancesWithErrorCount().desc())
+                .build());
+  }
+
+  @Test
+  void shouldPaginateIncidentProcessInstanceStatisticsByError() {
+    // given
+    when(incidentServices.incidentProcessInstanceStatisticsByError(
+            any(IncidentProcessInstanceStatisticsByErrorQuery.class)))
+        .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_QUERY_RESULT);
+
+    final var request =
+        """
+            {
+              "page": { "from": 0, "limit": 5 }
+            }
+            """;
+
+    // when/then
+    webClient
+        .post()
+        .uri(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            EXPECTED_INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_RESPONSE,
+            JsonCompareMode.STRICT);
+
+    verify(incidentServices)
+        .incidentProcessInstanceStatisticsByError(
+            new IncidentProcessInstanceStatisticsByErrorQuery.Builder()
+                .filter(f -> f.states(IncidentState.ACTIVE.name()))
+                .page(p -> p.from(0).size(5))
+                .build());
+  }
+
+  @Test
   void shouldReturnIncidentProcessInstanceStatisticsByDefinition() {
     // given
     when(incidentServices.searchIncidentProcessInstanceStatisticsByDefinition(
@@ -682,5 +769,43 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                     f -> f.errorMessageHashes(ERROR_HASH_CODE).states(IncidentState.ACTIVE.name()))
                 .page(p -> p.from(0).size(5))
                 .build());
+  }
+
+  @Test
+  void shouldRejectIncidentProcessInstanceStatisticsByErrorRequestWithFilter() {
+    final var request =
+        """
+            {
+              "filter": {
+                "errorHashCode": 123456
+              }
+            }
+            """;
+
+    webClient
+        .post()
+        .uri(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        // We only assert the stable bits here: 400 + instance path. The detail message for unknown
+        // properties is produced by Jackson and may change between versions.
+        .json(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "Bad Request",
+                  "status": 400,
+                  "instance": "%s"
+                }
+                """
+                .formatted(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_URL),
+            JsonCompareMode.LENIENT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -464,7 +464,6 @@ public class IncidentQueryControllerTest extends RestControllerTest {
     verify(incidentServices)
         .incidentProcessInstanceStatisticsByError(
             new IncidentProcessInstanceStatisticsByErrorQuery.Builder()
-                .filter(f -> f.states(IncidentState.ACTIVE.name()))
                 .sort(s -> s.errorMessage().asc().activeInstancesWithErrorCount().desc())
                 .build());
   }
@@ -503,7 +502,6 @@ public class IncidentQueryControllerTest extends RestControllerTest {
     verify(incidentServices)
         .incidentProcessInstanceStatisticsByError(
             new IncidentProcessInstanceStatisticsByErrorQuery.Builder()
-                .filter(f -> f.states(IncidentState.ACTIVE.name()))
                 .page(p -> p.from(0).size(5))
                 .build());
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements the document-based (Elasticsearch/OpenSearch) data layer for the parent incident process instance statistics endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42650
