### PR TITLE
test: Enable MappingRuleIT for RDBMS

### DIFF
--- a/docs/testing/acceptance.md
+++ b/docs/testing/acceptance.md
@@ -137,7 +137,6 @@ We want to highlight some special features for the authentication tests here.
 
 ```java
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 class ProcessAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIT.java
@@ -19,10 +19,8 @@ import java.net.http.HttpClient;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class GetMappingRuleIT {
 
   private static CamundaClient camundaClient;


### PR DESCRIPTION
## Description

* Enables the last remaining, disabled MultiDbTest (MappingRuleIT) for secondary storage RDBMS

closes #39335
