### PR TITLE
[Backport stable/8.8] Remove max RocksDB size validation.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -7,17 +7,14 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
-import com.sun.management.OperatingSystemMXBean;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
-import java.lang.management.ManagementFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RocksDbSharedCache {
   public static final long MINIMUM_PARTITION_MEMORY_LIMIT = 32 * 1024 * 1024L;
-  private static final double MAX_ROCKSDB_MEMORY_FRACTION = 0.5;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 
@@ -46,22 +43,6 @@ public class RocksDbSharedCache {
 
   public static void validateRocksDbMemory(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
     final long blockCacheBytes = getBlockCacheBytes(rocksdbCfg, partitionsCount);
-    final long totalMemorySize =
-        ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
-    // Heap by default is 25% of the RAM, and off-heap (unless configured otherwise) is the same.
-    // So 50% of your RAM goes to the JVM, for both heap and off-heap (aka direct) memory.
-    // Leaving 50% of RAM for OS page cache and other processes.
-
-    final long maxRocksDbMem = (long) (totalMemorySize * MAX_ROCKSDB_MEMORY_FRACTION);
-
-    if (blockCacheBytes > maxRocksDbMem) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected the allocated memory for RocksDB to be below or "
-                  + "equal %.2f %% of ram memory, but was %.2f %%.",
-              MAX_ROCKSDB_MEMORY_FRACTION * 100,
-              ((double) blockCacheBytes / totalMemorySize * 100)));
-    }
 
     if (blockCacheBytes / partitionsCount < MINIMUM_PARTITION_MEMORY_LIMIT) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
# Description
Backport of #42922 to `stable/8.8`.

relates to 