### PR TITLE
ChildProcessInstanceMigration additional assertion

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -145,8 +145,22 @@ test.describe('Child Process Instance Migration', () => {
       await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
         parentInstanceKey,
       );
-      await expect(page.getByText('1 result')).toBeVisible({
-        timeout: 30000,
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
+          await operateFiltersPanelPage.selectVersion(sourceVersion);
+          await operateFiltersPanelPage.displayOptionalFilter(
+            'Parent Process Instance Key',
+          );
+          await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
+            parentInstanceKey,
+          );
+        },
       });
     });
 


### PR DESCRIPTION
## Description

This PR adds `waitForAssertion` to reduce flakiness.

## On demand workflow
[Was all green](https://github.com/camunda/camunda/actions/runs/20568678056)


