### PR TITLE
Poc OIDC rp initiated logout v2

### DIFF
--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -37,6 +37,8 @@ export const docsUrl = "https://docs.camunda.io";
 
 export const isSaaS = Boolean(getClientConfigString("organizationId"));
 
+export const endSessionEndpoint = getClientConfigString("endSessionEndpoint");
+
 export function getApiBaseUrl() {
   return getBasePathBeforeIdentity() + apiBaseUrl;
 }

--- a/identity/client/src/types/global.d.ts
+++ b/identity/client/src/types/global.d.ts
@@ -14,6 +14,7 @@ export declare global {
     organizationId?: string;
     clusterId?: string;
     idPattern?: string;
+    endSessionEndpoint?: string;
   }
 
   interface Window {

--- a/identity/client/src/utility/auth/index.ts
+++ b/identity/client/src/utility/auth/index.ts
@@ -6,7 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getLoginApiUrl, getLogoutApiUrl } from "src/configuration";
+import {
+  getLoginApiUrl,
+  getLogoutApiUrl,
+  endSessionEndpoint,
+} from "src/configuration";
 
 let loggedIn = false;
 
@@ -65,7 +69,12 @@ export function logout(): Promise<void> {
       if (response.status < 400) {
         // redirect to Keycloak logout endpoint
         // hardcoding post_logout_redirect_uri and client_id for now
-        window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:8080/identity&client_id=orchestration-cluster`;
+        window.location.href =
+          endSessionEndpoint +
+          `?post_logout_redirect_uri=http://localhost:8080/identity&client_id=orchestration-cluster`;
+        // Full url for reference:
+        // http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:8080/identity&client_id=orchestration-cluster
+        // initial version:
         // window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout`;
       }
     })

--- a/identity/client/src/utility/auth/index.ts
+++ b/identity/client/src/utility/auth/index.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getBaseUrl, getLoginApiUrl, getLogoutApiUrl } from "src/configuration";
+import { getLoginApiUrl, getLogoutApiUrl } from "src/configuration";
 
 let loggedIn = false;
 
@@ -63,10 +63,30 @@ export function logout(): Promise<void> {
   })
     .then((response: Response) => {
       if (response.status < 400) {
-        window.location.href = `${getBaseUrl()}/`;
+        // redirect to Keycloak logout endpoint
+        // hardcoding post_logout_redirect_uri and client_id for now
+        window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:8080/identity&client_id=orchestration-cluster`;
+        // window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout`;
       }
     })
     .catch((e) => {
       console.log(e);
     });
 }
+
+// export function logout(): Promise<void> {
+//   const data = new FormData();
+//   return fetch(getLogoutApiUrl(), {
+//     method: "post",
+//     body: data,
+//   })
+//     .then(() => {
+//       window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout`;
+//       /*if (response.status < 400) {
+//         window.location.href = `${getBaseUrl()}/`;
+//       }*/
+//     })
+//     .catch((e) => {
+//       console.log(e);
+//     });
+// }

--- a/operate/client/src/modules/stores/authentication.ts
+++ b/operate/client/src/modules/stores/authentication.ts
@@ -80,7 +80,10 @@ class Authentication {
 
     storeStateLocally({wasReloaded: true});
 
-    window.location.reload();
+    // redirect to Keycloak logout endpoint
+    // hardcoding post_logout_redirect_uri and client_id for now
+    window.location.href = `http://localhost:18080/auth/realms/camunda/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:8080/operate&client_id=orchestration-cluster`;
+    // window.location.reload();
   };
 
   handleLogout = async () => {


### PR DESCRIPTION
## Description
In this POC:

On Identity (but not Operate, this is TODO) Logout:

- clear Camunda session as before
- redirect to Keycloak logout endpoint to clear IdP session are well
- pass hardcoded (for now) `post_logout_redirect_uri` and `client_id` for redirect after logout

Keycloak logout endpoint is hardcoded and is passed through `IdentityClientConfigController.getClientConfig()`
I had to refactor `IdentityClientConfigController` class to ensure we pass the correct endpoint (as we may have multiple providers)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #43407
