### PR TITLE
Batch operation actor in java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationActorTypeEnum.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationActorTypeEnum.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum BatchOperationActorTypeEnum {
+  USER,
+  CLIENT,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
+import io.camunda.client.api.search.enums.BatchOperationActorTypeEnum;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
@@ -73,4 +74,28 @@ public interface BatchOperationFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   BatchOperationFilter state(Consumer<BatchOperationStateProperty> fn);
+
+  /**
+   * Filters batch operations by the specified actor type.
+   *
+   * @param actorType the actor type
+   * @return the updated filter
+   */
+  BatchOperationFilter actorType(final BatchOperationActorTypeEnum actorType);
+
+  /**
+   * Filters batch operations by the specified actor id.
+   *
+   * @param actorId the actor id
+   * @return the updated filter
+   */
+  BatchOperationFilter actorId(final String actorId);
+
+  /**
+   * Filter by actorId using {@link StringProperty} consumer.
+   *
+   * @param fn the consumer to apply to the StringProperty
+   * @return the updated filter
+   */
+  BatchOperationFilter actorId(final Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.response;
 
+import io.camunda.client.api.search.enums.BatchOperationActorTypeEnum;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import java.time.OffsetDateTime;
@@ -42,4 +43,20 @@ public interface BatchOperation {
   Integer getOperationsCompletedCount();
 
   List<BatchOperationError> getErrors();
+
+  /**
+   * The type of actor that created the batch operation. May be {@code null} is no actor information
+   * is known.
+   *
+   * @since 8.9.0 - on older batch operations, this value is {@code null}.
+   */
+  BatchOperationActorTypeEnum getActorType();
+
+  /**
+   * The ID of the actor that created the batch operation. May be {@code null} is no actor
+   * information is known.
+   *
+   * @since 8.9.0 - on older batch operations, this value is {@code null}.
+   */
+  String getActorId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
@@ -45,18 +45,18 @@ public interface BatchOperation {
   List<BatchOperationError> getErrors();
 
   /**
-   * The type of actor that created the batch operation. May be {@code null} is no actor information
-   * is known.
+   * The type of actor that created the batch operation. Is {@code null} if no actor information is
+   * known (e.g. when authentication is not required).
    *
-   * @since 8.9.0 - on older batch operations, this value is {@code null}.
+   * @since 8.9.0 - on older batch operations, this value is always {@code null}.
    */
   BatchOperationActorTypeEnum getActorType();
 
   /**
-   * The ID of the actor that created the batch operation. May be {@code null} is no actor
-   * information is known.
+   * The ID of the actor that created the batch operation. Is {@code null} if no actor information
+   * is known (e.g. when authentication is not required).
    *
-   * @since 8.9.0 - on older batch operations, this value is {@code null}.
+   * @since 8.9.0 - on older batch operations, this value is always {@code null}.
    */
   String getActorId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationSort.java
@@ -28,4 +28,8 @@ public interface BatchOperationSort extends SearchRequestSort<BatchOperationSort
   BatchOperationSort startDate();
 
   BatchOperationSort endDate();
+
+  BatchOperationSort actorType();
+
+  BatchOperationSort actorId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
@@ -25,7 +25,9 @@ import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationTypePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.BatchOperationFilter;
 import java.util.function.Consumer;
 
@@ -98,17 +100,29 @@ public class BatchOperationFilterImpl
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter actorType(
       final BatchOperationActorTypeEnum actorType) {
+    if (actorType == null) {
+      filter.setActorType(null);
+      return this;
+    }
+
+    filter.setActorType(
+        EnumUtil.convert(
+            actorType, io.camunda.client.protocol.rest.BatchOperationActorTypeEnum.class));
     return this;
   }
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter actorId(final String actorId) {
+    actorId(p -> p.eq(actorId));
     return this;
   }
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter actorId(
       final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setActorId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
@@ -15,11 +15,13 @@
  */
 package io.camunda.client.impl.search.filter;
 
+import io.camunda.client.api.search.enums.BatchOperationActorTypeEnum;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationTypePropertyImpl;
@@ -90,6 +92,23 @@ public class BatchOperationFilterImpl
     final BatchOperationStateProperty property = new BatchOperationStatePropertyImpl();
     fn.accept(property);
     filter.setState(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter actorType(
+      final BatchOperationActorTypeEnum actorType) {
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter actorId(final String actorId) {
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter actorId(
+      final Consumer<StringProperty> fn) {
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.search.response;
 
+import io.camunda.client.api.search.enums.BatchOperationActorTypeEnum;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.BatchOperation;
@@ -111,5 +112,15 @@ public class BatchOperationImpl implements BatchOperation {
   @Override
   public List<BatchOperationError> getErrors() {
     return new ArrayList<>(errors);
+  }
+
+  @Override
+  public BatchOperationActorTypeEnum getActorType() {
+    return null;
+  }
+
+  @Override
+  public String getActorId() {
+    return null;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -36,6 +36,8 @@ public class BatchOperationImpl implements BatchOperation {
   private final BatchOperationState status;
   private final OffsetDateTime startDate;
   private final OffsetDateTime endDate;
+  private final BatchOperationActorTypeEnum actorType;
+  private final String actorId;
   private final Integer operationsTotalCount;
   private final Integer operationsFailedCount;
   private final Integer operationsCompletedCount;
@@ -48,6 +50,8 @@ public class BatchOperationImpl implements BatchOperation {
     status = null;
     startDate = null;
     endDate = null;
+    actorType = null;
+    actorId = null;
     operationsTotalCount = null;
     operationsFailedCount = null;
     operationsCompletedCount = null;
@@ -59,6 +63,8 @@ public class BatchOperationImpl implements BatchOperation {
     status = EnumUtil.convert(item.getState(), BatchOperationState.class);
     startDate = ParseUtil.parseOffsetDateTimeOrNull(item.getStartDate());
     endDate = ParseUtil.parseOffsetDateTimeOrNull(item.getEndDate());
+    actorType = EnumUtil.convert(item.getActorType(), BatchOperationActorTypeEnum.class);
+    actorId = item.getActorId();
     operationsTotalCount = item.getOperationsTotalCount();
     operationsFailedCount = item.getOperationsFailedCount();
     operationsCompletedCount = item.getOperationsCompletedCount();
@@ -116,11 +122,11 @@ public class BatchOperationImpl implements BatchOperation {
 
   @Override
   public BatchOperationActorTypeEnum getActorType() {
-    return null;
+    return actorType;
   }
 
   @Override
   public String getActorId() {
-    return null;
+    return actorId;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationSortImpl.java
@@ -47,6 +47,16 @@ public class BatchOperationSortImpl extends SearchRequestSortBase<BatchOperation
   }
 
   @Override
+  public BatchOperationSort actorType() {
+    return field("actorType");
+  }
+
+  @Override
+  public BatchOperationSort actorId() {
+    return field("actorId");
+  }
+
+  @Override
   protected BatchOperationSort self() {
     return this;
   }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -46,7 +46,9 @@ public class QueryBatchOperationTest extends ClientRestTest {
             .state(BatchOperationStateEnum.UNKNOWN_DEFAULT_OPEN_API)
             .batchOperationType(BatchOperationTypeEnum.UNKNOWN_DEFAULT_OPEN_API)
             .endDate(dateTime.toString())
-            .startDate(dateTime.toString()));
+            .startDate(dateTime.toString())
+            .actorType(null)
+            .actorId(null));
 
     // when
     final BatchOperation result =

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.BatchOperationActorTypeEnum;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.BatchOperation;
@@ -63,5 +64,31 @@ public class QueryBatchOperationTest extends ClientRestTest {
     assertThat(result.getStatus()).isEqualTo(BatchOperationState.UNKNOWN_ENUM_VALUE);
     assertThat(result.getStartDate()).isEqualTo(dateTime);
     assertThat(result.getEndDate()).isEqualTo(dateTime);
+
+    assertThat(result.getActorType()).isNull();
+    assertThat(result.getActorId()).isNull();
+  }
+
+  @Test
+  public void shouldIncludeActorInfoInGetBatchOperationResponse() {
+    // given
+    final String batchOperationKey = "123";
+
+    gatewayService.onBatchOperationRequest(
+        batchOperationKey,
+        Instancio.create(BatchOperationResponse.class)
+            .batchOperationKey(batchOperationKey)
+            .actorType(io.camunda.client.protocol.rest.BatchOperationActorTypeEnum.USER)
+            .actorId("demo-user")
+            .endDate(OffsetDateTime.now().toString())
+            .startDate(OffsetDateTime.now().toString()));
+
+    // when
+    final BatchOperation result =
+        client.newBatchOperationGetRequest(batchOperationKey).send().join();
+
+    // then
+    assertThat(result.getActorType()).isEqualTo(BatchOperationActorTypeEnum.USER);
+    assertThat(result.getActorId()).isEqualTo("demo-user");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -19,6 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
 import io.camunda.client.util.ClientRestTest;
@@ -34,22 +37,31 @@ public class QueryBatchOperationTest extends ClientRestTest {
   public void shouldGetBatchOperationByKey() {
     // given
     final String batchOperationKey = "123";
+    final OffsetDateTime dateTime = OffsetDateTime.now();
     gatewayService.onBatchOperationRequest(
         batchOperationKey,
         Instancio.create(BatchOperationResponse.class)
+            .batchOperationKey(batchOperationKey)
             .state(BatchOperationStateEnum.UNKNOWN_DEFAULT_OPEN_API)
             .batchOperationType(BatchOperationTypeEnum.UNKNOWN_DEFAULT_OPEN_API)
-            .endDate(OffsetDateTime.now().toString())
-            .startDate(OffsetDateTime.now().toString())
-            .endDate(OffsetDateTime.now().toString()));
+            .endDate(dateTime.toString())
+            .startDate(dateTime.toString()));
 
     // when
-    client.newBatchOperationGetRequest(batchOperationKey).send().join();
+    final BatchOperation result =
+        client.newBatchOperationGetRequest(batchOperationKey).send().join();
 
-    // then
+    // then it sends the correct request
     final LoggedRequest request = RestGatewayService.getLastRequest();
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
     assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/123");
     assertThat(request.getBodyAsString()).isEmpty();
+
+    // and maps the response correctly
+    assertThat(result.getBatchOperationKey()).isEqualTo("123");
+    assertThat(result.getType()).isEqualTo(BatchOperationType.UNKNOWN_ENUM_VALUE);
+    assertThat(result.getStatus()).isEqualTo(BatchOperationState.UNKNOWN_ENUM_VALUE);
+    assertThat(result.getStartDate()).isEqualTo(dateTime);
+    assertThat(result.getEndDate()).isEqualTo(dateTime);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
@@ -237,4 +237,26 @@ class SearchBatchOperationsTest extends ClientRestTest {
     assertThat(request.getFilter().getActorId().get$Like()).isEqualTo("demo-%");
     assertThat(request.getFilter().getActorId().get$Neq()).isEqualTo("demo-user");
   }
+
+  @Test
+  void shouldSearchBatchOperationWithActorInfoSorting() {
+    // when
+    client
+        .newBatchOperationSearchRequest()
+        .sort(s -> s.actorType().asc().actorId().desc())
+        .send()
+        .join();
+
+    // then
+    final BatchOperationSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationSearchQuery.class);
+
+    assertThat(request.getSort()).hasSize(2);
+    assertThat(request.getSort().get(0).getField())
+        .isEqualTo(BatchOperationSearchQuerySortRequest.FieldEnum.ACTOR_TYPE);
+    assertThat(request.getSort().get(0).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(1).getField())
+        .isEqualTo(BatchOperationSearchQuerySortRequest.FieldEnum.ACTOR_ID);
+    assertThat(request.getSort().get(1).getOrder()).isEqualTo(SortOrderEnum.DESC);
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
@@ -200,4 +200,41 @@ class SearchBatchOperationsTest extends ClientRestTest {
     assertThat(mapped.getActorType()).isEqualTo(BatchOperationActorTypeEnum.USER);
     assertThat(mapped.getActorId()).isEqualTo("demo-user");
   }
+
+  @Test
+  void shouldSearchBatchOperationWithActorInfoFilter() {
+    // when
+    client
+        .newBatchOperationSearchRequest()
+        .filter(f -> f.actorType(BatchOperationActorTypeEnum.USER).actorId("demo-user"))
+        .send()
+        .join();
+
+    // then
+    final BatchOperationSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationSearchQuery.class);
+
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getActorType())
+        .isEqualTo(io.camunda.client.protocol.rest.BatchOperationActorTypeEnum.USER);
+    assertThat(request.getFilter().getActorId().get$Eq()).isEqualTo("demo-user");
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithAdvancedActorIdFilter() {
+    // when
+    client
+        .newBatchOperationSearchRequest()
+        .filter(f -> f.actorId(p -> p.like("demo-%").neq("demo-user")))
+        .send()
+        .join();
+
+    // then
+    final BatchOperationSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationSearchQuery.class);
+
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getActorId().get$Like()).isEqualTo("demo-%");
+    assertThat(request.getFilter().getActorId().get$Neq()).isEqualTo("demo-user");
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -22,6 +22,8 @@ public class RestGatewayPaths {
   private static final String URL_AUTHORIZATION = REST_API_PATH + "/authorizations/%s";
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
   private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
+  private static final String URL_BATCH_OPERATIONS_SEARCH =
+      REST_API_PATH + "/batch-operations/search";
   private static final String URL_CLUSTER_VARIABLES = REST_API_PATH + "/cluster-variables";
   private static final String URL_CLUSTER_VARIABLES_CREATE_GLOBAL =
       URL_CLUSTER_VARIABLES + "/global";
@@ -329,6 +331,10 @@ public class RestGatewayPaths {
 
   public static String getBatchOperationUrl(final String batchOperationKey) {
     return String.format(URL_BATCH_OPERATION, batchOperationKey);
+  }
+
+  public static String getBatchOperationsSearchUrl() {
+    return URL_BATCH_OPERATIONS_SEARCH;
   }
 
   public static String getVariableUrl(final long variableKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -27,6 +27,7 @@ import io.camunda.client.protocol.rest.AuthorizationCreateResult;
 import io.camunda.client.protocol.rest.AuthorizationResult;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
+import io.camunda.client.protocol.rest.BatchOperationSearchQueryResult;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import io.camunda.client.protocol.rest.DecisionInstanceResult;
@@ -341,6 +342,10 @@ public class RestGatewayService {
   public void onBatchOperationRequest(
       final String batchOperationKey, final BatchOperationResponse response) {
     registerGet(RestGatewayPaths.getBatchOperationUrl(batchOperationKey), response);
+  }
+
+  public void onSearchBatchOperationsRequest(final BatchOperationSearchQueryResult response) {
+    registerPost(RestGatewayPaths.getBatchOperationsSearchUrl(), response);
   }
 
   public void onVariableRequest(final long variableKey, final VariableResult response) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
@@ -463,6 +463,8 @@ public class BatchOperationSearchIT {
     assertThat(batch.getOperationsTotalCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_1.size());
     assertThat(batch.getOperationsCompletedCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_1.size());
     assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+    assertThat(batch.getActorType()).isEqualTo(BatchOperationActorTypeEnum.USER);
+    assertThat(batch.getActorId()).isEqualTo(InitializationConfiguration.DEFAULT_USER_USERNAME);
   }
 
   private static void assertMigrateBatchOperation(final BatchOperation batch) {
@@ -473,6 +475,8 @@ public class BatchOperationSearchIT {
     assertThat(batch.getOperationsTotalCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_2.size());
     assertThat(batch.getOperationsCompletedCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_2.size());
     assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+    assertThat(batch.getActorType()).isEqualTo(BatchOperationActorTypeEnum.USER);
+    assertThat(batch.getActorId()).isEqualTo(InitializationConfiguration.DEFAULT_USER_USERNAME);
   }
 
   private static void assertItems(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
@@ -558,6 +558,13 @@ public class BatchOperationSearchIT {
             new SortTestArguments<>(BatchOperation::getStartDate, BatchOperationSort::startDate)
                 .get()),
         argumentSet(
+            "actorType",
+            new SortTestArguments<>(BatchOperation::getActorType, BatchOperationSort::actorType)
+                .get()),
+        argumentSet(
+            "actorId",
+            new SortTestArguments<>(BatchOperation::getActorId, BatchOperationSort::actorId).get()),
+        argumentSet(
             "state",
             new SortTestArguments<>(BatchOperation::getStatus, BatchOperationSort::state).get()));
   }


### PR DESCRIPTION
## Description

This PR adds support for interacting with the **actor** for **batch operations** in the **Java client**.

### Motivation
Batch operations can be triggered on behalf of a user/actor. Until now, the Java client did not expose a way to interact with this.

### What’s included
- Introduces a way to receive the `actorType` and `actorId` when searching batch operations via the Java client API
- Introduces a way to filter by `actorType` and `actorId` when searching batch operations
- Introduces a way to sort by `actorType` and `actorId` when searching batch operations
- Wires the new field through request building/serialization so it is sent to and received from the backend
- Updates/extends tests to cover the new behavior

### API / behavior changes
- New optional actor fields for batch operation requests (no behavior change when omitted)
- New properties added to response
- Backwards compatible: existing usages continue to work unchanged

## How to review?
Reviewing by commit is recommended as they are small and choices are described in the commit messages.

## Related issues

closes #42070