### PR TITLE
feat: add rootProcessInstanceKey in event records used for audit logs

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -198,6 +198,7 @@ public class ProcessInstanceCreationHelper {
       final ProcessInstanceCreationRecord record, final ProcessInstanceRecord processInstance) {
     record
         .setProcessInstanceKey(processInstance.getProcessInstanceKey())
+        .setRootProcessInstanceKey(processInstance.getRootProcessInstanceKey())
         .setBpmnProcessId(processInstance.getBpmnProcessId())
         .setVersion(processInstance.getVersion())
         .setProcessDefinitionKey(processInstance.getProcessDefinitionKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -195,6 +195,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     }
 
     value.setTenantId(processInstance.getValue().getTenantId());
+    value.setRootProcessInstanceKey(processInstance.getValue().getRootProcessInstanceKey());
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
     responseWriter.writeEventOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -323,6 +323,7 @@ public final class ProcessInstanceModificationModifyProcessor
     final var extendedRecord = new ProcessInstanceModificationRecord();
     extendedRecord
         .setProcessInstanceKey(value.getProcessInstanceKey())
+        .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey())
         .setTenantId(processInstance.getValue().getTenantId());
 
     final var requiredKeysForActivation =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
@@ -76,6 +76,7 @@ public class ProcessEventsClaimsTest {
             .withInstanceKey(processInstanceKey)
             .findFirst();
     assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
   }
 
   @Test
@@ -100,6 +101,7 @@ public class ProcessEventsClaimsTest {
             .withProcessInstanceKey(processInstanceKey)
             .findFirst();
     assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -686,9 +686,11 @@ public class MigrateCallActivityTest {
             RecordingExporter.processInstanceMigrationRecords(
                     ProcessInstanceMigrationIntent.MIGRATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .exists())
+                .findFirst())
         .describedAs("Expect that process instance is migrated")
-        .isTrue();
+        .isPresent()
+        .map(record -> record.getValue().getRootProcessInstanceKey())
+        .hasValue(processInstanceKey);
   }
 
   @Test
@@ -806,8 +808,10 @@ public class MigrateCallActivityTest {
             RecordingExporter.processInstanceMigrationRecords(
                     ProcessInstanceMigrationIntent.MIGRATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .exists())
+                .findFirst())
         .describedAs("Expect that process instance is migrated")
-        .isTrue();
+        .isPresent()
+        .map(record -> record.getValue().getRootProcessInstanceKey())
+        .hasValue(processInstanceKey);
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -61,6 +63,10 @@ final class BulkIndexRequest implements ContentProducer {
               ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionMixin.class)
           .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
+          .addMixIn(
+              ProcessInstanceCreationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(
+              ProcessInstanceMigrationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
@@ -221,7 +227,10 @@ final class BulkIndexRequest implements ContentProducer {
   })
   private static final class ProcessMessageSubscriptionMixin {}
 
-  @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})
+  @JsonIgnoreProperties({
+    PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY,
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
+  })
   private static final class ProcessInstanceModificationMixin {}
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -56,6 +56,9 @@
             },
             "tags": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -37,6 +37,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -91,6 +91,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -650,6 +650,9 @@ final class BulkIndexRequestTest {
           "DECISION_EVALUATION",
           "JOB",
           "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+          "PROCESS_INSTANCE_MIGRATION",
+          "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
           "USER_TASK"
         })
@@ -685,6 +688,9 @@ final class BulkIndexRequestTest {
           "DECISION_EVALUATION",
           "JOB",
           "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+          "PROCESS_INSTANCE_MIGRATION",
+          "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
           "USER_TASK"
         })

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -61,6 +63,10 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(
               ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationMixin.class)
