### PR TITLE
fix: Eliminate need for top_hits limit when fetching grouped processes

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
@@ -59,17 +59,12 @@ public class ProcessStoreGroupedProcessesIT extends OperateSearchAbstractIT {
             TenantOwned.DEFAULT_TENANT_IDENTIFIER, Set.of(BPMN_PROCESS_ID));
 
     // then
-    final List<ProcessEntity> versions = results.get(processKey);
-    assertThat(versions).hasSize(TOTAL_VERSIONS);
-    assertThat(versions.getFirst().getVersion()).isEqualTo(TOTAL_VERSIONS);
-    assertThat(versions.getLast().getVersion()).isEqualTo(1);
-
-    final Set<Integer> returnedVersions =
-        versions.stream()
-            .map(ProcessEntity::getVersion)
-            .collect(java.util.stream.Collectors.toSet());
-    for (int i = 1; i <= TOTAL_VERSIONS; i++) {
-      assertThat(returnedVersions).contains(i);
-    }
+    final List<ProcessEntity> processEntities = results.get(processKey);
+    assertThat(processEntities)
+        .extracting(ProcessEntity::getVersion)
+        .hasSize(TOTAL_VERSIONS)
+        .startsWith(TOTAL_VERSIONS)
+        .endsWith(1)
+        .isSortedAccordingTo((v1, v2) -> Integer.compare(v2, v1));
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.it.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.store.ProcessStore;
+import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProcessStoreGroupedProcessesIT extends OperateSearchAbstractIT {
+
+  private static final String BPMN_PROCESS_ID = "processWithManyVersions";
+  private static final int TOTAL_VERSIONS = 120;
+
+  @Autowired private ProcessIndex processDefinitionIndex;
+
+  @Autowired private ProcessStore processStore;
+
+  @Override
+  protected void runAdditionalBeforeAllSetup() throws Exception {
+    for (int version = 1; version <= TOTAL_VERSIONS; version++) {
+      final long key = 9000000000000000L + version;
+      final ProcessEntity processEntity =
+          new ProcessEntity()
+              .setKey(key)
+              .setId(String.valueOf(key))
+              .setBpmnProcessId(BPMN_PROCESS_ID)
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+              .setName("Process with many versions")
+              .setVersion(version);
+      testSearchRepository.createOrUpdateDocumentFromObject(
+          processDefinitionIndex.getFullQualifiedName(), processEntity.getId(), processEntity);
+    }
+    searchContainerManager.refreshIndices("*operate*");
+  }
+
+  @Test
+  public void shouldReturnAllVersionsSortedDescending() {
+    // given
+    final ProcessStore.ProcessKey processKey =
+        new ProcessStore.ProcessKey(BPMN_PROCESS_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // when
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, Set.of(BPMN_PROCESS_ID));
+
+    // then
+    final List<ProcessEntity> versions = results.get(processKey);
+    assertThat(versions).hasSize(TOTAL_VERSIONS);
+    assertThat(versions.getFirst().getVersion()).isEqualTo(TOTAL_VERSIONS);
+    assertThat(versions.getLast().getVersion()).isEqualTo(1);
+
+    final Set<Integer> returnedVersions =
+        versions.stream()
+            .map(ProcessEntity::getVersion)
+            .collect(java.util.stream.Collectors.toSet());
+    for (int i = 1; i <= TOTAL_VERSIONS; i++) {
+      assertThat(returnedVersions).contains(i);
+    }
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
@@ -500,6 +500,27 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
     assertThat(deleted).isEqualTo(4);
   }
 
+  @Test
+  public void testGetProcessesGroupedWithEmptyAllowedBpmnProcessIds() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(TenantOwned.DEFAULT_TENANT_IDENTIFIER, Set.of());
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithMixedExistingAndNonExistingIds() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+            Set.of(firstProcessDefinition.getBpmnProcessId(), "nonExistentProcess"));
+
+    assertThat(results).hasSize(1);
+    assertThat(results)
+        .containsKey(
+            new ProcessStore.ProcessKey(
+                firstProcessDefinition.getBpmnProcessId(), TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  }
+
   private String getFullIndexNameForDependant(final String indexName) {
     final ProcessInstanceDependant dependant =
         processInstanceDependantTemplates.stream()

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -8,13 +8,10 @@
 package io.camunda.operate.store.opensearch;
 
 import static io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TERMS_AGG_SIZE;
-import static io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TOPHITS_AGG_SIZE;
 import static io.camunda.operate.store.opensearch.client.sync.OpenSearchRetryOperation.UPDATE_RETRY_COUNT;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.cardinalityAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.filtersAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.termAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.topHitsAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.withTenantCheck;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ALL;
@@ -124,9 +121,8 @@ public class OpensearchProcessStore implements ProcessStore {
   @Override
   public Map<ProcessKey, List<ProcessEntity>> getProcessesGrouped(
       final String tenantId, final Set<String> allowedBPMNProcessIds) {
-    final String tenantsGroupsAggName = "group_by_tenantId";
     final String groupsAggName = "group_by_bpmnProcessId";
-    final String processesAggName = "processes";
+
     final List<String> sourceFields =
         List.of(
             ProcessIndex.ID,
@@ -135,64 +131,49 @@ public class OpensearchProcessStore implements ProcessStore {
             ProcessIndex.VERSION_TAG,
             ProcessIndex.BPMN_PROCESS_ID,
             ProcessIndex.TENANT_ID);
+
     final Query query =
         allowedBPMNProcessIds == null
             ? matchAll()
             : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowedBPMNProcessIds);
-    final var searchRequestBuilder =
+
+    final var aggRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
             .query(withTenantCheck(withTenantIdQuery(tenantId, query)))
             .size(0)
             .aggregations(
-                tenantsGroupsAggName,
-                withSubaggregations(
-                    termAggregation(ProcessIndex.TENANT_ID, TERMS_AGG_SIZE),
-                    Map.of(
-                        groupsAggName,
-                        withSubaggregations(
-                            termAggregation(ProcessIndex.BPMN_PROCESS_ID, TERMS_AGG_SIZE),
-                            Map.of(
-                                processesAggName,
-                                topHitsAggregation(
-                                        sourceFields,
-                                        TOPHITS_AGG_SIZE,
-                                        sortOptions(ProcessIndex.VERSION, SortOrder.Desc))
-                                    ._toAggregation())))));
+                groupsAggName,
+                termAggregation(ProcessIndex.BPMN_PROCESS_ID, TERMS_AGG_SIZE)._toAggregation());
 
-    final SearchResponse<Object> response =
-        richOpenSearchClient.doc().search(searchRequestBuilder, Object.class);
+    final SearchResponse<Void> aggResponse =
+        richOpenSearchClient.doc().search(aggRequestBuilder, Void.class);
+
+    final List<String> bpmnProcessIds =
+        aggResponse.aggregations().get(groupsAggName).sterms().buckets().array().stream()
+            .map(b -> b.key())
+            .toList();
+
+    if (bpmnProcessIds.isEmpty()) {
+      return new HashMap<>();
+    }
+
+    final Query docsQuery = stringTerms(ListViewTemplate.BPMN_PROCESS_ID, bpmnProcessIds);
+
+    final var searchRequestBuilder =
+        searchRequestBuilder(processIndex.getAlias())
+            .query(withTenantCheck(withTenantIdQuery(tenantId, docsQuery)))
+            .source(sourceInclude(sourceFields))
+            .sort(sortOptions(ProcessIndex.VERSION, SortOrder.Desc));
+
+    final List<ProcessEntity> allProcesses =
+        richOpenSearchClient.doc().scrollValues(searchRequestBuilder, ProcessEntity.class);
+
     final Map<ProcessKey, List<ProcessEntity>> result = new HashMap<>();
-
-    response
-        .aggregations()
-        .get(tenantsGroupsAggName)
-        .sterms()
-        .buckets()
-        .array()
-        .forEach(
-            tenantBucket ->
-                tenantBucket
-                    .aggregations()
-                    .get(groupsAggName)
-                    .sterms()
-                    .buckets()
-                    .array()
-                    .forEach(
-                        bpmnProcessIdBucket -> {
-                          final String key = tenantBucket.key() + "_" + bpmnProcessIdBucket.key();
-                          final List<ProcessEntity> value =
-                              bpmnProcessIdBucket
-                                  .aggregations()
-                                  .get(processesAggName)
-                                  .topHits()
-                                  .hits()
-                                  .hits()
-                                  .stream()
-                                  .map(h -> h.source().to(ProcessEntity.class))
-                                  .toList();
-
-                          result.put(new ProcessKey(key, tenantId), value);
-                        }));
+    for (final ProcessEntity processEntity : allProcesses) {
+      final ProcessKey groupKey =
+          new ProcessKey(processEntity.getBpmnProcessId(), processEntity.getTenantId());
+      result.computeIfAbsent(groupKey, k -> new ArrayList<>()).add(processEntity);
+    }
 
     return result;
   }


### PR DESCRIPTION
## Description

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/41058
