### PR TITLE
feat: re-introduce `useSourceParentKey` as an ancestor scope resolution instruction

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -120,6 +120,25 @@ public interface ModifyProcessInstanceCommandStep1
       final String sourceElementId, final String targetElementId);
 
   /**
+   * Create a move instruction for the given element ids. The element instances will be determined
+   * at runtime. All source element instances will be terminated and will activate a new one at the
+   * target element id. For multi-instance elements, only the body element will activate a new
+   * element instance.
+   *
+   * <p>This instructs the engine to use the source's direct parent key as the ancestor scope key
+   * for the target element. This is a simpler alternative to {@link
+   * #moveElementsWithInferredAncestor(String, String)} that skips hierarchy traversal and directly
+   * uses the source's parent key. This is useful when source and target elements are siblings
+   * within the same flow scope.
+   *
+   * @param sourceElementId the id of the elements to move
+   * @param targetElementId the id of target element to move to
+   * @return the builder for this command
+   */
+  ModifyProcessInstanceCommandStep3 moveElementsWithSourceParentAsAncestor(
+      final String sourceElementId, final String targetElementId);
+
+  /**
    * Create a move instruction for the given element instance. This source element instance will be
    * terminated and will activate a new one at the target element id. For multi-instance elements,
    * only the body element will activate a new element instance.
@@ -169,6 +188,24 @@ public interface ModifyProcessInstanceCommandStep1
    * @return the builder for this command
    */
   ModifyProcessInstanceCommandStep3 moveElementWithInferredAncestor(
+      final long sourceElementInstanceKey, final String targetElementId);
+
+  /**
+   * Create a move instruction for the given element instance. The source element instance with
+   * given key will be terminated and will activate a new one at the target element id. For
+   * multi-instance elements, only the body element will activate a new element instance.
+   *
+   * <p>This instructs the engine to use the source's direct parent key as the ancestor scope key
+   * for the target element. This is a simpler alternative to {@link
+   * #moveElementWithInferredAncestor(long, String)} that skips hierarchy traversal and directly
+   * uses the source's parent key. This is useful when source and target elements are siblings
+   * within the same flow scope.
+   *
+   * @param sourceElementInstanceKey the key of the element to move
+   * @param targetElementId the id of target element to move to
+   * @return the builder for this command
+   */
+  ModifyProcessInstanceCommandStep3 moveElementWithSourceParentAsAncestor(
       final long sourceElementInstanceKey, final String targetElementId);
 
   interface ModifyProcessInstanceCommandStep2

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -168,6 +168,23 @@ public final class ModifyProcessInstanceCommandImpl
   }
 
   @Override
