### PR TITLE
feat: export rootProcessInstanceKey from PI records to ES/OS

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
@@ -543,14 +543,9 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
       final OperationType operationType,
       final String batchOperationId) {
     final ProcessInstanceSource processInstanceSource =
-        new ProcessInstanceSource().setProcessInstanceKey(processInstanceKey);
-    final Optional<ProcessInstanceForListViewEntity> optionalProcessInstance =
-        tryGetProcessInstance(processInstanceKey);
-    optionalProcessInstance.ifPresent(
-        processInstance ->
-            processInstanceSource
-                .setProcessDefinitionKey(processInstance.getProcessDefinitionKey())
-                .setBpmnProcessId(processInstance.getBpmnProcessId()));
+        tryGetProcessInstance(processInstanceKey)
+            .map(ProcessInstanceSource::fromProcessInstanceForListViewEntity)
+            .orElseGet(() -> new ProcessInstanceSource(processInstanceKey, null, null, null));
 
     return createOperationEntity(processInstanceSource, operationType, batchOperationId);
   }
@@ -569,7 +564,8 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
         .setState(OperationState.SCHEDULED)
         .setBatchOperationId(batchOperationId)
         .setUsername(
-            camundaAuthenticationProvider.getCamundaAuthentication().authenticatedUsername());
+            camundaAuthenticationProvider.getCamundaAuthentication().authenticatedUsername())
+        .setRootProcessInstanceKey(processInstanceSource.getRootProcessInstanceKey());
   }
 
   private void validateTotalHits(final SearchHits hits) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -521,14 +521,9 @@ public class OpensearchBatchOperationWriter
       final OperationType operationType,
       final String batchOperationId) {
     final ProcessInstanceSource processInstanceSource =
-        new ProcessInstanceSource().setProcessInstanceKey(processInstanceKey);
-    final Optional<ProcessInstanceForListViewEntity> optionalProcessInstance =
-        tryGetProcessInstance(processInstanceKey);
-    optionalProcessInstance.ifPresent(
-        processInstance ->
-            processInstanceSource
-                .setProcessDefinitionKey(processInstance.getProcessDefinitionKey())
-                .setBpmnProcessId(processInstance.getBpmnProcessId()));
+        tryGetProcessInstance(processInstanceKey)
+            .map(ProcessInstanceSource::fromProcessInstanceForListViewEntity)
+            .orElseGet(() -> new ProcessInstanceSource(processInstanceKey, null, null, null));
 
     return createOperationEntity(processInstanceSource, operationType, batchOperationId);
   }
