### PR TITLE
feat: add batch process instance deletion to CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -30,6 +30,13 @@ public interface CreateBatchOperationCommandStep1 {
   CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceCancel();
 
   /**
+   * Defines the type of the batch operation to delete process instances.
+   *
+   * @return the builder for this command
+   */
+  CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceDelete();
+
+  /**
    * Defines the type of the batch operation to resolve incidents.
    *
    * @return the builder for this command

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -37,6 +37,7 @@ import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceCancellationBatchOperationRequest;
+import io.camunda.client.protocol.rest.ProcessInstanceDeletionBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceIncidentResolutionBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
@@ -131,6 +132,8 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
     switch (type) {
       case CANCEL_PROCESS_INSTANCE:
         return "/process-instances/cancellation";
+      case DELETE_PROCESS_INSTANCE:
+        return "/process-instances/deletion";
       case RESOLVE_INCIDENT:
         return "/process-instances/incident-resolution";
       case MIGRATE_PROCESS_INSTANCE:
@@ -154,6 +157,9 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
             .moveInstructions(moveInstructions);
       case CANCEL_PROCESS_INSTANCE:
         return new ProcessInstanceCancellationBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter));
+      case DELETE_PROCESS_INSTANCE:
+        return new ProcessInstanceDeletionBatchOperationRequest()
             .filter(provideSearchRequestProperty(filter));
       case RESOLVE_INCIDENT:
         return new ProcessInstanceIncidentResolutionBatchOperationRequest()
@@ -212,6 +218,15 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
           httpClient,
           jsonMapper,
           BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE,
+          SearchRequestBuilders::processInstanceFilter);
+    }
+
+    @Override
+    public CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceDelete() {
+      return new CreateBatchOperationCommandImpl<>(
+          httpClient,
+          jsonMapper,
+          BatchOperationTypeEnum.DELETE_PROCESS_INSTANCE,
           SearchRequestBuilders::processInstanceFilter);
     }
 

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -67,6 +67,8 @@ public class RestGatewayPaths {
   private static final String URL_PROCESS_INSTANCES = REST_API_PATH + "/process-instances";
   private static final String URL_PROCESS_INSTANCES_CANCELLATION =
       REST_API_PATH + "/process-instances/cancellation";
+  private static final String URL_PROCESS_INSTANCES_DELETION =
+      REST_API_PATH + "/process-instances/deletion";
   private static final String URL_PROCESS_INSTANCES_INCIDENT_RESOLUTION =
       REST_API_PATH + "/process-instances/incident-resolution";
   private static final String URL_PROCESS_INSTANCES_MIGRATION =
@@ -275,6 +277,10 @@ public class RestGatewayPaths {
 
   public static String getProcessInstancesCancelUrl() {
     return URL_PROCESS_INSTANCES_CANCELLATION;
+  }
+
+  public static String getProcessInstancesDeletionUrl() {
+    return URL_PROCESS_INSTANCES_DELETION;
   }
 
   public static String getProcessInstancesIncidentResolutionUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -266,6 +266,10 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getProcessInstancesCancelUrl(), response);
   }
 
+  public void onDeleteProcessInstancesRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesDeletionUrl(), response);
+  }
+
   public void onResolveIncidentsRequest(final BatchOperationCreatedResult response) {
     registerPost(RestGatewayPaths.getProcessInstancesIncidentResolutionUrl(), response);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationDeleteProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationDeleteProcessInstanceIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.getScopedVariables;
+import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static io.camunda.it.util.TestHelper.waitForProcessInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.HistoryDeletion;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchOperationDeleteProcessInstanceIT {
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withDataConfig(
+              config -> {
+                final var historyDeletionConfig = new HistoryDeletion();
+                historyDeletionConfig.setDelayBetweenRuns(Duration.ofMillis(100));
+                historyDeletionConfig.setMaxDelayBetweenRuns(Duration.ofMillis(100));
+                config.setHistoryDeletion(historyDeletionConfig);
+              });
+
+  private static CamundaClient camundaClient;
+  String testScopeId;
+  final String processName = "processA";
+
+  @BeforeEach
+  public void beforeEach(final TestInfo testInfo) {
+    Objects.requireNonNull(camundaClient);
+    testScopeId =
+        testInfo.getTestMethod().map(Method::toString).orElse(UUID.randomUUID().toString());
+
+    deployProcessAndWaitForIt(
+        camundaClient,
+        Bpmn.createExecutableProcess(processName).startEvent().endEvent().done(),
+        processName + ".bpmn");
+    startScopedProcessInstance(camundaClient, processName, testScopeId);
+    startScopedProcessInstance(camundaClient, processName, testScopeId);
+
+    waitForProcessInstancesToBeCompleted(camundaClient, 2);
+  }
+
+  @Test
+  void shouldDeleteProcessInstancesWithBatch() {
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceDelete()
+            .filter(f -> f.variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    final var batchOperationKey = result.getBatchOperationKey();
+
+    // and check that batch operation has been created with correct operation count
+    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 2);
+
+    // and check that process instances have been deleted
+    waitForProcessInstances(camundaClient, f -> f.variables(getScopedVariables(testScopeId)), 0);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -608,6 +608,24 @@ public final class TestHelper {
             });
   }
 
+  public static void waitForProcessInstancesToBeCompleted(
+      final CamundaClient camundaClient, final int expectedCount) {
+    Awaitility.await("should wait until process instances are completed")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newProcessInstanceSearchRequest()
+                      .filter(f -> f.state(ProcessInstanceState.COMPLETED))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(result).hasSize(expectedCount);
+            });
+  }
+
   public static void waitForProcessInstance(
       final CamundaClient client,
       final Consumer<ProcessInstanceFilter> filter,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding batch process instance deletion to the CamundaClient.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/41752
