### PR TITLE
invalidate cache only on purge

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -243,6 +244,8 @@ final class ClusterApiUtils {
           new Operation()
               .operation(OperationEnum.UPDATE_ROUTING_STATE)
               .brokerId(Integer.parseInt(updateRoutingState.memberId().id()));
+      case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
+          new Operation().operation(OperationEnum.UPDATE_INCARNATION_NUMBER);
       default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }
@@ -500,6 +503,10 @@ final class ClusterApiUtils {
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UPDATE_ROUTING_STATE)
                   .brokerId(Integer.parseInt(updateRoutingState.memberId().id()));
+          case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.UPDATE_INCARNATION_NUMBER)
+                  .brokerId(Integer.parseInt(updateIncarnationNumberOperation.memberId().id()));
           default ->
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -328,6 +328,7 @@ schemas:
           - UPDATE_ROUTING_STATE
           - DELETE_HISTORY
           - PARTITION_DELETE_EXPORTER
+          - UPDATE_INCARNATION_NUMBER
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
@@ -297,6 +298,7 @@ final class ClusterApiUtilsTest {
         new MemberRemoveOperation(memberId1, memberId2),
         new DeleteHistoryOperation(memberId1),
         new UpdateRoutingState(memberId1, emptyRoutingState),
+        new UpdateIncarnationNumberOperation(memberId1),
 
         // Scale up operations
         new StartPartitionScaleUp(memberId1, 8),

--- a/service/src/main/java/io/camunda/service/cache/ProcessCache.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCache.java
@@ -104,7 +104,7 @@ public class ProcessCache {
     }
 
     @Override
-    public void completedClusterChange() {
+    public void clusterIncarnationChanged() {
       cache.invalidate();
       LOGGER.debug("Process cache invalidated");
     }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -20,4 +20,6 @@ public interface BrokerTopologyListener {
   default void brokerRemoved(final MemberId memberId) {}
 
   default void completedClusterChange() {}
+
+  default void clusterIncarnationChanged() {}
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.impl;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.Collection;
@@ -34,6 +35,8 @@ public record BrokerClientTopologyImpl(
   public static final int UNINITIALIZED_CLUSTER_SIZE = -1;
   public static final long NO_COMPLETED_LAST_CHANGE_ID = -1;
   public static final String NO_CLUSTER_ID = "";
+  private static final long UNINITIALIZED_INCARNATION_NUMBER =
+      ClusterConfiguration.INITIAL_INCARNATION_NUMBER;
 
   public static BrokerClientTopologyImpl uninitialized() {
     return new BrokerClientTopologyImpl(
@@ -44,7 +47,8 @@ public record BrokerClientTopologyImpl(
             0,
             List.of(),
             NO_COMPLETED_LAST_CHANGE_ID,
-            NO_CLUSTER_ID));
+            NO_CLUSTER_ID,
+            UNINITIALIZED_INCARNATION_NUMBER));
   }
 
   @Override
@@ -144,7 +148,8 @@ public record BrokerClientTopologyImpl(
       int replicationFactor,
       List<Integer> partitionIds,
       long lastChangeId,
-      String clusterId) {}
+      String clusterId,
+      long incarnationNumber) {}
 
   static class LiveClusterState {
     private static final Long TERM_NONE = -1L;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -233,6 +233,11 @@ public final class BrokerTopologyManagerImpl extends Actor
                 })
             .orElse(oldTopology.getLastCompletedChangeId());
 
