### PR TITLE
ci: run operate e2e tests on pull requests

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -150,7 +150,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           ZEEBE_REST_ADDRESS: "http://localhost:8080"
           PLAYWRIGHT_BASE_URL: "http://localhost:8080"
-        run: npm run test -- --project=operate-e2e --reporter=html
+        run: npm run test -- --project=operate-e2e
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -1,5 +1,5 @@
 # description: Workflow for Front-End end to end tests for Operate only. Tests will use a running instance of Operate for the API
-# test location: operate/client/e2e-playwright/tests
+# test location: qa/c8-orchestration-cluster-e2e-test-suite
 # type: CI
 # owner: @camunda/core-features
 name: "[Legacy] Operate / E2E Tests"
@@ -20,6 +20,7 @@ on:
       - "zeebe/exporters/camunda-exporter/**"
       - "parent/*"
       - "pom.xml"
+
   pull_request:
     paths:
       - ".ci/**"
@@ -41,8 +42,6 @@ concurrency:
 
 jobs:
   test:
-    # Temporarily disabled E2E tests while we fix them
-    if: false
     runs-on: gcp-core-4-default
     services:
       elasticsearch:
@@ -70,14 +69,30 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
-      - name: Build frontend
-        uses: ./.github/actions/build-frontend
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - name: Install Playwright
-        run: npx playwright install -- --with-deps chromium
+          node-version: "22"
+
+      - name: Install node dependencies
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: npm ci
+
+      - name: Install frontend dependencies
         working-directory: ./operate/client
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: ./operate/client
+        run: npm run build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -118,17 +133,30 @@ jobs:
           CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
           CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: true
           CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: false
+
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Run tests
-        working-directory: ./operate/client
-        run: npm run test:e2e:ci
+        shell: bash
         env:
-          ZEEBE_GATEWAY_ADDRESS: localhost:26500
-          ZEEBE_REST_GATEWAY_ADDRESS: http://localhost:8080
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: http://localhost:8080
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          PLAYWRIGHT_BASE_URL: "http://localhost:8080"
+        run: npm run test -- --project=operate-e2e --reporter=html
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Playwright report
-          path: operate/client/playwright-report/
+          name: C8 Orchestration Cluster E2E Test Result (operate)
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 30
 
       - name: Collect docker logs on failure

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
@@ -38,7 +38,15 @@ class OperateDecisionInstancePage {
   }
 
   async getDecisionInstanceId(): Promise<string> {
-    return this.decisionInstanceIdCell.innerText();
+    const url = this.page.url();
+
+    const match = url.match(/\/decisions\/([^/?]+)/);
+    if (match && match[1]) {
+      const decisionInstanceId = match[1];
+      return decisionInstanceId;
+    }
+
+    throw new Error(`Could not extract decision instance ID from URL: ${url}`);
   }
 
   async gotoDecisionInstancePage(options: {id: string}): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { devices, defineConfig } from '@playwright/test';
