### PR TITLE
feat: add Docker Build and Helm Integration Test workflow

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -23,6 +23,10 @@ on:
         description: 'Test scenario'
         type: string
         default: 'keycloak-original'
+      deployment-ttl:
+        description: 'Deployment TTL'
+        type: string
+        default: ''
       shortname:
         description: 'Short name for the deployment'
         type: string
@@ -252,7 +256,7 @@ jobs:
       namespace-prefix: monorepo
       test-enabled: true
       e2e-enabled: true
-      deployment-ttl: ""
+      deployment-ttl: ${{ inputs.deployment-ttl || '' }}
       scenario: ${{ inputs.scenario || 'keycloak-original' }}
       shortname: ${{ inputs.shortname || 'kcor' }}
       always-delete-namespace: true

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -152,8 +152,8 @@ jobs:
       - name: Get Maven project version
         id: maven-version
         run: |
-          VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args="\${project.version}" --non-recursive exec:exec)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set semantic image tag
         id: set-image-tag
@@ -161,13 +161,14 @@ jobs:
           MAVEN_VERSION="${{ steps.maven-version.outputs.version }}"
           if [[ -n "${{ inputs.version }}" ]]; then
             # Use explicitly provided version
-            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # For PRs: <maven-version>-pr<number> (e.g., 8.9.0-SNAPSHOT-pr123)
-            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
             # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.9.0-SNAPSHOT-abc1234)
-            echo "tag=${MAVEN_VERSION}-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+            SHA_SHORT="${GITHUB_SHA::7}"
+            echo "tag=${MAVEN_VERSION}-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download Operate frontend artifact
@@ -207,11 +208,13 @@ jobs:
 
       - name: Output image details
         run: |
-          echo "### Docker Image Built and Pushed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository:** ${{ env.HARBOR_REPOSITORY }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ steps.set-image-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Full Image:** ${{ env.HARBOR_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Docker Image Built and Pushed"
+            echo ""
+            echo "**Repository:** ${{ env.HARBOR_REPOSITORY }}"
+            echo "**Tag:** ${{ steps.set-image-tag.outputs.tag }}"
+            echo "**Full Image:** ${{ env.HARBOR_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Observe build status
         if: always()
@@ -238,10 +241,11 @@ jobs:
         shell: bash
         run: |
           # Create a unique identifier based on run ID and short SHA
-          IDENTIFIER="docker-helm-${{ github.run_id }}-${GITHUB_SHA::7}"
+          SHA_SHORT="${GITHUB_SHA::7}"
+          IDENTIFIER="docker-helm-${{ github.run_id }}-${SHA_SHORT}"
           # Truncate to max 40 chars if needed (k8s namespace limit)
           IDENTIFIER="${IDENTIFIER:0:40}"
-          echo "identifier=${IDENTIFIER}" >> $GITHUB_OUTPUT
+          echo "identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
 
   helm-deploy:
     name: Helm chart Integration Tests

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -55,14 +55,81 @@ env:
   HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda
 
 jobs:
-  build-and-push:
-    name: Build and Push Docker Image
-    # Only run on PRs from eamonnmoloney or remcowesterhoud (unless labelled skip-always-green), or on manual dispatch
+  # Gate job - checks conditions once, all other jobs depend on this
+  should-run:
+    name: Check Run Conditions
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
        (github.actor == 'eamonnmoloney' || github.actor == 'remcowesterhoud') &&
        !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
+    steps:
+      - run: echo "Workflow conditions met, proceeding with build"
+
+  # Parallel frontend builds
+  build-operate-frontend:
+    name: Build Operate Frontend
+    needs: should-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-frontend
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - name: Upload Operate frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: operate-frontend
+          path: operate/client/build
+          retention-days: 1
+
+  build-tasklist-frontend:
+    name: Build Tasklist Frontend
+    needs: should-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-frontend
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - name: Upload Tasklist frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tasklist-frontend
+          path: tasklist/client/build
+          retention-days: 1
+
+  build-identity-frontend:
+    name: Build Identity Frontend
+    needs: should-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-frontend
+        with:
+          directory: ./identity/client
+          package-manager: "npm"
+      - name: Upload Identity frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: identity-frontend
+          path: identity/client/build
+          retention-days: 1
+
+  # Main build job - waits for all frontends to complete
+  build-and-push:
+    name: Build and Push Docker Image
+    needs: [build-operate-frontend, build-tasklist-frontend, build-identity-frontend]
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     outputs:
@@ -93,23 +160,23 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
 
