### PR TITLE
feat: always use snapshots to latest camunda and connectors

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -3,6 +3,8 @@ ELASTICSEARCH_VERSION=8.18.6
 CAMUNDA_VERSION=8.9.0-SNAPSHOT
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.9.0-SNAPSHOT
+# Set to true to launch connectors via Spring Boot's PropertiesLauncher (needed for Boot 4+ runtimes). Switch to false for legacy JarLauncher.
+CONNECTORS_USE_PROPERTIES_LAUNCHER=true
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.9
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.9

--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.18.6
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.9.0-alpha2
+CAMUNDA_VERSION=8.9.0-SNAPSHOT
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.9.0-alpha2
+CONNECTORS_VERSION=8.9.0-SNAPSHOT
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.9
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.9

--- a/c8run/.env
+++ b/c8run/.env
@@ -3,8 +3,6 @@ ELASTICSEARCH_VERSION=8.18.6
 CAMUNDA_VERSION=8.9.0-SNAPSHOT
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.9.0-SNAPSHOT
-# Set to true to launch connectors via Spring Boot's PropertiesLauncher (needed for Boot 4+ runtimes). Switch to false for legacy JarLauncher.
-CONNECTORS_USE_PROPERTIES_LAUNCHER=true
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.9
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.9

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -41,6 +41,6 @@ Only CI checks related to C8Run (those with "c8run" in the name) and CI runs mar
 
 To build and run C8Run locally run `./package.sh` followed by `./start.sh`
 
-### Switching the connectors launcher
+### Connectors launcher
 
-C8Run now defaults to starting the connectors runtime through Spring Boot's `PropertiesLauncher`, which matches how the connectors project ships its Docker entrypoint for Spring Boot 4+. This keeps the jar immutable while still letting `custom_connectors` be layered via the classpath. If you need to fall back to the legacy `JarLauncher`, set `CONNECTORS_USE_PROPERTIES_LAUNCHER=false` (the default `.env` enables it).
+C8Run automatically starts the connectors runtime through Spring Boot's `PropertiesLauncher` for connector bundles versioned 8.9.0 or newer (including snapshots). Older bundles continue to run via the legacy `JarLauncher`, so you can switch versions in `.env` without extra configuration.

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -40,3 +40,7 @@ Only CI checks related to C8Run (those with "c8run" in the name) and CI runs mar
 ## Build C8run locally
 
 To build and run C8Run locally run `./package.sh` followed by `./start.sh`
+
+### Switching the connectors launcher
+
+C8Run now defaults to starting the connectors runtime through Spring Boot's `PropertiesLauncher`, which matches how the connectors project ships its Docker entrypoint for Spring Boot 4+. This keeps the jar immutable while still letting `custom_connectors` be layered via the classpath. If you need to fall back to the legacy `JarLauncher`, set `CONNECTORS_USE_PROPERTIES_LAUNCHER=false` (the default `.env` enables it).

--- a/c8run/configuration/application.yaml
+++ b/c8run/configuration/application.yaml
@@ -8,6 +8,9 @@ camunda:
         password:
         flushInterval: PT0.5S
         queueSize: 1000
+  cluster:
+    raft:
+      segment-preallocation-strategy: FILL
   security:
     initialization:
       users:

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -48,11 +48,11 @@ printf "\nTest: test --config flag\n"
 #        exit 1
 #fi
 
-printf "\nTest: connectors api \n"
-
-STATUS="$(curl localhost:8086/actuator/health | jq '.status')"
-echo $STATUS
-if [[ "$STATUS" != "\"UP\"" ]]; then
-        echo "test failed"
-        exit 1
-fi
+#printf "\nTest: connectors api \n"
+#
+#STATUS="$(curl localhost:8086/actuator/health | jq '.status')"
+#echo $STATUS
+#if [[ "$STATUS" != "\"UP\"" ]]; then
+#        echo "test failed"
+#        exit 1
+#fi

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -48,11 +48,11 @@ printf "\nTest: test --config flag\n"
 #        exit 1
 #fi
 
-#printf "\nTest: connectors api \n"
-#
-#STATUS="$(curl localhost:8086/actuator/health | jq '.status')"
-#echo $STATUS
-#if [[ "$STATUS" != "\"UP\"" ]]; then
-#        echo "test failed"
-#        exit 1
-#fi
+printf "\nTest: connectors api \n"
+
+STATUS="$(curl localhost:8086/actuator/health | jq '.status')"
+echo $STATUS
+if [[ "$STATUS" != "\"UP\"" ]]; then
+        echo "test failed"
+        exit 1
+fi

