### PR TITLE
batchMoveModification test fix

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -52,12 +52,6 @@ test.describe('Process Instance Batch Modification', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Meow', async () => {
-    await test.step('Just a placeholder test', async () => {
-      console.log('Meow');
-    });
-  });
-
   test('Move Operation', async ({
     page,
     operateProcessesPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -16,6 +16,7 @@ import {
   gotoProcessesPage,
 } from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
+import { waitForAssertion } from 'utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -51,6 +52,12 @@ test.describe('Process Instance Batch Modification', () => {
     await captureFailureVideo(page, testInfo);
   });
 
+  test('Meow', async () => {
+    await test.step('Just a placeholder test', async () => {
+      console.log('Meow');
+    });
+  });
+
   test('Move Operation', async ({
     page,
     operateProcessesPage,
@@ -63,7 +70,7 @@ test.describe('Process Instance Batch Modification', () => {
       (instance) => instance.processInstanceKey,
     );
 
-    await test.step('Navigate to processes page with filters', async () => {
+    await test.step('Navigate to processes page with filters and verify results', async () => {
       await gotoProcessesPage(page, {
         searchParams: {
           active: 'true',
@@ -72,12 +79,24 @@ test.describe('Process Instance Batch Modification', () => {
           flowNodeId: 'checkPayment',
         },
       });
-    });
 
-    await test.step('Verify correct number of instances displayed', async () => {
-      await expect(
-        page.getByText(`${NUM_PROCESS_INSTANCES} results`),
-      ).toBeVisible();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            page.getByText(`${NUM_PROCESS_INSTANCES} results`),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await gotoProcessesPage(page, {
+            searchParams: {
+              active: 'true',
+              process: 'orderProcessBatchMod',
+              version: '1',
+              flowNodeId: 'checkPayment',
+            },
+          });
+        },
+      });
     });
 
     await test.step('Select 4 process instances for move modification', async () => {


### PR DESCRIPTION
## Description

This PR combines action and assertion step into one test-step, adds `waitForAssertion` to avoid test failing because of eventual consistency.

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/20572142627)
