### PR TITLE
fix: Ensure backward-compatible serialization of `AuthorizationRecord` with `resourcePropertyName` property

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -46,6 +47,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
+          .addMixIn(AuthorizationRecordValue.class, AuthorizationMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
@@ -71,6 +73,7 @@ final class BulkIndexRequest implements ContentProducer {
       "processDefinitionKey";
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
+  private static final String RESOURCE_PROPERTY_NAME_PROPERTY = "resourcePropertyName";
   private static final String TERMINATE_INSTRUCTIONS_ELEMENT_ID_PROPERTY = "elementId";
   private final List<BulkOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
@@ -211,6 +214,9 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})
   private static final class ProcessInstanceModificationMixin {}
+
+  @JsonIgnoreProperties({RESOURCE_PROPERTY_NAME_PROPERTY})
+  private static final class AuthorizationMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -46,6 +47,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
+          .addMixIn(AuthorizationRecordValue.class, AuthorizationMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(CheckpointRecordValue.class, CheckpointRecordMixin.class)
@@ -71,6 +73,7 @@ final class BulkIndexRequest implements ContentProducer {
       "processDefinitionKey";
   private static final String PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY =
       "moveInstructions";
+  private static final String RESOURCE_PROPERTY_NAME_PROPERTY = "resourcePropertyName";
   private static final String TERMINATE_INSTRUCTIONS_ELEMENT_ID_PROPERTY = "elementId";
 
   private final List<BulkOperation> operations = new ArrayList<>();
@@ -212,6 +215,9 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({PROCESS_INSTANCE_MODIFICATION_MOVE_INSTRUCTIONS_PROPERTY})
   private static final class ProcessInstanceModificationMixin {}
+
+  @JsonIgnoreProperties({RESOURCE_PROPERTY_NAME_PROPERTY})
+  private static final class AuthorizationMixin {}
 
   public interface TerminateInstructionsMixin {
     @JsonIgnore


### PR DESCRIPTION
## Description

This PR ensures backward compatibility when exporting `AuthorizationRecord` to Elasticsearch and OpenSearch indices created by previous minor versions. 

## Problem

In #40191 we added the `resourcePropertyName` field to `AuthorizationRecord` to support property-based authorization and enabled exporting of this field in #40353.  However, this introduced a potential issue during version upgrades: 

- ES/OS index templates use `"dynamic": "strict"` mapping configuration
- When the exporter processes backlogged records destined for indices created by a previous version, serializing the new `resourcePropertyName` field causes export failures
- The old indices don't have this field in their mapping and will reject documents containing unknown fields

As noted by Houssain ([ref](https://camunda.slack.com/archives/C08NQKV761G/p1760528546270409?thread_ts=1755502200.860919&cid=C08NQKV761G)): 
> We have a single record datamodel, when exported to old indices (can happen when the exporter still processing previous records), we want to avoid serializing the new fields, with default values, that are unknown for the old indices.  We cannot put `@JsonIgnore` on the record, since we want them to be serialized in the new indices.

### Solution

Add an `AuthorizationMixin` to the `PREVIOUS_VERSION_MAPPER` in both Elasticsearch and OpenSearch exporters that excludes the `resourcePropertyName` field during JSON serialization when exporting to previous version indices.

This follows the established pattern already used for other record types (`CheckpointRecordMixin`, `MessageSubscriptionMixin`, ..).

The current version mapper continues to serialize all fields normally, ensuring new indices receive the complete data. 

### Changes
- **Elasticsearch/OpenSearch exporters** (`BulkIndexRequest.java`): Added `AuthorizationMixin` to `PREVIOUS_VERSION_MAPPER`
- **Tests**:  Added test cases to verify: 
  - `resourcePropertyName` is excluded when serializing for previous version indices
  - `resourcePropertyName` is included when serializing for current version indices

## Related issues
Closes follow-up to #40116
Original implementation: #40191, #40353
