### PR TITLE
refactor: migrate processes.list store usage to selected-process-definition hook

### DIFF
--- a/operate/client/src/App/Processes/ListView/index.tsx
+++ b/operate/client/src/App/Processes/ListView/index.tsx
@@ -26,6 +26,8 @@ import {reaction} from 'mobx';
 import {tracking} from 'modules/tracking';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {ProcessDefinitionKeyContext} from './processDefinitionKeyContext';
+import {useSelectedProcessDefinition} from 'modules/hooks/processDefinitions';
+import {SelectedProcessDefinitionContext} from './selectedProcessDefinitionContext';
 
 type LocationType = Omit<Location, 'state'> & {
   state: {refreshContent?: boolean};
@@ -123,20 +125,25 @@ const ListView: React.FC = observer(() => {
     tenant,
     version,
   });
+  const {data: selectedProcessDefinition} = useSelectedProcessDefinition();
 
   return (
     <ProcessDefinitionKeyContext.Provider value={processDefinitionKey}>
-      <VisuallyHiddenH1>Operate Process Instances</VisuallyHiddenH1>
-      <InstancesList
-        type="process"
-        leftPanel={<Filters />}
-        topPanel={<DiagramPanel />}
-        bottomPanel={<InstancesTable />}
-        frame={{
-          isVisible: batchModificationStore.state.isEnabled,
-          headerTitle: 'Batch Modification Mode',
-        }}
-      />
+      <SelectedProcessDefinitionContext.Provider
+        value={selectedProcessDefinition}
+      >
+        <VisuallyHiddenH1>Operate Process Instances</VisuallyHiddenH1>
+        <InstancesList
+          type="process"
+          leftPanel={<Filters />}
+          topPanel={<DiagramPanel />}
+          bottomPanel={<InstancesTable />}
+          frame={{
+            isVisible: batchModificationStore.state.isEnabled,
+            headerTitle: 'Batch Modification Mode',
+          }}
+        />
+      </SelectedProcessDefinitionContext.Provider>
     </ProcessDefinitionKeyContext.Provider>
   );
 });

--- a/operate/client/src/App/Processes/ListView/selectedProcessDefinitionContext.ts
+++ b/operate/client/src/App/Processes/ListView/selectedProcessDefinitionContext.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ProcessDefinition} from '@camunda/camunda-api-zod-schemas/8.8';
+import {createContext, useContext} from 'react';
+
+const SelectedProcessDefinitionContext = createContext<
+  ProcessDefinition | undefined
+>(undefined);
+
+function useSelectedProcessDefinitionContext() {
+  return useContext(SelectedProcessDefinitionContext);
+}
+
+export {useSelectedProcessDefinitionContext, SelectedProcessDefinitionContext};