+import {devices, defineConfig} from '@playwright/test';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -13,7 +13,7 @@ const testRailOptions = {
 const useReportersWithoutSlack: any[] = [
   ['list'],
   ['junit', testRailOptions],
-  ['html', { outputFolder: 'html-report' }],
+  ['html', {outputFolder: 'html-report'}],
 ];
 
 // Define reporters with SlackReporter
@@ -67,7 +67,7 @@ export default defineConfig({
       testMatch: ['tests/api/**/*.spec.ts'],
       testIgnore: ['tests/api/v2/clock/*.spec.ts'],
       use: devices['Desktop Chrome'],
-      teardown: 'clock-api-tests'
+      teardown: 'clock-api-tests',
     },
     {
       name: 'clock-api-tests',
@@ -83,10 +83,7 @@ export default defineConfig({
       testMatch: changedFolders.includes('chromium')
         ? changedFolders.map((folder) => `**/${folder}/*.spec.ts`)
         : undefined,
-      testIgnore: [
-        'task-panel.spec.ts',
-        'tests/api/**/*.spec.ts',
-      ],
+      testIgnore: ['task-panel.spec.ts', 'tests/api/**/*.spec.ts'],
       grep: /^(?!.*@v2-only).*$/,
       teardown: 'chromium-subset',
     },
@@ -99,10 +96,7 @@ export default defineConfig({
     {
       name: 'firefox',
       use: devices['Desktop Firefox'],
-      testIgnore: [
-        'task-panel.spec.ts',
-        'tests/api/**/*.spec.ts',
-      ],
+      testIgnore: ['task-panel.spec.ts', 'tests/api/**/*.spec.ts'],
       grep: /^(?!.*@v2-only).*$/,
       teardown: 'firefox-subset',
     },
@@ -115,10 +109,7 @@ export default defineConfig({
     {
       name: 'msedge',
       use: devices['Desktop Edge'],
-      testIgnore: [
-        'task-panel.spec.ts',
-        'tests/api/**/*.spec.ts',
-      ],
+      testIgnore: ['task-panel.spec.ts', 'tests/api/**/*.spec.ts'],
       grep: /^(?!.*@v2-only).*$/,
       teardown: 'msedge-subset',
     },
@@ -133,10 +124,7 @@ export default defineConfig({
       name: 'tasklist-v1-e2e',
       testMatch: ['tests/tasklist/*.spec.ts', 'tests/tasklist/v1/*.spec.ts'],
       use: devices['Desktop Edge'],
-      testIgnore: [
-        'task-panel.spec.ts', 
-        'tests/api/**/*.spec.ts'
-      ],
+      testIgnore: ['task-panel.spec.ts', 'tests/api/**/*.spec.ts'],
       grep: /^(?!.*@v2-only).*$/,
       teardown: 'chromium-subset',
     },
@@ -147,7 +135,7 @@ export default defineConfig({
       testIgnore: [
         'task-panel.spec.ts',
         'tests/tasklist/v1/*.spec.ts',
-        'tests/api/**/*.spec.ts'
+        'tests/api/**/*.spec.ts',
       ],
       grep: /^(?!.*@v1-only).*$/,
       teardown: 'chromium-subset',
@@ -157,6 +145,12 @@ export default defineConfig({
       testMatch: ['tests/identity/*.spec.ts'],
       testIgnore: ['tests/api/**/*.spec.ts'],
       use: devices['Desktop Chrome'],
+    },
+    {
+      name: 'operate-e2e',
+      testMatch: ['tests/operate/*.spec.ts'],
+      use: devices['Desktop Chrome'],
+      testIgnore: ['tests/api/**/*.spec.ts'],
     },
   ],
   reporter:

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -16,6 +16,7 @@ import {
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expectInViewport} from 'utils/expectInViewport';
+import {sleep} from 'utils/sleep';
 
 test.beforeAll(async () => {
   await deploy([
@@ -52,6 +53,7 @@ test.describe('Process Instance Variables', () => {
       await operateProcessesPage.filterByProcessName(
         'variable scrolling process',
       );
+      await sleep(100);
       await operateProcessesPage.clickProcessInstanceLink();
       await expect(operateProcessInstancePage.addVariableButton).toBeEnabled();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -22,7 +22,7 @@ export async function createDemoOperations(
   };
 
   await Promise.all(
-    [...new Array(count)].map(async () => {
+    [...new Array(count)].map(async (_, index) => {
       const response = await request.post(
         `${credentials.baseUrl}/api/process-instances/${processInstanceKey}/operation`,
         {
@@ -35,11 +35,15 @@ export async function createDemoOperations(
       if (!response.ok()) {
         const errorBody = await response.text();
         console.error(
-          `Failed to create operation: ${response.status()} ${response.statusText()}`,
+          `Failed to create operation ${index + 1}/${count}: ${response.status()} ${response.statusText()}`,
         );
+        console.error(`Process Instance Key: ${processInstanceKey}`);
         console.error(`Response body: ${errorBody}`);
       }
-      expect(response.ok()).toBeTruthy();
+      expect(
+        response.ok(),
+        `Operation ${index + 1}/${count} failed: ${response.status()} ${response.statusText()}`,
+      ).toBeTruthy();
       return response;
     }),
   );


### PR DESCRIPTION
## Description
After migrating the Operate E2E tests from main to the OC test suite, re-enable the Operate E2E test checks on PRs so they run from the OC suite.
<!-- Describe the goal and purpose of this PR. -->



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