@@ -547,7 +542,8 @@ public class OpensearchBatchOperationWriter
         .setState(OperationState.SCHEDULED)
         .setBatchOperationId(batchOperationId)
         .setUsername(
-            camundaAuthenticationProvider.getCamundaAuthentication().authenticatedUsername());
+            camundaAuthenticationProvider.getCamundaAuthentication().authenticatedUsername())
+        .setRootProcessInstanceKey(processInstanceSource.getRootProcessInstanceKey());
   }
 
   private Optional<ProcessInstanceForListViewEntity> tryGetProcessInstance(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
@@ -170,7 +170,8 @@ public class PersistOperationHelper {
             .setState(OperationState.SCHEDULED)
             .setBatchOperationId(batchOperationId)
             .setUsername(
-                camundaAuthenticationProvider.getCamundaAuthentication().authenticatedUsername());
+                camundaAuthenticationProvider.getCamundaAuthentication().authenticatedUsername())
+            .setRootProcessInstanceKey(processInstanceSource.getRootProcessInstanceKey());
 
     return operationEntity;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/ProcessInstanceSource.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/ProcessInstanceSource.java
@@ -8,68 +8,45 @@
 package io.camunda.operate.webapp.writer;
 
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import java.util.Map;
-import java.util.Objects;
 
-public class ProcessInstanceSource {
-  private Long processInstanceKey;
-  private Long processDefinitionKey;
-  private String bpmnProcessId;
+public record ProcessInstanceSource(
+    Long processInstanceKey,
+    Long processDefinitionKey,
+    String bpmnProcessId,
+    Long rootProcessInstanceKey) {
 
   public static ProcessInstanceSource fromSourceMap(final Map<String, Object> sourceMap) {
-    final ProcessInstanceSource processInstanceSource = new ProcessInstanceSource();
-    processInstanceSource.setProcessInstanceKey(
-        (Long) sourceMap.get(OperationTemplate.PROCESS_INSTANCE_KEY));
-    processInstanceSource.setProcessDefinitionKey(
-        (Long) sourceMap.get(OperationTemplate.PROCESS_DEFINITION_KEY));
-    processInstanceSource.setBpmnProcessId(
-        (String) sourceMap.get(OperationTemplate.BPMN_PROCESS_ID));
-    return processInstanceSource;
+    return new ProcessInstanceSource(
+        (Long) sourceMap.get(OperationTemplate.PROCESS_INSTANCE_KEY),
+        (Long) sourceMap.get(OperationTemplate.PROCESS_DEFINITION_KEY),
+        (String) sourceMap.get(OperationTemplate.BPMN_PROCESS_ID),
+        (Long) sourceMap.get(OperationTemplate.ROOT_PROCESS_INSTANCE_KEY));
+  }
+
+  public static ProcessInstanceSource fromProcessInstanceForListViewEntity(
+      final ProcessInstanceForListViewEntity source) {
+    return new ProcessInstanceSource(
+        source.getProcessInstanceKey(),
+        source.getProcessDefinitionKey(),
+        source.getBpmnProcessId(),
+        source.getRootProcessInstanceKey());
   }
 
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }
 
-  public ProcessInstanceSource setProcessInstanceKey(final Long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-    return this;
-  }
-
   public Long getProcessDefinitionKey() {
     return processDefinitionKey;
-  }
-
-  public ProcessInstanceSource setProcessDefinitionKey(final Long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-    return this;
   }
 
   public String getBpmnProcessId() {
     return bpmnProcessId;
   }
 
-  public ProcessInstanceSource setBpmnProcessId(final String bpmnProcessId) {
-    this.bpmnProcessId = bpmnProcessId;
-    return this;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(processInstanceKey, processDefinitionKey, bpmnProcessId);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ProcessInstanceSource that = (ProcessInstanceSource) o;
-    return Objects.equals(processInstanceKey, that.processInstanceKey)
-        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
-        && Objects.equals(bpmnProcessId, that.bpmnProcessId);
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
@@ -57,6 +57,7 @@ public class ListViewTemplate extends AbstractTemplateDescriptor implements Prio
       "activity"; // now we call it flow node instance
   public static final String VARIABLES_JOIN_RELATION = "variable";
   public static final String TAGS = "tags";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   public ListViewTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/FlowNodeInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/FlowNodeInstanceForListViewEntity.java
@@ -8,10 +8,12 @@
 package io.camunda.webapps.schema.entities.listview;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -50,6 +52,11 @@ public class FlowNodeInstanceForListViewEntity
 
   @JsonIgnore private Long startTime;
   @JsonIgnore private Long endTime;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long rootProcessInstanceKey;
 
   @Override
   public String getId() {
@@ -230,6 +237,16 @@ public class FlowNodeInstanceForListViewEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public FlowNodeInstanceForListViewEntity setRootProcessInstanceKey(
+      final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -247,7 +264,8 @@ public class FlowNodeInstanceForListViewEntity
         position,
         positionIncident,
         positionJob,
-        joinRelation);
+        joinRelation,
+        rootProcessInstanceKey);
   }
 
   @Override
@@ -265,6 +283,7 @@ public class FlowNodeInstanceForListViewEntity
         && incident == that.incident
         && jobFailedWithRetriesLeft == that.jobFailedWithRetriesLeft
         && Objects.equals(processInstanceKey, that.processInstanceKey)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
         && Objects.equals(activityId, that.activityId)
         && activityState == that.activityState
         && activityType == that.activityType

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -10,9 +10,11 @@ package io.camunda.webapps.schema.entities.listview;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -56,6 +58,11 @@ public class ProcessInstanceForListViewEntity
 
   @BeforeVersion880 private Long position;
   @BeforeVersion880 private Set<String> tags;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long rootProcessInstanceKey;
 
   @JsonIgnore private Object[] sortValues;
 
@@ -265,6 +272,16 @@ public class ProcessInstanceForListViewEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public ProcessInstanceForListViewEntity setRootProcessInstanceKey(
+      final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -287,7 +304,8 @@ public class ProcessInstanceForListViewEntity
         tenantId,
         joinRelation,
         position,
-        tags);
+        tags,
+        rootProcessInstanceKey);
   }
 
   @Override