+    if (oldTopology.configuredClusterState().incarnationNumber()
+        != clusterTopology.incarnationNumber()) {
+      topologyListeners.forEach(BrokerTopologyListener::clusterIncarnationChanged);
+    }
+
     if (newClusterSize != oldTopology.getClusterSize()
         || newPartitionsCount != oldTopology.getPartitionsCount()
         || newReplicationFactor != oldTopology.getReplicationFactor()
@@ -252,7 +257,8 @@ public final class BrokerTopologyManagerImpl extends Actor
               newReplicationFactor,
               partitionIds,
               newLastChange,
-              clusterId);
+              clusterId,
+              clusterTopology.incarnationNumber());
 
       return new BrokerClientTopologyImpl(oldTopology.liveClusterState(), newClusterInfo);
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -404,13 +404,11 @@ final class BrokerTopologyManagerTest {
 
     // when
     final ClusterConfiguration clusterTopology =
-        new ClusterConfiguration(
-            1,
-            Map.of(),
-            Optional.of(new CompletedChange(1, Status.COMPLETED, Instant.now(), Instant.now())),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty());
+        ClusterConfiguration.builder()
+            .version(1)
+            .lastChange(
+                Optional.of(new CompletedChange(1, Status.COMPLETED, Instant.now(), Instant.now())))
+            .build();
 
     topologyManager.onClusterConfigurationUpdated(clusterTopology);
     actorSchedulerRule.workUntilDone();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -60,14 +59,13 @@ final class RoundRobinDispatchStrategyTest {
         .addPartition(2, 1)
         .addPartition(3, 2)
         .withClusterConfiguration(
-            new ClusterConfiguration(
-                1,
-                Map.of(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(
-                    new RoutingState(1, new AllPartitions(2), new MessageCorrelation.HashMod(2))),
-                Optional.empty()));
+            ClusterConfiguration.builder()
+                .version(1)
+                .routingState(
+                    Optional.of(
+                        new RoutingState(
+                            1, new AllPartitions(2), new MessageCorrelation.HashMod(2))))
+                .build());
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -86,17 +84,15 @@ final class RoundRobinDispatchStrategyTest {
         .addPartition(2, 1)
         .addPartition(3, 2)
         .withClusterConfiguration(
-            new ClusterConfiguration(
-                1,
-                Map.of(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.of(
-                    new RoutingState(
-                        1,
-                        new ActivePartitions(1, Set.of(3), Set.of()),
-                        new MessageCorrelation.HashMod(3))),
-                Optional.empty()));
+            ClusterConfiguration.builder()
+                .version(1)
+                .routingState(
+                    Optional.of(
+                        new RoutingState(
+                            1,
+                            new ActivePartitions(1, Set.of(3), Set.of()),
+                            new MessageCorrelation.HashMod(3))))
+                .build());
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -113,17 +109,15 @@ final class RoundRobinDispatchStrategyTest {
 
     // when -- starting with routing state version 1, with active partitions 1 and 3
     topologyManager.withClusterConfiguration(
-        new ClusterConfiguration(
-            1,
-            Map.of(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(
-                new RoutingState(
-                    1,
-                    new ActivePartitions(1, Set.of(3), Set.of()),
-                    new MessageCorrelation.HashMod(1))),
-            Optional.empty()));
+        ClusterConfiguration.builder()
+            .version(1)
+            .routingState(
+                Optional.of(
+                    new RoutingState(
+                        1,
+                        new ActivePartitions(1, Set.of(3), Set.of()),
+                        new MessageCorrelation.HashMod(1))))
+            .build());
 
     // then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -131,14 +125,12 @@ final class RoundRobinDispatchStrategyTest {
 
     // when -- updating to routing state version 2, with active partitions 1, 2 and 3
     topologyManager.withClusterConfiguration(
-        new ClusterConfiguration(
-            1,
-            Map.of(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(
-                new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1))),
-            Optional.empty()));
+        ClusterConfiguration.builder()
+            .version(1)
+            .routingState(
+                Optional.of(
+                    new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1))))
+            .build());
 
     // then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
@@ -50,7 +50,8 @@ public class ClusterIdInitializer implements ClusterConfigurationModifier {
             configuration.lastChange(),
             configuration.pendingChanges(),
             configuration.routingState(),
-            Optional.ofNullable(clusterId));
+            Optional.ofNullable(clusterId),
+            configuration.incarnationNumber());
     return CompletableActorFuture.completed(withClusterId);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -40,7 +40,8 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier {
             configuration.lastChange(),
             configuration.pendingChanges(),
             Optional.of(routingState),
-            configuration.clusterId());
+            configuration.clusterId(),
+            configuration.incarnationNumber());
     return CompletableActorFuture.completed(withRoutingState);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.util.Either;
@@ -64,6 +65,7 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
     }
 
     operations.add(new DeleteHistoryOperation(firstMember.get()));
+    operations.add(new UpdateIncarnationNumberOperation(firstMember.get()));
 
     primaries.forEach(
         (partitionId, bootstrapOperation) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -84,7 +84,8 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
         config.lastChange(),
         config.pendingChanges(),
         Optional.of(routingState),
-        config.clusterId());
+        config.clusterId(),
+        config.incarnationNumber());
   }
 
   private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 
 public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppliers {
@@ -116,6 +117,8 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
           };
       case final UpdateRoutingState updateRoutingState ->
           new UpdateRoutingStateApplier(updateRoutingState, partitionScalingChangeExecutor);
+      case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
+          new UpdateIncarnationNumberApplier();
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -115,7 +115,8 @@ final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
                             config.lastChange(),
                             config.pendingChanges(),
                             config.routingState().map(this::updateRoutingState),
-                            config.clusterId()));
+                            config.clusterId(),
+                            config.incarnationNumber()));
               }
             });
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateIncarnationNumberApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateIncarnationNumberApplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * Applier for updating the incarnation number in the cluster configuration. This operation
+ * increments the incarnation number by 1.
+ */
+final class UpdateIncarnationNumberApplier implements ClusterOperationApplier {
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    return CompletableActorFuture.completed(
+        config ->
+            ClusterConfiguration.builder()
+                .from(config)
+                .incarnationNumber(config.incarnationNumber() + 1)
+                .build());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -160,13 +160,16 @@ public class ProtoBufSerializer
             ? Optional.empty()
             : Optional.of(encodedClusterTopology.getClusterId());
 
+    final long incarnationNumber = encodedClusterTopology.getIncarnationNumber();
+
     return new ClusterConfiguration(
         encodedClusterTopology.getVersion(),
         members,
         completedChange,
         currentChange,
         routingState,
-        clusterId);
+        clusterId,
+        incarnationNumber);
   }
 
   private Map<MemberId, io.camunda.zeebe.dynamic.config.state.MemberState> decodeMemberStateMap(
@@ -195,6 +198,7 @@ public class ProtoBufSerializer
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
     clusterConfiguration.clusterId().ifPresent(clusterId -> builder.setClusterId(clusterId));
+    builder.setIncarnationNumber(clusterConfiguration.incarnationNumber());
 
     return builder.build();
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -54,6 +54,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
@@ -504,6 +505,9 @@ public class ProtoBufSerializer
         msg.routingState().ifPresent(s -> b.setRoutingState(encodeRoutingState(s)));
         builder.setUpdateRoutingState(b);
       }
