### PR TITLE
fix: resolve flaky test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -284,6 +284,15 @@ test.describe('task details page', () => {
     await taskDetailsPage.clickCompleteTaskButton();
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
+    await expect(async () => {
+      await expect(
+        taskPanelPage.availableTasks
+
+          .getByText('processWithDeployedForm')
+
+          .first(),
+      ).toBeVisible();
+    }).toPass();
     await taskPanelPage.openTask('processWithDeployedForm');
 
     await taskDetailsPage.assertFieldValue('Client Name*', 'Jon');
@@ -580,7 +589,6 @@ test.describe('task details page', () => {
   test('task completion with large variable form', async ({
     taskPanelPage,
     taskDetailsPage,
-    page,
   }) => {
     await taskPanelPage.filterBy('Unassigned');
     await taskPanelPage.openTask('Big Variable Usertask');


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Test was attempting to open a task before it became available in the task panel, causing intermittent failures.

## Solution
Added explicit wait for task visibility in the task panel before attempting to open it.
🧪 [Test run](https://github.com/camunda/camunda/actions/runs/20616580393)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
