### PR TITLE
feat: add rootProcessInstanceKey for incident record value

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
@@ -41,6 +41,55 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
   }
 
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public ErrorType getErrorType() {
+    return errorType;
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public long getJobKey() {
+    return jobKey;
+  }
+
+  @Override
+  public long getVariableScopeKey() {
+    return variableScopeKey;
+  }
+
   @JsonIgnore
   @Override
   public List<List<Long>> getElementInstancePath() {
@@ -59,56 +108,25 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
     throw new UnsupportedOperationException("Operation not supported");
   }
 
-  public String getErrorMessage() {
-    return this.errorMessage;
+  @Override
+  public long getRootProcessInstanceKey() {
+    return -1L; // Not used in Optimize
   }
 
-  public String getBpmnProcessId() {
-    return this.bpmnProcessId;
+  public void setVariableScopeKey(final long variableScopeKey) {
+    this.variableScopeKey = variableScopeKey;
   }
 
-  public String getElementId() {
-    return this.elementId;
-  }
-
-  public long getElementInstanceKey() {
-    return this.elementInstanceKey;
-  }
-
-  public long getProcessInstanceKey() {
-    return this.processInstanceKey;
-  }
-
-  public long getProcessDefinitionKey() {
-    return this.processDefinitionKey;
-  }
-
-  public long getJobKey() {
-    return this.jobKey;
-  }
-
-  public ErrorType getErrorType() {
-    return this.errorType;
-  }
-
-  public long getVariableScopeKey() {
-    return this.variableScopeKey;
-  }
-
-  public void setErrorMessage(final String errorMessage) {
-    this.errorMessage = errorMessage;
-  }
-
-  public void setBpmnProcessId(final String bpmnProcessId) {
-    this.bpmnProcessId = bpmnProcessId;
-  }
-
-  public void setElementId(final String elementId) {
-    this.elementId = elementId;
+  public void setJobKey(final long jobKey) {
+    this.jobKey = jobKey;
   }
 
   public void setElementInstanceKey(final long elementInstanceKey) {
     this.elementInstanceKey = elementInstanceKey;
+  }
+
+  public void setElementId(final String elementId) {
+    this.elementId = elementId;
   }
 
   public void setProcessInstanceKey(final long processInstanceKey) {
@@ -119,44 +137,31 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
     this.processDefinitionKey = processDefinitionKey;
   }
 
-  public void setJobKey(final long jobKey) {
-    this.jobKey = jobKey;
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
   }
 
   public void setErrorType(final ErrorType errorType) {
     this.errorType = errorType;
   }
 
-  public void setVariableScopeKey(final long variableScopeKey) {
-    this.variableScopeKey = variableScopeKey;
-  }
-
-  public void setTenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public String toString() {
-    return "ZeebeIncidentDataDto(errorMessage="
-        + this.getErrorMessage()
-        + ", bpmnProcessId="
-        + this.getBpmnProcessId()
-        + ", elementId="
-        + this.getElementId()
-        + ", elementInstanceKey="
-        + this.getElementInstanceKey()
-        + ", processInstanceKey="
-        + this.getProcessInstanceKey()
-        + ", processDefinitionKey="
-        + this.getProcessDefinitionKey()
-        + ", jobKey="
-        + this.getJobKey()
-        + ", errorType="
-        + this.getErrorType()
-        + ", variableScopeKey="
-        + this.getVariableScopeKey()
-        + ", tenantId="
-        + this.getTenantId()
-        + ")";
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        errorMessage,
+        bpmnProcessId,
+        elementId,
+        elementInstanceKey,
+        processInstanceKey,
+        processDefinitionKey,
+        jobKey,
+        errorType,
+        variableScopeKey,
+        tenantId);
   }
 
   @Override
@@ -181,18 +186,28 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(
-        errorMessage,
-        bpmnProcessId,
-        elementId,
-        elementInstanceKey,
-        processInstanceKey,
-        processDefinitionKey,
-        jobKey,
-        errorType,
-        variableScopeKey,
-        tenantId);
+  public String toString() {
+    return "ZeebeIncidentDataDto(errorMessage="
+        + getErrorMessage()
+        + ", bpmnProcessId="
+        + getBpmnProcessId()
+        + ", elementId="
+        + getElementId()
+        + ", elementInstanceKey="
+        + getElementInstanceKey()
+        + ", processInstanceKey="
+        + getProcessInstanceKey()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", jobKey="
+        + getJobKey()
+        + ", errorType="
+        + getErrorType()
+        + ", variableScopeKey="
+        + getVariableScopeKey()
+        + ", tenantId="
+        + getTenantId()
+        + ")";
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -192,6 +192,7 @@ public final class CallActivityIncidentTest {
 
     assertIncidentCreated(incident, elementInstance)
         .hasElementInstancePath(List.of(List.of(processInstanceKey, elementInstance.getKey())))
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasProcessDefinitionKey(incident.getValue().getProcessDefinitionKey())
         .hasErrorType(ErrorType.CALLED_ELEMENT_ERROR)
         .hasErrorMessage(
@@ -276,6 +277,7 @@ public final class CallActivityIncidentTest {
 
     assertIncidentCreated(incident, elementInstance, tenantId)
         .hasElementInstancePath(List.of(List.of(processInstanceKey, elementInstance.getKey())))
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasProcessDefinitionKey(incident.getValue().getProcessDefinitionKey())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -337,6 +337,7 @@ public class MigrateCallActivityTest {
             List.of(
                 List.of(processInstanceKey, callActivityElementInstanceKey),
                 List.of(childProcessInstanceKey)))
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasProcessDefinitionPath(List.of(targetProcessDefinitionKey))
         .hasCallingElementPath(List.of(0));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java
@@ -136,6 +136,7 @@ public class MigrateProcessInstanceTest {
         .describedAs("Expect that version number did not change")
         .hasVersion(1)
         .hasElementInstancePath(List.of(processInstanceKey))
+        .hasRootProcessInstanceKey(processInstanceKey)
         .describedAs(
             "Expect that process definition path changed to contain new process definition key")
         .hasProcessDefinitionPath(List.of(otherProcessDefinitionKey))
@@ -199,6 +200,7 @@ public class MigrateProcessInstanceTest {
         .describedAs("Expect that bpmn process id and element id did not change")
         .hasBpmnProcessId(processId)
         .hasElementInstancePath(List.of(processInstanceKey))
+        .hasRootProcessInstanceKey(processInstanceKey)
         .describedAs(
             "Expect that process definition path changed to contain new process definition key")
         .hasProcessDefinitionPath(List.of(v2ProcessDefinitionKey))

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -56,6 +57,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(JobRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(ProcessInstanceRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -57,6 +57,9 @@
             },
             "callingElementPath": {
               "enabled": false
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -648,6 +648,7 @@ final class BulkIndexRequestTest {
         value = ValueType.class,
         names = {
           "DECISION_EVALUATION",
+          "INCIDENT",
           "JOB",
           "PROCESS_INSTANCE",
           "PROCESS_INSTANCE_CREATION",
@@ -686,6 +687,7 @@ final class BulkIndexRequestTest {
         value = ValueType.class,
         names = {
           "DECISION_EVALUATION",
+          "INCIDENT",
           "JOB",
           "PROCESS_INSTANCE",
           "PROCESS_INSTANCE_CREATION",

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -56,6 +57,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(IncidentRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(JobRecordValue.class, IgnoreRootProcessInstanceKeyMixin.class)
           .addMixIn(MessageSubscriptionRecordValue.class, MessageSubscriptionMixin.class)
           .addMixIn(

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -57,6 +57,9 @@
             },
             "callingElementPath": {
               "enabled": false
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -648,6 +648,7 @@ final class BulkIndexRequestTest {
         value = ValueType.class,
         names = {
           "DECISION_EVALUATION",
+          "INCIDENT",
           "JOB",
           "PROCESS_INSTANCE",
           "PROCESS_INSTANCE_CREATION",
@@ -686,6 +687,7 @@ final class BulkIndexRequestTest {
         value = ValueType.class,
         names = {
           "DECISION_EVALUATION",
+          "INCIDENT",
           "JOB",
           "PROCESS_INSTANCE",
           "PROCESS_INSTANCE_CREATION",

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -232,6 +232,21 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    // The root process instance key is the first element of the first list in the
+    // elementInstancePath
+    final var iterator = elementInstancePathProp.iterator();
+    if (iterator.hasNext()) {
+      final var firstList = iterator.next();
+      final var listIterator = firstList.iterator();
+      if (listIterator.hasNext()) {
+        return listIterator.next().getValue();
+      }
+    }
+    return -1L;
+  }
+
   public IncidentRecord setJobKey(final long jobKey) {
     jobKeyProp.setValue(jobKey);
     return this;

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -699,7 +699,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "elementInstancePath":[[101, 102], [103, 104]],
                   "processDefinitionPath": [101, 102],
-                  "callingElementPath": [12345, 67890]
+                  "callingElementPath": [12345, 67890],
+                  "rootProcessInstanceKey": 101
                 }
                 """
       },
@@ -725,7 +726,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "elementInstancePath":[],
                   "processDefinitionPath":[],
-                  "callingElementPath":[]
+                  "callingElementPath":[],
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IncidentRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IncidentRecord.golden
@@ -232,6 +232,21 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    // The root process instance key is the first element of the first list in the
+    // elementInstancePath
+    final var iterator = elementInstancePathProp.iterator();
+    if (iterator.hasNext()) {
+      final var firstList = iterator.next();
+      final var listIterator = firstList.iterator();
+      if (listIterator.hasNext()) {
+        return listIterator.next().getValue();
+      }
+    }
+    return -1L;
+  }
+
   public IncidentRecord setJobKey(final long jobKey) {
     jobKeyProp.setValue(jobKey);
     return this;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -104,4 +104,16 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    *     entry is a reference to the call activity in BPMN model containing an incident.
    */
   List<Integer> getCallingElementPath();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for incidents created after version 8.8.0. For older
+   * incidents, the method will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds `getRootProcessInstanceKey()` to the `IncidentRecordValue` interface.
Implements `getRootProcessInstanceKey()` in `IncidentRecord`, extracting the key from the first element of the `elementInstancePath` or returning -1 if not available.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41655 
depends on https://github.com/camunda/camunda/pull/42708 and https://github.com/camunda/camunda/pull/42352