+          .addMixIn(
+              ProcessInstanceCreationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
+          .addMixIn(
+              ProcessInstanceMigrationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(
               ProcessInstanceModificationTerminateInstructionValue.class,
               TerminateInstructionsMixin.class)
@@ -222,7 +228,10 @@ final class BulkIndexRequest implements ContentProducer {
   })
   private static final class ProcessMessageSubscriptionMixin {}
 
-  @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})
+  @JsonIgnoreProperties({
+    PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY,
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
+  })
   private static final class ProcessInstanceModificationMixin {}
 
   @JsonIgnoreProperties({ROOT_PROCESS_INSTANCE_KEY_PROPERTY})

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -56,6 +56,9 @@
             },
             "tags": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -37,6 +37,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -91,6 +91,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -650,6 +650,9 @@ final class BulkIndexRequestTest {
           "DECISION_EVALUATION",
           "JOB",
           "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+          "PROCESS_INSTANCE_MIGRATION",
+          "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
           "USER_TASK"
         })
@@ -685,6 +688,9 @@ final class BulkIndexRequestTest {
           "DECISION_EVALUATION",
           "JOB",
           "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_CREATION",
+          "PROCESS_INSTANCE_MIGRATION",
+          "PROCESS_INSTANCE_MODIFICATION",
           "PROCESS_MESSAGE_SUBSCRIPTION",
           "USER_TASK"
         })

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -45,6 +45,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue RUNTIME_INSTRUCTIONS_KEY =
       new StringValue("runtimeInstructions");
   private static final StringValue TAGS_KEY = new StringValue("tags");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -66,9 +68,11 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
               RUNTIME_INSTRUCTIONS_KEY, ProcessInstanceCreationRuntimeInstruction::new);
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceCreationRecord() {
-    super(10);
+    super(11);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -78,7 +82,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(startInstructionsProperty)
         .declareProperty(runtimeInstructionsProperty)
         .declareProperty(tenantIdProperty)
-        .declareProperty(tagsProperty);
+        .declareProperty(tagsProperty)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
   @Override
@@ -143,6 +148,17 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     if (tags != null) {
       tags.forEach(tag -> tagsProperty.add().wrap(BufferUtil.wrapString(tag)));
     }
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceCreationRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -29,6 +29,8 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringValue("targetProcessDefinitionKey");
   private static final StringValue MAPPING_INSTRUCTIONS_KEY =
       new StringValue("mappingInstructions");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
@@ -40,13 +42,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   private final StringProperty tenantIdProperty =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceMigrationRecord() {
-    super(4);
+    super(5);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
-        .declareProperty(tenantIdProperty);
+        .declareProperty(tenantIdProperty)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
   @Override
@@ -88,6 +93,17 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
               return (ProcessInstanceMigrationMappingInstructionValue) elementCopy;
             })
         .toList();
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
   }
 
   /** Returns true if this record has mapping instructions, otherwise false. */

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -35,6 +35,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   private static final StringValue MOVE_INSTRUCTIONS_KEY = new StringValue("moveInstructions");
   private static final StringValue ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY =
       new StringValue("activatedElementInstanceKeys");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final StringProperty tenantIdProp =
