### PR TITLE
fix: update search-decision-definition api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
@@ -470,8 +470,26 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
         totalItemGreaterThan: 1,
       });
       const json = await res.json();
-      expect(json.items[0].name).toBe(decisionDefinition2.name);
-      expect(json.items[1].name).toBe(decisionDefinition1.name);
+
+      // Find our deployed decisions in the results
+      const def1Index = json.items.findIndex(
+        (item: {decisionDefinitionKey: string}) =>
+          item.decisionDefinitionKey ===
+          decisionDefinition1.decisionDefinitionKey,
+      );
+      const def2Index = json.items.findIndex(
+        (item: {decisionDefinitionKey: string}) =>
+          item.decisionDefinitionKey ===
+          decisionDefinition2.decisionDefinitionKey,
+      );
+
+      // Verify both exist
+      expect(def1Index).toBeGreaterThanOrEqual(0);
+      expect(def2Index).toBeGreaterThanOrEqual(0);
+
+      // Verify correct sort order: GenerationsDecision (def2) should come before SingleTableDecision (def1)
+      expect(def2Index).toBeLessThan(def1Index);
+
       assertDecisionDefinitionInResponse(
         json,
         expectedBody1,
@@ -506,8 +524,26 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
         totalItemGreaterThan: 1,
       });
       const json = await res.json();
-      expect(json.items[0].name).toBe(decisionDefinition1.name);
-      expect(json.items[1].name).toBe(decisionDefinition2.name);
+
+      // Find our deployed decisions in the results
+      const def1Index = json.items.findIndex(
+        (item: {decisionDefinitionKey: string}) =>
+          item.decisionDefinitionKey ===
+          decisionDefinition1.decisionDefinitionKey,
+      );
+      const def2Index = json.items.findIndex(
+        (item: {decisionDefinitionKey: string}) =>
+          item.decisionDefinitionKey ===
+          decisionDefinition2.decisionDefinitionKey,
+      );
+
+      // Verify both exist
+      expect(def1Index).toBeGreaterThanOrEqual(0);
+      expect(def2Index).toBeGreaterThanOrEqual(0);
+
+      // Verify correct sort order: SingleTableDecision (def1) should come before GenerationsDecision (def2) in DESC
+      expect(def1Index).toBeLessThan(def2Index);
+
       assertDecisionDefinitionInResponse(
         json,
         expectedBody1,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
@@ -16,8 +16,10 @@ import {
   assertRequiredFields,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import {createMammalProcessInstanceAndDeployMammalDecision, DecisionInstance} from '@requestHelpers';
-import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createMammalProcessInstanceAndDeployMammalDecision,
+  DecisionInstance,
+} from '@requestHelpers';
 import {decisionInstanceRequiredFields} from 'utils/beans/requestBeans';
 
 const DECISION_INSTANCES_SEARCH_ENDPOINT = '/decision-instances/search';
@@ -81,7 +83,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
       );
 
       await assertStatusCode(res, 200);
-      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it. 
+      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it.
       // await validateResponse(
       //   {
       //     path: DECISION_INSTANCES_SEARCH_ENDPOINT,
@@ -123,7 +125,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
       );
 
       await assertStatusCode(res, 200);
-      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it. 
+      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it.
       // await validateResponse(
       //   {
       //     path: DECISION_INSTANCES_SEARCH_ENDPOINT,
@@ -165,7 +167,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
       );
 
       await assertStatusCode(res, 200);
-      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it. 
+      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it.
       // await validateResponse(
       //   {
       //     path: DECISION_INSTANCES_SEARCH_ENDPOINT,
@@ -206,7 +208,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
       );
 
       await assertStatusCode(res, 200);
-      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it. 
+      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it.
       // await validateResponse(
       //   {
       //     path: DECISION_INSTANCES_SEARCH_ENDPOINT,
@@ -250,7 +252,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
       );
 
       await assertStatusCode(res, 200);
-      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it. 
+      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it.
       // await validateResponse(
       //   {
       //     path: DECISION_INSTANCES_SEARCH_ENDPOINT,
@@ -289,7 +291,7 @@ test.describe.parallel('Search Decision Instances API Tests', () => {
       );
 
       await assertStatusCode(res, 200);
-      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it. 
+      // this assertion is commented as response shape isn't correct yet. As soon as it's fixed, uncomment it.
       // await validateResponse(
       //   {
       //     path: DECISION_INSTANCES_SEARCH_ENDPOINT,


### PR DESCRIPTION
## Description
Sorting of decision definition tests were failing due to assuming specific array positions, which breaks when other decisions exist in the database from other tests.

## Solution
- Use `findIndex()` to locate decisions by key instead of positional array access
- Verify relative sort order between our deployed decisions


## Changes
- [search-decision-definitions-api.tests.spec.ts](qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts): Updated sort tests to be resilient
- Minor formatting cleanup (trailing whitespace, imports)

🧪 [Test Run](https://github.com/camunda/camunda/actions/runs/20616134556/job/59209214930)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
