### PR TITLE
Add RDBMS history cleanup for audit log PI and DI-related data

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -977,7 +977,14 @@
       <column name="DEPLOYMENT_KEY" type="BIGINT"/>
       <column name="FORM_KEY" type="BIGINT"/>
       <column name="RESOURCE_KEY" type="BIGINT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
     </createTable>
+
+    <createIndex tableName="${prefix}AUDIT_LOG" indexName="${prefix}IDX_AUDIT_LOG_HIST">
+      <column name="PARTITION_ID" />
+      <column name="HISTORY_CLEANUP_DATE" />
+    </createIndex>
 
     <modifySql dbms="mariadb,mysql">
       <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -11,7 +11,7 @@ import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import java.util.List;
 
-public interface AuditLogMapper extends ProcessInstanceDependantMapper {
+public interface AuditLogMapper extends ProcessInstanceDependantMapper, HistoryCleanupMapper {
 
   void insert(AuditLogDbModel auditLog);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -102,7 +102,7 @@ public class RdbmsWriters {
 
     writers.put(
         AuditLogWriter.class,
-        new AuditLogWriter(executionQueue, auditLogMapper, vendorDatabaseProperties));
+        new AuditLogWriter(executionQueue, auditLogMapper, vendorDatabaseProperties, config));
     writers.put(AuthorizationWriter.class, new AuthorizationWriter(executionQueue));
     writers.put(DecisionDefinitionWriter.class, new DecisionDefinitionWriter(executionQueue));
     writers.put(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuditLogDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuditLogDbModel.java
@@ -44,7 +44,9 @@ public record AuditLogDbModel(
     Long decisionEvaluationKey,
     Long deploymentKey,
     Long formKey,
-    Long resourceKey)
+    Long resourceKey,
+    int partitionId,
+    OffsetDateTime historyCleanupDate)
     implements DbModel<AuditLogDbModel> {
 
   @Override
@@ -83,8 +85,47 @@ public record AuditLogDbModel(
                 .decisionEvaluationKey(decisionEvaluationKey)
                 .deploymentKey(deploymentKey)
                 .formKey(formKey)
-                .resourceKey(resourceKey))
+                .resourceKey(resourceKey)
+                .partitionId(partitionId)
+                .historyCleanupDate(historyCleanupDate))
         .build();
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .auditLogKey(auditLogKey)
+        .entityKey(entityKey)
+        .entityType(entityType)
+        .operationType(operationType)
+        .entityVersion(entityVersion)
+        .entityValueType(entityValueType)
+        .entityOperationIntent(entityOperationIntent)
+        .batchOperationKey(batchOperationKey)
+        .batchOperationType(batchOperationType)
+        .timestamp(timestamp)
+        .actorType(actorType)
+        .actorId(actorId)
+        .tenantId(tenantId)
+        .tenantScope(tenantScope)
+        .result(result)
+        .annotation(annotation)
+        .category(category)
+        .processDefinitionId(processDefinitionId)
+        .decisionRequirementsId(decisionRequirementsId)
+        .decisionDefinitionId(decisionDefinitionId)
+        .processDefinitionKey(processDefinitionKey)
+        .processInstanceKey(processInstanceKey)
+        .elementInstanceKey(elementInstanceKey)
+        .jobKey(jobKey)
+        .userTaskKey(userTaskKey)
+        .decisionRequirementsKey(decisionRequirementsKey)
+        .decisionDefinitionKey(decisionDefinitionKey)
+        .decisionEvaluationKey(decisionEvaluationKey)
+        .deploymentKey(deploymentKey)
+        .formKey(formKey)
+        .resourceKey(resourceKey)
+        .partitionId(partitionId)
+        .historyCleanupDate(historyCleanupDate);
   }
 
   public static class Builder implements ObjectBuilder<AuditLogDbModel> {
@@ -120,6 +161,8 @@ public record AuditLogDbModel(
     private Long deploymentKey;
     private Long formKey;
     private Long resourceKey;
+    private int partitionId;
+    private OffsetDateTime historyCleanupDate;
 
     public Builder() {}
 
@@ -278,6 +321,16 @@ public record AuditLogDbModel(
       return this;
     }
 
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder historyCleanupDate(final OffsetDateTime historyCleanupDate) {
+      this.historyCleanupDate = historyCleanupDate;
+      return this;
+    }
+
     @Override
     public AuditLogDbModel build() {
       return new AuditLogDbModel(
@@ -311,7 +364,9 @@ public record AuditLogDbModel(
           decisionEvaluationKey,
           deploymentKey,
           formKey,
-          resourceKey);
+          resourceKey,
+          partitionId,
+          historyCleanupDate);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -11,36 +11,55 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.sql.ProcessBasedHistoryCleanupMapper;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpdateHistoryCleanupDateMerger;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import java.time.OffsetDateTime;
 
 public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final AuditLogMapper mapper;
   private final ExecutionQueue executionQueue;
+  private final RdbmsWriterConfig config;
 
   public AuditLogWriter(
       final ExecutionQueue executionQueue,
       final AuditLogMapper mapper,
-      final VendorDatabaseProperties vendorDatabaseProperties) {
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final RdbmsWriterConfig config) {
     super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
+    this.config = config;
   }
 
   public void create(final AuditLogDbModel auditLog) {
+    // standalone decisions are completed on evaluation and should be cleaned up based on the
+    // decision instance TTL
+    final AuditLogDbModel finalAuditLog;
+    if (AuditLogEntityType.DECISION.equals(auditLog.entityType())
+        && (auditLog.processInstanceKey() == null || auditLog.processInstanceKey() == -1L)
+        && auditLog.historyCleanupDate() == null) {
+      finalAuditLog =
+          auditLog.toBuilder()
+              .historyCleanupDate(auditLog.timestamp().plus(config.history().decisionInstanceTTL()))
+              .build();
+    } else {
+      finalAuditLog = auditLog;
+    }
+
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.AUDIT_LOG,
             WriteStatementType.INSERT,
-            auditLog.entityKey(),
+            finalAuditLog.auditLogKey(),
             "io.camunda.db.rdbms.sql.AuditLogMapper.insert",
-            auditLog));
+            finalAuditLog));
   }
 
   public void scheduleProcessInstanceLogsForHistoryCleanup(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -108,6 +108,8 @@ public class HistoryCleanupService {
     messageSubscriptionWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
     correlatedMessageSubscriptionWriter.scheduleForHistoryCleanup(
         processInstanceKey, historyCleanupDate);
+    auditLogWriter.scheduleProcessInstanceLogsForHistoryCleanup(
+        processInstanceKey, historyCleanupDate);
   }
 
   public void scheduleBatchOperationForHistoryCleanup(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -49,6 +49,7 @@ public class HistoryCleanupService {
   private final CorrelatedMessageSubscriptionWriter correlatedMessageSubscriptionWriter;
   private final UsageMetricWriter usageMetricWriter;
   private final UsageMetricTUWriter usageMetricTUWriter;
+  private final AuditLogWriter auditLogWriter;
 
   private final Map<Integer, Duration> lastCleanupInterval = new HashMap<>();
 
@@ -85,6 +86,7 @@ public class HistoryCleanupService {
     metrics = rdbmsWriters.getMetrics();
     usageMetricWriter = rdbmsWriters.getUsageMetricWriter();
     usageMetricTUWriter = rdbmsWriters.getUsageMetricTUWriter();
+    auditLogWriter = rdbmsWriters.getAuditLogWriter();
   }
 
   public void scheduleProcessForHistoryCleanup(
@@ -174,6 +176,8 @@ public class HistoryCleanupService {
           "correlatedMessageSubscription",
           correlatedMessageSubscriptionWriter.cleanupHistory(
               partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "auditLog", auditLogWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
       final long end = System.currentTimeMillis();
       logCleanUpInfo("", partitionId, numDeletedRecords, cleanupDate, end, start);
       final var nextDuration =

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -52,7 +52,9 @@
         DECISION_EVALUATION_KEY,
         DEPLOYMENT_KEY,
         FORM_KEY,
-        RESOURCE_KEY
+        RESOURCE_KEY,
+        PARTITION_ID,
+        HISTORY_CLEANUP_DATE
       FROM ${prefix}AUDIT_LOG
       <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.searchFilter" />
     ) t
@@ -238,7 +240,9 @@
       DECISION_EVALUATION_KEY,
       DEPLOYMENT_KEY,
       FORM_KEY,
-      RESOURCE_KEY
+      RESOURCE_KEY,
+      PARTITION_ID,
+      HISTORY_CLEANUP_DATE
     )
     VALUES (
       #{auditLogKey},
@@ -250,7 +254,7 @@
       #{entityOperationIntent},
       #{batchOperationKey},
       #{batchOperationType},
-      #{timestamp},
+      #{timestamp, jdbcType=TIMESTAMP},
       #{actorType},
       #{actorId},
       #{tenantId},
@@ -271,13 +275,29 @@
       #{decisionEvaluationKey},
       #{deploymentKey},
       #{formKey},
-      #{resourceKey}
+      #{resourceKey},
+      #{partitionId},
+      #{historyCleanupDate, jdbcType=TIMESTAMP}
     )
   </insert>
+
+  <update id="updateProcessHistoryCleanupDate">
+    UPDATE ${prefix}AUDIT_LOG SET
+    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE PROCESS_INSTANCE_KEY IN
+    <foreach collection="processInstanceKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+  </update>
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'AUDIT_LOG'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletion"/>
+  </delete>
+
+  <delete id="cleanupHistory">
+    <bind name="tableName" value="'AUDIT_LOG'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
   </delete>
 
 </mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AuditLogWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AuditLogWriterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -26,8 +27,9 @@ class AuditLogWriterTest {
   private final AuditLogMapper mapper = mock(AuditLogMapper.class);
   private final VendorDatabaseProperties vendorDatabaseProperties =
       mock(VendorDatabaseProperties.class);
+  private final RdbmsWriterConfig config = mock(RdbmsWriterConfig.class);
   private final AuditLogWriter writer =
-      new AuditLogWriter(executionQueue, mapper, vendorDatabaseProperties);
+      new AuditLogWriter(executionQueue, mapper, vendorDatabaseProperties, config);
 
   @Test
   void shouldCreateAuditLog() {
@@ -41,7 +43,7 @@ class AuditLogWriterTest {
                 new QueueItem(
                     ContextType.AUDIT_LOG,
                     WriteStatementType.INSERT,
-                    model.entityKey(),
+                    model.auditLogKey(),
                     "io.camunda.db.rdbms.sql.AuditLogMapper.insert",
                     model)));
   }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -44,6 +44,7 @@ class HistoryCleanupServiceTest {
   private CorrelatedMessageSubscriptionWriter correlatedMessageSubscriptionWriter;
   private UsageMetricWriter usageMetricWriter;
   private UsageMetricTUWriter usageMetricTUWriter;
+  private AuditLogWriter auditLogWriter;
 
   private HistoryCleanupService historyCleanupService;
 
@@ -63,6 +64,7 @@ class HistoryCleanupServiceTest {
     correlatedMessageSubscriptionWriter = mock(CorrelatedMessageSubscriptionWriter.class);
     usageMetricWriter = mock(UsageMetricWriter.class);
     usageMetricTUWriter = mock(UsageMetricTUWriter.class);
+    auditLogWriter = mock(AuditLogWriter.class);
 
     when(processInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(flowNodeInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
@@ -79,6 +81,7 @@ class HistoryCleanupServiceTest {
         .thenReturn(0);
     when(usageMetricWriter.cleanupMetrics(anyInt(), any(), anyInt())).thenReturn(0);
     when(usageMetricTUWriter.cleanupMetrics(anyInt(), any(), anyInt())).thenReturn(0);
+    when(auditLogWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
 
     final var historyConfig = mock(RdbmsWriterConfig.HistoryConfig.class);
     when(config.history()).thenReturn(historyConfig);
@@ -113,6 +116,7 @@ class HistoryCleanupServiceTest {
     when(rdbmsWriters.getUsageMetricTUWriter()).thenReturn(usageMetricTUWriter);
     when(rdbmsWriters.getMetrics())
         .thenReturn(mock(RdbmsWriterMetrics.class, Mockito.RETURNS_DEEP_STUBS));
+    when(rdbmsWriters.getAuditLogWriter()).thenReturn(auditLogWriter);
 
     historyCleanupService = new HistoryCleanupService(config, rdbmsWriters);
   }
@@ -133,6 +137,7 @@ class HistoryCleanupServiceTest {
     when(messageSubscriptionWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
     when(correlatedMessageSubscriptionWriter.cleanupHistory(anyInt(), any(), anyInt()))
         .thenReturn(1);
+    when(auditLogWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
 
     // when
     final Duration nextCleanupInterval =
@@ -152,6 +157,7 @@ class HistoryCleanupServiceTest {
     verify(batchOperationWriter).cleanupHistory(CLEANUP_DATE, 100);
     verify(messageSubscriptionWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(correlatedMessageSubscriptionWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
+    verify(auditLogWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
   }
 
   @Test
@@ -187,6 +193,7 @@ class HistoryCleanupServiceTest {
     numDeletedRecords.put("batchOperation", 0);
     numDeletedRecords.put("messageSubscription", 0);
     numDeletedRecords.put("correlatedMessageSubscription", 0);
+    numDeletedRecords.put("auditLog", 0);
 
     // when
     final Duration nextDuration =
@@ -213,6 +220,7 @@ class HistoryCleanupServiceTest {
     numDeletedRecords.put("batchOperation", 100);
     numDeletedRecords.put("messageSubscription", 100);
     numDeletedRecords.put("correlatedMessageSubscription", 100);
+    numDeletedRecords.put("auditLog", 100);
 
     // when
     final Duration nextDuration =
@@ -238,6 +246,7 @@ class HistoryCleanupServiceTest {
     numDeletedRecords.put("batchOperation", 50);
     numDeletedRecords.put("messageSubscription", 50);
     numDeletedRecords.put("correlatedMessageSubscription", 50);
+    numDeletedRecords.put("auditLog", 50);
 
     // when
     final Duration nextDuration =
@@ -263,6 +272,7 @@ class HistoryCleanupServiceTest {
     numDeletedRecords.put("batchOperation", 20);
     numDeletedRecords.put("messageSubscription", 20);
     numDeletedRecords.put("correlatedMessageSubscription", 20);
+    numDeletedRecords.put("auditLog", 20);
 
     // when
     final Duration nextDuration =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
+import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ElementInstanceFixtures;
@@ -23,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -55,7 +57,8 @@ public class HistoryCleanupIT {
           "PROCESS_INSTANCE",
           "USER_TASK",
           "INCIDENT",
-          "DECISION_INSTANCE");
+          "DECISION_INSTANCE",
+          "AUDIT_LOG");
 
   @Autowired JdbcTemplate jdbcTemplate;
 
@@ -147,6 +150,9 @@ public class HistoryCleanupIT {
         rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
 
     DecisionInstanceFixtures.createAndSaveRandomDecisionInstances(
+        rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
+
+    AuditLogFixtures.createAndSaveRandomAuditLogs(
         rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
 
     return processInstanceKey;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
@@ -59,10 +59,10 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
   private AuditLogDbModel map(final Record<R> record) {
     final AuditLogEntry log = transformer.create(record);
 
-    return toAuditLogModel(log);
+    return toAuditLogModel(log, record);
   }
 
-  private AuditLogDbModel toAuditLogModel(final AuditLogEntry log) {
+  private AuditLogDbModel toAuditLogModel(final AuditLogEntry log, final Record<R> record) {
     final var key =
         RandomStringUtils.insecure()
             .nextAlphanumeric(vendorDatabaseProperties.userCharColumnSize());
@@ -102,7 +102,8 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
             .decisionDefinitionKey(log.getDecisionDefinitionKey())
             .deploymentKey(log.getDeploymentKey())
             .formKey(log.getFormKey())
-            .resourceKey(log.getResourceKey());
+            .resourceKey(log.getResourceKey())
+            .partitionId(record.getPartitionId());
 
     return auditLog.build();
   }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
@@ -193,5 +193,6 @@ class AuditLogExportHandlerTest {
     assertThat(entity.deploymentKey()).isEqualTo(606L);
     assertThat(entity.formKey()).isEqualTo(707L);
     assertThat(entity.resourceKey()).isEqualTo(808L);
+    assertThat(entity.partitionId()).isEqualTo(record.getPartitionId());
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Enable the RDBMS history cleanup mechanism for process instance- and decision instance-related audit log data.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43476
