### PR TITLE
docs: better javadoc comment for RdbmsTableNames

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -16,8 +16,11 @@ import java.util.List;
 public final class RdbmsTableNames {
 
   /**
-   * List of all known RDBMS table names. The order is important for the purger, so do not change it
-   * without verifying that the purge operation still works correctly.
+   * List of all known RDBMS table names. The order of tables in this list will be used by the
+   * RdbmsPurger to determine the order in which the tables are truncated. It is important to always
+   * truncate source tables of a FK reference before the target table of a FK reference is
+   * truncated. Failure to do so will result in FK constraint violations during truncation. Easiest
+   * symptom is a flaky test RdbmsPurgerIT in the CI pipeline.
    */
   public static final List<String> TABLE_NAMES =
       List.of(


### PR DESCRIPTION
## Description

Explain, why the table name order in `RdbmsTableNames` is important.
