### PR TITLE
ci: run operate e2e tests on pull requests

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -1,5 +1,5 @@
 # description: Workflow for Front-End end to end tests for Operate only. Tests will use a running instance of Operate for the API
-# test location: operate/client/e2e-playwright/tests
+# test location: qa/c8-orchestration-cluster-e2e-test-suite
 # type: CI
 # owner: @camunda/core-features
 name: "[Legacy] Operate / E2E Tests"
@@ -20,6 +20,7 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
   pull_request:
     paths:
       - ".ci/**"
@@ -32,6 +33,7 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence
@@ -41,8 +43,6 @@ concurrency:
 
 jobs:
   test:
-    # Temporarily disabled E2E tests while we fix them
-    if: false
     runs-on: gcp-core-4-default
     services:
       elasticsearch:
@@ -70,14 +70,30 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
-      - name: Build frontend
-        uses: ./.github/actions/build-frontend
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - name: Install Playwright
-        run: npx playwright install -- --with-deps chromium
+          node-version: "22"
+
+      - name: Install node dependencies
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: npm ci
+
+      - name: Install frontend dependencies
         working-directory: ./operate/client
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Build frontend
+        working-directory: ./operate/client
+        run: npm run build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -118,17 +134,29 @@ jobs:
           CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
           CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: true
           CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: false
+
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Run tests
-        working-directory: ./operate/client
-        run: npm run test:e2e:ci
+        shell: bash
         env:
-          ZEEBE_GATEWAY_ADDRESS: localhost:26500
-          ZEEBE_REST_GATEWAY_ADDRESS: http://localhost:8080
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: http://localhost:8080
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+        run: npm run test -- --project=operate-e2e
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Playwright report
-          path: operate/client/playwright-report/
+          name: C8 Orchestration Cluster E2E Test Result (operate)
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 30
 
       - name: Collect docker logs on failure

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
-      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
+
   pull_request:
     paths:
       - ".ci/**"
@@ -33,7 +33,6 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
-      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
@@ -35,7 +35,15 @@ class OperateDecisionInstancePage {
   }
 
   async getDecisionInstanceId(): Promise<string> {
-    return this.instanceHeader.getByRole('cell').nth(1).innerText();
+    const url = this.page.url();
+
+    const match = url.match(/\/decisions\/([^/?]+)/);
+    if (match && match[1]) {
+      const decisionInstanceId = match[1];
+      return decisionInstanceId;
+    }
+
+    throw new Error(`Could not extract decision instance ID from URL: ${url}`);
   }
 
   async gotoDecisionInstancePage(options: {id: string}): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -28,7 +28,6 @@ function getTestTypeLabel(): string {
   return `Nightly Test Results for Mono Repo - ${process.env.VERSION} (Tasklist ${tasklistMode})`;
 }
 
-
 // Reporters
 const useReportersWithoutSlack: any[] = [
   ['list'],
@@ -70,7 +69,7 @@ const normalProjects = [
     testMatch: ['tests/api/**/*.spec.ts'],
     testIgnore: ['tests/api/v2/clock/*.spec.ts'],
     use: devices['Desktop Chrome'],
-    teardown: 'clock-api-tests'
+    teardown: 'clock-api-tests',
   },
   {
     name: 'clock-api-tests',
@@ -206,6 +205,12 @@ const normalProjects = [
   {
     name: 'identity-e2e',
     testMatch: ['tests/identity/*.spec.ts'],
+    use: devices['Desktop Chrome'],
+    testIgnore: ['v2-stateless-tests/**', 'tests/api/**/*.spec.ts'],
+  },
+  {
+    name: 'operate-e2e',
+    testMatch: ['tests/operate/*.spec.ts'],
     use: devices['Desktop Chrome'],
     testIgnore: ['v2-stateless-tests/**', 'tests/api/**/*.spec.ts'],
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -45,7 +45,7 @@ test.beforeAll(async ({request}) => {
       bpmnProcessId: 'operationsProcessB',
     })),
   };
-  await sleep(1000);
+  await sleep(2000);
   await createDemoOperations(
     request,
     initialData.singleOperationInstance.processInstanceKey,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -16,6 +16,7 @@ import {
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expectInViewport} from 'utils/expectInViewport';
+import {sleep} from 'utils/sleep';
 
 test.beforeAll(async () => {
   await deploy([
@@ -52,6 +53,7 @@ test.describe('Process Instance Variables', () => {
       await operateProcessesPage.filterByProcessName(
         'variable scrolling process',
       );
+      await sleep(100);
       await operateProcessesPage.clickProcessInstanceLink();
       await expect(operateProcessInstancePage.addVariableButton).toBeEnabled();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -22,7 +22,7 @@ export async function createDemoOperations(
   };
 
   await Promise.all(
-    [...new Array(count)].map(async () => {
+    [...new Array(count)].map(async (_, index) => {
       const response = await request.post(
         `${credentials.baseUrl}/api/process-instances/${processInstanceKey}/operation`,
         {
@@ -35,11 +35,15 @@ export async function createDemoOperations(
       if (!response.ok()) {
         const errorBody = await response.text();
         console.error(
-          `Failed to create operation: ${response.status()} ${response.statusText()}`,
+          `Failed to create operation ${index + 1}/${count}: ${response.status()} ${response.statusText()}`,
         );
+        console.error(`Process Instance Key: ${processInstanceKey}`);
         console.error(`Response body: ${errorBody}`);
       }
-      expect(response.ok()).toBeTruthy();
+      expect(
+        response.ok(),
+        `Operation ${index + 1}/${count} failed: ${response.status()} ${response.statusText()}`,
+      ).toBeTruthy();
       return response;
     }),
   );


### PR DESCRIPTION
## Description
After migrating the Operate E2E tests from main to the OC test suite, re-enable the Operate E2E test checks on PRs so they run from the OC suite, and address flakiness in the affected tests.

<!-- Describe the goal and purpose of this PR. -->

## Testing
[Example of  CI run ](https://github.com/camunda/camunda/actions/runs/20713449959/job/59459071539?pr=43382)
❗ Visual regression tests failure are unrelated to my changes as reported [here](https://camunda.slack.com/archives/C071KP5BTHB/p1767608148004889)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
