### PR TITLE
[Backport release-8.9.0-alpha3] feat: add default secondary storage type for load tests

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -296,6 +296,11 @@ jobs:
           --set orchestration.image.repository=zeebe-io/zeebe
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/load-tests/camunda-platform-values.yaml
+<<<<<<< HEAD
+=======
+          ${{ inputs.secondary-storage-type == 'elasticsearch' && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/load-tests/camunda-platform-values-elasticsearch.yaml', github.ref) || '' }}
+          ${{ inputs.secondary-storage-type == 'postgresql' && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/load-tests/camunda-platform-values-rdbms.yaml --set orchestration.data.secondaryStorage.type=postgresql', github.ref) || '' }}
+>>>>>>> d992390f (feat: add default secondary storage type for load tests)
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/load-tests/setup/default/values-stable.yaml', github.ref) || '' }}
       - name: Summarize deployment

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -49,6 +49,9 @@ postgresql:
 ################################################### Orchestration cluster configuration
 ########################################################################################
 orchestration:
+  data:
+      secondaryStorage:
+        type: elasticsearch
   security:
     authentication:
       unprotectedApi: true


### PR DESCRIPTION
# Description
Backport of #43477 to `release-8.9.0-alpha3`.

relates to #43475