@@ -53,15 +55,18 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
 
   private final ArrayProperty<LongValue> activatedElementInstanceKeys =
       new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceModificationRecord() {
-    super(6);
+    super(7);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
         .declareProperty(moveInstructionsProperty)
         .declareProperty(activatedElementInstanceKeys)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
   /**
@@ -139,6 +144,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
             .flatMap(Set::stream)
             .collect(Collectors.toSet()));
     return activatedElementInstanceKeys;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProperty.setValue(key);
+    return this;
   }
 
   /** Returns true if this record has terminate instructions, otherwise false. */

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1708,6 +1708,7 @@ final class JsonSerializableToJsonTest {
               final long key = 1L;
               final int version = 1;
               final long instanceKey = 2L;
+              final long rootProcessInstanceKey = 3L;
 
               return new ProcessInstanceCreationRecord()
                   .setBpmnProcessId(processId)
@@ -1720,7 +1721,8 @@ final class JsonSerializableToJsonTest {
                   .addStartInstruction(
                       new ProcessInstanceCreationStartInstruction().setElementId("element"))
                   .setProcessInstanceKey(instanceKey)
-                  .setTags(Set.of("tag1", "tag2"));
+                  .setTags(Set.of("tag1", "tag2"))
+                  .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
                 {
@@ -1739,7 +1741,8 @@ final class JsonSerializableToJsonTest {
                   ],
                   "tenantId": "test-tenant",
                   "runtimeInstructions": [],
-                  "tags": ["tag1", "tag2"]
+                  "tags": ["tag1", "tag2"],
+                  "rootProcessInstanceKey": 3
                 }
                 """
       },
@@ -1762,7 +1765,8 @@ final class JsonSerializableToJsonTest {
                   "startInstructions": [],
                   "tenantId": "<default>",
                   "runtimeInstructions": [],
-                  "tags": []
+                  "tags": [],
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },
@@ -1781,6 +1785,7 @@ final class JsonSerializableToJsonTest {
               final var elementIdToActivate = "activity";
               final var ancestorScopeKey = 3L;
               final var variableInstructionElementId = "sub-process";
+              final var rootProcessInstanceKey = 4L;
 
               return new ProcessInstanceModificationRecord()
                   .setProcessInstanceKey(key)
@@ -1807,7 +1812,8 @@ final class JsonSerializableToJsonTest {
                               new ProcessInstanceModificationVariableInstruction()
                                   .setVariables(VARIABLES_MSGPACK)
                                   .setElementId(variableInstructionElementId))
-                          .addAncestorScopeKeys(Set.of(key, ancestorScopeKey)));
+                          .addAncestorScopeKeys(Set.of(key, ancestorScopeKey)))
+                  .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
                 {
@@ -1841,7 +1847,8 @@ final class JsonSerializableToJsonTest {
                     "ancestorScopeKeys": [1,3]
                   }],
                   "ancestorScopeKeys": [1,3],
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": 4
                 }
                 """
       },
@@ -1862,7 +1869,8 @@ final class JsonSerializableToJsonTest {
                   "moveInstructions": [],
                   "activateInstructions": [],
                   "ancestorScopeKeys": [],
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },
@@ -2888,7 +2896,8 @@ final class JsonSerializableToJsonTest {
                             .setSourceElementId("sourceId2"))
                     .addMappingInstruction(
                         new ProcessInstanceMigrationMappingInstruction()
-                            .setTargetElementId("targetId3")),
+                            .setTargetElementId("targetId3"))
+                    .setRootProcessInstanceKey(321L),
         """
                 {
                   "tenantId": "tenantId",
@@ -2903,7 +2912,8 @@ final class JsonSerializableToJsonTest {
                   }, {
                     "sourceElementId": "",
                     "targetElementId": "targetId3"
-                  }]
+                  }],
+                  "rootProcessInstanceKey": 321
                 }
                 """
       },
@@ -2925,7 +2935,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "processInstanceKey": 123,
                   "targetProcessDefinitionKey": 456,