--- a/c8run/internal/connectors/launcher.go
+++ b/c8run/internal/connectors/launcher.go
@@ -1,23 +1,41 @@
 package connectors
 
 import (
-	"os"
+	"strconv"
 	"strings"
 )
 
-const propertiesLauncherEnvVar = "CONNECTORS_USE_PROPERTIES_LAUNCHER"
-
-func UsePropertiesLauncher() bool {
-	value := strings.TrimSpace(os.Getenv(propertiesLauncherEnvVar))
-	if value == "" {
+func UsePropertiesLauncher(version string) bool {
+	major, minor, ok := parseMajorMinor(version)
+	if !ok {
 		return false
 	}
-
-	value = strings.ToLower(value)
-	switch value {
-	case "1", "true", "yes", "on":
+	if major > 8 {
 		return true
-	default:
+	}
+	if major < 8 {
 		return false
 	}
+	return minor >= 9
+}
+
+func parseMajorMinor(version string) (int, int, bool) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return 0, 0, false
+	}
+	base := strings.SplitN(version, "-", 2)[0]
+	parts := strings.Split(base, ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }

--- a/c8run/internal/connectors/launcher.go
+++ b/c8run/internal/connectors/launcher.go
@@ -1,0 +1,23 @@
+package connectors
+
+import (
+	"os"
+	"strings"
+)
+
+const propertiesLauncherEnvVar = "CONNECTORS_USE_PROPERTIES_LAUNCHER"
+
+func UsePropertiesLauncher() bool {
+	value := strings.TrimSpace(os.Getenv(propertiesLauncherEnvVar))
+	if value == "" {
+		return false
+	}
+
+	value = strings.ToLower(value)
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/c8run/internal/connectors/launcher_test.go
+++ b/c8run/internal/connectors/launcher_test.go
@@ -3,23 +3,24 @@ package connectors
 import "testing"
 
 func TestUsePropertiesLauncher(t *testing.T) {
-	t.Setenv(propertiesLauncherEnvVar, "true")
-	if !UsePropertiesLauncher() {
-		t.Fatalf("expected PropertiesLauncher to be enabled when env var is true")
+	cases := []struct {
+		version string
+		expect  bool
+	}{
+		{"8.9.0-SNAPSHOT", true},
+		{"8.10.0", true},
+		{"9.0.0-alpha1", true},
+		{"8.8.5", false},
+		{"7.17.0", false},
+		{"invalid", false},
+		{"", false},
 	}
 
-	t.Setenv(propertiesLauncherEnvVar, "false")
-	if UsePropertiesLauncher() {
-		t.Fatalf("expected PropertiesLauncher to be disabled when env var is false")
-	}
-
-	t.Setenv(propertiesLauncherEnvVar, "YES")
-	if !UsePropertiesLauncher() {
-		t.Fatalf("expected PropertiesLauncher to support truthy string")
-	}
-
-	t.Setenv(propertiesLauncherEnvVar, "")
-	if UsePropertiesLauncher() {
-		t.Fatalf("expected PropertiesLauncher to be disabled when env var unset")
+	for _, tc := range cases {
+		t.Run(tc.version, func(t *testing.T) {
+			if UsePropertiesLauncher(tc.version) != tc.expect {
+				t.Fatalf("expected %v for version %s", tc.expect, tc.version)
+			}
+		})
 	}
 }

--- a/c8run/internal/connectors/launcher_test.go
+++ b/c8run/internal/connectors/launcher_test.go
@@ -1,0 +1,25 @@
+package connectors
+
+import "testing"
+
+func TestUsePropertiesLauncher(t *testing.T) {
+	t.Setenv(propertiesLauncherEnvVar, "true")
+	if !UsePropertiesLauncher() {
+		t.Fatalf("expected PropertiesLauncher to be enabled when env var is true")
+	}
+
+	t.Setenv(propertiesLauncherEnvVar, "false")
+	if UsePropertiesLauncher() {
+		t.Fatalf("expected PropertiesLauncher to be disabled when env var is false")
+	}
+
+	t.Setenv(propertiesLauncherEnvVar, "YES")
+	if !UsePropertiesLauncher() {
+		t.Fatalf("expected PropertiesLauncher to support truthy string")
+	}
+
+	t.Setenv(propertiesLauncherEnvVar, "")
+	if UsePropertiesLauncher() {
+		t.Fatalf("expected PropertiesLauncher to be disabled when env var unset")
+	}
+}

--- a/c8run/internal/processmanagement/processhandler_test.go
+++ b/c8run/internal/processmanagement/processhandler_test.go
@@ -26,7 +26,7 @@ func (m *mockC8) ElasticsearchCmd(ctx context.Context, elasticsearchVersion stri
 	return nil
 }
 
-func (m *mockC8) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
+func (m *mockC8) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
 	return nil
 }
 

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -326,7 +326,7 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 	}
 
 	s.ProcessHandler.AttemptToStartProcess(processInfo.Connectors.PidPath, "Connectors", func() {
-		connectorsCmd := c8.ConnectorsCmd(ctx, javaBinary, parentDir, processInfo.Camunda.Version, state.Settings.Port)
+		connectorsCmd := c8.ConnectorsCmd(ctx, javaBinary, parentDir, processInfo.Connectors.Version, state.Settings.Port)
 		connectorsLogPath := filepath.Join(parentDir, "log", "connectors.log")
 		err := s.startApplication(connectorsCmd, processInfo.Connectors.PidPath, connectorsLogPath, stop)
 		if err != nil {

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -10,7 +10,7 @@ type C8Run interface {
 	ProcessTree(commandPid int) []int
 	VersionCmd(ctx context.Context, javaBinaryPath string) *exec.Cmd
 	ElasticsearchCmd(ctx context.Context, elasticsearchVersion string, parentDir string) *exec.Cmd
-	ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd
+	ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd
 	CamundaCmd(ctx context.Context, camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd
 }
 

--- a/c8run/internal/unix/stub.go
+++ b/c8run/internal/unix/stub.go
@@ -23,7 +23,7 @@ func (w *UnixC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion s
 	panic("Platform was not built for unix")
 }
 
-func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
+func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
 	panic("Platform was not built for unix")
 }
 

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"runtime/debug"
 	"syscall"
+
+	"github.com/camunda/camunda/c8run/internal/connectors"
 )
 
 func (w *UnixC8Run) OpenBrowser(ctx context.Context, url string) error {
@@ -58,6 +60,9 @@ func (w *UnixC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion s
 func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
 	classPath := parentDir + "/*:" + parentDir + "/custom_connectors/*"
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+	if connectors.UsePropertiesLauncher() {
+		mainClass = "org.springframework.boot.loader.launch.PropertiesLauncher"
+	}
 	springConfigLocation := "--spring.config.additional-location=" + parentDir + "/connectors-application.properties"
 	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-cp", classPath, mainClass, springConfigLocation)
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -57,10 +57,10 @@ func (w *UnixC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion s
 	return elasticsearchCmd
 }
 
-func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
+func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
 	classPath := parentDir + "/*:" + parentDir + "/custom_connectors/*"
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
-	if connectors.UsePropertiesLauncher() {
+	if connectors.UsePropertiesLauncher(connectorsVersion) {
 		mainClass = "org.springframework.boot.loader.launch.PropertiesLauncher"
 	}
 	springConfigLocation := "--spring.config.additional-location=" + parentDir + "/connectors-application.properties"

--- a/c8run/internal/unix/unix_test.go
+++ b/c8run/internal/unix/unix_test.go
@@ -128,10 +128,9 @@ func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
 	}
 }
 
-func TestConnectorsCmdUsesPropertiesLauncherWhenEnabled(t *testing.T) {
+func TestConnectorsCmdUsesPropertiesLauncherWhenVersionRequiresIt(t *testing.T) {
 	ctx := context.Background()
 	unixC8Run := &UnixC8Run{}
-	t.Setenv("CONNECTORS_USE_PROPERTIES_LAUNCHER", "true")
 
 	cmd := unixC8Run.ConnectorsCmd(
 		ctx,

--- a/c8run/internal/unix/unix_test.go
+++ b/c8run/internal/unix/unix_test.go
@@ -127,3 +127,25 @@ func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
 		}
 	}
 }
+
+func TestConnectorsCmdUsesPropertiesLauncherWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+	unixC8Run := &UnixC8Run{}
+	t.Setenv("CONNECTORS_USE_PROPERTIES_LAUNCHER", "true")
+
+	cmd := unixC8Run.ConnectorsCmd(
+		ctx,
+		"java",
+		"/test/parent/dir",
+		"8.9.0",
+		8080,
+	)
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "org.springframework.boot.loader.launch.PropertiesLauncher") {
+		t.Fatalf("expected PropertiesLauncher to be used when env var enabled, got args: %s", args)
+	}
+	if strings.Contains(args, "io.camunda.connector.runtime.app.ConnectorRuntimeApplication") {
+		t.Fatalf("did not expect legacy main class when PropertiesLauncher is enabled")
+	}
+}

--- a/c8run/internal/windows/stub.go
+++ b/c8run/internal/windows/stub.go
@@ -23,7 +23,7 @@ func (w *WindowsC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersio
 	panic("Platform was not built for windows")
 }
 
-func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
+func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
 	panic("Platform was not built for windows")
 }
 

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"syscall"
+
+	"github.com/camunda/camunda/c8run/internal/connectors"
 )
 
 func (w *WindowsC8Run) OpenBrowser(ctx context.Context, url string) error {
@@ -52,7 +54,11 @@ func (w *WindowsC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersio
 }
 
 func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
-	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*", "io.camunda.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.additional-location="+parentDir+"\\connectors-application.properties")
+	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+	if connectors.UsePropertiesLauncher() {
+		mainClass = "org.springframework.boot.loader.launch.PropertiesLauncher"
+	}
+	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*", mainClass, "--spring.config.additional-location="+parentDir+"\\connectors-application.properties")
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		// CreationFlags: 0x00000008 | 0x00000200, // DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -53,9 +53,9 @@ func (w *WindowsC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersio
 	return elasticsearchCmd
 }
 
-func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
+func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
-	if connectors.UsePropertiesLauncher() {
+	if connectors.UsePropertiesLauncher(connectorsVersion) {
 		mainClass = "org.springframework.boot.loader.launch.PropertiesLauncher"
 	}
 	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*", mainClass, "--spring.config.additional-location="+parentDir+"\\connectors-application.properties")

--- a/c8run/internal/windows/windows_test.go
+++ b/c8run/internal/windows/windows_test.go
@@ -127,3 +127,25 @@ func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
 		}
 	}
 }
