### PR TITLE
fix: remove authentication from status controller

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthIT.java
@@ -13,7 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.StatusResponse;
+import io.camunda.client.api.response.StatusResponse.Status;
 import io.camunda.client.api.statistics.response.UsageMetricsStatistics;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.qa.util.auth.Permissions;
@@ -39,7 +42,10 @@ public class GlobalErrorControllerWithAuthIT {
 
   @MultiDbTestApplication
   private static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticatedAccess();
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -70,6 +76,16 @@ public class GlobalErrorControllerWithAuthIT {
               .join();
 
       assertThat(usageMetrics).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldPassForUnauthenticatedEndpoint() throws URISyntaxException {
+    try (final CamundaClient client = createClient(null, "")) {
+
+      final StatusResponse statusResponse = client.newStatusRequest().send().join();
+      assertThat(statusResponse).isNotNull();
+      assertThat(statusResponse.getStatus()).isEqualTo(Status.UP);
     }
   }
 
@@ -121,16 +137,22 @@ public class GlobalErrorControllerWithAuthIT {
 
   private static CamundaClient createClient(final TestUser user, final String path)
       throws URISyntaxException {
-    return BROKER
-        .newClientBuilder()
-        .restAddress(new URI("http://localhost:" + BROKER.mappedPort(TestZeebePort.REST) + path))
-        .defaultRequestTimeout(Duration.ofMinutes(10))
-        .preferRestOverGrpc(true)
-        .credentialsProvider(
-            new BasicAuthCredentialsProviderBuilder()
-                .username(user.username())
-                .password(user.password())
-                .build())
-        .build();
+    final CamundaClientBuilder camundaClientBuilder =
+        BROKER
+            .newClientBuilder()
+            .restAddress(
+                new URI("http://localhost:" + BROKER.mappedPort(TestZeebePort.REST) + path))
+            .defaultRequestTimeout(Duration.ofMinutes(10))
+            .preferRestOverGrpc(true);
+    if (user != null) {
+      camundaClientBuilder.credentialsProvider(
+          new BasicAuthCredentialsProviderBuilder()
+              .username(user.username())
+              .password(user.password())
+              .build());
+    } else {
+      camundaClientBuilder.credentialsProvider(null);
+    }
+    return camundaClientBuilder.build();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthIT.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.StatusResponse;
 import io.camunda.client.api.response.StatusResponse.Status;
@@ -137,22 +136,18 @@ public class GlobalErrorControllerWithAuthIT {
 
   private static CamundaClient createClient(final TestUser user, final String path)
       throws URISyntaxException {
-    final CamundaClientBuilder camundaClientBuilder =
-        BROKER
-            .newClientBuilder()
-            .restAddress(
-                new URI("http://localhost:" + BROKER.mappedPort(TestZeebePort.REST) + path))
-            .defaultRequestTimeout(Duration.ofMinutes(10))
-            .preferRestOverGrpc(true);
-    if (user != null) {
-      camundaClientBuilder.credentialsProvider(
-          new BasicAuthCredentialsProviderBuilder()
-              .username(user.username())
-              .password(user.password())
-              .build());
-    } else {
-      camundaClientBuilder.credentialsProvider(null);
-    }
-    return camundaClientBuilder.build();
+    return BROKER
+        .newClientBuilder()
+        .restAddress(new URI("http://localhost:" + BROKER.mappedPort(TestZeebePort.REST) + path))
+        .defaultRequestTimeout(Duration.ofMinutes(10))
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            user == null
+                ? null
+                : new BasicAuthCredentialsProviderBuilder()
+                    .username(user.username())
+                    .password(user.password())
+                    .build())
+        .build();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/StatusController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/StatusController.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TopologyServices;
 import io.camunda.service.TopologyServices.ClusterStatus;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
@@ -22,22 +22,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class StatusController {
 
   private final TopologyServices topologyServices;
-  private final CamundaAuthenticationProvider authenticationProvider;
 
-  public StatusController(
-      final TopologyServices topologyServices,
-      final CamundaAuthenticationProvider authenticationProvider) {
+  public StatusController(final TopologyServices topologyServices) {
     this.topologyServices = topologyServices;
-    this.authenticationProvider = authenticationProvider;
   }
 
   @CamundaGetMapping(path = "/status")
   public CompletableFuture<ResponseEntity<Object>> getStatus() {
     return RequestMapper.executeServiceMethod(
-        () ->
-            topologyServices
-                .withAuthentication(authenticationProvider.getCamundaAuthentication())
-                .getStatus(),
+        () -> topologyServices.withAuthentication(CamundaAuthentication.none()).getStatus(),
         StatusController::getStatusResponse);
   }
 


### PR DESCRIPTION
## Description

Removes the Camunda authentication from the status controller since it can be called without authentication. The topology service doesn't consider the authentication data either, so providing a "none" object is fine.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Follow-up of https://github.com/camunda/camunda/pull/42813
Closes https://github.com/camunda/camunda/issues/43397
