### PR TITLE
[Backport stable/8.8] fix: Add process name to UserTask interface

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
@@ -48,6 +48,9 @@ public interface UserTask {
   /** BPMN process id of the process associated with this task */
   String getBpmnProcessId();
 
+  /** Name of the process definition */
+  String getProcessName();
+
   /** Key of the process definition */
   Long getProcessDefinitionKey();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
@@ -35,6 +35,7 @@ public class UserTaskImpl implements UserTask {
   private final List<String> candidateGroup;
   private final List<String> candidateUser;
   private final String bpmnProcessId;
+  private final String processName;
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
   private final Long formKey;
@@ -58,6 +59,7 @@ public class UserTaskImpl implements UserTask {
     candidateGroup = item.getCandidateGroups();
     candidateUser = item.getCandidateUsers();
     bpmnProcessId = item.getProcessDefinitionId();
+    processName = item.getProcessName();
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     formKey = ParseUtil.parseLongOrNull(item.getFormKey());
@@ -115,6 +117,11 @@ public class UserTaskImpl implements UserTask {
   @Override
   public String getBpmnProcessId() {
     return bpmnProcessId;
+  }
+
+  @Override
+  public String getProcessName() {
+    return processName;
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #43240 to `stable/8.8`.

relates to camunda/camunda#42857