### PR TITLE
feat: add batch operations details page

### DIFF
--- a/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {BatchOperationItem} from '@camunda/camunda-api-zod-schemas/8.8';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {BatchItemsTable} from './BatchItemsTable';
+import {MemoryRouter} from 'react-router-dom';
+
+const BATCH_OPERATION_KEY = 'migrate-operation-123';
+
+const createMockBatchOperationItems = (
+  count: number,
+  options?: {
+    withErrors?: boolean;
+    state?: BatchOperationItem['state'];
+  },
+): BatchOperationItem[] => {
+  return Array.from({length: count}, (_, i) => ({
+    batchOperationKey: BATCH_OPERATION_KEY,
+    itemKey: `item-${i + 1}`,
+    processInstanceKey: `2251799813685${250 + i}`,
+    state: options?.state ?? 'COMPLETED',
+    processedDate: '2023-11-22T09:03:29.564+0100',
+    errorMessage: options?.withErrors
+      ? `Error processing item ${i + 1}`
+      : undefined,
+  }));
+};
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+describe('<BatchItemsTable />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryBatchOperationItems().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+  });
+
+  it('should render empty state when no items exist', async () => {
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        isLoading={false}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.queryByText('0 Items')).not.toBeInTheDocument();
+    expect(screen.getByText('No items found')).toBeInTheDocument();
+  });
+
+  it('should render skeleton state when loading', async () => {
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        isLoading={false}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.queryByTestId('data-table-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('should render table with batch operation items', async () => {
+    const items = createMockBatchOperationItems(3);
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 3},
+    });
+
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        isLoading={false}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('3 Items')).toBeInTheDocument();
+    expect(screen.getByText('2251799813685250')).toBeInTheDocument();
+    expect(screen.getByText('2251799813685251')).toBeInTheDocument();
+    expect(screen.getByText('2251799813685252')).toBeInTheDocument();
+  });
+
+  it('should render items with failed state', async () => {
+    const items = createMockBatchOperationItems(2, {state: 'FAILED'});
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 2},
+    });
+
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        isLoading={false}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    const failedStates = screen.getAllByText('Failed');
+    expect(failedStates.length).toBeGreaterThan(0);
+  });
+
+  it('should render error messages for failed items', async () => {
+    const items = createMockBatchOperationItems(1, {
+      withErrors: true,
+      state: 'FAILED',
+    });
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 1},
+    });
+
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        isLoading={false}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+    expect(screen.getByText('Failure reason:')).toBeInTheDocument();
+    expect(screen.getByText('Error processing item 1')).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/BatchOperation/BatchItemsTable.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMemo, useCallback} from 'react';
+import {SortableTable} from 'modules/components/SortableTable';
+import {useBatchOperationItems} from 'modules/queries/batch-operations/useBatchOperationItems';
+import {BatchStateIndicator} from 'App/BatchOperations/BatchStateIndicator';
+import {formatDate} from 'modules/utils/date';
+
+const TABLE_HEADERS = [
+  {key: 'processInstanceKey', header: 'Process Instance Key', isDisabled: true},
+  {key: 'state', header: 'Batch state', isDisabled: true},
+  {key: 'processedDate', header: 'Time', sortKey: 'processedDate'},
+];
+
+type Props = {
+  batchOperationKey: string;
+  isLoading: boolean;
+};
+
+export const BatchItemsTable: React.FC<Props> = ({
+  batchOperationKey,
+  isLoading,
+}) => {
+  const {
+    data,
+    status,
+    isFetching,
+    isFetched,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchingPreviousPage,
+  } = useBatchOperationItems({
+    filter: {batchOperationKey},
+    sort: [{field: 'processedDate', order: 'desc'}],
+  });
+
+  const items = useMemo(
+    () => data?.pages.flatMap((page) => page.items) ?? [],
+    [data],
+  );
+
+  const totalItems = data?.pages?.[0]?.page?.totalItems ?? 0;
+
+  const rows = useMemo(
+    () =>
+      items.map((item) => ({
+        id: item.itemKey.toString(),
+        processInstanceKey: item.processInstanceKey,
+        state: <BatchStateIndicator status={item.state} />,
+        processedDate: formatDate(item.processedDate ?? ''),
+      })),
+    [items],
+  );
+
+  const rowOperationError = useCallback(
+    (rowId: string) => {
+      const item = items.find((item) => item.itemKey.toString() === rowId);
+      return item?.errorMessage ? (
+        <>
+          <strong>Failure reason:</strong> {item.errorMessage}
+        </>
+      ) : null;
+    },
+    [items],
+  );
+
+  const getTableState = () => {
+    switch (true) {
+      case isLoading:
+      case status === 'pending' && !data:
+        return 'skeleton';
+      case isFetched && items.length === 0:
+        return 'empty';
+      case isFetching && !isFetchingPreviousPage && !isFetchingNextPage:
+        return 'loading';
+      case status === 'error':
+        return 'error';
+
+      default:
+        return 'content';
+    }
+  };
+
+  return (
+    <>
+      {totalItems > 0 && <strong>{totalItems} Items</strong>}
+      <SortableTable
+        batchOperationId={batchOperationKey}
+        state={getTableState()}
+        rows={rows}
+        headerColumns={TABLE_HEADERS}
+        rowOperationError={rowOperationError}
+        onVerticalScrollEndReach={() => {
+          if (hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+          }
+        }}
+        emptyMessage={{message: 'No items found'}}
+        stickyHeader
+      />
+    </>
+  );
+};

