### PR TITLE
feat: multi-instance usertask migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -589,7 +589,10 @@ public final class ProcessInstanceMigrationPreconditions {
     final AbstractFlowElement targetElement =
         targetProcessDefinition.getProcess().getElementById(targetElementId);
     final BpmnElementType targetElementType = targetElement.getElementType();
-    if (targetElementType != BpmnElementType.USER_TASK) {
+
+    if (targetElementType != BpmnElementType.USER_TASK
+        && !(targetElement instanceof final ExecutableMultiInstanceBody tmi
+            && tmi.getInnerActivity().getElementType() == BpmnElementType.USER_TASK)) {
       return false;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -189,7 +189,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     if (entity.getState() != null) {
       updateFields.put(TaskTemplate.STATE, entity.getState());
       // Add update fields for migrated user tasks
-      if (entity.getState() == TaskState.CREATED) {
+      if (entity.getState() == TaskState.CREATING) {
         updateFields.put(TaskTemplate.KEY, entity.getKey());
         if (entity.getImplementation() != null) {
           updateFields.put(TaskTemplate.IMPLEMENTATION, entity.getImplementation());
@@ -202,6 +202,9 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
         }
         if (entity.getFormKey() != null) {
           updateFields.put(TaskTemplate.FORM_KEY, entity.getFormKey());
+        }
+        if (entity.getFormVersion() != null) {
+          updateFields.put(TaskTemplate.FORM_VERSION, entity.getFormVersion());
         }
       }
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -854,7 +854,6 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
-    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getAssignee()).isEqualTo(taskRecordValue.getAssignee());
@@ -898,7 +897,6 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.ASSIGNEE, null);
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
-    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getAssignee()).isEqualTo(null);
@@ -1001,7 +999,6 @@ public class UserTaskHandlerTest {
         List.of(
             "priority", "dueDate", "followUpDate", "candidateUsersList", "candidateGroupsList"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
-    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
@@ -1068,7 +1065,6 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("priority", "assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
-    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
@@ -1079,14 +1075,16 @@ public class UserTaskHandlerTest {
   }
 
   @Test
-  void flushedCreateEntityShouldContainUserTaskMigrationUpdates() {
+  void flushedCreatingEntityShouldContainUserTaskMigrationUpdates() {
     // given
     final long processInstanceKey = 123;
     final long flowNodeInstanceKey = 456;
     final long recordKey = 110;
+    final String bpmnProcessId = "process-id";
     final String formId = "my-form-id";
-    final String formKey = "my-form-key";
+    final long formKey = 789L;
     exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 100);
+    formCache.put(String.valueOf(formKey), new CachedFormEntity(formId, 3L));
     final var dateTime = OffsetDateTime.now();
     final UserTaskRecordValue taskRecordValue =
         ImmutableUserTaskRecordValue.builder()
@@ -1098,30 +1096,28 @@ public class UserTaskHandlerTest {
                     "candidateUsersList",
                     "candidateGroupsList"))
             .withProcessInstanceKey(processInstanceKey)
+            .withBpmnProcessId(bpmnProcessId)
+            .withProcessDefinitionVersion(2)
             .withPriority(99)
             .withDueDate(dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
             .withFollowUpDate(dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
             .withCandidateUsersList(Arrays.asList("user1", "user2"))
             .withCandidateGroupsList(Arrays.asList("group1", "group2"))
             .withElementInstanceKey(flowNodeInstanceKey)
+            .withFormKey(formKey)
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =
         factory.generateRecord(
             ValueType.USER_TASK,
             r ->
-                r.withIntent(UserTaskIntent.CREATED)
+                r.withIntent(UserTaskIntent.CREATING)
                     .withValue(taskRecordValue)
                     .withKey(recordKey)
                     .withTimestamp(System.currentTimeMillis()));
 
     // when
-    final TaskEntity taskEntity =
-        underTest
-            .createNewEntity(String.valueOf(recordKey))
-            .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
-            .setFormId(formId)
-            .setFormKey(formKey);
+    final TaskEntity taskEntity = underTest.createNewEntity(String.valueOf(recordKey));
     underTest.updateEntity(taskRecord, taskEntity);
 
     final BatchRequest mockRequest = mock(BatchRequest.class);
@@ -1129,26 +1125,22 @@ public class UserTaskHandlerTest {
     underTest.flush(taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
-    expectedUpdates.put(TaskTemplate.FOLLOW_UP_DATE, taskEntity.getFollowUpDate());
-    expectedUpdates.put(TaskTemplate.DUE_DATE, taskEntity.getDueDate());
-    expectedUpdates.put(TaskTemplate.CANDIDATE_USERS, taskEntity.getCandidateUsers());
-    expectedUpdates.put(TaskTemplate.CANDIDATE_GROUPS, taskEntity.getCandidateGroups());
-    expectedUpdates.put(
-        TaskTemplate.CHANGED_ATTRIBUTES,
-        List.of(
-            "priority", "dueDate", "followUpDate", "candidateUsersList", "candidateGroupsList"));
-    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATING);
     expectedUpdates.put(TaskTemplate.IMPLEMENTATION, taskEntity.getImplementation());
     expectedUpdates.put(TaskTemplate.FORM_ID, taskEntity.getFormId());
     expectedUpdates.put(TaskTemplate.FORM_KEY, taskEntity.getFormKey());
     expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
+    expectedUpdates.put(TaskTemplate.FORM_VERSION, 3L);
+    expectedUpdates.put(TaskTemplate.PROCESS_DEFINITION_ID, taskEntity.getProcessDefinitionId());
+    expectedUpdates.put(TaskTemplate.BPMN_PROCESS_ID, taskEntity.getBpmnProcessId());
+    expectedUpdates.put(TaskTemplate.PROCESS_DEFINITION_VERSION, 2);
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
     assertThat(taskEntity.getDueDate()).isEqualTo(taskRecordValue.getDueDate());
     assertThat(taskEntity.getFollowUpDate()).isEqualTo(taskRecordValue.getFollowUpDate());
     assertThat(taskEntity.getFormId()).isEqualTo(formId);
-    assertThat(taskEntity.getFormKey()).isEqualTo(formKey);
+    assertThat(taskEntity.getFormKey()).isEqualTo(String.valueOf(formKey));
     assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
     assertThat(Arrays.stream(taskEntity.getCandidateGroups()).toList())
         .isEqualTo(taskRecordValue.getCandidateGroupsList());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Add support for multi-instance migration for user task implementation migration
- Fixed wrong/missing entity updates (doing the updates on CREATED did not work as expected because we don't usually set any of the needed fields to update in the entity, so they get skipped. This lead to e.g. the implementation not being updated in ES, because the update fields are set based on the data in the entity. CREATING sets all fields) and added form version since that was not set previously.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/42818
