### PR TITLE
feat: use element selection hook in element instance tree

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
@@ -97,7 +97,7 @@ describe('VariablePanel', () => {
     const statistics = [
       {
         elementId: 'TEST_FLOW_NODE',
-        active: 0,
+        active: 1,
         canceled: 0,
         incidents: 0,
         completed: 1,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
@@ -450,7 +450,7 @@ describe('VariablePanel', () => {
         },
         {
           elementId: 'Activity_0qtp1k6',
-          active: 2,
+          active: 1,
           canceled: 0,
           incidents: 0,
           completed: 0,
@@ -544,7 +544,7 @@ describe('VariablePanel', () => {
     ).not.toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 2, 2, {});
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
     });
 
     await waitFor(() => {

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
@@ -102,10 +102,10 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
               }
             } else {
               if (IS_ELEMENT_SELECTION_V2) {
-                selectElementInstance(
-                  incident.elementId,
-                  incident.elementInstanceKey,
-                );
+                selectElementInstance({
+                  elementId: incident.elementId,
+                  elementInstanceKey: incident.elementInstanceKey,
+                });
               } else {
                 selectFlowNode(rootNode, {
                   flowNodeId: incident.elementId,

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -407,7 +407,10 @@ const TopPanel: React.FC = observer(() => {
                     if (modificationsStore.state.status !== 'adding-token') {
                       if (IS_ELEMENT_SELECTION_V2) {
                         if (flowNodeId !== undefined) {
-                          selectElement(flowNodeId, isMultiInstance);
+                          selectElement({
+                            elementId: flowNodeId,
+                            isMultiInstanceBody: isMultiInstance,
+                          });
                         } else {
                           clearSelection();
                         }

--- a/operate/client/src/modules/hooks/flowNodeMetadata.ts
+++ b/operate/client/src/modules/hooks/flowNodeMetadata.ts
@@ -6,17 +6,23 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {
   useHasRunningOrFinishedTokens,
   useNewTokenCountForSelectedNode,
 } from './flowNodeSelection';
+import {useElementInstancesCount} from './useElementInstancesCount';
 
 const useHasMultipleInstances = () => {
   const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
-  const {metaData} = flowNodeMetaDataStore.state;
+  const elementInstancesCount = useElementInstancesCount(
+    flowNodeSelectionStore.state.selection?.flowNodeId,
+  );
+
+  if (flowNodeSelectionStore.state.selection?.isMultiInstance) {
+    return false;
+  }
 
   if (
     flowNodeSelectionStore.state.selection?.flowNodeInstanceId !== undefined
@@ -28,7 +34,7 @@ const useHasMultipleInstances = () => {
     return newTokenCountForSelectedNode > 1;
   }
 
-  return (metaData?.instanceCount ?? 0) > 1 || newTokenCountForSelectedNode > 0;
+  return (elementInstancesCount ?? 0) > 1 || newTokenCountForSelectedNode > 0;
 };
 
 export {useHasMultipleInstances};

--- a/operate/client/src/modules/hooks/useElementInstancesCount.ts
+++ b/operate/client/src/modules/hooks/useElementInstancesCount.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
+
+const useElementInstancesCount = (elementId?: string) => {
+  const {data: statistics} = useFlownodeInstancesStatistics();
+
+  if (!statistics?.items || !elementId) {
+    return null;
+  }
+  const elementStats = statistics.items.find(
+    (stat) => stat.elementId === elementId,
+  );
+  if (!elementStats) {
+    return 0;
+  }
+
+  return (
+    elementStats.active +
+    elementStats.completed +
+    elementStats.canceled +
+    elementStats.incidents
+  );
+};
+
+export {useElementInstancesCount};

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
@@ -98,7 +98,7 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElement('service-task-1');
+        result.current.selectElement({elementId: 'service-task-1'});
       });
 
       expect(result.current.selectedElementId).toBe('service-task-1');
@@ -131,10 +131,10 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElementInstance(
-          'service-task-1',
-          '2251799813699889',
-        );
+        result.current.selectElementInstance({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+        });
       });
 
       expect(result.current.location.search).toContain(
@@ -142,7 +142,7 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElement('service-task-2');
+        result.current.selectElement({elementId: 'service-task-2'});
       });
 
       expect(result.current.selectedElementId).toBe('service-task-2');
@@ -172,7 +172,10 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElement('service-task-1', true);
+        result.current.selectElement({
+          elementId: 'service-task-1',
+          isMultiInstanceBody: true,
+        });
       });
 
       expect(result.current.selectedElementId).toBe('service-task-1');
@@ -202,7 +205,10 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElement('service-task-1', false);
+        result.current.selectElement({
+          elementId: 'service-task-1',
+          isMultiInstanceBody: false,
+        });
       });
 
       expect(result.current.selectedElementId).toBe('service-task-1');
@@ -294,10 +300,10 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElementInstance(
-          'service-task-1',
-          '2251799813699889',
-        );
+        result.current.selectElementInstance({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+        });
       });
 
       expect(result.current.selectedElementId).toBe('service-task-1');
@@ -326,11 +332,11 @@ describe('useProcessInstanceElementSelection', () => {
       );
 
       act(() => {
-        result.current.selectElementInstance(
-          'service-task-1',
-          '2251799813699889',
-          true,
-        );
+        result.current.selectElementInstance({
+          elementId: 'service-task-1',
+          elementInstanceKey: '2251799813699889',
+          isMultiInstanceBody: true,
+        });
       });
 
       expect(result.current.selectedElementId).toBe('service-task-1');

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -66,7 +66,13 @@ const useProcessInstanceElementSelection = () => {
     searchParams.get(IS_MULTI_INSTANCE_BODY) === 'true';
 
   const selectElement = useCallback(
-    (elementId: string, isMultiInstanceBody: boolean = false) => {
+    ({
+      elementId,
+      isMultiInstanceBody = false,
+    }: {
+      elementId: string;
+      isMultiInstanceBody?: boolean;
+    }) => {
       setSearchParams((params) => {
         return updateSelectionSearchParams(params, {
           elementId,
@@ -78,11 +84,14 @@ const useProcessInstanceElementSelection = () => {
   );
 
   const selectElementInstance = useCallback(
-    (
-      elementId: string,
-      elementInstanceKey: string,
-      isMultiInstanceBody: boolean = false,
-    ) => {
+    ({
+      elementId,
+      elementInstanceKey,
+      isMultiInstanceBody = false,
+      elementId: string;
+      elementInstanceKey: string;
+      isMultiInstanceBody?: boolean;
+    }) => {
       setSearchParams((params) => {
         return updateSelectionSearchParams(params, {
           elementId,

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -15,17 +15,23 @@ import {useElementInstancesSearch} from 'modules/queries/elementInstances/useEle
 const ELEMENT_ID = 'elementId';
 const ELEMENT_INSTANCE_KEY = 'elementInstanceKey';
 const IS_MULTI_INSTANCE_BODY = 'isMultiInstanceBody';
+const IS_PLACEHOLDER = 'isPlaceholder';
+const ANCHOR_ELEMENT_ID = 'anchorElementId';
 
 type SelectionSearchParams = {
   [ELEMENT_ID]?: string;
   [ELEMENT_INSTANCE_KEY]?: string;
   [IS_MULTI_INSTANCE_BODY]?: boolean;
+  [IS_PLACEHOLDER]?: boolean;
+  [ANCHOR_ELEMENT_ID]?: string;
 };
 
 const deleteSelectionSearchParams = (params: URLSearchParams) => {
   params.delete(ELEMENT_ID);
   params.delete(ELEMENT_INSTANCE_KEY);
   params.delete(IS_MULTI_INSTANCE_BODY);
+  params.delete(IS_PLACEHOLDER);
+  params.delete(ANCHOR_ELEMENT_ID);
   return params;
 };
 
@@ -41,6 +47,12 @@ const setSelectionSearchParams = (
   }
   if (newParams[IS_MULTI_INSTANCE_BODY] === true) {
     params.set(IS_MULTI_INSTANCE_BODY, 'true');
+  }
+  if (newParams[IS_PLACEHOLDER] === true) {
+    params.set(IS_PLACEHOLDER, 'true');
+  }
+  if (newParams[ANCHOR_ELEMENT_ID]) {
+    params.set(ANCHOR_ELEMENT_ID, newParams[ANCHOR_ELEMENT_ID]);
   }
   return params;
 };
@@ -64,6 +76,8 @@ const useProcessInstanceElementSelection = () => {
   const elementId = searchParams.get(ELEMENT_ID);
   const isMultiInstanceBody =
     searchParams.get(IS_MULTI_INSTANCE_BODY) === 'true';
+  const isPlaceholder = searchParams.get(IS_PLACEHOLDER) === 'true';
+  const anchorElementId = searchParams.get(ANCHOR_ELEMENT_ID);
 
   const selectElement = useCallback(
     ({
@@ -88,15 +102,22 @@ const useProcessInstanceElementSelection = () => {
       elementId,
       elementInstanceKey,
       isMultiInstanceBody = false,
+      isPlaceholder = false,
+      anchorElementId,
+    }: {
       elementId: string;
       elementInstanceKey: string;
       isMultiInstanceBody?: boolean;
+      isPlaceholder?: boolean;
+      anchorElementId?: string;
     }) => {
       setSearchParams((params) => {
         return updateSelectionSearchParams(params, {
           elementId,
           elementInstanceKey,
           isMultiInstanceBody,
+          isPlaceholder,
+          anchorElementId,
         });
       });
     },
@@ -109,12 +130,13 @@ const useProcessInstanceElementSelection = () => {
     });
   }, [setSearchParams]);
 
-  // If elementInstanceKey is in URL, fetch element instance by key
+  // If elementInstanceKey is in URL, fetch element instance by key.
+  // Skip fetching if elementInstanceKey is a placeholder key
   const {
     data: elementInstanceByKey,
     isFetching: isFetchingElementInstanceByKey,
   } = useElementInstance(elementInstanceKey ?? '', {
-    enabled: !!elementInstanceKey,
+    enabled: !!elementInstanceKey && isPlaceholder === false,
   });
 
   // If only elementId is in URL, search for all instances
@@ -148,6 +170,8 @@ const useProcessInstanceElementSelection = () => {
      */
     selectedElementInstanceKey: elementInstanceKey,
     isSelectedInstanceMultiInstanceBody: isMultiInstanceBody,
+    isSelectedInstancePlaceholder: isPlaceholder,
+    selectedAnchorElementId: anchorElementId,
     isFetchingElement:
       isFetchingElementInstanceByKey || isFetchingElementInstancesSearch,
   };


### PR DESCRIPTION
## Description

This PR uses the element selection hook functions in the element instance tree.

- change parameters of selectElement and selectElementInstance to options object
- add support for anchorElementId and isPlaceholder to useProcessInstanceElementSelection
- use selectElement and selectElementInstance in element instance tree

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41827
