### PR TITLE
[Backport main] Decision instances get API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertStatusCode,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  assertNotFoundRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  createMammalProcessInstanceAndDeployMammalDecision,
+  DecisionInstance,
+} from '@requestHelpers';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  getDecisionInstanceResponseRequiredFields,
+  decisionInstanceRequiredFields,
+} from 'utils/beans/requestBeans';
+
+test.describe.parallel('Search Decision Instances API Tests', () => {
+  let decisionInstances: DecisionInstance[] = [];
+  let processInstanceKey: string;
+
+  test.beforeAll(async ({request}) => {
+    const result =
+      await createMammalProcessInstanceAndDeployMammalDecision(request);
+    processInstanceKey = result.instance.processInstanceKey;
+    decisionInstances = result.decisions;
+  });
+
+  test('Get Decision Instance - Success', async ({request}) => {
+    const decisionInstanceToGet = decisionInstances[0];
+    const decisionEvaluationInstanceKeyToGet =
+      decisionInstanceToGet.decisionEvaluationInstanceKey;
+
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/decision-instances/{decisionEvaluationInstanceKey}',
+          method: 'GET',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.decisionEvaluationInstanceKey).toBe(
+        decisionEvaluationInstanceKeyToGet,
+      );
+      expect(body.processInstanceKey).toBe(processInstanceKey);
+      assertRequiredFields(body, getDecisionInstanceResponseRequiredFields);
+      assertEqualsForKeys(
+        decisionInstanceToGet,
+        body,
+        decisionInstanceRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Decision Instance - Not found', async ({request}) => {
+    const someRandomNotExistingKey = '9999999999999999';
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl(`/decision-instances/${someRandomNotExistingKey}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertNotFoundRequest(
+        res,
+        `Decision Instance with id '${someRandomNotExistingKey}' not found`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Decision Instances - Unauthorized', async ({request}) => {
+    const decisionInstanceToGet = decisionInstances[0];
+    const decisionEvaluationInstanceKeyToGet =
+      decisionInstanceToGet.decisionEvaluationInstanceKey;
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+        },
+      );
+
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -165,6 +165,7 @@ export const getDecisionInstanceResponseRequiredFields: string[] = [
   'elementInstanceKey',
   'evaluatedInputs',
   'matchedRules',
+  'rootDecisionDefinitionKey',
 ];
 export const evaluateDecisionRequiredFields: string[] = [
   'decisionDefinitionId',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -165,8 +165,6 @@ export const getDecisionInstanceResponseRequiredFields: string[] = [
   'elementInstanceKey',
   'evaluatedInputs',
   'matchedRules',
-  // 'evaluationFailure',          // optional, present on failure
-  // 'rootDecisionDefinitionKey',  // present from 8.9
 ];
 export const evaluateDecisionRequiredFields: string[] = [
   'decisionDefinitionId',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -148,6 +148,26 @@ export const decisionInstanceRequiredFields: string[] = [
   'elementInstanceKey',
   'rootDecisionDefinitionKey',
 ];
+export const getDecisionInstanceResponseRequiredFields: string[] = [
+  'decisionEvaluationInstanceKey',
+  'state',
+  'evaluationDate',
+  'decisionDefinitionId',
+  'decisionDefinitionName',
+  'decisionDefinitionVersion',
+  'decisionDefinitionType',
+  'result',
+  'tenantId',
+  'decisionEvaluationKey',
+  'processDefinitionKey',
+  'processInstanceKey',
+  'decisionDefinitionKey',
+  'elementInstanceKey',
+  'evaluatedInputs',
+  'matchedRules',
+  // 'evaluationFailure',          // optional, present on failure
+  // 'rootDecisionDefinitionKey',  // present from 8.9
+];
 export const evaluateDecisionRequiredFields: string[] = [
   'decisionDefinitionId',
   'decisionDefinitionName',


### PR DESCRIPTION
## Description
Backport of #43267 to `main`.

relates to #37204

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/20775188008)