+  public ModifyProcessInstanceCommandStep3 moveElementsWithSourceParentAsAncestor(
+      final String sourceElementId, final String targetElementId) {
+    return addMoveInstruction(
+        MoveInstruction.newBuilder()
+            .setSourceElementId(sourceElementId)
+            .setTargetElementId(targetElementId)
+            .setUseSourceParentKeyAsAncestorScopeKey(true)
+            .build(),
+        new ProcessInstanceModificationMoveInstruction()
+            .sourceElementInstruction(
+                new SourceElementInstruction().sourceType("byId").sourceElementId(sourceElementId))
+            .targetElementId(targetElementId)
+            .ancestorScopeInstruction(
+                new AncestorScopeInstruction().ancestorScopeType("sourceParent")));
+  }
+
+  @Override
   public ModifyProcessInstanceCommandStep3 moveElement(
       final long sourceElementInstanceKey, final String targetElementId) {
     return moveElement(sourceElementInstanceKey, targetElementId, EMPTY_ANCESTOR_KEY);
@@ -214,6 +231,25 @@ public final class ModifyProcessInstanceCommandImpl
             .targetElementId(targetElementId)
             .ancestorScopeInstruction(
                 new AncestorScopeInstruction().ancestorScopeType("inferred")));
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep3 moveElementWithSourceParentAsAncestor(
+      final long sourceElementInstanceKey, final String targetElementId) {
+    return addMoveInstruction(
+        MoveInstruction.newBuilder()
+            .setSourceElementInstanceKey(sourceElementInstanceKey)
+            .setTargetElementId(targetElementId)
+            .setUseSourceParentKeyAsAncestorScopeKey(true)
+            .build(),
+        new ProcessInstanceModificationMoveInstruction()
+            .sourceElementInstruction(
+                new SourceElementInstruction()
+                    .sourceType("byKey")
+                    .sourceElementInstanceKey(ParseUtil.keyToString(sourceElementInstanceKey)))
+            .targetElementId(targetElementId)
+            .ancestorScopeInstruction(
+                new AncestorScopeInstruction().ancestorScopeType("sourceParent")));
   }
 
   private ModifyProcessInstanceCommandStep3 addActivateInstruction(

--- a/clients/java/src/test/java/io/camunda/client/process/ModifyProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/ModifyProcessInstanceTest.java
@@ -467,6 +467,22 @@ public class ModifyProcessInstanceTest extends ClientTest {
   }
 
   @Test
+  public void shouldMoveElementsWithDirectSourceParentKey() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .moveElementsWithSourceParentAsAncestor(ELEMENT_ID_A, ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 0, 1, 0);
+    final MoveInstruction moveInstruction = request.getMoveInstructions(0);
+    assertMoveInstruction(moveInstruction, ELEMENT_ID_A, ELEMENT_ID_B, 0, false, true, 0);
+  }
+
+  @Test
   public void shouldMoveElementsWithSingleVariable() {
     // when
     client
@@ -589,13 +605,33 @@ public class ModifyProcessInstanceTest extends ClientTest {
       final String expectedSourceElementId,
       final String expectedTargetElementId,
       final long expectedAncestorKey,
-      final boolean expectedUseParentScope,
+      final boolean expectedInferAncestorScope,
+      final int expectedVariableInstructions) {
+    assertMoveInstruction(
+        moveInstruction,
+        expectedSourceElementId,
+        expectedTargetElementId,
+        expectedAncestorKey,
+        expectedInferAncestorScope,
+        false,
+        expectedVariableInstructions);
+  }
+
+  private void assertMoveInstruction(
+      final MoveInstruction moveInstruction,
+      final String expectedSourceElementId,
+      final String expectedTargetElementId,
+      final long expectedAncestorKey,
+      final boolean expectedInferAncestorScope,
+      final boolean expectedUseSourceParentKey,
       final int expectedVariableInstructions) {
     assertThat(moveInstruction.getSourceElementId()).isEqualTo(expectedSourceElementId);
     assertThat(moveInstruction.getTargetElementId()).isEqualTo(expectedTargetElementId);
     assertThat(moveInstruction.getAncestorElementInstanceKey()).isEqualTo(expectedAncestorKey);
     assertThat(moveInstruction.getInferAncestorScopeFromSourceHierarchy())
-        .isEqualTo(expectedUseParentScope);
+        .isEqualTo(expectedInferAncestorScope);
+    assertThat(moveInstruction.getUseSourceParentKeyAsAncestorScopeKey())
+        .isEqualTo(expectedUseSourceParentKey);
     assertThat(moveInstruction.getVariableInstructionsCount())
         .isEqualTo(expectedVariableInstructions);
   }

--- a/gateways/gateway-models/src/main/java/io/camunda/gateway/model/mapper/RequestMapper.java
+++ b/gateways/gateway-models/src/main/java/io/camunda/gateway/model/mapper/RequestMapper.java
@@ -99,6 +99,7 @@ import io.camunda.gateway.protocol.model.SourceElementIdInstruction;
 import io.camunda.gateway.protocol.model.SourceElementInstanceKeyInstruction;
 import io.camunda.gateway.protocol.model.TenantCreateRequest;
 import io.camunda.gateway.protocol.model.TenantUpdateRequest;
+import io.camunda.gateway.protocol.model.UseSourceParentKeyInstruction;
 import io.camunda.gateway.protocol.model.UserRequest;
 import io.camunda.gateway.protocol.model.UserTaskAssignmentRequest;
 import io.camunda.gateway.protocol.model.UserTaskCompletionRequest;
@@ -1288,6 +1289,8 @@ public class RequestMapper {
                 case final DirectAncestorKeyInstruction direct ->
                     mappedInstruction.setAncestorScopeKey(
                         getAncestorKey(direct.getAncestorElementInstanceKey()));
+                case final UseSourceParentKeyInstruction sourceParent ->
+                    mappedInstruction.setUseSourceParentKeyAsAncestorScopeKey(true);
                 default -> mappedInstruction.setInferAncestorScopeFromSourceHierarchy(true);
               }
               instruction.getVariableInstructions().stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -462,10 +462,7 @@ public final class ProcessInstanceModificationModifyProcessor
         if (moveInstructions.containsKey(elementId)) {
           final var moveInstruction = moveInstructions.get(elementId);
           final var ancestorScopeKey =
-              moveInstruction.isInferAncestorScopeFromSourceHierarchy()
-                  ? findProperAncestorScopeKeyForTarget(
-                      elementInstance.getParentKey(), moveInstruction.getTargetElementId(), process)
-                  : moveInstruction.getAncestorScopeKey();
+              determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
           final var activateInstruction =
               new ProcessInstanceModificationActivateInstruction()
                   .setElementId(moveInstruction.getTargetElementId())
@@ -512,10 +509,7 @@ public final class ProcessInstanceModificationModifyProcessor
           elementInstanceState.getInstance(moveInstruction.getSourceElementInstanceKey());
 
       final var ancestorScopeKey =
-          moveInstruction.isInferAncestorScopeFromSourceHierarchy()
-              ? findProperAncestorScopeKeyForTarget(
-                  elementInstance.getParentKey(), moveInstruction.getTargetElementId(), process)
-              : moveInstruction.getAncestorScopeKey();
+          determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
 
       final var activateInstruction =
           new ProcessInstanceModificationActivateInstruction()
@@ -533,6 +527,28 @@ public final class ProcessInstanceModificationModifyProcessor
           new ProcessInstanceModificationTerminateInstruction()
               .setElementId(elementInstance.getValue().getElementId())
               .setElementInstanceKey(moveInstruction.getSourceElementInstanceKey()));
+    }
+  }
+
+  /**
+   * Determines the ancestor scope key for a move instruction based on its configuration.
+   *
+   * @param moveInstruction the move instruction with ancestor scope configuration
+   * @param sourceParentKey the parent key of the source element instance
+   * @param process the deployed process containing the elements
+   * @return the determined ancestor scope key
+   */
+  private long determineAncestorScopeKey(
+      final ProcessInstanceModificationMoveInstructionValue moveInstruction,
+      final long sourceParentKey,
+      final DeployedProcess process) {
+    if (moveInstruction.isUseSourceParentKeyAsAncestorScopeKey()) {
+      return sourceParentKey;
+    } else if (moveInstruction.isInferAncestorScopeFromSourceHierarchy()) {
+      return findProperAncestorScopeKeyForTarget(
+          sourceParentKey, moveInstruction.getTargetElementId(), process);
+    } else {
+      return moveInstruction.getAncestorScopeKey();
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.agrona.DirectBuffer;
 import org.agrona.Strings;
 
@@ -104,6 +105,10 @@ public final class ProcessInstanceModificationModifyProcessor
   private static final String ERROR_MESSAGE_MOVE_SOURCE_ELEMENT_INSTANCE_WRONG_PROCESS =
       "Expected to modify instance of process '%s' but it contains one or more move instructions"
           + " with a source element instance that does not belong to the modified process instance: '%s'";
+  private static final String ERROR_MESSAGE_MOVE_AMBIGUOUS_ANCESTOR_SCOPE =
+      "Expected to modify instance of process '%s' but it contains one or more move instructions"
+          + " with multiple ancestor scope options set. Only one of the following can be specified: "
+          + "ancestorScopeKey, inferAncestorScopeFromSourceHierarchy, or useSourceParentKeyAsAncestorScopeKey: '%s'";
   private static final String ERROR_COMMAND_TOO_LARGE =
       "Unable to modify process instance with key '%d' as the size exceeds the maximum batch size."
           + " Please reduce the size by splitting the modification into multiple commands.";
@@ -711,6 +716,7 @@ public final class ProcessInstanceModificationModifyProcessor
     return validateHasMoveInstructions(moveInstructions, process)
         .flatMap(valid -> validateNoDuplicatedMoveInstructions(moveInstructions, process))
         .flatMap(valid -> validateNoMoveSourceWithBothIdAndInstanceKey(moveInstructions, process))
+        .flatMap(valid -> validateNoAmbiguousAncestorScopeOptions(moveInstructions, process))
         .map(valid -> VALID);
   }
 
@@ -801,6 +807,46 @@ public final class ProcessInstanceModificationModifyProcessor
             BufferUtil.bufferAsString(process.getBpmnProcessId()),
             String.join("', '", duplicateDefinitions));
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+  }
+
+  private Either<Rejection, Object> validateNoAmbiguousAncestorScopeOptions(
+      final List<ProcessInstanceModificationMoveInstructionValue> moveInstructions,
+      final DeployedProcess process) {
+    final var ambiguousInstructions =
+        moveInstructions.stream()
+            .filter(this::hasMultipleAncestorScopeOptionsSet)
+            .map(
+                moveInstruction ->
+                    "(%s, %s)"
+                        .formatted(
+                            moveInstruction.getSourceElementId().isBlank()
+                                ? moveInstruction.getSourceElementInstanceKey()
+                                : moveInstruction.getSourceElementId(),
+                            moveInstruction.getTargetElementId()))
+            .toList();
+
+    if (ambiguousInstructions.isEmpty()) {
+      return VALID;
+    }
+
+    final String reason =
+        String.format(
+            ERROR_MESSAGE_MOVE_AMBIGUOUS_ANCESTOR_SCOPE,
+            BufferUtil.bufferAsString(process.getBpmnProcessId()),
+            String.join("', '", ambiguousInstructions));
+    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+  }
+
+  private boolean hasMultipleAncestorScopeOptionsSet(
+      final ProcessInstanceModificationMoveInstructionValue moveInstruction) {
+    final long ancestorScopeOptionsCount =
+        Stream.of(
+                moveInstruction.getAncestorScopeKey() > 0,
+                moveInstruction.isInferAncestorScopeFromSourceHierarchy(),
+                moveInstruction.isUseSourceParentKeyAsAncestorScopeKey())
+            .filter(b -> b)
+            .count();
+    return ancestorScopeOptionsCount > 1;
   }
 
   private Either<Rejection, ?> validateInstructions(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -456,13 +456,22 @@ public final class ProcessInstanceClient {
               .setTargetElementId(targetElementId));
     }
 