-                  "mappingInstructions": []
+                  "mappingInstructions": [],
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
@@ -45,6 +45,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue RUNTIME_INSTRUCTIONS_KEY =
       new StringValue("runtimeInstructions");
   private static final StringValue TAGS_KEY = new StringValue("tags");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -66,9 +68,11 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
               RUNTIME_INSTRUCTIONS_KEY, ProcessInstanceCreationRuntimeInstruction::new);
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceCreationRecord() {
-    super(10);
+    super(11);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -78,7 +82,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(startInstructionsProperty)
         .declareProperty(runtimeInstructionsProperty)
         .declareProperty(tenantIdProperty)
-        .declareProperty(tagsProperty);
+        .declareProperty(tagsProperty)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
   @Override
@@ -143,6 +148,17 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     if (tags != null) {
       tags.forEach(tag -> tagsProperty.add().wrap(BufferUtil.wrapString(tag)));
     }
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceCreationRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
@@ -29,6 +29,8 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringValue("targetProcessDefinitionKey");
   private static final StringValue MAPPING_INSTRUCTIONS_KEY =
       new StringValue("mappingInstructions");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
@@ -40,13 +42,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   private final StringProperty tenantIdProperty =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceMigrationRecord() {
-    super(4);
+    super(5);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
-        .declareProperty(tenantIdProperty);
+        .declareProperty(tenantIdProperty)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
   @Override
@@ -88,6 +93,17 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
               return (ProcessInstanceMigrationMappingInstructionValue) elementCopy;
             })
         .toList();
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
   }
 
   /** Returns true if this record has mapping instructions, otherwise false. */

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
@@ -10,12 +10,14 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,7 +35,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   private static final StringValue MOVE_INSTRUCTIONS_KEY = new StringValue("moveInstructions");
   private static final StringValue ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY =
       new StringValue("activatedElementInstanceKeys");
-
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final StringProperty tenantIdProp =
@@ -52,15 +55,18 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
 
   private final ArrayProperty<LongValue> activatedElementInstanceKeys =
       new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceModificationRecord() {
-    super(6);
+    super(7);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
         .declareProperty(moveInstructionsProperty)
         .declareProperty(activatedElementInstanceKeys)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
   /**
@@ -140,6 +146,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
     return activatedElementInstanceKeys;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProperty.setValue(key);
+    return this;
+  }
+
   /** Returns true if this record has terminate instructions, otherwise false. */
   @JsonIgnore
   public boolean hasTerminateInstructions() {
@@ -152,7 +168,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
     return this;
   }
 
-  /** Returns true if this record has activate instructions, otherwise false. */
+  /** Returns true if this record has move instructions, otherwise false. */
   @JsonIgnore
   public boolean hasMoveInstructions() {
     return !moveInstructionsProperty.isEmpty();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -49,6 +49,19 @@ public interface ProcessInstanceCreationRecordValue
   /** Returns a set of tags */
   Set<String> getTags();
 
+  /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for process instance records created after version 8.9.0
+   * and part of hierarchies created after that version. For older process instances, the method
+   * will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
+
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableProcessInstanceCreationStartInstructionValue.Builder.class)
   interface ProcessInstanceCreationStartInstructionValue {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
@@ -36,6 +36,19 @@ public interface ProcessInstanceMigrationRecordValue
   List<ProcessInstanceMigrationMappingInstructionValue> getMappingInstructions();
 
   /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for process instance records created after version 8.9.0
+   * and part of hierarchies created after that version. For older process instances, the method
+   * will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
+
+  /**
    * Mapping instructions for the migration describe how to map elements from the source process
    * definition to the target process definition.
    *

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -46,6 +46,19 @@ public interface ProcessInstanceModificationRecordValue
   @Deprecated
   Set<Long> getAncestorScopeKeys();
 
+  /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for process instance records created after version 8.9.0
+   * and part of hierarchies created after that version. For older process instances, the method
+   * will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
+
   @Value.Immutable
   @ImmutableProtocol(
       builder = ImmutableProcessInstanceModificationTerminateInstructionValue.Builder.class)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request introduces support for tracking and exporting the `rootProcessInstanceKey` across process instance creation, migration, and modification records, that are used as source for the exported Audit logs and operation entities in the secondary storage
For now, this is restricted to the following intents
- ProcessInstanceCreationIntent.CREATED
- ProcessInstanceMigrationIntent.MIGRATED
- ProcessInstanceModificationIntent.MODIFIED

The other intents that are exported as audit logs for the command rejections, will be handled in a later pull request as discussed in [Slack](https://camunda.slack.com/archives/C09HWN20VJL/p1767085807270359)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41655
depends on https://github.com/camunda/camunda/pull/42708 and https://github.com/camunda/camunda/pull/42352
