### PR TITLE
test: click authorization on the retry

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/index.ts
@@ -501,8 +501,8 @@ export function validateResponseShape<
 }
 export function validateResponse<
   P extends RoutePath = RoutePath,
-  M extends MethodFor<P>,
-  S extends StatusFor<P, M>,
+  M extends MethodFor<P> = MethodFor<P>,
+  S extends StatusFor<P, M> = StatusFor<P, M>,
 >(
   spec: {path: P; method: M; status: S},
   response: PlaywrightAPIResponse,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/responses.json
@@ -2,7 +2,7 @@
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda-orchestration-cluster-api",
     "commit": "8fe19877bb473c834b44b52dafb33e9b5ec235bd",
-    "generatedAt": "2025-12-22T09:14:02.149Z",
+    "generatedAt": "2026-01-06T06:35:37.769Z",
     "specPath": "specification/rest-api.yaml",
     "specSha256": "c6c3f5f4c9c24b7b7d6873e31f72d83db79418de81dc00f09a21843b4ce0d507"
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -128,6 +128,9 @@ export class IdentityAuthorizationsPage {
   async fillResourceId(resourceId: string) {
     await expect(this.createAuthorizationResourceIdField).toBeVisible();
     await this.createAuthorizationResourceIdField.fill(resourceId);
+    await expect(this.createAuthorizationResourceIdField).toHaveValue(
+      resourceId,
+    );
   }
 
   async checkAccessPermissions(permission: string[]) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -264,8 +264,12 @@ export class IdentityAuthorizationsPage {
     ownerId: string,
     ownerType: string,
     accessPermissions?: string[],
+    authorizationTab?: string,
   ) {
-    const exists = await this.findAuthorizationInPaginatedList(ownerId);
+    const exists = await this.findAuthorizationInPaginatedList(
+      ownerId,
+      authorizationTab,
+    );
 
     if (!exists) {
       throw new Error(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -34,8 +34,7 @@ test.describe.parallel('Search Batch Operation Tests', () => {
     }
   });
 
-  //Skipped due to bug 43161: https://github.com/camunda/camunda/issues/43161
-  test.skip('Search Batch Operations Success', async ({request}) => {
+  test('Search Batch Operations Success', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl('/batch-operations/search'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-search-api.spec.ts
@@ -34,7 +34,8 @@ test.describe.parallel('Search Batch Operation Tests', () => {
     }
   });
 
-  test('Search Batch Operations Success', async ({request}) => {
+  //Skipped due to bug 43161: https://github.com/camunda/camunda/issues/43161
+  test.skip('Search Batch Operations Success', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl('/batch-operations/search'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -380,6 +380,7 @@ test.describe('Identity User Flows', () => {
         TEST_GROUP.groupId,
         'Group',
         ['Read'],
+        'Authorization',
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -380,6 +380,7 @@ test.describe('Identity User Flows', () => {
         TEST_GROUP.groupId,
         'Group',
         ['Read'],
+        'Authorization',
       );
     });
 


### PR DESCRIPTION
## Description

- We now have an Audit Log section under Authorizations. When retrying, we need to click the Authorizations section, since the default view is Audit Log.
- Updated json response to fetch the latest changes.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

Successful run [here](https://github.com/camunda/camunda/actions/runs/20740922615).

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
