### PR TITLE
feat: audit: add decision requirements resource operations audit log export handler

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -61,6 +62,7 @@ public record AuditLogInfo(
       case BATCH_OPERATION_CREATION:
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
       case DECISION_EVALUATION:
+      case DECISION_REQUIREMENTS:
       case DECISION:
       case FORM:
       case INCIDENT:
@@ -101,6 +103,8 @@ public record AuditLogInfo(
       case DECISION:
       case DECISION_EVALUATION:
         return AuditLogEntityType.DECISION;
+      case DECISION_REQUIREMENTS:
+        return AuditLogEntityType.RESOURCE;
       case BATCH_OPERATION_CREATION:
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
         return AuditLogEntityType.BATCH;
@@ -151,14 +155,19 @@ public record AuditLogInfo(
       case BatchOperationIntent.CANCEL:
         return AuditLogOperationType.CANCEL;
 
+      case DecisionEvaluationIntent.EVALUATED:
+      case DecisionEvaluationIntent.FAILED:
+        return AuditLogOperationType.EVALUATE;
+
       case DecisionIntent.CREATED:
         return AuditLogOperationType.CREATE;
       case DecisionIntent.DELETED:
         return AuditLogOperationType.DELETE;
 
-      case DecisionEvaluationIntent.EVALUATED:
-      case DecisionEvaluationIntent.FAILED:
-        return AuditLogOperationType.EVALUATE;
+      case DecisionRequirementsIntent.CREATED:
+        return AuditLogOperationType.CREATE;
+      case DecisionRequirementsIntent.DELETED:
+        return AuditLogOperationType.DELETE;
 
       case FormIntent.CREATED:
         return AuditLogOperationType.CREATE;

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATIO
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
+import static io.camunda.zeebe.protocol.record.ValueType.DECISION_REQUIREMENTS;
 import static io.camunda.zeebe.protocol.record.ValueType.GROUP;
 import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -70,12 +72,16 @@ public class AuditLogTransformerConfigs {
               BatchOperationIntent.CANCEL)
           .withRejectionTypes(RejectionType.INVALID_STATE);
 
-  public static final TransformerConfig DECISION_CONFIG =
-      TransformerConfig.with(DECISION).withIntents(DecisionIntent.CREATED, DecisionIntent.DELETED);
-
   public static final TransformerConfig DECISION_EVALUATION_CONFIG =
       TransformerConfig.with(DECISION_EVALUATION)
           .withIntents(DecisionEvaluationIntent.EVALUATED, DecisionEvaluationIntent.FAILED);
+
+  public static final TransformerConfig DECISION_CONFIG =
+      TransformerConfig.with(DECISION).withIntents(DecisionIntent.CREATED, DecisionIntent.DELETED);
+
+  public static final TransformerConfig DECISION_REQUIREMENTS_CONFIG =
+      TransformerConfig.with(DECISION_REQUIREMENTS)
+          .withIntents(DecisionRequirementsIntent.CREATED, DecisionRequirementsIntent.DELETED);
 
   public static final TransformerConfig FORM_CONFIG =
       TransformerConfig.with(ValueType.FORM).withIntents(FormIntent.CREATED, FormIntent.DELETED);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.auditlog.transformers;
+
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+
+public class DecisionRequirementsRecordAuditLogTransformer
+    implements AuditLogTransformer<DecisionRequirementsRecordValue> {
+
+  @Override
+  public TransformerConfig config() {
+    return AuditLogTransformerConfigs.DECISION_REQUIREMENTS_CONFIG;
+  }
+
+  @Override
+  public void transform(
+      final Record<DecisionRequirementsRecordValue> record, final AuditLogEntry log) {
+    final var value = record.getValue();
+    log.setDecisionRequirementsKey(value.getDecisionRequirementsKey());
+    log.setDecisionRequirementsId(value.getDecisionRequirementsId());
+    log.setDeploymentKey(value.getDeploymentKey());
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfoTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfoTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -200,10 +201,12 @@ class AuditLogInfoTest {
         Arguments.of(BatchOperationIntent.RESUMED, AuditLogOperationType.RESUME),
         Arguments.of(BatchOperationIntent.SUSPEND, AuditLogOperationType.SUSPEND),
         Arguments.of(BatchOperationIntent.SUSPENDED, AuditLogOperationType.SUSPEND),
-        Arguments.of(DecisionIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(DecisionIntent.DELETED, AuditLogOperationType.DELETE),
         Arguments.of(DecisionEvaluationIntent.EVALUATED, AuditLogOperationType.EVALUATE),
         Arguments.of(DecisionEvaluationIntent.FAILED, AuditLogOperationType.EVALUATE),
+        Arguments.of(DecisionIntent.CREATED, AuditLogOperationType.CREATE),
+        Arguments.of(DecisionIntent.DELETED, AuditLogOperationType.DELETE),
+        Arguments.of(DecisionRequirementsIntent.CREATED, AuditLogOperationType.CREATE),
+        Arguments.of(DecisionRequirementsIntent.DELETED, AuditLogOperationType.DELETE),
         Arguments.of(FormIntent.CREATED, AuditLogOperationType.CREATE),
         Arguments.of(FormIntent.DELETED, AuditLogOperationType.DELETE),
         Arguments.of(GroupIntent.CREATED, AuditLogOperationType.CREATE),

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.auditlog.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRequirementsRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class DecisionRequirementsRecordAuditLogTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final DecisionRequirementsRecordAuditLogTransformer transformer =
+      new DecisionRequirementsRecordAuditLogTransformer();
+
+  @Test
+  void shouldTransformDecisionRequirementsCreatedRecord() {
+    // given
+    final DecisionRequirementsRecordValue recordValue =
+        ImmutableDecisionRequirementsRecordValue.builder()
+            .from(factory.generateObject(DecisionRequirementsRecordValue.class))
+            .withDecisionRequirementsKey(123L)
+            .withDecisionRequirementsId("decision-requirements-1")
+            .withTenantId("tenant-1")
+            .withDeploymentKey(1234L)
+            .build();
+
+    final Record<DecisionRequirementsRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_REQUIREMENTS,
+            r -> r.withIntent(DecisionRequirementsIntent.CREATED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionRequirementsKey()).isEqualTo(123L);
+    assertThat(entity.getDecisionRequirementsId()).isEqualTo("decision-requirements-1");
+    assertThat(entity.getDeploymentKey()).isEqualTo(1234L);
+  }
+
+  @Test
+  void shouldTransformDecisionRequirementsDeletedRecord() {
+    // given
+    final DecisionRequirementsRecordValue recordValue =
+        ImmutableDecisionRequirementsRecordValue.builder()
+            .from(factory.generateObject(DecisionRequirementsRecordValue.class))
+            .withDecisionRequirementsKey(456L)
+            .withDecisionRequirementsId("decision-requirements-2")
+            .withTenantId("tenant-2")
+            .withDeploymentKey(1234L)
+            .build();
+
+    final Record<DecisionRequirementsRecordValue> record =
+        factory.generateRecord(
+            ValueType.DECISION_REQUIREMENTS,
+            r -> r.withIntent(DecisionRequirementsIntent.DELETED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getDecisionRequirementsKey()).isEqualTo(456L);
+    assertThat(entity.getDecisionRequirementsId()).isEqualTo("decision-requirements-2");
+    assertThat(entity.getDeploymentKey()).isEqualTo(1234L);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -122,6 +122,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationCrea
 import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionEvaluationAuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionRequirementsRecordAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.FormAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupEntityAuditLogTransformer;
@@ -479,6 +480,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
           .addHandler(new BatchOperationLifecycleManagementAuditLogTransformer())
           .addHandler(new DecisionAuditLogTransformer())
           .addHandler(new DecisionEvaluationAuditLogTransformer())
+          .addHandler(new DecisionRequirementsRecordAuditLogTransformer())
           .addHandler(new FormAuditLogTransformer())
           .addHandler(new GroupAuditLogTransformer())
           .addHandler(new GroupEntityAuditLogTransformer())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationCrea
 import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionEvaluationAuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionRequirementsRecordAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.FormAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupEntityAuditLogTransformer;
@@ -191,6 +192,9 @@ public class DefaultExporterResourceProviderTest {
                 ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
             Map.entry(DecisionAuditLogTransformer.class, ValueType.DECISION),
             Map.entry(DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
+            Map.entry(
+                DecisionRequirementsRecordAuditLogTransformer.class,
+                ValueType.DECISION_REQUIREMENTS),
             Map.entry(FormAuditLogTransformer.class, ValueType.FORM),
             Map.entry(GroupAuditLogTransformer.class, ValueType.GROUP),
             Map.entry(GroupEntityAuditLogTransformer.class, ValueType.GROUP),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationCrea
 import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionEvaluationAuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionRequirementsRecordAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.FormAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupEntityAuditLogTransformer;
@@ -322,6 +323,7 @@ public class RdbmsExporterWrapper implements Exporter {
             new BatchOperationLifecycleManagementAuditLogTransformer(),
             new DecisionAuditLogTransformer(),
             new DecisionEvaluationAuditLogTransformer(),
+            new DecisionRequirementsRecordAuditLogTransformer(),
             new FormAuditLogTransformer(),
             new GroupAuditLogTransformer(),
             new GroupEntityAuditLogTransformer(),

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationCrea
 import io.camunda.zeebe.exporter.common.auditlog.transformers.BatchOperationLifecycleManagementAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionEvaluationAuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.DecisionRequirementsRecordAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.FormAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.GroupEntityAuditLogTransformer;
@@ -107,6 +108,9 @@ class RdbmsExporterWrapperTest {
                 ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
             Map.entry(DecisionAuditLogTransformer.class, ValueType.DECISION),
             Map.entry(DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
+            Map.entry(
+                DecisionRequirementsRecordAuditLogTransformer.class,
+                ValueType.DECISION_REQUIREMENTS),
             Map.entry(FormAuditLogTransformer.class, ValueType.FORM),
             Map.entry(GroupAuditLogTransformer.class, ValueType.GROUP),
             Map.entry(GroupEntityAuditLogTransformer.class, ValueType.GROUP),


### PR DESCRIPTION
## Description

feat: audit: add decision requirements resource operations audit log export handler

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41504
