### PR TITLE
fix: Flakey OpenSearch ISM Tests

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.agrona.CloseHelper;
 import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -142,6 +143,7 @@ final class TestClient implements CloseableSilently {
     try {
       final var request =
           new Request("PUT", "_plugins/_ism/policies/" + config.retention.getPolicyName());
+      decoratePolicyVersionSeq(request);
       final var requestEntity = createPutIndexManagementPolicyRequest(minimumAge);
       request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
       restClient.performRequest(request);
@@ -168,6 +170,19 @@ final class TestClient implements CloseableSilently {
   @Override
   public void close() {
     CloseHelper.quietCloseAll(osClient._transport());
+  }
+
+  private void decoratePolicyVersionSeq(final Request request) {
+    try {
+      final GetIndexStateManagementPolicyResponse policy = getIndexStateManagementPolicy();
+      request.addParameter("if_seq_no", String.valueOf(policy.seqNo()));
+      request.addParameter("if_primary_term", String.valueOf(policy.primaryTerm()));
+    } catch (final Exception e) {
+      if (!(e.getCause() instanceof final ResponseException responseException
+          && responseException.getResponse().getStatusLine().getStatusCode() == 404)) {
+        throw e;
+      }
+    }
   }
 
   private PutIndexStateManagementPolicyRequest createPutIndexManagementPolicyRequest(


### PR DESCRIPTION


## Description

The OpenSearch ISM update is failing as ISM policy version mismatch and this would add the current version to the update operation to avoid that.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
