### PR TITLE
ci: mitigate Maven Central incident affecting GH-hosted runners

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -62,7 +62,7 @@ jobs:
   build-operate-backend:
     if: inputs.runBeTests
     name: "Build Back End"
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-4-default
     timeout-minutes: 10
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
@@ -360,7 +360,7 @@ jobs:
     if: inputs.runBeTests
     name: "Integration / Backup Restore ITs"
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: gcp-perf-core-8-default
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       DOCKER_IMAGE_TAG: current-test

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -296,7 +296,7 @@ jobs:
     if: inputs.runBeTests
     name: "Integration / Backup Restore ITs"
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: gcp-perf-core-8-default
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       DOCKER_IMAGE_TAG: current-test

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -42,14 +42,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows, linux ]
+        # os: [ windows, linux ]
+        os: [ linux ]
         arch: [ amd64 ]
         include:
           - os: macos
             runner: macos-latest
             arch: arm64
-          - os: windows
-            runner: windows-latest
+          # - os: windows
+          #   runner: windows-latest
           - os: linux
             runner: gcp-perf-core-8-default
           - os: linux
@@ -254,6 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
+    if: false
     env:
       TEST_OWNER: Core Features
       TEST_TYPE: Unit
@@ -313,7 +315,7 @@ jobs:
 
   docker-checks:
     name: "Build / Docker Checks"
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-4-default
     timeout-minutes: 20
     permissions:
       security-events: write
@@ -398,7 +400,7 @@ jobs:
       - property-tests
       - performance-tests
       - docker-checks
-      - strace-tests
+      # - strace-tests
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     if: needs.detect-changes.outputs.maven-spotless-linter == 'true'
     name: "Lint / Maven Spotless"
     needs: [ detect-changes ]
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-4-default
     timeout-minutes: 5
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
@@ -817,10 +817,10 @@ jobs:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"
     needs: [ detect-changes ]
-    runs-on: ubuntu-latest
+    runs-on: gcp-perf-core-8-default
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       security-events: write
     services:


### PR DESCRIPTION
## Description

I tried to find all jobs part of required status checks that are Java-based and use Github-hosted runners. Those jobs got changed to use equivalent self-hosted runner from https://confluence.camunda.com/spaces/HAN/pages/123308536/Github+Actions+Self-Hosted+Runners which should not be affected.

We have to disable jobs with Maven connection problems that we have no equivalent runners for:

* smoke tests requiring `root`
* Windows based jobs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to INC-4187
