### PR TITLE
feat: use statistics endpoint to get element instances count

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
@@ -44,15 +44,16 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
 
   const {data: statistics} = useFlownodeInstancesStatistics();
 
-  const elementInstancesCount = useElementInstancesCount(elementId);
-  const isMultiInstanceBody = selection?.isMultiInstance ?? false;
-
+  let elementInstancesCount = useElementInstancesCount(elementId);
+  if (selection?.isMultiInstance) {
+    elementInstancesCount = 1;
+  }
   const incidentCount =
     statistics?.items.find((stat) => stat.elementId === elementId)?.incidents ??
     0;
 
   const shouldFetchElementInstances =
-    (elementInstancesCount === 1 || isMultiInstanceBody) &&
+    elementInstancesCount === 1 &&
     !elementInstanceKey &&
     !!processInstance?.processInstanceKey &&
     !!elementId;
@@ -79,7 +80,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
 
     if (
       !elementInstanceKey &&
-      (elementInstancesCount === 1 || isMultiInstanceBody) &&
+      elementInstancesCount === 1 &&
       elementInstancesSearchResult?.items?.length === 1
     ) {
       return elementInstancesSearchResult.items[0];
@@ -91,7 +92,6 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     elementInstance,
     elementInstancesCount,
     elementInstancesSearchResult,
-    isMultiInstanceBody,
   ]);
 
   if (
@@ -116,8 +116,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
       <Stack gap={3}>
         {elementInstancesCount !== null &&
           elementInstancesCount > 1 &&
-          !elementInstanceKey &&
-          !isMultiInstanceBody && (
+          !elementInstanceKey && (
             <>
               <Header
                 title={`This element instance triggered ${elementInstancesCount} times`}

--- a/operate/client/src/modules/hooks/useElementInstancesCount.test.tsx
+++ b/operate/client/src/modules/hooks/useElementInstancesCount.test.tsx
@@ -117,35 +117,6 @@ describe('useElementInstancesCount', () => {
     await waitFor(() => expect(result.current).toBe(18));
   });
 
-  it('should return correct count for different element', async () => {
-    const mockData: GetProcessInstanceStatisticsResponseBody = {
-      items: [
-        {
-          elementId: 'node1',
-          active: 5,
-          completed: 10,
-          canceled: 2,
-          incidents: 1,
-        },
-        {
-          elementId: 'node2',
-          active: 3,
-          completed: 7,
-          canceled: 0,
-          incidents: 2,
-        },
-      ],
-    };
-
-    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
-
-    const {result} = renderHook(() => useElementInstancesCount('node2'), {
-      wrapper: Wrapper,
-    });
-
-    await waitFor(() => expect(result.current).toBe(12));
-  });
-
   it('should return 0 when there are no instances', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [

--- a/operate/client/src/modules/hooks/useElementInstancesCount.test.tsx
+++ b/operate/client/src/modules/hooks/useElementInstancesCount.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {useElementInstancesCount} from './useElementInstancesCount';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {type GetProcessInstanceStatisticsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {
+  createProcessInstance,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+
+describe('useElementInstancesCount', () => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+
+  beforeEach(async () => {
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessInstance().withSuccess(createProcessInstance());
+  });
+
+  it('should return null when no elementId is provided', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'node1',
+          active: 5,
+          completed: 10,
+          canceled: 2,
+          incidents: 1,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useElementInstancesCount(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it('should return null when element is not found in statistics', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'node1',
+          active: 5,
+          completed: 10,
+          canceled: 2,
+          incidents: 1,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useElementInstancesCount('nonexistent'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it('should return correct sum of all instance counts', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'node1',
+          active: 5,
+          completed: 10,
+          canceled: 2,
+          incidents: 1,
+        },
+        {
+          elementId: 'node2',
+          active: 3,
+          completed: 7,
+          canceled: 0,
+          incidents: 2,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useElementInstancesCount('node1'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).toBe(18));
+  });
+
+  it('should return correct count for different element', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'node1',
+          active: 5,
+          completed: 10,
+          canceled: 2,
+          incidents: 1,
+        },
+        {
+          elementId: 'node2',
+          active: 3,
+          completed: 7,
+          canceled: 0,
+          incidents: 2,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useElementInstancesCount('node2'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).toBe(12));
+  });
+
+  it('should return 0 when there are no instances', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'node1',
+          active: 0,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useElementInstancesCount('node1'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).toBe(0));
+  });
+});

--- a/operate/client/src/modules/hooks/useElementInstancesCount.ts
+++ b/operate/client/src/modules/hooks/useElementInstancesCount.ts
@@ -18,7 +18,7 @@ const useElementInstancesCount = (elementId?: string) => {
     (stat) => stat.elementId === elementId,
   );
   if (!elementStats) {
-    return 0;
+    return null;
   }
 
   return (

--- a/operate/client/src/modules/hooks/useElementInstancesCount.ts
+++ b/operate/client/src/modules/hooks/useElementInstancesCount.ts
@@ -9,23 +9,19 @@
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 
 const useElementInstancesCount = (elementId?: string) => {
-  const {data: statistics} = useFlownodeInstancesStatistics();
-
-  if (!statistics?.items || !elementId) {
-    return null;
-  }
-  const elementStats = statistics.items.find(
-    (stat) => stat.elementId === elementId,
+  const {data: elementInstanceStatistics} = useFlownodeInstancesStatistics(
+    (data) => data.items.find((item) => item.elementId === elementId),
   );
-  if (!elementStats) {
+
+  if (!elementInstanceStatistics) {
     return null;
   }
 
   return (
-    elementStats.active +
-    elementStats.completed +
-    elementStats.canceled +
-    elementStats.incidents
+    elementInstanceStatistics.active +
+    elementInstanceStatistics.completed +
+    elementInstanceStatistics.canceled +
+    elementInstanceStatistics.incidents
   );
 };
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Replace state.metaData.instanceCount by data from element instances statistics endpoint. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41821 