@@ -304,6 +322,7 @@ public class ProcessInstanceForListViewEntity
         && partitionId == that.partitionId
         && incident == that.incident
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
         && Objects.equals(processName, that.processName)
         && Objects.equals(processVersion, that.processVersion)
         && Objects.equals(processVersionTag, that.processVersionTag)

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskProcessInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskProcessInstanceEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -30,6 +31,11 @@ public class TaskProcessInstanceEntity
   @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long rootProcessInstanceKey;
 
   public TaskProcessInstanceEntity() {}
 
@@ -83,9 +89,18 @@ public class TaskProcessInstanceEntity
     return this;
   }
 
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public TaskProcessInstanceEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(id, tenantId, partitionId, processInstanceId, join);
+    return Objects.hash(id, tenantId, partitionId, processInstanceId, join, rootProcessInstanceKey);
   }
 
   @Override
@@ -94,6 +109,7 @@ public class TaskProcessInstanceEntity
       return false;
     }
     return partitionId == that.partitionId
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
         && Objects.equals(id, that.id)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(processInstanceId, that.processInstanceId)

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -142,6 +142,9 @@
       },
       "tags": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
@@ -142,6 +142,9 @@
       },
       "tags": {
         "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
       }
 		}
 	}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
@@ -27,5 +27,9 @@ public class ProcessInstanceCancelAuditLogTransformer
     log.setProcessDefinitionId(record.getValue().getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessInstanceKey(value.getProcessInstanceKey());
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformerTest.java
@@ -61,5 +61,8 @@ class ProcessInstanceCancelAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(123L);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(234L);
     assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -135,6 +135,10 @@ public class FlowNodeInstanceFromProcessInstanceHandler
             recordValue.getBpmnElementType() == null
                 ? null
                 : recordValue.getBpmnElementType().name()));
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
@@ -113,8 +113,12 @@ public class ListViewFlowNodeFromProcessInstanceHandler
                 : recordValue.getBpmnElementType().name()));
 
     // set parent
-    final Long processInstanceKey = recordValue.getProcessInstanceKey();
+    final long processInstanceKey = recordValue.getProcessInstanceKey();
     entity.getJoinRelation().setParent(processInstanceKey);
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -145,6 +145,10 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
           .setParentProcessInstanceKey(recordValue.getParentProcessInstanceKey())
           .setParentFlowNodeInstanceKey(recordValue.getParentElementInstanceKey());
     }
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      piEntity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -64,6 +64,10 @@ public class SequenceFlowDeletedHandler
         .setBpmnProcessId(recordValue.getBpmnProcessId())
         .setActivityId(recordValue.getElementId())
         .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -63,6 +63,10 @@ public class SequenceFlowHandler
         .setBpmnProcessId(recordValue.getBpmnProcessId())
         .setActivityId(recordValue.getElementId())
         .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -64,6 +64,10 @@ public class UserTaskProcessInstanceHandler
     join.setName(TaskJoinRelationshipType.PROCESS.getType());
 
     entity.setJoin(join);
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
@@ -87,6 +87,10 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
         .setType(getRelevantOperationType())
         .setItemKey(getItemKey(record))
         .setProcessInstanceKey(getProcessInstanceKey(record));
+    final var rootProcessInstanceKey = getRootProcessInstanceKey(record);
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
 
     if (isCompleted(record)) {
       entity.setState(OperationState.COMPLETED);
@@ -117,6 +121,8 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
     batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
     LOGGER.trace("Updated operation {} with fields {}", entity.getId(), updateFields);
   }
