### PR TITLE
ci: explicitly enable Elasticsearch in helm upgrade

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -318,6 +318,8 @@ jobs:
           --namespace ${{ inputs.name }}
           --reset-then-reuse-values
           --render-subchart-notes
+          --set elasticsearch.enabled=true
+          --set global.elasticsearch.enabled=true
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set orchestration.image.registry=gcr.io
           --set orchestration.image.repository=zeebe-io/zeebe


### PR DESCRIPTION
## Description

This pull request makes a small update to the Camunda load test workflow by enabling Elasticsearch in the Helm deployment configuration. This change ensures that both the local and global Elasticsearch services are activated during test runs. 
Related to this discussion: https://camunda.slack.com/archives/C06UWQNCU7M/p1767694308252559?thread_ts=1767629885.248709&cid=C06UWQNCU7M

* Enabled Elasticsearch by setting `elasticsearch.enabled=true` and `global.elasticsearch.enabled=true` in the Helm deployment step within `.github/workflows/camunda-load-test.yml`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