--- a/operate/client/src/App/BatchOperation/index.test.tsx
+++ b/operate/client/src/App/BatchOperation/index.test.tsx
@@ -17,12 +17,10 @@ import {
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {Paths} from 'modules/Routes';
-import type {
-  BatchOperationItem,
-  BatchOperation as BatchOperationType,
-} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {BatchOperation as BatchOperationType} from '@camunda/camunda-api-zod-schemas/8.8';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockGetBatchOperation} from 'modules/mocks/api/v2/batchOperations/getBatchOperation';
+import {notificationsStore} from 'modules/stores/notifications';
 
 const operation: BatchOperationType = {
   batchOperationKey: 'migrate-operation-123',
@@ -42,29 +40,20 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
     >
       <Routes>
         <Route path={Paths.batchOperation()} element={children} />
+        <Route
+          path={Paths.batchOperations()}
+          element={<div data-testid="batch-operations" />}
+        />
       </Routes>
     </MemoryRouter>
   </QueryClientProvider>
 );
 
-const createMockBatchOperationItems = (
-  count: number,
-  options?: {
-    withErrors?: boolean;
-    state?: BatchOperationItem['state'];
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
   },
-): BatchOperationItem[] => {
-  return Array.from({length: count}, (_, i) => ({
-    batchOperationKey: `migrate-operation-${i + 1}`,
-    itemKey: `item-${i + 1}`,
-    processInstanceKey: `2251799813685${250 + i}`,
-    state: options?.state ?? 'COMPLETED',
-    processedDate: '2023-11-22T09:03:29.564+0100',
-    errorMessage: options?.withErrors
-      ? `Error processing item ${i + 1}`
-      : undefined,
-  }));
-};
+}));
 
 describe('<BatchOperation />', () => {
   beforeEach(() => {
@@ -76,25 +65,23 @@ describe('<BatchOperation />', () => {
     });
   });
 
-  it('should render skeleton state when loading', async () => {
+  it('should render items count summary', async () => {
     render(<BatchOperation />, {
       wrapper: Wrapper,
     });
 
-    expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
-
     await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
+      screen.queryAllByTestId('text-skeleton'),
     );
 
-    expect(screen.queryByTestId('data-table-skeleton')).not.toBeInTheDocument();
+    expect(screen.getByText(/2 successful/)).toBeInTheDocument();
   });
 
   it('should render page title with formatted operation type', async () => {
     render(<BatchOperation />, {wrapper: Wrapper});
 
     await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
+      screen.queryAllByTestId('text-skeleton'),
     );
 
     expect(
@@ -106,7 +93,7 @@ describe('<BatchOperation />', () => {
     render(<BatchOperation />, {wrapper: Wrapper});
 
     await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
+      screen.queryAllByTestId('text-skeleton'),
     );
 
     expect(screen.getByText('State')).toBeInTheDocument();
@@ -119,7 +106,7 @@ describe('<BatchOperation />', () => {
     render(<BatchOperation />, {wrapper: Wrapper});
 
     await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
+      screen.queryAllByTestId('text-skeleton'),
     );
 
     expect(screen.getByText('Completed')).toBeInTheDocument();
@@ -129,92 +116,11 @@ describe('<BatchOperation />', () => {
     render(<BatchOperation />, {wrapper: Wrapper});
 
     await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
+      screen.queryAllByTestId('text-skeleton'),
     );
 
     const tiles = screen.getAllByText(/2021|2023/);
     expect(tiles.length).toBeGreaterThan(0);
-  });
-
-  it('should render items count summary', async () => {
-    const items = createMockBatchOperationItems(2);
-    mockQueryBatchOperationItems().withSuccess({
-      items,
-      page: {totalItems: 2},
-    });
-    render(<BatchOperation />, {wrapper: Wrapper});
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
-    );
-
-    expect(screen.getByText(/2 successful/)).toBeInTheDocument();
-  });
-
-  it('should render empty state when no items exist', async () => {
-    render(<BatchOperation />, {wrapper: Wrapper});
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
-    );
-
-    expect(screen.getByText('0 Items')).toBeInTheDocument();
-    expect(screen.getByText('No items found')).toBeInTheDocument();
-  });
-
-  it('should render table with batch operation items', async () => {
-    const items = createMockBatchOperationItems(3);
-    mockQueryBatchOperationItems().withSuccess({
-      items,
-      page: {totalItems: 3},
-    });
-
-    render(<BatchOperation />, {wrapper: Wrapper});
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
-    );
-
-    expect(screen.getByText('3 Items')).toBeInTheDocument();
-    expect(screen.getByText('2251799813685250')).toBeInTheDocument();
-    expect(screen.getByText('2251799813685251')).toBeInTheDocument();
-    expect(screen.getByText('2251799813685252')).toBeInTheDocument();
-  });
-
-  it('should render items with failed state', async () => {
-    const items = createMockBatchOperationItems(2, {state: 'FAILED'});
-    mockQueryBatchOperationItems().withSuccess({
-      items,
-      page: {totalItems: 2},
-    });
-
-    render(<BatchOperation />, {wrapper: Wrapper});
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
-    );
-
-    const failedStates = screen.getAllByText('Failed');
-    expect(failedStates.length).toBeGreaterThan(0);
-  });
-
-  it('should render error messages for failed items', async () => {
-    const items = createMockBatchOperationItems(1, {
-      withErrors: true,
-      state: 'FAILED',
-    });
-    mockQueryBatchOperationItems().withSuccess({
-      items,
-      page: {totalItems: 1},
-    });
-
-    render(<BatchOperation />, {wrapper: Wrapper});
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
-    );
-    expect(screen.getByText('Failure reason:')).toBeInTheDocument();
-    expect(screen.getByText('Error processing item 1')).toBeInTheDocument();
   });
 
   it('should show error notification when batch operation fails to load', async () => {
@@ -235,7 +141,7 @@ describe('<BatchOperation />', () => {
     render(<BatchOperation />, {wrapper: Wrapper});
 
     await waitForElementToBeRemoved(() =>
-      screen.queryAllByTestId('data-table-skeleton'),
+      screen.queryAllByTestId('text-skeleton'),
     );
 
     expect(
@@ -243,5 +149,21 @@ describe('<BatchOperation />', () => {
         '403 - You do not have permission to view this information',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should redirect to batch operations page and display notification if batch operation is not found (404)', async () => {
+    mockGetBatchOperation().withServerError(404);
+
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('batch-operations')).toBeInTheDocument();
+    });
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'batch operation migrate-operation-123 could not be found',
+      isDismissable: true,
+    });
   });
 });