+      case final UpdateIncarnationNumberOperation msg ->
+          builder.setUpdateIncarnationNumber(
+              Topology.UpdateIncarnationNumberOperation.newBuilder().build());
     }
     return builder.build();
   }
@@ -756,6 +760,8 @@ public class ProtoBufSerializer
           topologyChangeOperation.getUpdateRoutingState().getRoutingState();
       final var routingState = decodeRoutingState(protoRoutingState);
       return new UpdateRoutingState(memberId, routingState);
+    } else if (topologyChangeOperation.hasUpdateIncarnationNumber()) {
+      return new UpdateIncarnationNumberOperation(memberId);
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -377,4 +377,111 @@ public record ClusterConfiguration(
       return this;
     }
   }
+
+  /** Returns a new builder for creating ClusterConfiguration instances. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder class for creating ClusterConfiguration instances. */
+  public static class Builder {
+    private long version = INITIAL_VERSION;
+    private Map<MemberId, MemberState> members = Map.of();
+    private Optional<CompletedChange> lastChange = Optional.empty();
+    private Optional<ClusterChangePlan> pendingChanges = Optional.empty();
+    private Optional<RoutingState> routingState = Optional.empty();
+    private Optional<String> clusterId = Optional.empty();
+
+    /**
+     * Copies all properties from the given ClusterConfiguration.
+     *
+     * @param config the ClusterConfiguration to copy from
+     * @return this builder
+     */
+    public Builder from(final ClusterConfiguration config) {
+      version = config.version;
+      members = config.members;
+      lastChange = config.lastChange;
+      pendingChanges = config.pendingChanges;
+      routingState = config.routingState;
+      clusterId = config.clusterId;
+      return this;
+    }
+
+    /**
+     * Sets the version.
+     *
+     * @param version the version
+     * @return this builder
+     */
+    public Builder version(final long version) {
+      this.version = version;
+      return this;
+    }
+
+    /**
+     * Sets the members.
+     *
+     * @param members the members map
+     * @return this builder
+     */
+    public Builder members(final Map<MemberId, MemberState> members) {
+      this.members = members;
+      return this;
+    }
+
+    /**
+     * Sets the last change.
+     *
+     * @param lastChange the last completed change
+     * @return this builder
+     */
+    public Builder lastChange(final Optional<CompletedChange> lastChange) {
+      this.lastChange = lastChange;
+      return this;
+    }
+
+    /**
+     * Sets the pending changes.
+     *
+     * @param pendingChanges the pending changes
+     * @return this builder
+     */
+    public Builder pendingChanges(final Optional<ClusterChangePlan> pendingChanges) {
+      this.pendingChanges = pendingChanges;
+      return this;
+    }
+
+    /**
+     * Sets the routing state.
+     *
+     * @param routingState the routing state
+     * @return this builder
+     */
+    public Builder routingState(final Optional<RoutingState> routingState) {
+      this.routingState = routingState;
+      return this;
+    }
+
+    /**
+     * Sets the cluster ID.
+     *
+     * @param clusterId the cluster ID
+     * @return this builder
+     */
+    public Builder clusterId(final Optional<String> clusterId) {
+      this.clusterId = clusterId;
+      return this;
+    }
+
+    /**
+     * Builds and returns a new ClusterConfiguration instance.
+     *
+     * @return the new ClusterConfiguration
+     */
+    public ClusterConfiguration build() {
+      return new ClusterConfiguration(
+          version, members, lastChange, pendingChanges, routingState, clusterId);
+    }
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -242,7 +242,7 @@ public record ClusterConfiguration(
           mergedChanges,
           mergedRoutingState,
           clusterId,
-          incarnationNumber);
+          Math.max(incarnationNumber, other.incarnationNumber()));
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
  *     the coordinator when a new configuration change is triggered.
  * @param members - represents the state of each member
  * @param pendingChanges - keeps track of the ongoing configuration changes
+ * @param incarnationNumber - represents the incarnation number of the cluster configuration
  *     <p>This class is immutable. Each mutable methods returns a new instance with the updated
  *     state.
  */