-    public MoveInstructionBuilder moveElementsWithSourceParent(
+    public MoveInstructionBuilder moveElementsWithInferredScope(
         final String sourceElementId, final String targetElementId) {
       return moveElements(
           new ProcessInstanceModificationMoveInstruction()
               .setSourceElementId(sourceElementId)
               .setTargetElementId(targetElementId)
               .setInferAncestorScopeFromSourceHierarchy(true));
+    }
+
+    public MoveInstructionBuilder moveElementsWithSourceParentScope(
+        final String sourceElementId, final String targetElementId) {
+      return moveElements(
+          new ProcessInstanceModificationMoveInstruction()
+              .setSourceElementId(sourceElementId)
+              .setTargetElementId(targetElementId)
+              .setUseSourceParentKeyAsAncestorScopeKey(true));
     }
 
     public MoveInstructionBuilder moveElements(
@@ -497,13 +506,30 @@ public final class ProcessInstanceClient {
      * @param targetElementId the id of the target element to activate
      * @return this MoveInstruction builder for chaining
      */
-    public MoveInstructionBuilder moveElementInstanceWithSourceParent(
+    public MoveInstructionBuilder moveElementInstanceWithInferredScope(
         final long sourceElementInstanceKey, final String targetElementId) {
       return moveElements(
           new ProcessInstanceModificationMoveInstruction()
               .setSourceElementInstanceKey(sourceElementInstanceKey)
               .setTargetElementId(targetElementId)
               .setInferAncestorScopeFromSourceHierarchy(true));
+    }
+
+    /**
+     * Add a move element instance instruction by source element instance key, using the source's
+     * direct parent key as ancestor scope.
+     *
+     * @param sourceElementInstanceKey the key of the element instance to move
+     * @param targetElementId the id of the target element to activate
+     * @return this MoveInstruction builder for chaining
+     */
+    public MoveInstructionBuilder moveElementInstanceWithSourceParentScope(
+        final long sourceElementInstanceKey, final String targetElementId) {
+      return moveElements(
+          new ProcessInstanceModificationMoveInstruction()
+              .setSourceElementInstanceKey(sourceElementInstanceKey)
+              .setTargetElementId(targetElementId)
+              .setUseSourceParentKeyAsAncestorScopeKey(true));
     }
 
     /**

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -60,6 +60,9 @@
                 },
                 "inferAncestorScopeFromSourceHierarchy": {
                   "type": "boolean"
+                },
+                "useSourceParentKeyAsAncestorScopeKey": {
+                  "type": "boolean"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -60,6 +60,9 @@
                 },
                 "inferAncestorScopeFromSourceHierarchy": {
                   "type": "boolean"
+                },
+                "useSourceParentKeyAsAncestorScopeKey": {
+                  "type": "boolean"
                 }
               }
             },

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -806,6 +806,10 @@ message ModifyProcessInstanceRequest {
     // whether to use the source element hierarchy to infer the ancestor element
     // instance key
     bool inferAncestorScopeFromSourceHierarchy = 6;
+    // whether to use the source's direct parent key as the ancestor scope key;
+    // this is a simpler alternative to inferAncestorScopeFromSourceHierarchy
+    // that skips hierarchy traversal and directly uses the source's parent key
+    bool useSourceParentKeyAsAncestorScopeKey = 7;
   }
 }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1499,9 +1499,11 @@ components:
         mapping:
           direct: '#/components/schemas/DirectAncestorKeyInstruction'
           inferred: '#/components/schemas/InferredAncestorKeyInstruction'
+          sourceParent: '#/components/schemas/UseSourceParentKeyInstruction'
       oneOf:
         - $ref: "#/components/schemas/DirectAncestorKeyInstruction"
         - $ref: "#/components/schemas/InferredAncestorKeyInstruction"
+        - $ref: "#/components/schemas/UseSourceParentKeyInstruction"
 
     DirectAncestorKeyInstruction:
       type: object
@@ -1534,6 +1536,18 @@ components:
           description: The type of ancestor scope instruction.
           type: string
           example: inferred
+      required:
+        - ancestorScopeType
+
+    UseSourceParentKeyInstruction:
+      type: object
+      description: |
+        Instructs the engine to use the source's direct parent key as the ancestor scope key for the target element. This is a simpler alternative to `inferred` that skips hierarchy traversal and directly uses the source's parent key. This is useful when the source and target elements are siblings within the same flow scope.
+      properties:
+        ancestorScopeType:
+          description: The type of ancestor scope instruction.
+          type: string
+          example: sourceParent
       required:
         - ancestorScopeType
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -117,6 +117,7 @@ class RequestMapperTest {
               assertThat(instruction.getTargetElementId()).isEqualTo("target1");
               assertThat(instruction.getAncestorScopeKey()).isEqualTo(-1L);
               assertThat(instruction.isInferAncestorScopeFromSourceHierarchy()).isTrue();
+              assertThat(instruction.isUseSourceParentKeyAsAncestorScopeKey()).isFalse();
               assertThat(instruction.getVariableInstructions()).isEmpty();
             });
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -976,6 +976,11 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                     .setAncestorScopeKey(-1L)
                     .setInferAncestorScopeFromSourceHierarchy(true),
                 new ProcessInstanceModificationMoveInstruction()
+                    .setSourceElementId("sourceElementId4b")
+                    .setTargetElementId("targetElementId4b")
+                    .setAncestorScopeKey(-1L)
+                    .setUseSourceParentKeyAsAncestorScopeKey(true),
+                new ProcessInstanceModificationMoveInstruction()
                     .setSourceElementId("sourceElementId5")
                     .setTargetElementId("targetElementId5")
                     .setAncestorScopeKey(-1L)
@@ -1097,6 +1102,16 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                   "targetElementId": "targetElementId4",
                   "ancestorScopeInstruction": {
                     "ancestorScopeType": "inferred"
+                  }
+                },
+                {
+                  "sourceElementInstruction": {
+                    "sourceType": "byId",
+                    "sourceElementId": "sourceElementId4b"
+                  },
+                  "targetElementId": "targetElementId4b",
+                  "ancestorScopeInstruction": {
+                    "ancestorScopeType": "sourceParent"
                   }
                 },
                 {
@@ -1517,7 +1532,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                 "title":"Bad Request",
                 "status":400,
                 "detail": "Cannot map value 'unknown' for type 'ancestorScopeInstruction'. \
-            Use any of the following values: [direct, inferred]",
+            Use any of the following values: [direct, inferred, sourceParent]",
                 "instance":"/v2/process-instances/1/modification"
              }""";
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerModifyProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerModifyProcessInstanceRequest.java
@@ -101,7 +101,9 @@ public final class BrokerModifyProcessInstanceRequest
                       .setTargetElementId(moveInstruction.getTargetElementId())
                       .setAncestorScopeKey(moveInstruction.getAncestorElementInstanceKey())
                       .setInferAncestorScopeFromSourceHierarchy(
-                          moveInstruction.getInferAncestorScopeFromSourceHierarchy());
+                          moveInstruction.getInferAncestorScopeFromSourceHierarchy())
+                      .setUseSourceParentKeyAsAncestorScopeKey(
+                          moveInstruction.getUseSourceParentKeyAsAncestorScopeKey());
               moveInstruction.getVariableInstructionsList().stream()
                   .map(this::mapVariableInstruction)
                   .forEach(mappedInstruction::addVariableInstruction);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationMoveInstruction.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationMoveInstruction.java
@@ -39,15 +39,18 @@ public final class ProcessInstanceModificationMoveInstruction extends ObjectValu
   private final LongProperty ancestorScopeKeyProperty = new LongProperty("ancestorScopeKey", -1);
   private final BooleanProperty inferAncestorScopeFromSourceHierarchy =
       new BooleanProperty("inferAncestorScopeFromSourceHierarchy", false);
+  private final BooleanProperty useSourceParentKeyAsAncestorScopeKey =
+      new BooleanProperty("useSourceParentKeyAsAncestorScopeKey", false);
 
   public ProcessInstanceModificationMoveInstruction() {
-    super(6);
+    super(7);
     declareProperty(sourceElementIdProperty)
         .declareProperty(sourceElementInstanceKeyProperty)
         .declareProperty(targetElementIdProperty)
         .declareProperty(variableInstructionsProperty)
         .declareProperty(ancestorScopeKeyProperty)
-        .declareProperty(inferAncestorScopeFromSourceHierarchy);
+        .declareProperty(inferAncestorScopeFromSourceHierarchy)
+        .declareProperty(useSourceParentKeyAsAncestorScopeKey);
   }
 
   @Override
@@ -105,6 +108,17 @@ public final class ProcessInstanceModificationMoveInstruction extends ObjectValu
     return this;
   }
 
+  @Override
+  public boolean isUseSourceParentKeyAsAncestorScopeKey() {
+    return useSourceParentKeyAsAncestorScopeKey.getValue();
+  }
+
+  public ProcessInstanceModificationMoveInstruction setUseSourceParentKeyAsAncestorScopeKey(
+      final boolean useSourceParentKey) {
+    useSourceParentKeyAsAncestorScopeKey.setValue(useSourceParentKey);
+    return this;
+  }
+
   public ProcessInstanceModificationMoveInstruction setTargetElementId(
       final String targetElementId) {
     targetElementIdProperty.setValue(targetElementId);
@@ -155,6 +169,7 @@ public final class ProcessInstanceModificationMoveInstruction extends ObjectValu
         .forEach(this::addVariableInstruction);
     setAncestorScopeKey(object.getAncestorScopeKey());
     setInferAncestorScopeFromSourceHierarchy(object.isInferAncestorScopeFromSourceHierarchy());
+    setUseSourceParentKeyAsAncestorScopeKey(object.isUseSourceParentKeyAsAncestorScopeKey());
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1833,7 +1833,8 @@ final class JsonSerializableToJsonTest {
                       }
                     }],
                     "ancestorScopeKey": 3,
-                    "inferAncestorScopeFromSourceHierarchy": true
+                    "inferAncestorScopeFromSourceHierarchy": true,
+                    "useSourceParentKeyAsAncestorScopeKey": false
                   }],
                   "activateInstructions": [{
                     "ancestorScopeKey": 3,
@@ -3779,11 +3780,12 @@ final class JsonSerializableToJsonTest {
                            }
                          }],
                          "ancestorScopeKey": 55555,
-                         "inferAncestorScopeFromSourceHierarchy": true
+                         "inferAncestorScopeFromSourceHierarchy": true,
+                         "useSourceParentKeyAsAncestorScopeKey": false
                        }
                      ],
                      "empty": false,
-                     "encodedLength": 226
+                     "encodedLength": 265
                    },
                    "authenticationBuffer": {
                      "expandable": false

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationMoveInstruction.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationMoveInstruction.golden
@@ -39,15 +39,18 @@ public final class ProcessInstanceModificationMoveInstruction extends ObjectValu
   private final LongProperty ancestorScopeKeyProperty = new LongProperty("ancestorScopeKey", -1);
   private final BooleanProperty inferAncestorScopeFromSourceHierarchy =
       new BooleanProperty("inferAncestorScopeFromSourceHierarchy", false);
+  private final BooleanProperty useSourceParentKeyAsAncestorScopeKey =
+      new BooleanProperty("useSourceParentKeyAsAncestorScopeKey", false);
 
   public ProcessInstanceModificationMoveInstruction() {
-    super(6);
+    super(7);
     declareProperty(sourceElementIdProperty)
         .declareProperty(sourceElementInstanceKeyProperty)
         .declareProperty(targetElementIdProperty)
         .declareProperty(variableInstructionsProperty)
         .declareProperty(ancestorScopeKeyProperty)
-        .declareProperty(inferAncestorScopeFromSourceHierarchy);
+        .declareProperty(inferAncestorScopeFromSourceHierarchy)
+        .declareProperty(useSourceParentKeyAsAncestorScopeKey);
   }
 
   @Override
@@ -105,6 +108,17 @@ public final class ProcessInstanceModificationMoveInstruction extends ObjectValu
     return this;
   }
 
+  @Override
+  public boolean isUseSourceParentKeyAsAncestorScopeKey() {
+    return useSourceParentKeyAsAncestorScopeKey.getValue();
+  }
+
+  public ProcessInstanceModificationMoveInstruction setUseSourceParentKeyAsAncestorScopeKey(
+      final boolean useSourceParentKey) {
+    useSourceParentKeyAsAncestorScopeKey.setValue(useSourceParentKey);
+    return this;
+  }
+
   public ProcessInstanceModificationMoveInstruction setTargetElementId(
       final String targetElementId) {
     targetElementIdProperty.setValue(targetElementId);
@@ -155,6 +169,7 @@ public final class ProcessInstanceModificationMoveInstruction extends ObjectValu
         .forEach(this::addVariableInstruction);
     setAncestorScopeKey(object.getAncestorScopeKey());
     setInferAncestorScopeFromSourceHierarchy(object.isInferAncestorScopeFromSourceHierarchy());
+    setUseSourceParentKeyAsAncestorScopeKey(object.isUseSourceParentKeyAsAncestorScopeKey());
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -151,5 +151,13 @@ public interface ProcessInstanceModificationRecordValue
      * hierarchy.
      */
     boolean isInferAncestorScopeFromSourceHierarchy();
+
+    /**
+     * Indicates whether the source's direct parent key should be used as the ancestor scope key for
+     * the target element. This is a simpler alternative to {@link
+     * #isInferAncestorScopeFromSourceHierarchy()} that skips hierarchy traversal and directly uses
+     * the source's parent key.
+     */
+    boolean isUseSourceParentKeyAsAncestorScopeKey();
   }
 }


### PR DESCRIPTION
## Description

This PR reintroduces `UseSourceParentKeyAsAncestorScopeKey` as an `AncestorScopeInstruction` option for move instructions in process instance modification.

When moving elements between flow scopes, the engine needs to determine the correct ancestor scope key for the target element. Currently, we support:
- **Direct**: Explicitly specifying an `ancestorElementInstanceKey`
- **Inferred**: Using `inferAncestorScopeFromSourceHierarchy` to traverse the source element's ancestry and find a matching flow scope

This PR adds a third option:
- **Source Parent**: Using the source's direct parent key as the ancestor scope key (`useSourceParentKeyAsAncestorScopeKey`)

### Why is this useful?

The `inferAncestorScopeFromSourceHierarchy` option requires inspecting the process model to find the hierarchy, which could be costly if the model is not in cache. 

For certain use cases—specifically batch operations (move) or a single `moveAll` instruction—it makes sense to simply use the source's direct parent key as the ancestor scope key. This is particularly useful when the front-end can infer that the source and target elements are siblings within the same flow scope, avoiding unnecessary hierarchy traversal.

## Usage

### REST API

```json
{
  "moveInstructions": [{
    "sourceElementInstruction": {
      "sourceType": "byId",
      "sourceElementId": "taskA"
    },
    "targetElementId": "taskB",
    "ancestorScopeInstruction": {
      "ancestorScopeType": "sourceParent"
    }
  }]
}
```

### Java Client

```java
client.newModifyProcessInstanceCommand(processInstanceKey)
    .moveElementsWithSourceParentAsAncestor("taskA", "taskB")
    .send()
    .join();
```

### gRPC

```protobuf
MoveInstruction {
  sourceElementId: "taskA"
  targetElementId: "taskB"
  useSourceParentKeyAsAncestorScopeKey: true
}
```

## Related issues

closes #42814