--- a/operate/client/src/App/BatchOperation/index.test.tsx
+++ b/operate/client/src/App/BatchOperation/index.test.tsx
@@ -162,7 +162,7 @@ describe('<BatchOperation />', () => {
 
     expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
       kind: 'error',
-      title: 'batch operation migrate-operation-123 could not be found',
+      title: 'Batch operation migrate-operation-123 could not be found',
       isDismissable: true,
     });
   });

--- a/operate/client/src/App/BatchOperation/index.test.tsx
+++ b/operate/client/src/App/BatchOperation/index.test.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {BatchOperation} from './index';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  waitFor,
+} from 'modules/testing-library';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {Paths} from 'modules/Routes';
+import type {
+  BatchOperationItem,
+  BatchOperation as BatchOperationType,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
+import {mockGetBatchOperation} from 'modules/mocks/api/v2/batchOperations/getBatchOperation';
+
+const operation: BatchOperationType = {
+  batchOperationKey: 'migrate-operation-123',
+  batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
+  startDate: '2021-02-20T18:31:18.625+0100',
+  endDate: '2023-11-22T09:03:29.564+0100',
+  state: 'COMPLETED',
+  operationsTotalCount: 2,
+  operationsCompletedCount: 2,
+  operationsFailedCount: 0,
+};
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    <MemoryRouter
+      initialEntries={[Paths.batchOperation(operation.batchOperationKey)]}
+    >
+      <Routes>
+        <Route path={Paths.batchOperation()} element={children} />
+      </Routes>
+    </MemoryRouter>
+  </QueryClientProvider>
+);
+
+const createMockBatchOperationItems = (
+  count: number,
+  options?: {
+    withErrors?: boolean;
+    state?: BatchOperationItem['state'];
+  },
+): BatchOperationItem[] => {
+  return Array.from({length: count}, (_, i) => ({
+    batchOperationKey: `migrate-operation-${i + 1}`,
+    itemKey: `item-${i + 1}`,
+    processInstanceKey: `2251799813685${250 + i}`,
+    state: options?.state ?? 'COMPLETED',
+    processedDate: '2023-11-22T09:03:29.564+0100',
+    errorMessage: options?.withErrors
+      ? `Error processing item ${i + 1}`
+      : undefined,
+  }));
+};
+
+describe('<BatchOperation />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetBatchOperation().withSuccess(operation);
+    mockQueryBatchOperationItems().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+  });
+
+  it('should render skeleton state when loading', async () => {
+    render(<BatchOperation />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.queryByTestId('data-table-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('should render page title with formatted operation type', async () => {
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(
+      screen.getByRole('heading', {name: 'Migrate Process Instance'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should render operation details tiles', async () => {
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('State')).toBeInTheDocument();
+    expect(screen.getByText('Summary of Items')).toBeInTheDocument();
+    expect(screen.getByText('Start time')).toBeInTheDocument();
+    expect(screen.getByText('End time')).toBeInTheDocument();
+  });
+
+  it('should render batch state indicator with correct state', async () => {
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+
+  it('should render formatted dates for start and end time', async () => {
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    const tiles = screen.getAllByText(/2021|2023/);
+    expect(tiles.length).toBeGreaterThan(0);
+  });
+
+  it('should render items count summary', async () => {
+    const items = createMockBatchOperationItems(2);
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 2},
+    });
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText(/2 successful/)).toBeInTheDocument();
+  });
+
+  it('should render empty state when no items exist', async () => {
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('0 Items')).toBeInTheDocument();
+    expect(screen.getByText('No items found')).toBeInTheDocument();
+  });
+
+  it('should render table with batch operation items', async () => {
+    const items = createMockBatchOperationItems(3);
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 3},
+    });
+
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('3 Items')).toBeInTheDocument();
+    expect(screen.getByText('2251799813685250')).toBeInTheDocument();
+    expect(screen.getByText('2251799813685251')).toBeInTheDocument();
+    expect(screen.getByText('2251799813685252')).toBeInTheDocument();
+  });
+
+  it('should render items with failed state', async () => {
+    const items = createMockBatchOperationItems(2, {state: 'FAILED'});
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 2},
+    });
+
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    const failedStates = screen.getAllByText('Failed');
+    expect(failedStates.length).toBeGreaterThan(0);
+  });
+
+  it('should render error messages for failed items', async () => {
+    const items = createMockBatchOperationItems(1, {
+      withErrors: true,
+      state: 'FAILED',
+    });
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {totalItems: 1},
+    });
+
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+    expect(screen.getByText('Failure reason:')).toBeInTheDocument();
+    expect(screen.getByText('Error processing item 1')).toBeInTheDocument();
+  });
+
+  it('should show error notification when batch operation fails to load', async () => {
+    mockGetBatchOperation().withServerError(500);
+
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to load batch operation details'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show forbidden page when user lacks permissions', async () => {
+    mockGetBatchOperation().withServerError(403);
+
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(
+      screen.getByText(
+        '403 - You do not have permission to view this information',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/BatchOperation/index.tsx
+++ b/operate/client/src/App/BatchOperation/index.tsx
@@ -67,7 +67,7 @@ const BatchOperation: React.FC = () => {
     if (error?.response?.status === 404 && batchOperationKey) {
       notificationsStore.displayNotification({
         kind: 'error',
-        title: `batch operation ${batchOperationKey} could not be found`,
+        title: `Batch operation ${batchOperationKey} could not be found`,
         isDismissable: true,
       });
       navigate(Paths.batchOperations(), {replace: true});

--- a/operate/client/src/App/BatchOperation/index.tsx
+++ b/operate/client/src/App/BatchOperation/index.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useEffect} from 'react';
+import {Link, useParams} from 'react-router-dom';
+import Breadcrumb from '@carbon/react/lib/components/Breadcrumb/Breadcrumb';
+import BreadcrumbItem from '@carbon/react/lib/components/Breadcrumb/BreadcrumbItem';
+import {VisuallyHiddenH1} from 'modules/components/VisuallyHiddenH1';
+import {Locations, Paths} from 'modules/Routes';
+import {useBatchOperation} from 'modules/queries/batch-operations/useBatchOperation';
+import {Forbidden} from 'modules/components/Forbidden';
+import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
+import {
+  PageContainer,
+  ContentContainer,
+  PageHeader,
+  TilesContainer,
+  Tile,
+  TileLabel,
+} from './styled';
+import {BatchStateIndicator} from 'App/BatchOperations/BatchStateIndicator';
+import {BatchItemsCount} from 'App/BatchOperations/BatchItemsCount';
+import {formatDate} from 'modules/utils/date';
+import {SortableTable} from 'modules/components/SortableTable';
+import {useBatchOperationItems} from 'modules/queries/batch-operations/useBatchOperationItems';
+import {PAGE_TITLE} from 'modules/constants';
+import {InlineNotification, SkeletonText} from '@carbon/react';
+
+const BatchOperation: React.FC = () => {
+  const {batchOperationKey = ''} = useParams<{batchOperationKey: string}>();
+  const {
+    data: batchOperationData,
+    error,
+    isLoading,
+  } = useBatchOperation(batchOperationKey);
+  const {
+    data: batchOperationItemsData,
+    status,
+    isFetching,
+    isFetched,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchingPreviousPage,
+  } = useBatchOperationItems({
+    filter: {batchOperationKey: batchOperationKey},
+    sort: [{field: 'processedDate', order: 'desc'}],
+  });
+
+  const {
+    batchOperationType,
+    state,
+    operationsCompletedCount,
+    operationsFailedCount,
+    operationsTotalCount,
+    startDate,
+    endDate,
+  } = batchOperationData || {};
+
+  const operationType = formatOperationType(batchOperationType ?? '');
+
+  useEffect(() => {
+    document.title = PAGE_TITLE.BATCH_OPERATION(operationType);
+  }, [operationType]);
+
+  const headers = [
+    {
+      key: 'processInstanceKey',
+      header: 'Process Instance Key',
+      isDisabled: true,
+    },
+    {key: 'state', header: 'Batch state', isDisabled: true},
+    {key: 'processedDate', header: 'Time', sortKey: 'processedDate'},
+  ];
+
+  const migrationItems =
+    batchOperationItemsData?.pages.flatMap((page) => page.items) ?? [];
+
+  const rows = migrationItems.map((item) => ({
+    id: item.itemKey.toString(),
+    processInstanceKey: item.processInstanceKey,
+    state: <BatchStateIndicator status={item.state} />,
+    processedDate: formatDate(item.processedDate ?? ''),
+  }));
+
+  const totalItems = batchOperationItemsData?.pages[0].page.totalItems;
+
+  const getTableState = () => {
+    switch (true) {
+      case isFetched && migrationItems.length === 0:
+        return 'empty';
+      case status === 'pending' && !batchOperationItemsData:
+        return 'skeleton';
+      case isFetching && !isFetchingPreviousPage && !isFetchingNextPage:
+        return 'loading';
+      case status === 'error':
+        return 'error';
+      case status === 'success' && totalItems === 0:
+        return 'content';
+      default:
+        return 'content';
+    }
+  };
+
+  if (error?.response?.status === HTTP_STATUS_FORBIDDEN) {
+    return <Forbidden />;
+  }
+
+  const tileData = [
+    {
+      label: 'State',
+      content: state ? <BatchStateIndicator status={state} /> : null,
+    },
+    {
+      label: 'Summary of Items',
+      content: (
+        <BatchItemsCount
+          operationsCompletedCount={operationsCompletedCount ?? 0}
+          operationsFailedCount={operationsFailedCount ?? 0}
+          operationsTotalCount={operationsTotalCount ?? 0}
+        />
+      ),
+    },
+    {
+      label: 'Start time',
+      content: formatDate(startDate ?? ''),
+    },
+    {
+      label: 'End time',
+      content: formatDate(endDate ?? ''),
+    },
+  ];
+
+  return (
+    <PageContainer gap={5}>
+      <VisuallyHiddenH1>Batch Operations</VisuallyHiddenH1>
+      <PageHeader>
+        <Breadcrumb noTrailingSlash>
+          <BreadcrumbItem>
+            <Link
+              to={Locations.processes()}
+              title="View processes"
+              aria-label="View processes"
+            >
+              Processes
+            </Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Link
+              to={Paths.batchOperations()}
+              title="View batch operations"
+              aria-label="View batch operations"
+            >
+              Batch Operations
+            </Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isCurrentPage>
+            <div>{operationType}</div>
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </PageHeader>
+      <ContentContainer gap={5}>
+        <h3>{operationType}</h3>
+        {error && (
+          <InlineNotification
+            kind="error"
+            statusIconDescription="notification"
+            hideCloseButton
+            role="alert"
+            title="Failed to load batch operation details"
+          />
+        )}
+        <TilesContainer gap={4} orientation="horizontal">
+          {tileData.map(({label, content}) => (
+            <Tile key={label}>
+              <TileLabel>{label}</TileLabel>
+              {isLoading ? <SkeletonText /> : content}
+            </Tile>
+          ))}
+        </TilesContainer>
+        <strong>{totalItems} Items</strong>
+        <SortableTable
+          batchOperationId={batchOperationKey}
+          size="md"
+          state={getTableState()}
+          rowOperationError={(rowId) => {
+            const item = migrationItems.find(
+              (item) => item.itemKey.toString() === rowId,
+            );
+
+            if (item && item.errorMessage) {
+              return (
+                <>
+                  <strong>Failure reason:</strong> {item.errorMessage}
+                </>
+              );
+            }
+
+            return null;
+          }}
+          rows={rows}
+          headerColumns={headers}
+          onVerticalScrollEndReach={() => {
+            if (hasNextPage && !isFetchingNextPage) {
+              fetchNextPage();
+            }
+          }}
+          emptyMessage={{message: 'No items found'}}
+          stickyHeader
+        />
+      </ContentContainer>
+    </PageContainer>
+  );
+};
+
+export {BatchOperation};
+
+const formatOperationType = (type: string) => {
+  return type
+    .split('_')
+    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(' ');
+};

--- a/operate/client/src/App/BatchOperation/styled.ts
+++ b/operate/client/src/App/BatchOperation/styled.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Stack, Tile as CarbonTile} from '@carbon/react';
+import styled from 'styled-components';
+
+const PageContainer = styled(Stack)`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background-color: var(--cds-layer);
+`;
+
+const ContentContainer = styled(Stack)`
+  display: flex;
+  flex-direction: column;
+  background-color: var(--cds-layer);
+  min-height: 0;
+  flex: 1;
+  padding: 0 var(--cds-spacing-05);
+`;
+
+const PageHeader = styled.div`
+  width: 100%;
+  border-bottom: 1px solid var(--cds-border-subtle-01);
+  padding: var(--cds-spacing-04) var(--cds-spacing-05);
+`;
+
+const TilesContainer = styled(Stack)`
+  align-self: flex-start;
+`;
+
+const Tile = styled(CarbonTile)`
+  min-width: 200px;
+  border: 1px solid var(--cds-border-subtle-01);
+  padding: var(--cds-spacing-05);
+`;
+
+const TileLabel = styled.span`
+  display: block;
+  font-size: var(--cds-label-01-font-size);
+  margin-bottom: var(--cds-spacing-02);
+  color: var(--cds-text-weak);
+`;
+
+export {
+  PageContainer,
+  ContentContainer,
+  PageHeader,
+  TilesContainer,
+  Tile,
+  TileLabel,
+};

--- a/operate/client/src/App/BatchOperations/formatOperationType.ts
+++ b/operate/client/src/App/BatchOperations/formatOperationType.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const formatOperationType = (type: string) => {
+  return type
+    .split('_')
+    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(' ');
+};
+
+export {formatOperationType};

--- a/operate/client/src/App/BatchOperations/index.tsx
+++ b/operate/client/src/App/BatchOperations/index.tsx
@@ -27,15 +27,9 @@ import {
 import {parseBatchOperationsSearchSort} from 'modules/utils/filter/batchOperationsSearchSort';
 import {BatchItemsCount} from './BatchItemsCount';
 import {BatchStateIndicator} from './BatchStateIndicator';
+import {formatOperationType} from './formatOperationType';
 
 const MAX_OPERATIONS_PER_REQUEST = 20;
-
-const formatOperationType = (type: string) => {
-  return type
-    .split('_')
-    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
-    .join(' ');
-};
 
 const BatchOperations: React.FC = () => {
   const [params, setParams] = useSearchParams();

--- a/operate/client/src/App/BatchOperations/index.tsx
+++ b/operate/client/src/App/BatchOperations/index.tsx
@@ -92,7 +92,11 @@ const BatchOperations: React.FC = () => {
     }) => {
       return {
         id: batchOperationKey,
-        operationType: formatOperationType(batchOperationType),
+        operationType: (
+          <Link to={batchOperationKey}>
+            {formatOperationType(batchOperationType)}
+          </Link>
+        ),
         state: <BatchStateIndicator status={state} />,
         items: (
           <BatchItemsCount
@@ -143,6 +147,7 @@ const BatchOperations: React.FC = () => {
                 additionalInfo:
                   'Try adjusting your filters or check back later.',
               }}
+              stickyHeader
             />
           </TableContainer>
           {totalItems > pageSize && (

--- a/operate/client/src/App/BatchOperations/styled.ts
+++ b/operate/client/src/App/BatchOperations/styled.ts
@@ -6,18 +6,19 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {Stack} from '@carbon/react';
 import styled from 'styled-components';
 
-const PageContainer = styled.div`
+const PageContainer = styled(Stack)`
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  background-color: var(--cds-layer);
 `;
 
 const PageHeader = styled.div`
   width: 100%;
-  background-color: var(--cds-layer-01);
   border-bottom: 1px solid var(--cds-border-subtle-01);
   padding: var(--cds-spacing-04) var(--cds-spacing-05);
 `;
@@ -25,7 +26,6 @@ const PageHeader = styled.div`
 const PageWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: var(--cds-layer);
   min-height: 0;
   flex: 1;
 `;
@@ -43,13 +43,6 @@ const TableContainer = styled.div`
   flex: 1;
   overflow: auto;
   padding: 0 var(--cds-spacing-05);
-
-  thead {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background-color: var(--cds-layer);
-  }
 
   .cds--popover-content {
     padding: var(--cds-spacing-02) var(--cds-spacing-03);

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -850,16 +850,16 @@ const ElementInstancesTree: React.FC<ElementInstancesTreeProps> = observer(
   (props) => {
     const {processInstance, businessObjects, errorMessage, ...rest} = props;
     const scrollableContainerRef = useRef<HTMLDivElement>(null);
-    const {data: {items: migrationItems} = {items: []}} =
-      useBatchOperationItems({
-        filter: {
-          processInstanceKey: processInstance.processInstanceKey,
-          operationType: 'MIGRATE_PROCESS_INSTANCE',
-          state: 'COMPLETED',
-        },
-        sort: [{field: 'processedDate', order: 'desc'}],
-        page: {limit: 1, from: 0},
-      });
+    const {data} = useBatchOperationItems({
+      filter: {
+        processInstanceKey: processInstance.processInstanceKey,
+        operationType: 'MIGRATE_PROCESS_INSTANCE',
+        state: 'COMPLETED',
+      },
+      sort: [{field: 'processedDate', order: 'desc'}],
+      page: {limit: 1, from: 0},
+    });
+    const migrationItems = data?.pages[0].items ?? [];
     const latestMigrationDate =
       migrationItems.length > 0 ? migrationItems[0].processedDate : undefined;
     const rootElementInstance = useMemo<ElementInstance>(() => {

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -116,6 +116,13 @@ const routes = createRoutesFromElements(
         }}
       />
       <Route
+        path={Paths.batchOperation()}
+        lazy={async () => {
+          const {BatchOperation} = await import('./BatchOperation/index');
+          return {Component: BatchOperation};
+        }}
+      />
+      <Route
         path={Paths.operationsLog()}
         lazy={async () => {
           const {OperationsLog} = await import('./OperationsLog/index');

--- a/operate/client/src/modules/Routes.tsx
+++ b/operate/client/src/modules/Routes.tsx
@@ -38,6 +38,9 @@ const Paths = {
   batchOperations() {
     return '/batch-operations';
   },
+  batchOperation(batchOperationKey: string = ':batchOperationKey') {
+    return `/batch-operations/${batchOperationKey}`;
+  },
 } as const;
 
 const Locations = {

--- a/operate/client/src/modules/components/SortableTable/index.tsx
+++ b/operate/client/src/modules/components/SortableTable/index.tsx
@@ -51,13 +51,14 @@ type Props = {
   onSelectAll?: () => void;
   onSelect?: (rowId: string) => void;
   checkIsRowSelected?: (rowId: string) => boolean; //must be a function because it depends on a store update: https://mobx.js.org/react-optimizations.html#function-props-
-  rowOperationError?: (rowId: string) => string | null; //must be a function because it depends on a store update: https://mobx.js.org/react-optimizations.html#function-props-
+  rowOperationError?: (rowId: string) => React.ReactNode | null; //must be a function because it depends on a store update: https://mobx.js.org/react-optimizations.html#function-props-
   checkIsAllSelected?: () => boolean; //must be a function because it depends on a store update: https://mobx.js.org/react-optimizations.html#function-props-
   checkIsIndeterminate?: () => boolean; //must be a function because it depends on a store update: https://mobx.js.org/react-optimizations.html#function-props-
   onSort?: React.ComponentProps<typeof ColumnHeader>['onSort'];
   columnsWithNoContentPadding?: string[];
   batchOperationId?: string;
   size?: React.ComponentProps<typeof Table>['size'];
+  stickyHeader?: boolean;
 } & Pick<
   React.ComponentProps<typeof InfiniteScroller>,
   'onVerticalScrollStartReach' | 'onVerticalScrollEndReach'
@@ -80,6 +81,7 @@ const SortableTable: React.FC<Props> = ({
   onVerticalScrollEndReach,
   columnsWithNoContentPadding,
   batchOperationId,
+  stickyHeader = false,
 }) => {
   let scrollableContentRef = useRef<HTMLDivElement | null>(null);
 
@@ -128,7 +130,7 @@ const SortableTable: React.FC<Props> = ({
           <TableContainer $hasError={!!batchOperationId}>
             {state === 'loading' && <Loading data-testid="data-table-loader" />}
             <Table {...getTableProps()} isSortable>
-              <TableHead>
+              <TableHead $stickyHeader={stickyHeader}>
                 <TableHeadRow>
                   {batchOperationId && (
                     <TableExpandHeader aria-label="expand row" />

--- a/operate/client/src/modules/components/SortableTable/styled.tsx
+++ b/operate/client/src/modules/components/SortableTable/styled.tsx
@@ -186,8 +186,23 @@ const TableCell = styled(BaseTableCell)<TableCellProps>`
     `;
   }}
 `;
-const TableHead = styled(BaseTableHead)`
-  white-space: nowrap;
+
+type TableHeadProps = {
+  $stickyHeader?: boolean;
+};
+
+const TableHead = styled(BaseTableHead)<TableHeadProps>`
+  ${({$stickyHeader}) => {
+    return css`
+      white-space: nowrap;
+      ${$stickyHeader &&
+      css`
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      `}
+    `;
+  }}
 `;
 
 const EmptyMessageContainer = styled.div`

--- a/operate/client/src/modules/constants.ts
+++ b/operate/client/src/modules/constants.ts
@@ -40,6 +40,7 @@ const PAGE_TITLE = {
   DECISION_INSTANCE: (id: string, name: string) =>
     `Operate: Decision Instance ${id} of ${name}`,
   BATCH_OPERATIONS: 'Operate: Batch Operations',
+  BATCH_OPERATION: (name: string) => `Operate: Batch Operation ${name}`,
   AUDIT_LOG: 'Operate: Operations Log',
 };
 

--- a/operate/client/src/modules/mocks/api/v2/batchOperations/getBatchOperation.ts
+++ b/operate/client/src/modules/mocks/api/v2/batchOperations/getBatchOperation.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type BatchOperation,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {mockGetRequest} from '../../mockRequest';
+
+const mockGetBatchOperation = (contextPath = '') =>
+  mockGetRequest<BatchOperation>(
+    `${contextPath}${endpoints.getBatchOperation.getUrl({batchOperationKey: ':batchOperationKey'})}`,
+  );
+
+export {mockGetBatchOperation};

--- a/operate/client/src/modules/queries/batch-operations/useBatchOperation.ts
+++ b/operate/client/src/modules/queries/batch-operations/useBatchOperation.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import type {BatchOperation} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {RequestError} from 'modules/request';
+import {getBatchOperation} from 'modules/api/v2/batchOperations/getBatchOperation';
+import {queryKeys} from '../queryKeys';
+
+const useBatchOperation = (batchOperationKey: string) => {
+  return useQuery<BatchOperation, RequestError>({
+    queryKey: queryKeys.batchOperations.get(batchOperationKey),
+    queryFn: async () => {
+      const {response, error} = await getBatchOperation({batchOperationKey});
+      if (response !== null) {
+        return response;
+      }
+
+      throw error;
+    },
+  });
+};
+
+export {useBatchOperation};

--- a/operate/client/src/modules/queries/batch-operations/useBatchOperationItems.ts
+++ b/operate/client/src/modules/queries/batch-operations/useBatchOperationItems.ts
@@ -18,13 +18,13 @@ const useBatchOperationItems = (
 ) => {
   return useInfiniteQuery({
     queryKey: queryKeys.batchOperationItems.query(payload),
-    queryFn: async () => {
+    queryFn: async ({pageParam = 0}) => {
       const requestPayload = {
         ...payload,
         page: {
           ...payload.page,
           limit: payload.page?.limit ?? MAX_OPERATIONS_PER_REQUEST,
-          from: payload.page?.from ?? 0,
+          from: pageParam,
         },
       };
 
@@ -41,7 +41,7 @@ const useBatchOperationItems = (
       const {page} = lastPage;
       const nextPage = lastPageParam + MAX_OPERATIONS_PER_REQUEST;
 
-      if (nextPage > page.totalItems) {
+      if (nextPage >= page.totalItems) {
         return null;
       }
 

--- a/operate/client/src/modules/queries/batch-operations/useBatchOperationItems.ts
+++ b/operate/client/src/modules/queries/batch-operations/useBatchOperationItems.ts
@@ -6,18 +6,29 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useQuery} from '@tanstack/react-query';
+import {useInfiniteQuery} from '@tanstack/react-query';
 import {queryBatchOperationItems} from 'modules/api/v2/batchOperations/queryBatchOperationItems';
 import type {QueryBatchOperationItemsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {queryKeys} from '../queryKeys';
 
+const MAX_OPERATIONS_PER_REQUEST = 50;
+
 const useBatchOperationItems = (
   payload: QueryBatchOperationItemsRequestBody,
 ) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: queryKeys.batchOperationItems.query(payload),
     queryFn: async () => {
-      const {response, error} = await queryBatchOperationItems(payload);
+      const requestPayload = {
+        ...payload,
+        page: {
+          ...payload.page,
+          limit: payload.page?.limit ?? MAX_OPERATIONS_PER_REQUEST,
+          from: payload.page?.from ?? 0,
+        },
+      };
+
+      const {response, error} = await queryBatchOperationItems(requestPayload);
 
       if (response !== null) {
         return response;
@@ -25,6 +36,27 @@ const useBatchOperationItems = (
 
       throw error;
     },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      const {page} = lastPage;
+      const nextPage = lastPageParam + MAX_OPERATIONS_PER_REQUEST;
+
+      if (nextPage > page.totalItems) {
+        return null;
+      }
+
+      return nextPage;
+    },
+    getPreviousPageParam: (_, __, firstPageParam) => {
+      const previousPage = firstPageParam - MAX_OPERATIONS_PER_REQUEST;
+
+      if (previousPage < 0) {
+        return null;
+      }
+
+      return previousPage;
+    },
+    maxPages: 2,
   });
 };
 


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR introduces a new Batch Operation details page, allowing users to view detailed information and items related to a single batch operation. It includes a new dedicated route that shows the operation summary and a list of the patch items in a table format.

To support this feature,  I had to also do the following:
* Improved table components (added sticky headers option) to prevent repetition, as it is currently being used in two places. 
* adjusted the `useBatchOperationsItems` to support infinite scrolling needed for displaying them in the batch details page.


**Out of scope**
* visual regression tests (will be done with https://github.com/camunda/camunda/issues/43263)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
closes #41688