-      - name: Build Operate frontend
-        uses: ./.github/actions/build-frontend
+      - name: Download Operate frontend artifact
+        uses: actions/download-artifact@v4
         with:
-          directory: ./operate/client
-          package-manager: "npm"
+          name: operate-frontend
+          path: operate/client/build
 
-      - name: Build Tasklist frontend
-        uses: ./.github/actions/build-frontend
+      - name: Download Tasklist frontend artifact
+        uses: actions/download-artifact@v4
         with:
-          directory: ./tasklist/client
-          package-manager: "npm"
+          name: tasklist-frontend
+          path: tasklist/client/build
 
-      - name: Build Identity frontend
-        uses: ./.github/actions/build-frontend
+      - name: Download Identity frontend artifact
+        uses: actions/download-artifact@v4
         with:
-          directory: ./identity/client
-          package-manager: "npm"
+          name: identity-frontend
+          path: identity/client/build
 
       - name: Build Camunda
         id: build-camunda
@@ -149,7 +216,8 @@ jobs:
 
   format-identifier:
     name: Format Identifier
-    needs: build-and-push
+    # Runs in parallel with frontend builds (no dependency on their outputs)
+    needs: should-run
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -178,8 +246,8 @@ jobs:
       namespace-prefix: camunda
       test-enabled: true
       e2e-enabled: true
-      scenario: ${{ inputs.scenario || 'keycloak-original' }}
-      shortname: ${{ inputs.shortname || 'kcor' }}
+      scenario: ${{ inputs.scenario || 'qa-elasticsearch' }}
+      shortname: ${{ inputs.shortname || 'qael' }}
       always-delete-namespace: true
       flows: install
       values-config: |
@@ -205,61 +273,4 @@ jobs:
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
 
-  notify:
-    name: Send Slack notification on failure
-    runs-on: ubuntu-latest
-    needs: [build-and-push, helm-deploy]
-    if: false
-    #if: failure() && github.event_name != 'pull_request'
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v3
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_WEBHOOK_URL;
-
-      - name: Send failure Slack notification
-        uses: slackapi/slack-github-action@v2
-        with:
-          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPOCI_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Docker Build + Helm Integration Test* failed!\n"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
-                  }
-                }
-              ]
-            }
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -252,6 +252,7 @@ jobs:
       namespace-prefix: monorepo
       test-enabled: true
       e2e-enabled: true
+      deployment-ttl: ""
       scenario: ${{ inputs.scenario || 'keycloak-original' }}
       shortname: ${{ inputs.shortname || 'kcor' }}
       always-delete-namespace: true

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -229,7 +229,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: identity-frontend
-          path: identity/client/build
+          path: identity/client/dist
 
       - name: Build Camunda
         id: build-camunda

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -135,18 +135,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image tag
-        id: set-image-tag
-        shell: bash
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "tag=pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Setup build environment
         uses: ./.github/actions/setup-build
         with:
@@ -156,6 +144,27 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+
+      - name: Get Maven project version
+        id: maven-version
+        run: |
+          VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set semantic image tag
+        id: set-image-tag
+        run: |
+          MAVEN_VERSION="${{ steps.maven-version.outputs.version }}"
+          if [[ -n "${{ inputs.version }}" ]]; then
+            # Use explicitly provided version
+            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # For PRs: <maven-version>-pr<number> (e.g., 8.9.0-SNAPSHOT-pr123)
+            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.9.0-SNAPSHOT-abc1234)
+            echo "tag=${MAVEN_VERSION}-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Download Operate frontend artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1,0 +1,265 @@
+name: Docker Build and Helm Integration Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Docker image version tag (defaults to pr-<sha> or Maven version)'
+        type: string
+        required: false
+      helmRepositoryBranchName:
+        description: 'Helm repository branch name'
+        type: string
+        default: 'main'
+      helmRepositoryDirName:
+        description: 'Helm chart directory name'
+        type: string
+        default: 'camunda-platform-8.9'
+      platform:
+        description: 'Platform to deploy on'
+        type: string
+        default: 'gke'
+      deployment_ttl:
+        description: 'Deployment TTL'
+        type: string
+        default: '30m'
+      it_tests_enabled:
+        description: 'Enable integration tests'
+        type: boolean
+        default: true
+      scenario:
+        description: 'Test scenario'
+        type: string
+        default: 'keycloak-original'
+      shortname:
+        description: 'Short name for the deployment'
+        type: string
+        default: 'kcor'
+      flows:
+        description: 'Flow'
+        type: string
+        default: 'install'
+  pull_request:
+    paths:
+      - ".github/workflows/docker-build-helm-integration.yml"
+      - "camunda.Dockerfile"
+      - "dist/**"
+      - "zeebe/**"
+      - "operate/**"
+      - "tasklist/**"
+      - "identity/**"
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+  HARBOR_REGISTRY: registry.camunda.cloud
+  HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    # Only run on PRs from eamonnmoloney or remcowesterhoud (unless labelled skip-always-green), or on manual dispatch
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       (github.actor == 'eamonnmoloney' || github.actor == 'remcowesterhoud') &&
+       !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
+    outputs:
+      image-tag: ${{ steps.set-image-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image tag
+        id: set-image-tag
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          harbor: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+
+      - name: Build Operate frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+
+      - name: Build Tasklist frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+
+      - name: Build Identity frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./identity/client
+          package-manager: "npm"
+
+      - name: Build Camunda
+        id: build-camunda
+        uses: ./.github/actions/build-zeebe
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
+      - name: Build and push Docker image to Harbor
+        id: build-docker
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: ${{ env.HARBOR_REPOSITORY }}
+          version: ${{ steps.set-image-tag.outputs.tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: linux/amd64
+          dockerfile: camunda.Dockerfile
+          push: true
+
+      - name: Output image details
+        run: |
+          echo "### Docker Image Built and Pushed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Repository:** ${{ env.HARBOR_REPOSITORY }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** ${{ steps.set-image-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Full Image:** ${{ env.HARBOR_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-build
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  format-identifier:
+    name: Format Identifier
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      identifier: ${{ steps.format.outputs.identifier }}
+    steps:
+      - name: Format identifier
+        id: format
+        shell: bash
+        run: |
+          # Create a unique identifier based on run ID and short SHA
+          IDENTIFIER="docker-helm-${{ github.run_id }}-${GITHUB_SHA::7}"
+          # Truncate to max 40 chars if needed (k8s namespace limit)
+          IDENTIFIER="${IDENTIFIER:0:40}"
+          echo "identifier=${IDENTIFIER}" >> $GITHUB_OUTPUT
+
+  helm-deploy:
+    name: Helm chart Integration Tests
+    needs: [build-and-push, format-identifier]
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    secrets: inherit
+    with:
+      identifier: ${{ needs.format-identifier.outputs.identifier }}
+      platforms: ${{ 'gke' }}
+      camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
+      camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
+      namespace-prefix: camunda
+      test-enabled: true
+      e2e-enabled: true
+      scenario: ${{ inputs.scenario || 'keycloak-original' }}
+      shortname: ${{ inputs.shortname || 'kcor' }}
+      always-delete-namespace: true
+      flows: install
+      values-config: |
+        {
+          "E2E_TESTS_CAMUNDA_HELM_DIR": "${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}",
+          "E2E_TESTS_IDENTITY_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_CONNECTORS_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_CONSOLE_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_OPTIMIZE_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_WEBMODELER_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_ORCHESTRATION_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_CORE_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
+          "E2E_TESTS_SEARCH_ENGINE": "elasticsearch",
+          "E2E_AWS_OS_INDEX_PREFIX": "qae2e-${{ github.run_id }}",
+          "E2E_AWS_OS_INDEX_PREFIX_ZEEBE": "${{ github.run_id }}-qae2e-zeebe",
+          "E2E_AWS_OS_INDEX_PREFIX_OPERATE": "${{ github.run_id }}-qae2e-operate",
+          "E2E_AWS_OS_INDEX_PREFIX_TASKLIST": "${{ github.run_id }}-qae2e-tasklist",
+          "E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE": "${{ github.run_id }}-qae2e-optimize"
+        }
+      vault-secret-mapping: |
+        secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR | TEST_DOCKER_USERNAME;
+        secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;
+        secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
+        secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
+
+  notify:
+    name: Send Slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [build-and-push, helm-deploy]
+    if: false
+    #if: failure() && github.event_name != 'pull_request'
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPOCI_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Docker Build + Helm Integration Test* failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: identity-frontend
-          path: identity/client/build
+          path: identity/client/dist
           retention-days: 1
 
   # Main build job - waits for all frontends to complete

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1,3 +1,7 @@
+# description: This workflow builds the Camunda Docker image, pushes it to Harbor, and runs Helm integration tests
+# type: CI
+# owner: @camunda/distribution
+---
 name: Docker Build and Helm Integration Test
 
 on:
@@ -15,18 +19,6 @@ on:
         description: 'Helm chart directory name'
         type: string
         default: 'camunda-platform-8.9'
-      platform:
-        description: 'Platform to deploy on'
-        type: string
-        default: 'gke'
-      deployment_ttl:
-        description: 'Deployment TTL'
-        type: string
-        default: '30m'
-      it_tests_enabled:
-        description: 'Enable integration tests'
-        type: boolean
-        default: true
       scenario:
         description: 'Test scenario'
         type: string
@@ -35,10 +27,6 @@ on:
         description: 'Short name for the deployment'
         type: string
         default: 'kcor'
-      flows:
-        description: 'Flow'
-        type: string
-        default: 'install'
   pull_request:
     paths:
       - ".github/workflows/docker-build-helm-integration.yml"
@@ -53,6 +41,10 @@ env:
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
   HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   # Gate job - checks conditions once, all other jobs depend on this
@@ -240,7 +232,7 @@ jobs:
     secrets: inherit
     with:
       identifier: ${{ needs.format-identifier.outputs.identifier }}
-      platforms: ${{ 'gke' }}
+      platforms: gke
       camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
       camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
       namespace-prefix: camunda

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1,4 +1,4 @@
-# description: This workflow builds the Camunda Docker image, pushes it to Harbor, and runs Helm integration tests
+# description: This workflow builds the Camunda Docker image, pushes it to Harbor, and runs Helm integration tests. This is part of the AlwaysGreen project where every PR is deployed via helm to confirm no breaking changes.
 # type: CI
 # owner: @camunda/distribution
 ---

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -68,7 +68,16 @@ jobs:
        !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
     steps:
       - run: echo "Workflow conditions met, proceeding with build"
-
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-should-run
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
@@ -88,7 +97,16 @@ jobs:
           name: operate-frontend
           path: operate/client/build
           retention-days: 1
-
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-operate-frontend
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   build-tasklist-frontend:
     name: Build Tasklist Frontend
     needs: should-run
@@ -107,7 +125,16 @@ jobs:
           name: tasklist-frontend
           path: tasklist/client/build
           retention-days: 1
-
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-tasklist-frontend
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   build-identity-frontend:
     name: Build Identity Frontend
     needs: should-run
@@ -126,6 +153,16 @@ jobs:
           name: identity-frontend
           path: identity/client/dist
           retention-days: 1
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-identity-frontend
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   # Main build job - waits for all frontends to complete
   build-and-push:

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -37,6 +37,11 @@ on:
       - "tasklist/**"
       - "identity/**"
 
+# Cancel in-progress runs when a new commit is pushed to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
@@ -248,6 +253,9 @@ jobs:
             registry: registry.camunda.cloud
             repository: team-camunda/camunda
             tag: ${{ needs.build-and-push.outputs.image-tag }}
+            pullSecrets:
+              - name: index-docker-io
+              - name: registry-camunda-cloud
       vault-secret-mapping: |
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR | TEST_DOCKER_USERNAME;
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -61,6 +61,7 @@ jobs:
     name: Check Run Conditions
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    permissions: { }
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
@@ -82,6 +83,7 @@ jobs:
   build-operate-frontend:
     name: Build Operate Frontend
     needs: should-run
+    permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -110,6 +112,7 @@ jobs:
   build-tasklist-frontend:
     name: Build Tasklist Frontend
     needs: should-run
+    permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -138,6 +141,7 @@ jobs:
   build-identity-frontend:
     name: Build Identity Frontend
     needs: should-run
+    permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -168,6 +172,7 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     needs: [build-operate-frontend, build-tasklist-frontend, build-identity-frontend]
+    permissions: { }
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     outputs:
@@ -268,6 +273,7 @@ jobs:
     name: Format Identifier
     # Runs in parallel with frontend builds (no dependency on their outputs)
     needs: should-run
+    permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -283,6 +289,16 @@ jobs:
           # Truncate to max 40 chars if needed (k8s namespace limit)
           IDENTIFIER="${IDENTIFIER:0:40}"
           echo "identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-format-identifier
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   helm-deploy:
     name: Helm chart Integration Tests

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -235,30 +235,19 @@ jobs:
       platforms: gke
       camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
       camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
-      namespace-prefix: camunda
+      namespace-prefix: monorepo
       test-enabled: true
       e2e-enabled: true
-      scenario: ${{ inputs.scenario || 'qa-elasticsearch' }}
-      shortname: ${{ inputs.shortname || 'qael' }}
+      scenario: ${{ inputs.scenario || 'keycloak-original' }}
+      shortname: ${{ inputs.shortname || 'kcor' }}
       always-delete-namespace: true
       flows: install
-      values-config: |
-        {
-          "E2E_TESTS_CAMUNDA_HELM_DIR": "${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}",
-          "E2E_TESTS_IDENTITY_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_CONNECTORS_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_CONSOLE_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_OPTIMIZE_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_WEBMODELER_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_ORCHESTRATION_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_CORE_IMAGE_TAG": "${{ needs.build-and-push.outputs.image-tag }}",
-          "E2E_TESTS_SEARCH_ENGINE": "elasticsearch",
-          "E2E_AWS_OS_INDEX_PREFIX": "qae2e-${{ github.run_id }}",
-          "E2E_AWS_OS_INDEX_PREFIX_ZEEBE": "${{ github.run_id }}-qae2e-zeebe",
-          "E2E_AWS_OS_INDEX_PREFIX_OPERATE": "${{ github.run_id }}-qae2e-operate",
-          "E2E_AWS_OS_INDEX_PREFIX_TASKLIST": "${{ github.run_id }}-qae2e-tasklist",
-          "E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE": "${{ github.run_id }}-qae2e-optimize"
-        }
+      extra-values: |
+        orchestration:
+          image:
+            registry: registry.camunda.cloud
+            repository: team-camunda/camunda
+            tag: ${{ needs.build-and-push.outputs.image-tag }}
       vault-secret-mapping: |
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR | TEST_DOCKER_USERNAME;
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for building Docker images and running Helm integration tests. The workflow is triggered manually or on pull requests, allowing for customizable inputs such as Docker image version, Helm repository details, and deployment configurations. Key jobs include building and pushing the Docker image, formatting identifiers, and executing Helm chart integration tests, with notifications set up for failures.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