@@ -40,9 +41,11 @@ public record ClusterConfiguration(
     Optional<CompletedChange> lastChange,
     Optional<ClusterChangePlan> pendingChanges,
     Optional<RoutingState> routingState,
-    Optional<String> clusterId) {
+    Optional<String> clusterId,
+    long incarnationNumber) {
 
   public static final int INITIAL_VERSION = 1;
+  public static final long INITIAL_INCARNATION_NUMBER = 0;
   private static final int UNINITIALIZED_VERSION = -1;
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -52,14 +55,16 @@ public record ClusterConfiguration(
       final Optional<CompletedChange> lastChange,
       final Optional<ClusterChangePlan> pendingChanges,
       final Optional<RoutingState> routingState,
-      final Optional<String> clusterId) {
+      final Optional<String> clusterId,
+      final long incarnationNumber) {
     this(
         version,
         ImmutableSortedMap.copyOf(members),
         lastChange,
         pendingChanges,
         routingState,
-        clusterId);
+        clusterId,
+        incarnationNumber);
   }
 
   public ClusterConfiguration {
@@ -73,6 +78,9 @@ public record ClusterConfiguration(
     Objects.requireNonNull(pendingChanges);
     Objects.requireNonNull(routingState);
     Objects.requireNonNull(clusterId);
+    if (incarnationNumber < 0) {
+      throw new IllegalArgumentException("Incarnation number must be >= 0");
+    }
   }
 
   public static ClusterConfiguration uninitialized() {
@@ -82,7 +90,8 @@ public record ClusterConfiguration(
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        INITIAL_INCARNATION_NUMBER);
   }
 
   public boolean isUninitialized() {
@@ -96,7 +105,8 @@ public record ClusterConfiguration(
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        INITIAL_INCARNATION_NUMBER);
   }
 
   public ClusterConfiguration addMember(final MemberId memberId, final MemberState state) {
@@ -110,12 +120,24 @@ public record ClusterConfiguration(
     final var newMembers =
         ImmutableMap.<MemberId, MemberState>builder().putAll(members).put(memberId, state).build();
     return new ClusterConfiguration(
-        version, newMembers, lastChange, pendingChanges, routingState, clusterId);
+        version,
+        newMembers,
+        lastChange,
+        pendingChanges,
+        routingState,
+        clusterId,
+        incarnationNumber);
   }
 
   public ClusterConfiguration setRoutingState(final RoutingState updatedRoutingState) {
     return new ClusterConfiguration(
-        version, members, lastChange, pendingChanges, Optional.of(updatedRoutingState), clusterId);
+        version,
+        members,
+        lastChange,
+        pendingChanges,
+        Optional.of(updatedRoutingState),
+        clusterId,
+        incarnationNumber);
   }
 
   /**
@@ -154,7 +176,13 @@ public record ClusterConfiguration(
 
     final var newMembers = mapBuilder.buildKeepingLast();
     return new ClusterConfiguration(
-        version, newMembers, lastChange, pendingChanges, routingState, clusterId);
+        version,
+        newMembers,
+        lastChange,
+        pendingChanges,
+        routingState,
+        clusterId,
+        incarnationNumber);
   }
 
   public ClusterConfiguration startConfigurationChange(
@@ -174,7 +202,8 @@ public record ClusterConfiguration(
           lastChange,
           Optional.of(ClusterChangePlan.init(newVersion, operations)),
           routingState,
-          clusterId);
+          clusterId,
+          incarnationNumber);
     }
   }
 
@@ -212,7 +241,8 @@ public record ClusterConfiguration(
           lastChange,
           mergedChanges,
           mergedRoutingState,
-          clusterId);
+          clusterId,
+          incarnationNumber);
     }
   }
 
@@ -267,7 +297,8 @@ public record ClusterConfiguration(
             lastChange,
             Optional.of(pendingChanges.orElseThrow().advance()),
             routingState,
-            clusterId);
+            clusterId,
+            incarnationNumber);
 
     if (!result.hasPendingChanges()) {
       // The last change has been applied. Clean up the members that are marked as LEFT in the
@@ -291,7 +322,8 @@ public record ClusterConfiguration(
           Optional.of(completedChange),
           Optional.empty(),
           routingState,
-          clusterId);
+          clusterId,
+          incarnationNumber);
     }
 
     return result;
@@ -372,7 +404,8 @@ public record ClusterConfiguration(
           Optional.of(cancelledChange),
           Optional.empty(),
           routingState,
-          clusterId);
+          clusterId,
+          incarnationNumber);
     } else {
       return this;
     }
@@ -391,6 +424,7 @@ public record ClusterConfiguration(
     private Optional<ClusterChangePlan> pendingChanges = Optional.empty();
     private Optional<RoutingState> routingState = Optional.empty();
     private Optional<String> clusterId = Optional.empty();
+    private long incarnationNumber = INITIAL_INCARNATION_NUMBER;
 
     /**
      * Copies all properties from the given ClusterConfiguration.
@@ -405,6 +439,7 @@ public record ClusterConfiguration(
       pendingChanges = config.pendingChanges;
       routingState = config.routingState;
       clusterId = config.clusterId;
+      incarnationNumber = config.incarnationNumber;
       return this;
     }
 
@@ -475,13 +510,24 @@ public record ClusterConfiguration(
     }
 
     /**
+     * Sets the incarnation number.
+     *
+     * @param incarnationNumber the incarnation number
+     * @return this builder
+     */
+    public Builder incarnationNumber(final long incarnationNumber) {
+      this.incarnationNumber = incarnationNumber;
+      return this;
+    }
+
+    /**
      * Builds and returns a new ClusterConfiguration instance.
      *
      * @return the new ClusterConfiguration
      */
     public ClusterConfiguration build() {
       return new ClusterConfiguration(
-          version, members, lastChange, pendingChanges, routingState, clusterId);
+          version, members, lastChange, pendingChanges, routingState, clusterId, incarnationNumber);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -63,6 +63,14 @@ public sealed interface ClusterConfigurationChangeOperation {
   record UpdateRoutingState(MemberId memberId, Optional<RoutingState> routingState)
       implements ClusterConfigurationChangeOperation {}
 
+  /**
+   * Represents an operation to update the incarnation number in the cluster configuration.
+   *
+   * @param memberId the identifier of the member who will update the incarnation number
+   */
+  record UpdateIncarnationNumberOperation(MemberId memberId)
+      implements ClusterConfigurationChangeOperation {}
+
   sealed interface ScaleUpOperation extends ClusterConfigurationChangeOperation {
     /**
      * Operation to initiate partition scale up. This instructs the cluster to redistribute

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -55,7 +55,8 @@ public final class ConfigurationUtil {
         Optional.empty(),
         Optional.empty(),
         routingState,
-        Optional.ofNullable(clusterId));
+        Optional.ofNullable(clusterId),
+        ClusterConfiguration.INITIAL_INCARNATION_NUMBER);
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -14,6 +14,7 @@ message ClusterTopology {
   ClusterChangePlan currentChange = 4;
   RoutingState routingState = 5;
   string clusterId = 6;
+  int64 incarnationNumber = 7;
 }
 
 message RoutingState {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -105,6 +105,7 @@ message TopologyChangeOperation {
     AwaitRelocationCompletion awaitRelocationCompletion = 15;
     UpdateRoutingState updateRoutingState = 16;
     PartitionDeleteExporterOperation partitionDeleteExporter = 17;
+    UpdateIncarnationNumberOperation updateIncarnationNumber = 18;
   }
 }
 
@@ -171,6 +172,8 @@ message AwaitRelocationCompletion {
 message UpdateRoutingState{
   RoutingState routing_state = 1;
 }
+
+message UpdateIncarnationNumberOperation {}
 
 message DeleteHistoryOperation { int32 memberId = 1; }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
@@ -315,13 +315,10 @@ final class ClusterConfigurationManagerTest {
     // when
     final var topologyWithoutMember = topologyWithMemberLeft.updateMember(localMemberId, m -> null);
     final var notConflictingTopology =
-        new ClusterConfiguration(
-            topologyWithoutMember.version() + 1,
-            topologyWithoutMember.members(),
-            topologyWithoutMember.lastChange(),
-            topologyWithoutMember.pendingChanges(),
-            topologyWithoutMember.routingState(),
-            topologyWithoutMember.clusterId());
+        ClusterConfiguration.builder()
+            .from(topologyWithoutMember)
+            .version(topologyWithoutMember.version() + 1)
+            .build();
     clusterTopologyManager.onGossipReceived(notConflictingTopology);
 
     // then

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
@@ -56,7 +57,6 @@ final class ClusterPurgeRequestTransformerTest {
         .right()
         .satisfies(
             operations -> {
-              assertThat(operations).hasSize(9);
               assertThat(operations)
                   .containsExactly(
                       new PartitionLeaveOperation(id0, 0, 0),
@@ -64,6 +64,7 @@ final class ClusterPurgeRequestTransformerTest {
                       new PartitionLeaveOperation(id1, 0, 0),
                       new PartitionLeaveOperation(id1, 1, 0),
                       new DeleteHistoryOperation(id0),
+                      new UpdateIncarnationNumberOperation(id0),
                       new PartitionBootstrapOperation(
                           id0, 0, 2, Optional.of(partitionConfig), false),
                       new PartitionBootstrapOperation(
@@ -98,7 +99,6 @@ final class ClusterPurgeRequestTransformerTest {
         .right()
         .satisfies(
             operations -> {
-              assertThat(operations).hasSize(13);
               assertThat(operations)
                   .containsExactly(
                       new PartitionLeaveOperation(id0, 0, 0),
@@ -108,6 +108,7 @@ final class ClusterPurgeRequestTransformerTest {
                       new PartitionLeaveOperation(id1, 1, 0),
                       new PartitionLeaveOperation(id1, 2, 0),
                       new DeleteHistoryOperation(id0),
+                      new UpdateIncarnationNumberOperation(id0),
                       new PartitionBootstrapOperation(
                           id0, 0, 2, Optional.of(partitionConfig), false),
                       new PartitionBootstrapOperation(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
@@ -31,24 +31,27 @@ public class AwaitRedistributionCompletionTest extends AbstractApplierTest {
 
   ClusterConfiguration empty = ClusterConfiguration.init();
   ClusterConfiguration validAllPartitionConfig =
-      new ClusterConfiguration(
-          1,
-          Map.of(),
-          Optional.empty(),
-          Optional.empty(),
-          Optional.of(RoutingState.initializeWithPartitionCount(3)),
-          Optional.empty());
+      ClusterConfiguration.builder()
+          .version(1)
+          .members(Map.of())
+          .lastChange(Optional.empty())
+          .pendingChanges(Optional.empty())
+          .routingState(Optional.of(RoutingState.initializeWithPartitionCount(3)))
+          .clusterId(Optional.empty())
+          .build();
 
   ClusterConfiguration valid3OutOf6Partitions =
-      new ClusterConfiguration(
-          1,
-          Map.of(),
-          Optional.empty(),
-          Optional.empty(),
-          Optional.of(
-              new RoutingState(
-                  1, new ActivePartitions(3, Set.of(), Set.of(4, 5, 6)), new HashMod(3))),
-          Optional.empty());
+      ClusterConfiguration.builder()
+          .version(1)
+          .members(Map.of())
+          .lastChange(Optional.empty())
+          .pendingChanges(Optional.empty())
+          .routingState(
+              Optional.of(
+                  new RoutingState(
+                      1, new ActivePartitions(3, Set.of(), Set.of(4, 5, 6)), new HashMod(3))))
+          .clusterId(Optional.empty())
+          .build();
 
   PartitionScalingChangeExecutor executor = new NoopPartitionScalingChangeExecutor();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
@@ -104,13 +104,10 @@ final class StartPartitionScaleUpApplierTest {
     final var routingState =
         new RoutingState(1, new ActivePartitions(1, Set.of(), Set.of(2, 3)), new HashMod(1));
     final var configuration =
-        new ClusterConfiguration(
-            initialConfiguration.version(),
-            initialConfiguration.members(),
-            initialConfiguration.lastChange(),
-            initialConfiguration.pendingChanges(),
-            Optional.of(routingState),
-            initialConfiguration.clusterId());
+        ClusterConfiguration.builder()
+            .from(initialConfiguration)
+            .routingState(Optional.of(routingState))
+            .build();
 
     // when - trying to init the operation to scale up
     final var result = new StartPartitionScaleUpApplier(executor, 4).init(configuration);
@@ -128,13 +125,10 @@ final class StartPartitionScaleUpApplierTest {
     // given - request handling is set up for three partitions
     final var routingState = new RoutingState(1, new AllPartitions(3), new HashMod(3));
     final var configuration =
-        new ClusterConfiguration(
-            initialConfiguration.version(),
-            initialConfiguration.members(),
-            initialConfiguration.lastChange(),
-            initialConfiguration.pendingChanges(),
-            Optional.of(routingState),
-            initialConfiguration.clusterId());
+        ClusterConfiguration.builder()
+            .from(initialConfiguration)
+            .routingState(Optional.of(routingState))
+            .build();
 
     // when - trying to init the operation to scale "up" to 2 partitions
     final var result = new StartPartitionScaleUpApplier(executor, 2).init(configuration);
@@ -152,13 +146,10 @@ final class StartPartitionScaleUpApplierTest {
     // given - routing state is stable, pointing at just one partition
     final var routingState = new RoutingState(1, new AllPartitions(1), new HashMod(1));
     final var configuration =
-        new ClusterConfiguration(
-            initialConfiguration.version(),
-            initialConfiguration.members(),
-            initialConfiguration.lastChange(),
-            initialConfiguration.pendingChanges(),
-            Optional.of(routingState),
-            initialConfiguration.clusterId());
+        ClusterConfiguration.builder()
+            .from(initialConfiguration)
+            .routingState(Optional.of(routingState))
+            .build();
 
     // when - applying the operation to scale up to three once
     final var expectedFailure = new RuntimeException("Expected failure");
@@ -178,13 +169,10 @@ final class StartPartitionScaleUpApplierTest {
     // given - routing state is stable, pointing at just one partition
     final var routingState = new RoutingState(1, new AllPartitions(3), new HashMod(1));
     final var configuration =
-        new ClusterConfiguration(
-            initialConfiguration.version(),
-            initialConfiguration.members(),
-            initialConfiguration.lastChange(),
-            initialConfiguration.pendingChanges(),
-            Optional.of(routingState),
-            initialConfiguration.clusterId());
+        ClusterConfiguration.builder()
+            .from(initialConfiguration)
+            .routingState(Optional.of(routingState))
+            .build();
 
     // when - applying the operation to scale up to three once
     when(executor.initiateScaleUp(anyInt())).thenReturn(CompletableActorFuture.completed(null));
@@ -200,13 +188,10 @@ final class StartPartitionScaleUpApplierTest {
     // given - routing state is stable, pointing at just one partition
     final var routingState = new RoutingState(1, new AllPartitions(3), new HashMod(3));
     final var configuration =
-        new ClusterConfiguration(
-            initialConfiguration.version(),
-            initialConfiguration.members(),
-            initialConfiguration.lastChange(),
-            initialConfiguration.pendingChanges(),
-            Optional.of(routingState),
-            initialConfiguration.clusterId());
+        ClusterConfiguration.builder()
+            .from(initialConfiguration)
+            .routingState(Optional.of(routingState))
+            .build();
 
     // when - applying the operation to scale up to three once
     when(executor.initiateScaleUp(anyInt())).thenReturn(CompletableActorFuture.completed(null));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/UpdateIncarnationNumberApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/UpdateIncarnationNumberApplierTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class UpdateIncarnationNumberApplierTest {
+
+  @Test
+  void shouldSucceedOnInit() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var applier = new UpdateIncarnationNumberApplier();
+
+    final ClusterConfiguration clusterConfiguration =
+        ClusterConfiguration.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = applier.init(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+  }
+
+  @Test
+  void shouldIncrementIncarnationNumberByOne() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var applier = new UpdateIncarnationNumberApplier();
+
+    final ClusterConfiguration initialConfiguration =
+        ClusterConfiguration.builder()
+            .from(
+                ClusterConfiguration.init()
+                    .addMember(memberId, MemberState.initializeAsActive(Map.of())))
+            .incarnationNumber(5)
+            .build();
+
+    // when
+    final var result = applier.apply();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+    final var updatedConfiguration = result.join().apply(initialConfiguration);
+    assertThat(updatedConfiguration.incarnationNumber()).isEqualTo(6);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -415,6 +415,15 @@ class ClusterConfigurationTest {
     assertThat(merged.incarnationNumber()).isEqualTo(6);
   }
 
+  @Test
+  void initialIncarnationNumberIsZero() {
+    // given
+    final var initialConfig = ClusterConfiguration.init();
+
+    // then
+    assertThat(initialConfig.incarnationNumber()).isZero();
+  }
+
   private MemberId member(final int id) {
     return MemberId.from(Integer.toString(id));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -246,17 +246,20 @@ class ClusterConfigurationTest {
 
     // then
     final var expected =
-        new ClusterConfiguration(
-            2,
-            Map.of(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1, emptyPartitionConfig)))),
-            Optional.of(
-                new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty());
+        ClusterConfiguration.builder()
+            .version(2)
+            .members(
+                Map.of(
+                    member(1),
+                    MemberState.initializeAsActive(
+                        Map.of(1, PartitionState.active(1, emptyPartitionConfig)))))
+            .lastChange(
+                Optional.of(
+                    new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())))
+            .pendingChanges(Optional.empty())
+            .routingState(Optional.empty())
+            .clusterId(Optional.empty())
+            .build();
 
     ClusterConfigurationAssert.assertThatClusterTopology(finalTopology).hasSameTopologyAs(expected);
   }
@@ -300,16 +303,19 @@ class ClusterConfigurationTest {
   void shouldMergeUninitializedDynamicConfig() {
     // given
     final var topologyWithUninitializedConfig =
-        new ClusterConfiguration(
-            0,
-            Map.of(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1, DynamicPartitionConfig.uninitialized())))),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty());
+        ClusterConfiguration.builder()
+            .version(0)
+            .members(
+                Map.of(
+                    member(1),
+                    MemberState.initializeAsActive(
+                        Map.of(
+                            1, PartitionState.active(1, DynamicPartitionConfig.uninitialized())))))
+            .lastChange(Optional.empty())
+            .pendingChanges(Optional.empty())
+            .routingState(Optional.empty())
+            .clusterId(Optional.empty())
+            .build();
 
     final DynamicPartitionConfig validConfig =
         new DynamicPartitionConfig(
@@ -317,15 +323,18 @@ class ClusterConfigurationTest {
                 ExportingState.EXPORTING,
                 Map.of("expA", new ExporterState(1, ENABLED, Optional.empty()))));
     final var topologyWithValidConfig =
-        new ClusterConfiguration(
-            0,
-            Map.of(
-                member(1),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, validConfig)))),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty());
+        ClusterConfiguration.builder()
+            .version(0)
+            .members(
+                Map.of(
+                    member(1),
+                    MemberState.initializeAsActive(
+                        Map.of(1, PartitionState.active(1, validConfig)))))
+            .lastChange(Optional.empty())
+            .pendingChanges(Optional.empty())
+            .routingState(Optional.empty())
+            .clusterId(Optional.empty())
+            .build();
 
     // when
     final var mergeValidToUninitialized =
@@ -346,14 +355,26 @@ class ClusterConfigurationTest {
     final var oldRoutingState =
         Optional.of(new RoutingState(1, new AllPartitions(3), new HashMod(3)));
     final var oldConfig =
-        new ClusterConfiguration(
-            1, Map.of(), Optional.empty(), Optional.empty(), oldRoutingState, Optional.empty());
+        ClusterConfiguration.builder()
+            .version(1)
+            .members(Map.of())
+            .lastChange(Optional.empty())
+            .pendingChanges(Optional.empty())
+            .routingState(oldRoutingState)
+            .clusterId(Optional.empty())
+            .build();
 
     final var newRoutingState =
         Optional.of(new RoutingState(2, new AllPartitions(4), new HashMod(4)));
     final var newConfig =
-        new ClusterConfiguration(
-            1, Map.of(), Optional.empty(), Optional.empty(), newRoutingState, Optional.empty());
+        ClusterConfiguration.builder()
+            .version(1)
+            .members(Map.of())
+            .lastChange(Optional.empty())
+            .pendingChanges(Optional.empty())
+            .routingState(newRoutingState)
+            .clusterId(Optional.empty())
+            .build();
 
     // when
     final var merged = oldConfig.merge(newConfig);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -383,6 +383,38 @@ class ClusterConfigurationTest {
     assertThat(merged.routingState()).isEqualTo(newRoutingState);
   }
 
+  @Test
+  void shouldMergeIncarnationNumber() {
+    // given
+    final var oldConfig =
+        ClusterConfiguration.builder()
+            .version(1)
+            .members(Map.of())
+            .lastChange(Optional.empty())
+            .pendingChanges(Optional.empty())
+            .routingState(Optional.empty())
+            .clusterId(Optional.empty())
+            .incarnationNumber(5)
+            .build();
+
+    final var newConfig =
+        ClusterConfiguration.builder()
+            .version(1)
+            .members(Map.of())
+            .lastChange(Optional.empty())
+            .pendingChanges(Optional.empty())
+            .routingState(Optional.empty())
+            .clusterId(Optional.empty())
+            .incarnationNumber(6)
+            .build();
+
+    // when
+    final var merged = oldConfig.merge(newConfig);
+
+    // then
+    assertThat(merged.incarnationNumber()).isEqualTo(6);
+  }
+
   private MemberId member(final int id) {
     return MemberId.from(Integer.toString(id));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -57,13 +57,15 @@ public final class ClusterTopologyDomain extends DomainContextBase {
         Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
     final var arbitraryRoutingState = routingStates().optional();
     final var arbitraryClusterId = Arbitraries.strings().ofMinLength(1).ofMaxLength(50).optional();
+    final var arbitraryIncarnationNumber = Arbitraries.longs().greaterOrEqual(0);
     return Combinators.combine(
             arbitraryVersion,
             arbitraryMembers,
             arbitraryCompletedChange,
             arbitraryChangePlan,
             arbitraryRoutingState,
-            arbitraryClusterId)
+            arbitraryClusterId,
+            arbitraryIncarnationNumber)
         .as(ClusterConfiguration::new);
   }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPar
 import io.camunda.zeebe.gateway.api.util.TestBrokerClusterState;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -56,13 +55,8 @@ final class PublishMessageDispatchStrategyTest {
     final var routingState =
         new RoutingState(1, new AllPartitions(3), new HashMod(messagePartitionCount));
     final var clusterConfiguration =
-        new ClusterConfiguration(
-            1,
-            Map.of(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(routingState),
-            Optional.empty());
+        ClusterConfiguration.builder().version(1).routingState(Optional.of(routingState)).build();
+
     final var topologyManager =
         new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -95,6 +95,7 @@ final class ClusterEndpointIT {
                   OperationEnum.PARTITION_LEAVE,
                   OperationEnum.PARTITION_LEAVE,
                   OperationEnum.DELETE_HISTORY,
+                  OperationEnum.UPDATE_INCARNATION_NUMBER,
                   OperationEnum.PARTITION_BOOTSTRAP,
                   OperationEnum.PARTITION_BOOTSTRAP,
                   OperationEnum.PARTITION_JOIN,

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -125,7 +125,8 @@ public class RestoreManager {
                 ClusterChangePlan.init(
                     1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
             base.routingState(),
-            base.clusterId());
+            base.clusterId(),
+            base.incarnationNumber());
     final var persistedConfiguration =
         PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
     persistedConfiguration.update(configuration);


### PR DESCRIPTION
This PR ensures that the ProcessCache is invalidated only during purge operation instead of every completed change in the cluster configuration.

* Added an `incarnationNumber` field to the `ClusterConfiguration` which represents an incarnation of the cluster. A change in incarnation number indicates the cluster has changed. Currently it is intended to be updated only after the cluster is purged. After a cluster purge the cluster resumes with a clean state, thus meaning a new incarnation.
* The `incarnationNumber` is updated via the operation `UpdateIncarnationNumberOperation`, which always increments the incarnation. Currently it is not possible to set a specific incarnation number. This can be added in future if required. 
* The operation is added to the list of operations generated for purge request. The incarnation number is updated after the data is deleted and before the partitions are re-added. 
* The listener in the `ProcessCache` is updated to react to changes in the incarnation number instead of the completed changes. 
* The existing IT test `ClusterPurgeMultiDbIT#shouldPurgeProcessCache()` covers this case. So no new IT tests are added.

## Related issues

closes #29865 
