### PR TITLE
fix: update flaky test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -159,7 +159,15 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Expect all incidents resolved', async () => {
-      await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessInstancePage.incidentsBanner).toBeHidden();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await sleep(500);
+        },
+      });
       await expect(operateProcessInstancePage.incidentsTable).toBeHidden();
       await expect(operateProcessInstancePage.completedIcon).toBeVisible();
     });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`Resolve Incidents` test was failing intermittently in CI with the incidents banner still being visible when expected to be hidden. The test was flaky in CI environments.

### Solution
Added `waitForAssertion` with retry logic to wait for the incidents banner to actually disappear after resolving the second incident. This handles timing differences between local and CI environments where incident resolution may take longer to reflect in the UI.

🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20571340513/job/59079167464)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
