### PR TITLE
feat: add rootProcessInstanceKey to ProcessMessageSubscription records

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -337,6 +337,7 @@ public final class CatchEventBehavior {
     final var messageName = result.messageName;
 
     final long processInstanceKey = context.getProcessInstanceKey();
+    final long rootProcessInstanceKey = context.getRootProcessInstanceKey();
     final DirectBuffer bpmnProcessId = cloneBuffer(context.getBpmnProcessId());
     final long elementInstanceKey = context.getElementInstanceKey();
     final long processDefinitionKey = context.getProcessDefinitionKey();
@@ -353,6 +354,7 @@ public final class CatchEventBehavior {
     subscription.setElementId(event.getId());
     subscription.setInterrupting(event.isInterrupting());
     subscription.setTenantId(context.getTenantId());
+    subscription.setRootProcessInstanceKey(rootProcessInstanceKey);
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -127,7 +127,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     final ProcessMessageSubscriptionRecord subscriptionRecord = subscription.getRecord();
     record
         .setElementId(subscriptionRecord.getElementIdBuffer())
-        .setInterrupting(subscriptionRecord.isInterrupting());
+        .setInterrupting(subscriptionRecord.isInterrupting())
+        .setRootProcessInstanceKey(subscriptionRecord.getRootProcessInstanceKey());
 
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.CORRELATED, record);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCatchElementTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCatchElementTest.java
@@ -205,6 +205,7 @@ public final class MessageCatchElementTest {
 
     Assertions.assertThat(processMessageSubscription.getValue())
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
         .hasMessageName("order canceled");
 
@@ -234,6 +235,7 @@ public final class MessageCatchElementTest {
 
     Assertions.assertThat(subscription.getValue())
         .hasProcessInstanceKey(processInstanceKey)
+        .hasRootProcessInstanceKey(processInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
         .hasMessageName("order canceled");
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -398,10 +398,11 @@ public final class MessageCorrelationTest {
                     ProcessMessageSubscriptionIntent.CORRELATED)
                 .limit(2))
         .extracting(Record::getValue)
-        .extracting(v -> tuple(v.getMessageKey(), v.getProcessInstanceKey()))
+        .extracting(
+            v -> tuple(v.getMessageKey(), v.getProcessInstanceKey(), v.getRootProcessInstanceKey()))
         .contains(
-            tuple(message.getKey(), processInstanceKey1),
-            tuple(message.getKey(), processInstanceKey2));
+            tuple(message.getKey(), processInstanceKey1, processInstanceKey1),
+            tuple(message.getKey(), processInstanceKey2, processInstanceKey2));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateEventBasedGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateEventBasedGatewayTest.java
@@ -215,6 +215,8 @@ public class MigrateEventBasedGatewayTest {
         .hasCorrelationKey(processMessageSubscriptionA.getValue().getCorrelationKey())
         .hasTenantId(processMessageSubscriptionA.getValue().getTenantId())
         .hasProcessInstanceKey(processMessageSubscriptionA.getValue().getProcessInstanceKey())
+        .hasRootProcessInstanceKey(
+            processMessageSubscriptionA.getValue().getRootProcessInstanceKey())
         .hasElementInstanceKey(processMessageSubscriptionA.getValue().getElementInstanceKey())
         .hasMessageKey(processMessageSubscriptionA.getValue().getMessageKey())
         .hasVariables(processMessageSubscriptionA.getValue().getVariables());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIntermediateCatchEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIntermediateCatchEventTest.java
@@ -187,7 +187,8 @@ public class MigrateIntermediateCatchEventTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("catch2")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key1");
+        .hasCorrelationKey("key1")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageSubscriptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageSubscriptionTest.java
@@ -193,7 +193,8 @@ public class MigrateMessageSubscriptionTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("boundary2")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key1");
+        .hasCorrelationKey("key1")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
@@ -318,7 +319,9 @@ public class MigrateMessageSubscriptionTest {
         .describedAs("Expect that the correlation key is not re-evaluated")
         .hasCorrelationKey("key1")
         .describedAs("Expected that the interrupting status is updated")
-        .isInterrupting();
+        .isInterrupting()
+        .describedAs("Expect the root process instance key is set")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
@@ -455,7 +458,9 @@ public class MigrateMessageSubscriptionTest {
         .describedAs("Expect that the correlation key is not re-evaluated")
         .hasCorrelationKey("key1")
         .describedAs("Expected that the interrupting status is updated")
-        .isNotInterrupting();
+        .isNotInterrupting()
+        .describedAs("Expect the root process instance key is set")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
@@ -597,7 +602,9 @@ public class MigrateMessageSubscriptionTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("boundary3")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key1");
+        .hasCorrelationKey("key1")
+        .describedAs("Expect the root process instance key is set")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
@@ -625,7 +632,9 @@ public class MigrateMessageSubscriptionTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("boundary4")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key2");
+        .hasCorrelationKey("key2")
+        .describedAs("Expect the root process instance key is set")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
@@ -749,7 +758,9 @@ public class MigrateMessageSubscriptionTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("boundary3")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key1");
+        .hasCorrelationKey("key1")
+        .describedAs("Expect the root process instance key is set")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
@@ -873,7 +884,9 @@ public class MigrateMessageSubscriptionTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("boundary2")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key1");
+        .hasCorrelationKey("key1")
+        .describedAs("Expect the root process instance key is set")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateReceiveTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateReceiveTaskTest.java
@@ -193,7 +193,9 @@ public class MigrateReceiveTaskTest {
         .hasBpmnProcessId(targetProcessId)
         .hasElementId("receive2")
         .describedAs("Expect that the correlation key is not re-evaluated")
-        .hasCorrelationKey("key1");
+        .hasCorrelationKey("key1")
+        .describedAs("Expect that the process instance is still the same")
+        .hasRootProcessInstanceKey(processInstanceKey);
 
     Assertions.assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -215,7 +215,10 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
   private static final class MessageSubscriptionMixin {}
 
-  @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
+  @JsonIgnoreProperties({
+    MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY,
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
+  })
   private static final class ProcessMessageSubscriptionMixin {}
 
   @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -51,6 +51,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -646,7 +646,13 @@ final class BulkIndexRequestTest {
     @ParameterizedTest
     @EnumSource(
         value = ValueType.class,
-        names = {"DECISION_EVALUATION", "JOB", "PROCESS_INSTANCE", "USER_TASK"})
+        names = {
+          "DECISION_EVALUATION",
+          "JOB",
+          "PROCESS_INSTANCE",
+          "PROCESS_MESSAGE_SUBSCRIPTION",
+          "USER_TASK"
+        })
     void shouldIndexWithoutRootProcessInstanceKeyOnPreviousVersion(final ValueType valueType)
         throws Exception {
       // given
@@ -675,7 +681,13 @@ final class BulkIndexRequestTest {
     @ParameterizedTest
     @EnumSource(
         value = ValueType.class,
-        names = {"DECISION_EVALUATION", "JOB", "PROCESS_INSTANCE", "USER_TASK"})
+        names = {
+          "DECISION_EVALUATION",
+          "JOB",
+          "PROCESS_INSTANCE",
+          "PROCESS_MESSAGE_SUBSCRIPTION",
+          "USER_TASK"
+        })
     void shouldIndexWithRootProcessInstanceKey(final ValueType valueType) throws Exception {
       // given
       final var record =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -216,7 +216,10 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
   private static final class MessageSubscriptionMixin {}
 
-  @JsonIgnoreProperties({MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY})
+  @JsonIgnoreProperties({
+    MESSAGE_SUBSCRIPTION_PROCESS_DEFINITION_KEY_PROPERTY,
+    ROOT_PROCESS_INSTANCE_KEY_PROPERTY
+  })
   private static final class ProcessMessageSubscriptionMixin {}
 
   @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -51,6 +51,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -646,7 +646,13 @@ final class BulkIndexRequestTest {
     @ParameterizedTest
     @EnumSource(
         value = ValueType.class,
-        names = {"DECISION_EVALUATION", "JOB", "PROCESS_INSTANCE", "USER_TASK"})
+        names = {
+          "DECISION_EVALUATION",
+          "JOB",
+          "PROCESS_INSTANCE",
+          "PROCESS_MESSAGE_SUBSCRIPTION",
+          "USER_TASK"
+        })
     void shouldIndexWithoutRootProcessInstanceKeyOnPreviousVersion(final ValueType valueType)
         throws Exception {
       // given
@@ -675,7 +681,13 @@ final class BulkIndexRequestTest {
     @ParameterizedTest
     @EnumSource(
         value = ValueType.class,
-        names = {"DECISION_EVALUATION", "JOB", "PROCESS_INSTANCE", "USER_TASK"})
+        names = {
+          "DECISION_EVALUATION",
+          "JOB",
+          "PROCESS_INSTANCE",
+          "PROCESS_MESSAGE_SUBSCRIPTION",
+          "USER_TASK"
+        })
     void shouldIndexWithRootProcessInstanceKey(final ValueType valueType) throws Exception {
       // given
       final var record =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -40,6 +40,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
   private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -56,9 +58,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public ProcessMessageSubscriptionRecord() {
-    super(12);
+    super(13);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -70,7 +74,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -86,6 +91,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setCorrelationKey(record.getCorrelationKeyBuffer());
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
+    setRootProcessInstanceKey(record.getRootProcessInstanceKey());
   }
 
   @JsonIgnore
@@ -190,6 +196,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setInterrupting(final boolean interrupting) {
     interruptingProp.setValue(interrupting);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1466,6 +1466,7 @@ final class JsonSerializableToJsonTest {
               final long processInstanceKey = 1345;
               final long processDefinitionKey = 444;
               final String correlationKey = "key";
+              final long rootProcessInstanceKey = 5678L;
 
               return new ProcessMessageSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -1477,7 +1478,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setVariables(VARIABLES_MSGPACK)
                   .setCorrelationKey(wrapString(correlationKey))
-                  .setElementId(wrapString("A"));
+                  .setElementId(wrapString("A"))
+                  .setRootProcessInstanceKey(rootProcessInstanceKey);
             },
         """
                 {
@@ -1493,7 +1495,8 @@ final class JsonSerializableToJsonTest {
                   "correlationKey": "key",
                   "elementId": "A",
                   "interrupting": true,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": 5678
                 }
                 """
       },
@@ -1526,7 +1529,8 @@ final class JsonSerializableToJsonTest {
                   "correlationKey": "",
                   "elementId": "",
                   "interrupting": true,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "rootProcessInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -40,6 +40,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
   private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -56,9 +58,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public ProcessMessageSubscriptionRecord() {
-    super(12);
+    super(13);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -70,7 +74,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(rootProcessInstanceKeyProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -86,6 +91,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setCorrelationKey(record.getCorrelationKeyBuffer());
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
+    setRootProcessInstanceKey(record.getRootProcessInstanceKey());
   }
 
   @JsonIgnore
@@ -190,6 +196,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setInterrupting(final boolean interrupting) {
     interruptingProp.setValue(interrupting);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setRootProcessInstanceKey(final long key) {
+    rootProcessInstanceKeyProp.setValue(key);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -75,4 +75,17 @@ public interface ProcessMessageSubscriptionRecordValue
    *     returns {@code false} if the event is non-interrupting.
    */
   boolean isInterrupting();
+
+  /**
+   * Returns the key of the root process instance in the hierarchy. For top-level process instances,
+   * this is equal to {@link #getProcessInstanceKey()}. For child process instances (created via
+   * call activities), this is the key of the topmost parent process instance.
+   *
+   * <p>Important: This value is only set for process instance records created after version 8.9.0
+   * and part of hierarchies created after that version. For older process instances, the method
+   * will return -1.
+   *
+   * @return the key of the root process instance, or {@code -1} if not set
+   */
+  long getRootProcessInstanceKey();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds the `rootProcessInstanceKey` in process message subscriptions event records that are exported for `CREATED`, `CORRELATED`, `DELETED` and `MIGRATED` intents.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41655 
depends on https://github.com/camunda/camunda/pull/42708 and https://github.com/camunda/camunda/pull/42352
