### PR TITLE
test: fix flaky BackupRestoreIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -218,7 +218,7 @@ public class BackupRestoreIT {
 
     webappsDBClient.deleteAllIndices(INDEX_PREFIX);
 
-    Awaitility.await().untilAsserted(() -> assertThat(webappsDBClient.cat()).isEmpty());
+    Awaitility.await().untilAsserted(() -> assertThat(webappsDBClient.cat(INDEX_PREFIX)).isEmpty());
 
     // RESTORE PROCEDURE
     webappsDBClient.restore(REPOSITORY_NAME, snapshots);
@@ -326,10 +326,7 @@ public class BackupRestoreIT {
     final var metadata = new Metadata(BACKUP_ID, "current", 1, 1);
     final List<String> indices;
     try {
-      indices =
-          webappsDBClient.cat().stream()
-              .filter(name -> name.startsWith(configurator.zeebeIndexPrefix()))
-              .toList();
+      indices = webappsDBClient.cat(configurator.zeebeIndexPrefix());
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
@@ -41,7 +41,7 @@ public interface DocumentClient extends AutoCloseable {
   BackupRepository zeebeBackupRepository(
       String repositoryName, SnapshotNameProvider snapshotNameProvider);
 
-  List<String> cat() throws IOException;
+  List<String> cat(String indexPrefix) throws IOException;
 
   /**
    * Index a document with the given ID and content to the specified index.
@@ -61,8 +61,8 @@ public interface DocumentClient extends AutoCloseable {
    * @param document the document content to index
    * @throws IOException if indexing fails after retries
    */
-  default void indexWithRetry(String indexName, String documentId, Object document)
-      throws IOException {
+  default void indexWithRetry(
+      final String indexName, final String documentId, final Object document) throws IOException {
     final int maxRetries = 3;
     IOException lastException = null;
 
@@ -70,12 +70,12 @@ public interface DocumentClient extends AutoCloseable {
       try {
         index(indexName, documentId, document);
         return; // Success, exit retry loop
-      } catch (IOException e) {
+      } catch (final IOException e) {
         lastException = e;
         if (attempt < maxRetries - 1) {
           try {
             Thread.sleep(100 * (attempt + 1)); // Progressive backoff
-          } catch (InterruptedException ie) {
+          } catch (final InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new IOException("Interrupted during retry", ie);
           }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
@@ -86,12 +86,15 @@ public class ESClient implements DocumentClient {
   }
 
   @Override
-  public List<String> cat() throws IOException {
-    return esClient.cat().indices().valueBody().stream().map(IndicesRecord::index).toList();
+  public List<String> cat(final String indexPrefix) throws IOException {
+    return esClient.cat().indices(r -> r.index(indexPrefix + "*")).valueBody().stream()
+        .map(IndicesRecord::index)
+        .toList();
   }
 
   @Override
-  public void index(String indexName, String documentId, Object document) throws IOException {
+  public void index(final String indexName, final String documentId, final Object document)
+      throws IOException {
     final var indexRequest =
         IndexRequest.of(i -> i.index(indexName).id(documentId).document(document));
 
@@ -110,7 +113,7 @@ public class ESClient implements DocumentClient {
   }
 
   @Override
-  public void refresh(String indexName) throws IOException {
+  public void refresh(final String indexName) throws IOException {
     final var refreshRequest = RefreshRequest.of(r -> r.index(indexName));
     final var response = esClient.indices().refresh(refreshRequest);
 
@@ -125,7 +128,8 @@ public class ESClient implements DocumentClient {
   }
 
   @Override
-  public void bulkIndex(String indexName, Collection<DocumentWithId> documents) throws IOException {
+  public void bulkIndex(final String indexName, final Collection<DocumentWithId> documents)
+      throws IOException {
     if (documents.isEmpty()) {
       return; // Nothing to index
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -90,12 +90,15 @@ public class OSClient implements DocumentClient {
   }
 
   @Override
-  public List<String> cat() throws IOException {
-    return opensearchClient.cat().indices().valueBody().stream().map(IndicesRecord::index).toList();
+  public List<String> cat(final String indexPrefix) throws IOException {
+    return opensearchClient.cat().indices(r -> r.index(indexPrefix + "*")).valueBody().stream()
+        .map(IndicesRecord::index)
+        .toList();
   }
 
   @Override
-  public void index(String indexName, String documentId, Object document) throws IOException {
+  public void index(final String indexName, final String documentId, final Object document)
+      throws IOException {
     final var indexRequest =
         IndexRequest.of(i -> i.index(indexName).id(documentId).document(document));
 
@@ -109,7 +112,7 @@ public class OSClient implements DocumentClient {
   }
 
   @Override
-  public void refresh(String indexName) throws IOException {
+  public void refresh(final String indexName) throws IOException {
     final var refreshRequest = RefreshRequest.of(r -> r.index(indexName));
     final var response = opensearchClient.indices().refresh(refreshRequest);
 
@@ -124,7 +127,8 @@ public class OSClient implements DocumentClient {
   }
 
   @Override
-  public void bulkIndex(String indexName, Collection<DocumentWithId> documents) throws IOException {
+  public void bulkIndex(final String indexName, final Collection<DocumentWithId> documents)
+      throws IOException {
     if (documents.isEmpty()) {
       return; // Nothing to index
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
https://github.com/camunda/camunda/actions/runs/20617755580/job/59213736939

```
Expecting empty but was: [".plugins-ml-config"]
	at io.camunda.it.backup.BackupRestoreIT.lambda$shouldBackupAndRestoreToPreviousState$2(BackupRestoreIT.java:221)
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