+
+  abstract long getRootProcessInstanceKey(final Record<R> record);
 
   /**
    * Extract the operation itemKey from the record.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
@@ -41,6 +41,11 @@ public class ProcessInstanceCancellationOperationHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
   long getItemKey(final Record<ProcessInstanceRecordValue> record) {
     return record.getValue().getProcessInstanceKey();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
@@ -35,6 +35,12 @@ public class ProcessInstanceMigrationOperationHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return -1; // TODO implement when available in the record
+    // https://github.com/camunda/camunda/pull/43315
+  }
+
+  @Override
   long getItemKey(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getValue().getProcessInstanceKey();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
@@ -40,6 +40,12 @@ public class ProcessInstanceModificationOperationHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
+    return -1; // TODO implement when available in the record
+    // https://github.com/camunda/camunda/pull/43315
+  }
+
+  @Override
   long getItemKey(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getValue().getProcessInstanceKey();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
@@ -30,6 +30,12 @@ public class ResolveIncidentOperationHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<IncidentRecordValue> record) {
+    return -1; // TODO implement when available in the record
+    // https://github.com/camunda/camunda/pull/43320
+  }
+
+  @Override
   long getItemKey(final Record<IncidentRecordValue> record) {
     return record.getKey();
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
@@ -254,6 +254,9 @@ public class ListViewFlowNodeFromProcessInstanceHandlerTest {
         .isEqualTo(
             new ListViewJoinRelation(ListViewTemplate.ACTIVITIES_JOIN_RELATION)
                 .setParent(processInstanceRecordValue.getProcessInstanceKey()));
+    assertThat(flowNodeInstanceForListViewEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(processInstanceRecordValue.getRootProcessInstanceKey());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -291,6 +291,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
         .isEqualTo(new ListViewJoinRelation(ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION));
     assertThat(processInstanceForListViewEntity.getTreePath()).isEqualTo("PI_111");
     assertThat(processInstanceForListViewEntity.getTags()).isEqualTo(Set.of("tag1", "tag2"));
+    assertThat(processInstanceForListViewEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(processInstanceRecordValue.getRootProcessInstanceKey());
 
     // process name and version tag is read from the cache
     assertThat(processInstanceForListViewEntity.getProcessName()).isEqualTo("test-process-name");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -150,5 +150,8 @@ public class SequenceFlowDeletedHandlerTest {
         .isEqualTo(processInstanceRecordValue.getElementId());
     assertThat(sequenceFlowEntity.getTenantId())
         .isEqualTo(processInstanceRecordValue.getTenantId());
+    assertThat(sequenceFlowEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(processInstanceRecordValue.getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
@@ -148,5 +148,8 @@ public class SequenceFlowHandlerTest {
         .isEqualTo(processInstanceRecordValue.getElementId());
     assertThat(sequenceFlowEntity.getTenantId())
         .isEqualTo(processInstanceRecordValue.getTenantId());
+    assertThat(sequenceFlowEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(processInstanceRecordValue.getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
@@ -158,5 +158,8 @@ public class UserTaskProcessInstanceHandlerTest {
     assertThat(processInstanceEntity.getJoin()).isNotNull();
     assertThat(processInstanceEntity.getJoin().getName())
         .isEqualTo(TaskJoinRelationshipType.PROCESS.getType());
+    assertThat(processInstanceEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(processInstanceRecord.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -39,8 +39,12 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 class BatchOperationStatusHandlerTest {
@@ -409,6 +413,32 @@ class BatchOperationStatusHandlerTest {
                           .build())
                   .withIntent(ProcessInstanceIntent.CANCEL)
                   .withBatchOperationReference(batchOperationKey));
+    }
+
+    @ParameterizedTest
+    @MethodSource("recordProviderStream")
+    void shouldUpdateEntitySetRootProcessInstanceKey(
+        final Function<
+                ProcessInstanceCancellationOperationHandlerTest, Record<ProcessInstanceRecordValue>>
+            recordProvider) {
+      final var record = recordProvider.apply(this);
+      final var entity = new OperationEntity();
+
+      handler.updateEntity(record, entity);
+
+      assertThat(entity.getRootProcessInstanceKey())
+          .isPositive()
+          .isEqualTo(record.getValue().getRootProcessInstanceKey());
+    }
+
+    static Stream<
+            Function<
+                ProcessInstanceCancellationOperationHandlerTest,
+                Record<ProcessInstanceRecordValue>>>
+        recordProviderStream() {
+      return Stream.of(
+          ProcessInstanceCancellationOperationHandlerTest::createSuccessRecord,
+          ProcessInstanceCancellationOperationHandlerTest::createFailureRecord);
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updated exporter handlers to populate the `rootProcessInstanceKey` in ES/OS secondary storage entities from process instance records when available.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41658 