+
+func TestConnectorsCmdUsesPropertiesLauncherWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+	windowsC8Run := &WindowsC8Run{}
+	t.Setenv("CONNECTORS_USE_PROPERTIES_LAUNCHER", "true")
+
+	cmd := windowsC8Run.ConnectorsCmd(
+		ctx,
+		"java",
+		"C:\\test\\parent\\dir",
+		"8.9.0",
+		8080,
+	)
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "org.springframework.boot.loader.launch.PropertiesLauncher") {
+		t.Fatalf("expected PropertiesLauncher to be used when env var enabled, got args: %s", args)
+	}
+	if strings.Contains(args, "io.camunda.connector.runtime.app.ConnectorRuntimeApplication") {
+		t.Fatalf("did not expect legacy main class when PropertiesLauncher is enabled")
+	}
+}

--- a/c8run/internal/windows/windows_test.go
+++ b/c8run/internal/windows/windows_test.go
@@ -128,10 +128,9 @@ func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
 	}
 }
 
-func TestConnectorsCmdUsesPropertiesLauncherWhenEnabled(t *testing.T) {
+func TestConnectorsCmdUsesPropertiesLauncherWhenVersionRequiresIt(t *testing.T) {
 	ctx := context.Background()
 	windowsC8Run := &WindowsC8Run{}
-	t.Setenv("CONNECTORS_USE_PROPERTIES_LAUNCHER", "true")
 
 	cmd := windowsC8Run.ConnectorsCmd(
 		ctx,


### PR DESCRIPTION
## Description

1. This will allow qa run tests against snapshots versions of camunda and connectors. 
2. it also has patch to start camunda with fix for macos 
```
 cluster:
    raft:
      segment-preallocation-strategy: FILL
```
3. also new version of connectors migrated to spring 5, so we should use new launcher type than it was before 8.9

closes #40501

