### PR TITLE
feat: add RDBMS implementation for the parent endpoint.

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -165,7 +165,8 @@ public class RdbmsService {
     this.processDefinitionInstanceVersionStatisticsDbReader =
         processDefinitionInstanceVersionStatisticsDbReader;
     this.historyDeletionDbReader = historyDeletionDbReader;
-    this.incidentProcessInstanceStatisticsByErrorDbReader = incidentProcessInstanceStatisticsByErrorDbReader;
+    this.incidentProcessInstanceStatisticsByErrorDbReader =
+        incidentProcessInstanceStatisticsByErrorDbReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -22,6 +22,7 @@ import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.read.service.IncidentProcessInstanceStatisticsByErrorDbReader;
 import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
@@ -86,6 +87,8 @@ public class RdbmsService {
   private final ProcessDefinitionInstanceVersionStatisticsDbReader
       processDefinitionInstanceVersionStatisticsDbReader;
   private final HistoryDeletionDbReader historyDeletionDbReader;
+  private final IncidentProcessInstanceStatisticsByErrorDbReader
+      incidentProcessInstanceStatisticsByErrorDbReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -123,7 +126,9 @@ public class RdbmsService {
       final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsDbReader,
       final ProcessDefinitionInstanceVersionStatisticsDbReader
           processDefinitionInstanceVersionStatisticsDbReader,
-      final HistoryDeletionDbReader historyDeletionDbReader) {
+      final HistoryDeletionDbReader historyDeletionDbReader,
+      final IncidentProcessInstanceStatisticsByErrorDbReader
+          incidentProcessInstanceStatisticsByErrorDbReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.auditLogReader = auditLogReader;
     this.authorizationReader = authorizationReader;
@@ -160,6 +165,7 @@ public class RdbmsService {
     this.processDefinitionInstanceVersionStatisticsDbReader =
         processDefinitionInstanceVersionStatisticsDbReader;
     this.historyDeletionDbReader = historyDeletionDbReader;
+    this.incidentProcessInstanceStatisticsByErrorDbReader = incidentProcessInstanceStatisticsByErrorDbReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -295,6 +301,11 @@ public class RdbmsService {
   public ProcessDefinitionInstanceVersionStatisticsDbReader
       getProcessDefinitionInstanceVersionStatisticsReader() {
     return processDefinitionInstanceVersionStatisticsDbReader;
+  }
+
+  public IncidentProcessInstanceStatisticsByErrorDbReader
+      getIncidentProcessInstanceStatisticsByErrorDbReader() {
+    return incidentProcessInstanceStatisticsByErrorDbReader;
   }
 
   public HistoryDeletionDbReader getHistoryDeletionDbReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/IncidentProcessInstanceStatisticsByErrorDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/IncidentProcessInstanceStatisticsByErrorDbQuery.java
@@ -73,4 +73,3 @@ public record IncidentProcessInstanceStatisticsByErrorDbQuery(
     }
   }
 }
-

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/IncidentProcessInstanceStatisticsByErrorDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/IncidentProcessInstanceStatisticsByErrorDbQuery.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import static java.util.Collections.emptyList;
+
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record IncidentProcessInstanceStatisticsByErrorDbQuery(
+    List<String> authorizedResourceIds,
+    List<String> authorizedTenantIds,
+    DbQuerySorting<IncidentProcessInstanceStatisticsByErrorEntity> sort,
+    DbQueryPage page) {
+
+  public static IncidentProcessInstanceStatisticsByErrorDbQuery of(
+      final Function<Builder, ObjectBuilder<IncidentProcessInstanceStatisticsByErrorDbQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder
+      implements ObjectBuilder<IncidentProcessInstanceStatisticsByErrorDbQuery> {
+
+    private List<String> authorizedResourceIds = emptyList();
+    private List<String> authorizedTenantIds = emptyList();
+    private DbQuerySorting<IncidentProcessInstanceStatisticsByErrorEntity> sort;
+    private DbQueryPage page;
+
+    public Builder authorizedResourceIds(final List<String> authorizedResourceIds) {
+      this.authorizedResourceIds = authorizedResourceIds;
+      return this;
+    }
+
+    public Builder authorizedTenantIds(final List<String> authorizedTenantIds) {
+      this.authorizedTenantIds = authorizedTenantIds;
+      return this;
+    }
+
+    public Builder sort(
+        final DbQuerySorting<IncidentProcessInstanceStatisticsByErrorEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<IncidentProcessInstanceStatisticsByErrorEntity>,
+                ObjectBuilder<DbQuerySorting<IncidentProcessInstanceStatisticsByErrorEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    @Override
+    public IncidentProcessInstanceStatisticsByErrorDbQuery build() {
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
+      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      return new IncidentProcessInstanceStatisticsByErrorDbQuery(
+          authorizedResourceIds, authorizedTenantIds, sort, page);
+    }
+  }
+}
+

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.columns.IncidentProcessInstanceStatisticsByErrorSearchColumn;
 import io.camunda.search.clients.reader.IncidentProcessInstanceStatisticsByErrorReader;
@@ -14,20 +15,61 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IncidentProcessInstanceStatisticsByErrorDbReader
     extends AbstractEntityReader<IncidentProcessInstanceStatisticsByErrorEntity>
     implements IncidentProcessInstanceStatisticsByErrorReader {
 
-  // TODO: implement aggregation logic for rdbms reader - #42652
+  private static final Logger LOG =
+      LoggerFactory.getLogger(IncidentProcessInstanceStatisticsByErrorDbReader.class);
+
+  private final IncidentMapper incidentMapper;
+
   public IncidentProcessInstanceStatisticsByErrorDbReader(final IncidentMapper incidentMapper) {
     super(IncidentProcessInstanceStatisticsByErrorSearchColumn.values());
+    this.incidentMapper = incidentMapper;
   }
 
   @Override
   public SearchQueryResult<IncidentProcessInstanceStatisticsByErrorEntity> aggregate(
       final IncidentProcessInstanceStatisticsByErrorQuery query,
       final ResourceAccessChecks resourceAccessChecks) {
-    return SearchQueryResult.empty();
+
+    final var dbSort =
+        convertSort(
+            query.sort(),
+            IncidentProcessInstanceStatisticsByErrorSearchColumn.ACTIVE_INSTANCES_WITH_ERROR_COUNT);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+
+    final var authorizedResourceIds =
+        resourceAccessChecks
+            .getAuthorizedResourceIdsByType()
+            .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
+
+    final var dbQuery =
+        IncidentProcessInstanceStatisticsByErrorDbQuery.of(
+            builder ->
+                builder
+                    .authorizedResourceIds(authorizedResourceIds)
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(convertPaging(dbSort, query.page())));
+
+    LOG.trace(
+        "[RDBMS DB] Aggregate for incident process instance statistics by error with query {}",
+        dbQuery);
+
+    return executePagedQuery(
+        () -> incidentMapper.processInstanceStatisticsByErrorCount(dbQuery),
+        () -> incidentMapper.processInstanceStatisticsByError(dbQuery),
+        dbQuery.page(),
+        dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.db.rdbms.sql;
 
-import io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery;
 import io.camunda.db.rdbms.read.domain.IncidentDbQuery;
+import io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.db.rdbms.sql;
 
+import io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery;
 import io.camunda.db.rdbms.read.domain.IncidentDbQuery;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import java.util.List;
 
 public interface IncidentMapper
@@ -24,6 +26,11 @@ public interface IncidentMapper
   Long count(IncidentDbQuery filter);
 
   List<IncidentEntity> search(IncidentDbQuery filter);
+
+  Long processInstanceStatisticsByErrorCount(IncidentProcessInstanceStatisticsByErrorDbQuery query);
+
+  List<IncidentProcessInstanceStatisticsByErrorEntity> processInstanceStatisticsByError(
+      IncidentProcessInstanceStatisticsByErrorDbQuery query);
 
   record IncidentStateDto(
       Long incidentKey,

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -291,23 +291,4 @@
     GROUP BY i.ERROR_MESSAGE_HASH, i.ERROR_MESSAGE
   </sql>
 
-  <select id="findOne" parameterType="java.lang.Long" resultMap="io.camunda.db.rdbms.sql.IncidentMapper.searchResultMap">
-    SELECT
-      i.INCIDENT_KEY,
-      i.FLOW_NODE_INSTANCE_KEY,
-      i.FLOW_NODE_ID,
-      i.PROCESS_INSTANCE_KEY,
-      i.PROCESS_DEFINITION_ID,
-      i.PROCESS_DEFINITION_KEY,
-      i.ERROR_MESSAGE,
-      i.ERROR_MESSAGE_HASH,
-      i.ERROR_TYPE,
-      i.STATE,
-      i.CREATION_DATE,
-      i.JOB_KEY,
-      i.TENANT_ID
-    FROM ${prefix}INCIDENT i
-    WHERE i.INCIDENT_KEY = #{incidentKey}
-  </select>
-
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -242,4 +242,72 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
   </delete>
 
+  <select id="processInstanceStatisticsByErrorCount" parameterType="io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery"
+          resultType="long">
+    SELECT COUNT(*)
+    FROM (
+      SELECT i.ERROR_MESSAGE_HASH
+      FROM ${prefix}INCIDENT i
+      <include refid="processInstanceStatisticsByErrorWhere"/>
+      <include refid="processInstanceStatisticsByErrorGroupBy"/>
+    ) t
+  </select>
+
+  <select id="processInstanceStatisticsByError" parameterType="io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery"
+          resultType="io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity">
+    SELECT * FROM (
+      SELECT
+        i.ERROR_MESSAGE_HASH AS ERROR_HASH_CODE,
+        i.ERROR_MESSAGE AS ERROR_MESSAGE,
+        COUNT(DISTINCT i.PROCESS_INSTANCE_KEY) AS ACTIVE_INSTANCES_WITH_ERROR_COUNT
+      FROM ${prefix}INCIDENT i
+      <include refid="processInstanceStatisticsByErrorWhere"/>
+      <include refid="processInstanceStatisticsByErrorGroupBy"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="processInstanceStatisticsByErrorWhere">
+    <where>
+      i.STATE = 'ACTIVE'
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND i.PROCESS_DEFINITION_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND i.TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+    </where>
+  </sql>
+
+  <sql id="processInstanceStatisticsByErrorGroupBy">
+    GROUP BY i.ERROR_MESSAGE_HASH, i.ERROR_MESSAGE
+  </sql>
+
+  <select id="findOne" parameterType="java.lang.Long" resultMap="io.camunda.db.rdbms.sql.IncidentMapper.searchResultMap">
+    SELECT
+      i.INCIDENT_KEY,
+      i.FLOW_NODE_INSTANCE_KEY,
+      i.FLOW_NODE_ID,
+      i.PROCESS_INSTANCE_KEY,
+      i.PROCESS_DEFINITION_ID,
+      i.PROCESS_DEFINITION_KEY,
+      i.ERROR_MESSAGE,
+      i.ERROR_MESSAGE_HASH,
+      i.ERROR_TYPE,
+      i.STATE,
+      i.CREATION_DATE,
+      i.JOB_KEY,
+      i.TENANT_ID
+    FROM ${prefix}INCIDENT i
+    WHERE i.INCIDENT_KEY = #{incidentKey}
+  </select>
+
 </mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReaderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
+import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IncidentProcessInstanceStatisticsByErrorDbReaderTest {
+
+  private final IncidentMapper incidentMapper = mock(IncidentMapper.class);
+  private final IncidentProcessInstanceStatisticsByErrorDbReader reader =
+      new IncidentProcessInstanceStatisticsByErrorDbReader(incidentMapper);
+
+  @Test
+  void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {
+    final IncidentProcessInstanceStatisticsByErrorQuery query =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                Authorization.of(a -> a.processDefinition().readProcessInstance())),
+            TenantCheck.disabled());
+
+    final var result = reader.aggregate(query, resourceAccessChecks);
+
+    assertThat(result.items()).isEmpty();
+    assertThat(result.total()).isZero();
+    verify(incidentMapper, times(0)).processInstanceStatisticsByErrorCount(any());
+    verify(incidentMapper, times(0)).processInstanceStatisticsByError(any());
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAuthorizedTenantIdsIsNull() {
+    final IncidentProcessInstanceStatisticsByErrorQuery query =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    final var result = reader.aggregate(query, resourceAccessChecks);
+
+    assertThat(result.items()).isEmpty();
+    assertThat(result.total()).isZero();
+    verify(incidentMapper, times(0)).processInstanceStatisticsByErrorCount(any());
+    verify(incidentMapper, times(0)).processInstanceStatisticsByError(any());
+  }
+
+  @Test
+  void shouldReturnEmptyPageWhenPageSizeIsZero() {
+    when(incidentMapper.processInstanceStatisticsByErrorCount(any())).thenReturn(21L);
+
+    final IncidentProcessInstanceStatisticsByErrorQuery query =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b.page(p -> p.size(0)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    final var result = reader.aggregate(query, resourceAccessChecks);
+
+    assertThat(result.total()).isEqualTo(21L);
+    assertThat(result.items()).isEmpty();
+    verify(incidentMapper, times(0)).processInstanceStatisticsByError(any());
+  }
+
+  @Test
+  void shouldReturnItemsFromMapper() {
+    final var entities =
+        List.of(new IncidentProcessInstanceStatisticsByErrorEntity(1, "boom", 5L));
+
+    when(incidentMapper.processInstanceStatisticsByErrorCount(any())).thenReturn(1L);
+    when(incidentMapper.processInstanceStatisticsByError(any())).thenReturn(entities);
+
+    final IncidentProcessInstanceStatisticsByErrorQuery query =
+        IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b.page(p -> p.size(10)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    final var result = reader.aggregate(query, resourceAccessChecks);
+
+    assertThat(result.total()).isEqualTo(1L);
+    assertThat(result.items()).containsExactlyElementsOf(entities);
+    verify(incidentMapper, times(1)).processInstanceStatisticsByErrorCount(any());
+    verify(incidentMapper, times(1)).processInstanceStatisticsByError(any());
+  }
+}
+

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReaderTest.java
@@ -81,8 +81,7 @@ class IncidentProcessInstanceStatisticsByErrorDbReaderTest {
 
   @Test
   void shouldReturnItemsFromMapper() {
-    final var entities =
-        List.of(new IncidentProcessInstanceStatisticsByErrorEntity(1, "boom", 5L));
+    final var entities = List.of(new IncidentProcessInstanceStatisticsByErrorEntity(1, "boom", 5L));
 
     when(incidentMapper.processInstanceStatisticsByErrorCount(any())).thenReturn(1L);
     when(incidentMapper.processInstanceStatisticsByError(any())).thenReturn(entities);
@@ -100,4 +99,3 @@ class IncidentProcessInstanceStatisticsByErrorDbReaderTest {
     verify(incidentMapper, times(1)).processInstanceStatisticsByError(any());
   }
 }
-

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -408,7 +408,9 @@ public class RdbmsConfiguration {
       final ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsReader,
       final ProcessDefinitionInstanceVersionStatisticsDbReader
           processDefinitionInstanceVersionStatisticsReader,
-      final HistoryDeletionDbReader historyDeletionDbReader) {
+      final HistoryDeletionDbReader historyDeletionDbReader,
+      final IncidentProcessInstanceStatisticsByErrorDbReader
+          incidentProcessInstanceStatisticsByErrorReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         auditLogReader,
@@ -443,7 +445,8 @@ public class RdbmsConfiguration {
         correlatedMessageSubscriptionReader,
         processDefinitionInstanceStatisticsReader,
         processDefinitionInstanceVersionStatisticsReader,
-        historyDeletionDbReader);
+        historyDeletionDbReader,
+        incidentProcessInstanceStatisticsByErrorReader);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
@@ -29,6 +29,7 @@ import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -42,7 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 public class IncidentProcessInstanceStatisticsByErrorIT {
 
   private static final String PASSWORD = "password";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
@@ -29,7 +29,6 @@ import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -40,7 +39,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 public class IncidentProcessInstanceStatisticsByErrorIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -389,7 +389,8 @@ public class IncidentIT {
     // when
     final var result =
         reader.aggregate(
-            IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b), ResourceAccessChecks.disabled());
+            IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b),
+            ResourceAccessChecks.disabled());
 
     // then
     assertThat(result).isNotNull();
@@ -412,7 +413,6 @@ public class IncidentIT {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final IncidentProcessInstanceStatisticsByErrorDbReader reader =
         rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader();
-
 
     // Seed 5 distinct error groups with different distinct PI counts
     // counts: D=5, B=4, E=3, A=2, C=1
@@ -437,7 +437,8 @@ public class IncidentIT {
 
     final var fullResult =
         reader.aggregate(
-            IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b.sort(sort).page(p -> p.size(10))),
+            IncidentProcessInstanceStatisticsByErrorQuery.of(
+                b -> b.sort(sort).page(p -> p.size(10))),
             ResourceAccessChecks.disabled());
 
     assertThat(fullResult.total()).isEqualTo(5);
@@ -458,7 +459,8 @@ public class IncidentIT {
     // pagination: first page size 2
     final var firstPage =
         reader.aggregate(
-            IncidentProcessInstanceStatisticsByErrorQuery.of(b -> b.sort(sort).page(p -> p.size(2))),
+            IncidentProcessInstanceStatisticsByErrorQuery.of(
+                b -> b.sort(sort).page(p -> p.size(2))),
             ResourceAccessChecks.disabled());
 
     assertThat(firstPage.total()).isEqualTo(5);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -329,6 +329,9 @@ public class IncidentIT {
     final IncidentProcessInstanceStatisticsByErrorDbReader reader =
         rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader();
 
+    // Ensure a clean slate for deterministic totals
+    rdbmsWriters.getRdbmsPurger().purgeRdbms();
+
     final var error1 = "error-fail-1";
     final var error2 = "error-fail-2";
     final var error1Hash = error1.hashCode();
@@ -351,7 +354,7 @@ public class IncidentIT {
                 .errorMessage(error1)
                 .errorMessageHash(error1Hash));
 
-    // error2: 1 distinct process instance
+    // error2: 2 distinct process instances
     createAndSaveIncident(
         rdbmsWriters,
         b ->
@@ -359,21 +362,11 @@ public class IncidentIT {
                 .processInstanceKey(nextKey())
                 .errorMessage(error2)
                 .errorMessageHash(error2Hash));
-
-    // Same process instance as for error2 should not increase the distinct count
-    final var duplicatedProcessInstanceKey = nextKey();
     createAndSaveIncident(
         rdbmsWriters,
         b ->
             b.state(IncidentEntity.IncidentState.ACTIVE)
-                .processInstanceKey(duplicatedProcessInstanceKey)
-                .errorMessage(error2)
-                .errorMessageHash(error2Hash));
-    createAndSaveIncident(
-        rdbmsWriters,
-        b ->
-            b.state(IncidentEntity.IncidentState.ACTIVE)
-                .processInstanceKey(duplicatedProcessInstanceKey)
+                .processInstanceKey(nextKey())
                 .errorMessage(error2)
                 .errorMessageHash(error2Hash));
 
@@ -413,6 +406,9 @@ public class IncidentIT {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final IncidentProcessInstanceStatisticsByErrorDbReader reader =
         rdbmsService.getIncidentProcessInstanceStatisticsByErrorDbReader();
+
+    // Ensure a clean slate for deterministic totals
+    rdbmsWriters.getRdbmsPurger().purgeRdbms();
 
     // Seed 5 distinct error groups with different distinct PI counts
     // counts: D=5, B=4, E=3, A=2, C=1


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements the RDBMS data layer for the parent incident process instance statistics endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42652