--- a/operate/client/src/App/Processes/ListView/tests/processOperations.test.tsx
+++ b/operate/client/src/App/Processes/ListView/tests/processOperations.test.tsx
@@ -26,6 +26,7 @@ describe('<ListView /> - operations', () => {
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
+    mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockFetchProcessInstances().withSuccess({
       processInstances: [],
       totalCount: 0,

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -12,18 +12,18 @@ import {Modal} from '@carbon/react';
 import {useLocation} from 'react-router-dom';
 import {type StateProps} from 'modules/components/ModalStateManager';
 import {getProcessInstanceFilters} from 'modules/utils/filter';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {Title, DataTable} from './styled';
 import {tracking} from 'modules/tracking';
 import {useInstancesCountV2} from 'modules/queries/processInstancesStatistics/useInstancesCountV2';
-import {useProcessDefinitionKeyContext} from '../../../../processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
 import {getFlowNodeName} from 'modules/utils/flowNodes';
 import {handleOperationError} from 'modules/utils/notifications';
 import {useModifyProcessInstancesBatchOperation} from 'modules/mutations/processes/useModifyProcessInstancesBatchOperation';
 import {useBatchOperationMutationRequestBody} from 'modules/hooks/useBatchOperationMutationRequestBody';
 import {useBatchOperationSuccessNotification} from 'modules/hooks/useBatchOperationSuccessNotification';
+import {useSelectedProcessDefinitionContext} from '../../../../selectedProcessDefinitionContext';
+import {getProcessDefinitionName} from 'modules/hooks/processDefinitions';
 
 const BatchModificationSummaryModal: React.FC<StateProps> = observer(
   ({open, setOpen}) => {
@@ -33,15 +33,13 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
       useBatchOperationMutationRequestBody();
 
     const processInstancesFilters = getProcessInstanceFilters(location.search);
-    const {flowNodeId: sourceElementId, process: bpmnProcessId} =
-      processInstancesFilters;
-    const process = processesStore.getProcess({bpmnProcessId});
-    const processName = process?.name ?? process?.bpmnProcessId ?? 'Process';
+    const {flowNodeId: sourceElementId} = processInstancesFilters;
+    const process = useSelectedProcessDefinitionContext();
+    const processName = process ? getProcessDefinitionName(process) : 'Process';
     const {selectedTargetElementId} = batchModificationStore.state;
 
-    const processDefinitionKey = useProcessDefinitionKeyContext();
     const {data: processDefinitionData} = useListViewXml({
-      processDefinitionKey,
+      processDefinitionKey: process?.processDefinitionKey,
     });
 
     const sourceFlowNodeName = getFlowNodeName({
@@ -56,7 +54,7 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
 
     const {data: instancesCount} = useInstancesCountV2(
       {},
-      processDefinitionKey,
+      process?.processDefinitionKey,
       sourceElementId,
     );
 

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.test.tsx
@@ -15,14 +15,13 @@ import {tracking} from 'modules/tracking';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {
+  PROCESS_ID,
   PROCESS_DEFINITION_ID,
   mockProcessInstancesV2,
   setupSelectionStoreWithInstances,
   getProcessInstance,
   createWrapper,
 } from '../tests/mocks';
-
-const PROCESS_ID = 'eventBasedGatewayProcess';
 
 const mockCalledProcessInstancesV2: ProcessInstance[] = [
   {
@@ -38,23 +37,6 @@ const mockCalledProcessInstancesV2: ProcessInstance[] = [
     parentProcessInstanceKey: '999',
   },
 ];
-
-vi.mock('modules/stores/processes/processes.list', () => {
-  const PROCESS_ID = 'eventBasedGatewayProcess';
-  const PROCESS_DEFINITION_ID = '2251799813685249';
-  return {
-    processesStore: {
-      getPermissions: vi.fn(),
-      getProcessId: () => PROCESS_ID,
-      state: {processes: []},
-      versionsByProcessAndTenant: {
-        [`{${PROCESS_ID}}-{<default>}`]: [
-          {id: PROCESS_DEFINITION_ID, version: 1},
-        ],
-      },
-    },
-  };
-});
 
 describe('<MigrateAction />', () => {
   beforeEach(() => {

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.test.tsx
@@ -15,8 +15,8 @@ import {tracking} from 'modules/tracking';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {
-  PROCESS_ID,
   PROCESS_DEFINITION_ID,
+  PROCESS_DEFINITION_KEY,
   mockProcessInstancesV2,
   setupSelectionStoreWithInstances,
   getProcessInstance,
@@ -27,7 +27,7 @@ const mockCalledProcessInstancesV2: ProcessInstance[] = [
   {
     processInstanceKey: '5',
     processDefinitionId: PROCESS_DEFINITION_ID,
-    processDefinitionKey: PROCESS_DEFINITION_ID,
+    processDefinitionKey: PROCESS_DEFINITION_KEY,
     processDefinitionName: 'Event Based Gateway Process',
     processDefinitionVersion: 1,
     state: 'ACTIVE',
@@ -211,7 +211,7 @@ describe('<MigrateAction />', () => {
   });
 
   it.skip('should set correct store states after migrate click', async () => {
-    const SEARCH_STRING = `?process=${PROCESS_ID}&version=1&active=true&incidents=false`;
+    const SEARCH_STRING = `?process=${PROCESS_DEFINITION_ID}&version=1&active=true&incidents=false`;
     vi.stubGlobal('clientConfig', {
       ...window.clientConfig,
       search: SEARCH_STRING,
@@ -244,7 +244,7 @@ describe('<MigrateAction />', () => {
       excludeIds: [],
       ids: [instance.processInstanceKey],
       incidents: false,
-      processIds: [PROCESS_DEFINITION_ID],
+      processIds: [PROCESS_DEFINITION_KEY],
       running: true,
     });
   });

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.tsx
@@ -9,7 +9,7 @@
 import {observer} from 'mobx-react';
 import {Link, OrderedList, Stack, TableBatchAction} from '@carbon/react';
 import {MigrateAlt} from '@carbon/react/icons';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelectionV2';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MigrateAction/index.tsx
@@ -7,13 +7,10 @@
  */
 
 import {observer} from 'mobx-react';
-import {useLocation} from 'react-router-dom';
 import {Link, OrderedList, Stack, TableBatchAction} from '@carbon/react';
 import {MigrateAlt} from '@carbon/react/icons';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelectionV2';
-import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
 import {ListItem} from './styled';
@@ -21,14 +18,12 @@ import {tracking} from 'modules/tracking';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {HelperModal} from 'modules/components/HelperModal';
 import {getStateLocally} from 'modules/utils/localStorage';
-import {useProcessDefinitionKeyContext} from '../../../../processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';
+import {useSelectedProcessDefinitionContext} from '../../../../selectedProcessDefinitionContext';
 
 const localStorageKey = 'hideMigrationHelperModal';
 
 const MigrateAction: React.FC = observer(() => {
-  const location = useLocation();
-  const {version, process, tenant} = getProcessInstanceFilters(location.search);
   const {
     selectedProcessInstanceIds,
     hasSelectedRunningInstances,
@@ -36,20 +31,20 @@ const MigrateAction: React.FC = observer(() => {
     state: {selectionMode},
   } = processInstancesSelectionStore;
 
-  const isVersionSelected = version !== undefined && version !== 'all';
-
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-  const processDefinition = useListViewXml({processDefinitionKey});
-  const hasXmlError = processDefinition?.isError;
+  const selectedProcessDefinition = useSelectedProcessDefinitionContext();
+  const processDefinitionXml = useListViewXml({
+    processDefinitionKey: selectedProcessDefinition?.processDefinitionKey,
+  });
+  const hasXmlError = processDefinitionXml?.isError;
 
   const isDisabled =
     batchModificationStore.state.isEnabled ||
-    !isVersionSelected ||
+    !selectedProcessDefinition ||
     !hasSelectedRunningInstances ||
     hasXmlError;
 
   const getTooltipText = () => {
-    if (!isVersionSelected) {
+    if (!selectedProcessDefinition) {
       return 'To start the migration process, choose a process and version first.';
     }
 
@@ -64,11 +59,7 @@ const MigrateAction: React.FC = observer(() => {
 
   const handleSubmit = () => {
     processInstanceMigrationStore.setSourceProcessDefinitionKey(
-      processesStore.getProcessId({
-        process,
-        tenant,
-        version,
-      }),
+      selectedProcessDefinition?.processDefinitionKey,
     );
 
     const requestFilterParameters = {

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MoveAction/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/MoveAction/tests/index.test.tsx
@@ -13,7 +13,7 @@ import {open} from 'modules/mocks/diagrams';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {
-  PROCESS_DEFINITION_ID,
+  PROCESS_DEFINITION_KEY,
   mockProcessInstancesV2,
   setupSelectionStoreWithInstances,
   getProcessInstance,
@@ -41,7 +41,7 @@ vi.mock('modules/stores/processes/processes.list', () => {
       state: {processes: []},
       versionsByProcessAndTenant: {
         [`{${PROCESS_ID}}-{<default>}`]: [
-          {id: PROCESS_DEFINITION_ID, version: 1},
+          {id: PROCESS_DEFINITION_KEY, version: 1},
         ],
       },
     },

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/tests/mocks.tsx
@@ -14,8 +14,17 @@ import {processInstancesSelectionStore} from 'modules/stores/processInstancesSel
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {createProcessDefinition} from 'modules/testUtils';
+import {SelectedProcessDefinitionContext} from 'App/Processes/ListView/selectedProcessDefinitionContext';
 
+const PROCESS_ID = 'eventBasedGatewayProcess';
 const PROCESS_DEFINITION_ID = '2251799813685249';
+
+const selectedProcessDefinition = createProcessDefinition({
+  processDefinitionId: PROCESS_ID,
+  version: 1,
+  processDefinitionKey: PROCESS_DEFINITION_ID,
+});
 
 const mockProcessInstancesV2: ProcessInstance[] = [
   {
@@ -114,28 +123,32 @@ function createWrapper(
 
     return (
       <ProcessDefinitionKeyContext.Provider value={PROCESS_DEFINITION_ID}>
-        <QueryClientProvider client={getMockQueryClient()}>
-          <MemoryRouter initialEntries={[initialPath]}>
-            {children}
-            {withTestButtons && (
-              <>
-                <button
-                  onClick={
-                    processInstancesSelectionStore.selectAllProcessInstances
-                  }
-                >
-                  Select all instances
-                </button>
-                <button onClick={batchModificationStore.enable}>
-                  Enter batch modification mode
-                </button>
-                <button onClick={batchModificationStore.reset}>
-                  Exit batch modification mode
-                </button>
-              </>
-            )}
-          </MemoryRouter>
-        </QueryClientProvider>
+        <SelectedProcessDefinitionContext.Provider
+          value={selectedProcessDefinition}
+        >
+          <QueryClientProvider client={getMockQueryClient()}>
+            <MemoryRouter initialEntries={[initialPath]}>
+              {children}
+              {withTestButtons && (
+                <>
+                  <button
+                    onClick={
+                      processInstancesSelectionStore.selectAllProcessInstances
+                    }
+                  >
+                    Select all instances
+                  </button>
+                  <button onClick={batchModificationStore.enable}>
+                    Enter batch modification mode
+                  </button>
+                  <button onClick={batchModificationStore.reset}>
+                    Exit batch modification mode
+                  </button>
+                </>
+              )}
+            </MemoryRouter>
+          </QueryClientProvider>
+        </SelectedProcessDefinitionContext.Provider>
       </ProcessDefinitionKeyContext.Provider>
     );
   };
@@ -144,6 +157,7 @@ function createWrapper(
 }
 
 export {
+  PROCESS_ID,
   PROCESS_DEFINITION_ID,
   mockProcessInstancesV2,
   setupSelectionStoreWithInstances,

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/tests/mocks.tsx
@@ -12,24 +12,23 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelectionV2';
 import {batchModificationStore} from 'modules/stores/batchModification';
-import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {createProcessDefinition} from 'modules/testUtils';
 import {SelectedProcessDefinitionContext} from 'App/Processes/ListView/selectedProcessDefinitionContext';
 
-const PROCESS_ID = 'eventBasedGatewayProcess';
-const PROCESS_DEFINITION_ID = '2251799813685249';
+const PROCESS_DEFINITION_ID = 'eventBasedGatewayProcess';
+const PROCESS_DEFINITION_KEY = '2251799813685249';
 
 const selectedProcessDefinition = createProcessDefinition({
-  processDefinitionId: PROCESS_ID,
+  processDefinitionId: PROCESS_DEFINITION_ID,
   version: 1,
-  processDefinitionKey: PROCESS_DEFINITION_ID,
+  processDefinitionKey: PROCESS_DEFINITION_KEY,
 });
 
 const mockProcessInstancesV2: ProcessInstance[] = [
   {
     processInstanceKey: '1',
-    processDefinitionKey: PROCESS_DEFINITION_ID,
+    processDefinitionKey: PROCESS_DEFINITION_KEY,
     processDefinitionId: PROCESS_DEFINITION_ID,
     processDefinitionName: 'Test Process',
     processDefinitionVersion: 1,
@@ -40,7 +39,7 @@ const mockProcessInstancesV2: ProcessInstance[] = [
   },
   {
     processInstanceKey: '2',
-    processDefinitionKey: PROCESS_DEFINITION_ID,
+    processDefinitionKey: PROCESS_DEFINITION_KEY,
     processDefinitionId: PROCESS_DEFINITION_ID,
     processDefinitionName: 'Test Process',
     processDefinitionVersion: 1,
@@ -51,7 +50,7 @@ const mockProcessInstancesV2: ProcessInstance[] = [
   },
   {
     processInstanceKey: '3',
-    processDefinitionKey: PROCESS_DEFINITION_ID,
+    processDefinitionKey: PROCESS_DEFINITION_KEY,
     processDefinitionId: PROCESS_DEFINITION_ID,
     processDefinitionName: 'Test Process',
     processDefinitionVersion: 1,
@@ -63,7 +62,7 @@ const mockProcessInstancesV2: ProcessInstance[] = [
   },
   {
     processInstanceKey: '4',
-    processDefinitionKey: PROCESS_DEFINITION_ID,
+    processDefinitionKey: PROCESS_DEFINITION_KEY,
     processDefinitionId: PROCESS_DEFINITION_ID,
     processDefinitionName: 'Test Process',
     processDefinitionVersion: 1,
@@ -122,34 +121,32 @@ function createWrapper(
     }, []);
 
     return (
-      <ProcessDefinitionKeyContext.Provider value={PROCESS_DEFINITION_ID}>
-        <SelectedProcessDefinitionContext.Provider
-          value={selectedProcessDefinition}
-        >
-          <QueryClientProvider client={getMockQueryClient()}>
-            <MemoryRouter initialEntries={[initialPath]}>
-              {children}
-              {withTestButtons && (
-                <>
-                  <button
-                    onClick={
-                      processInstancesSelectionStore.selectAllProcessInstances
-                    }
-                  >
-                    Select all instances
-                  </button>
-                  <button onClick={batchModificationStore.enable}>
-                    Enter batch modification mode
-                  </button>
-                  <button onClick={batchModificationStore.reset}>
-                    Exit batch modification mode
-                  </button>
-                </>
-              )}
-            </MemoryRouter>
-          </QueryClientProvider>
-        </SelectedProcessDefinitionContext.Provider>
-      </ProcessDefinitionKeyContext.Provider>
+      <SelectedProcessDefinitionContext.Provider
+        value={selectedProcessDefinition}
+      >
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[initialPath]}>
+            {children}
+            {withTestButtons && (
+              <>
+                <button
+                  onClick={
+                    processInstancesSelectionStore.selectAllProcessInstances
+                  }
+                >
+                  Select all instances
+                </button>
+                <button onClick={batchModificationStore.enable}>
+                  Enter batch modification mode
+                </button>
+                <button onClick={batchModificationStore.reset}>
+                  Exit batch modification mode
+                </button>
+              </>
+            )}
+          </MemoryRouter>
+        </QueryClientProvider>
+      </SelectedProcessDefinitionContext.Provider>
     );
   };
 
@@ -157,8 +154,8 @@ function createWrapper(
 }
 
 export {
-  PROCESS_ID,
   PROCESS_DEFINITION_ID,
+  PROCESS_DEFINITION_KEY,
   mockProcessInstancesV2,
   setupSelectionStoreWithInstances,
   getProcessInstance,

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/Toolbar/tests/mocks.tsx
@@ -15,6 +15,7 @@ import {batchModificationStore} from 'modules/stores/batchModification';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {createProcessDefinition} from 'modules/testUtils';
 import {SelectedProcessDefinitionContext} from 'App/Processes/ListView/selectedProcessDefinitionContext';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 const PROCESS_DEFINITION_ID = 'eventBasedGatewayProcess';
 const PROCESS_DEFINITION_KEY = '2251799813685249';
@@ -121,32 +122,36 @@ function createWrapper(
     }, []);
 
     return (
-      <SelectedProcessDefinitionContext.Provider
-        value={selectedProcessDefinition}
+      <ProcessDefinitionKeyContext.Provider
+        value={selectedProcessDefinition.processDefinitionKey}
       >
-        <QueryClientProvider client={getMockQueryClient()}>
-          <MemoryRouter initialEntries={[initialPath]}>
-            {children}
-            {withTestButtons && (
-              <>
-                <button
-                  onClick={
-                    processInstancesSelectionStore.selectAllProcessInstances
-                  }
-                >
-                  Select all instances
-                </button>
-                <button onClick={batchModificationStore.enable}>
-                  Enter batch modification mode
-                </button>
-                <button onClick={batchModificationStore.reset}>
-                  Exit batch modification mode
-                </button>
-              </>
-            )}
-          </MemoryRouter>
-        </QueryClientProvider>
-      </SelectedProcessDefinitionContext.Provider>
+        <SelectedProcessDefinitionContext.Provider
+          value={selectedProcessDefinition}
+        >
+          <QueryClientProvider client={getMockQueryClient()}>
+            <MemoryRouter initialEntries={[initialPath]}>
+              {children}
+              {withTestButtons && (
+                <>
+                  <button
+                    onClick={
+                      processInstancesSelectionStore.selectAllProcessInstances
+                    }
+                  >
+                    Select all instances
+                  </button>
+                  <button onClick={batchModificationStore.enable}>
+                    Enter batch modification mode
+                  </button>
+                  <button onClick={batchModificationStore.reset}>
+                    Exit batch modification mode
+                  </button>
+                </>
+              )}
+            </MemoryRouter>
+          </QueryClientProvider>
+        </SelectedProcessDefinitionContext.Provider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 

--- a/operate/client/src/App/Processes/ListView/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/index.tsx
@@ -21,10 +21,12 @@ import {PAGE_TITLE} from 'modules/constants';
 import {notificationsStore} from 'modules/stores/notifications';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {ProcessDefinitionKeyContext} from '../processDefinitionKeyContext';
+import {SelectedProcessDefinitionContext} from '../selectedProcessDefinitionContext';
 import {useFilters} from 'modules/hooks/useFilters';
 import {variableFilterStore} from 'modules/stores/variableFilter';
 import {reaction} from 'mobx';
 import {tracking} from 'modules/tracking';
+import {useSelectedProcessDefinition} from 'modules/hooks/processDefinitions';
 
 type LocationType = Omit<Location, 'state'> & {
   state: {refreshContent?: boolean};
@@ -37,7 +39,7 @@ const ListView: React.FC = observer(() => {
 
   const filters = getFilters();
 
-  const {process, tenant, version} = filters;
+  const {process, tenant} = filters;
   const {
     state: {status: processesStatus},
   } = processesStore;
@@ -103,25 +105,27 @@ const ListView: React.FC = observer(() => {
     }
   }, [process, tenant, navigate, processesStatus, location]);
 
-  const processDefinitionKey = processesStore.getProcessId({
-    process,
-    tenant,
-    version,
-  });
+  const {data: selectedProcessDefinition} = useSelectedProcessDefinition();
 
   return (
-    <ProcessDefinitionKeyContext.Provider value={processDefinitionKey}>
-      <VisuallyHiddenH1>Operate Process Instances</VisuallyHiddenH1>
-      <InstancesList
-        type="process"
-        leftPanel={<Filters />}
-        topPanel={<DiagramPanel />}
-        bottomPanel={<InstancesTableWrapper />}
-        frame={{
-          isVisible: batchModificationStore.state.isEnabled,
-          headerTitle: 'Batch Modification Mode',
-        }}
-      />
+    <ProcessDefinitionKeyContext.Provider
+      value={selectedProcessDefinition?.processDefinitionKey}
+    >
+      <SelectedProcessDefinitionContext.Provider
+        value={selectedProcessDefinition}
+      >
+        <VisuallyHiddenH1>Operate Process Instances</VisuallyHiddenH1>
+        <InstancesList
+          type="process"
+          leftPanel={<Filters />}
+          topPanel={<DiagramPanel />}
+          bottomPanel={<InstancesTableWrapper />}
+          frame={{
+            isVisible: batchModificationStore.state.isEnabled,
+            headerTitle: 'Batch Modification Mode',
+          }}
+        />
+      </SelectedProcessDefinitionContext.Provider>
     </ProcessDefinitionKeyContext.Provider>
   );
 });

--- a/operate/client/src/App/Processes/ListView/v2/tests/processOperations.test.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/tests/processOperations.test.tsx
@@ -36,6 +36,7 @@ describe('<ListView /> - operations', () => {
   beforeEach(() => {
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
+    mockSearchProcessDefinitions().withSuccess(mockProcessDefinitions);
     mockSearchProcessDefinitions().withSuccess(
       searchResult([
         createProcessDefinition({

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/tests/mocks.tsx
@@ -8,7 +8,6 @@
 
 import {useEffect} from 'react';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {MemoryRouter} from 'react-router-dom';
@@ -20,7 +19,6 @@ type Props = {
 const Wrapper = ({children}: Props) => {
   useEffect(() => {
     return () => {
-      processesStore.reset();
       processInstanceMigrationStore.reset();
     };
   });

--- a/operate/client/src/modules/hooks/processDefinitions.ts
+++ b/operate/client/src/modules/hooks/processDefinitions.ts
@@ -122,6 +122,26 @@ function useProcessDefinitionSelection() {
   });
 }
 
+function useSelectedProcessDefinition() {
+  const filters = useProcessDefinitionsSearchFilter();
+  return useProcessDefinitionsSearch<ProcessDefinition | undefined>({
+    enabled: !!filters.processDefinitionId && !!filters.version,
+    payload: {
+      filter: {
+        processDefinitionId: filters.processDefinitionId,
+        version: filters.version,
+        tenantId: filters.tenantId,
+      },
+      sort: [{field: 'version', order: 'desc'}],
+    },
+    select: (definitions) => {
+      if (definitions.length === 1) {
+        return definitions[0];
+      }
+    },
+  });
+}
+
 function useProcessDefinitionsSearchFilter() {
   const [searchParams] = useSearchParams();
   return useMemo(
@@ -138,4 +158,5 @@ export {
   useProcessDefinitions,
   useProcessDefinitionVersions,
   useProcessDefinitionSelection,
+  useSelectedProcessDefinition,
 };


### PR DESCRIPTION
## Description

This PR adds a new `useSelectedProcessDefinition` hook (query wrapper) and `useSelectedProcessDefinitionContext`. The context is used to propagate the loaded information, which makes it easier to update required tests - just provide a value instead of network mocking and handling the asynchrony...

The `BatchModificationSummaryModal` and `MigrateAction` components are refactored to use the new `useSelectedProcessDefinitionContext` instead of the `processes.list` store.

## Checklist

- [ ] Notice that this PR is stacked on #42862.

## Related issues

relates #42481
