### PR TITLE
ci: extend preview-env-smoke-test.yml workflow to run Playwright tests from camunda/c8-cross-component-e2e-tests

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/_helpers.tpl
+++ b/.ci/preview-environments/charts/c8sm/templates/_helpers.tpl
@@ -11,7 +11,8 @@ camunda.cloud/created-by: "{{ .Values.global.preview.git.repoUrl }}/blob/{{ .Val
 {{- end }}
 
 {{- define "ingress.domain" -}}
-{{- printf "%s.%s" .Release.Name .Values.global.preview.ingress.domain | trimPrefix "camunda-" -}}
+{{- $baseName := .Release.Name | trimPrefix "camunda-" -}}
+{{- printf "%s.%s" $baseName .Values.global.preview.ingress.domain -}}
 {{- end -}}
 
 # Temporary override the following (existing) template blocks

--- a/.ci/preview-environments/charts/c8sm/templates/ingress.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/ingress.yml
@@ -16,6 +16,11 @@ metadata:
     ingress.kubernetes.io/rewrite-target: "/"
     nginx.ingress.kubernetes.io/app-root: {{ .Values.camundaPlatform.console.contextPath }}
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    {{- if .Values.global.preview.ingress.internalAuthBypass.enabled }}
+    # Bypass Vouch/Okta for internal IPs (Teleport TCP tunnel)
+    nginx.ingress.kubernetes.io/satisfy: "any"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -32,6 +32,10 @@ global:
     ingress:
       # The domain name under which to expose the preview environment
       domain: camunda.camunda.cloud
+      # When enabled, bypasses Vouch/Okta for internal IPs (10.0.0.0/8),
+      # allowing CI access via Teleport TCP tunnel.
+      internalAuthBypass:
+        enabled: false
 
   # Camunda 8 Self-Managed global configurations
   elasticsearch:

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -32,8 +32,11 @@ global:
     ingress:
       # The domain name under which to expose the preview environment
       domain: camunda.camunda.cloud
-      # When enabled, bypasses Vouch/Okta for internal IPs (10.0.0.0/8),
-      # allowing CI access via Teleport TCP tunnel.
+      # WARNING: When enabled, this bypasses Vouch/Okta authentication for all
+      # requests originating from the 10.0.0.0/8 internal IP range, granting
+      # unauthenticated access to any client within that network. This is
+      # intended only for tightly controlled CI/testing scenarios (for example,
+      # CI access via a Teleport TCP tunnel).
       internalAuthBypass:
         enabled: false
 

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -21,6 +21,17 @@ on:
         required: false
         type: string
         default: ''
+      helm-extra-args:
+        description: |
+          Additional Helm arguments to pass to ArgoCD (newline-separated --helm-set pairs).
+          e.g., "--helm-set global.preview.ingress.domain=custom.domain"
+        required: false
+        type: string
+        default: ''
+    outputs:
+      host-name:
+        description: "Hostname of the deployed preview environment (e.g., smoke-123.camunda.camunda.cloud)"
+        value: ${{ jobs.deploy-preview.outputs.host-name }}
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 concurrency:
@@ -120,6 +131,8 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    outputs:
+      host-name: ${{ steps.set-host-name.outputs.host-name }}
     steps:
     #########################################################################
     # Validate app-name length (only for workflow_call input)
@@ -151,6 +164,14 @@ jobs:
         echo "app-name=${APP_NAME}" >> "$GITHUB_OUTPUT"
 
     #########################################################################
+    # Set the preview environment host output
+    - id: set-host-name
+      env:
+        APP_NAME: ${{ inputs.app-name || steps.sanitize.outputs.branch_name }}
+      run: |
+        echo "host-name=${APP_NAME}.camunda.camunda.cloud" >> "$GITHUB_OUTPUT"
+
+    #########################################################################
     # Setup: import secrets from vault
     - name: Import secrets
       id: secrets
@@ -176,6 +197,8 @@ jobs:
       run: |
         # Convert comma/newline-separated labels to multiple --label arguments
         label_args=$(echo "${labels}" | tr ',' '\n' | sed '/^$/d; s/^/--label /' | tr '\n' ' ')
+        # Convert newline-separated helm-extra-args to space-separated string
+        helm_extra=$(echo "${helm_extra_args}" | tr '\n' ' ' | sed 's/  */ /g; s/^ //; s/ $//')
         echo "argocd_arguments=--dest-namespace ${app_name} \
           --file .ci/preview-environments/argo/c8sm.yml \
           --helm-set global.preview.git.branch=${revision} \
@@ -185,9 +208,10 @@ jobs:
           --name ${app_name} \
           --revision ${revision} \
           --helm-set git.branch=${revision} \
-          --upsert ${label_args}" >> "$GITHUB_ENV"
+          --upsert ${label_args} ${helm_extra}" >> "$GITHUB_ENV"
       env:
         docker_tag: pr-${{ github.event.pull_request.head.sha || github.sha }}
+        helm_extra_args: ${{ inputs.helm-extra-args }}
         labels: ${{ inputs.labels }}
         revision: ${{ github.head_ref || github.ref_name }}
         app_name: camunda-${{ steps.set-app-name.outputs.app-name }}
@@ -200,7 +224,7 @@ jobs:
         revision: ${{ github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: camunda-${{ steps.set-app-name.outputs.app-name }}
-        app_url: https://${{ steps.set-app-name.outputs.app-name }}.camunda.camunda.cloud
+        app_url: https://${{ steps.set-host-name.outputs.host-name }}
         argocd_arguments: ${{ env.argocd_arguments }}
         argocd_server: argocd.int.camunda.com
         argocd_wait_for_sync_timeout: "1800" # waits up to 30 minutes

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -17,7 +17,7 @@ on:
         default: false
 
 jobs:
-  deploy-smoke-test:
+  deploy:
     name: Deploy Smoke Test Preview Environment
     uses: ./.github/workflows/preview-env-build-and-deploy.yml
     secrets: inherit
@@ -26,14 +26,135 @@ jobs:
       labels: |
         preview=smoke-test
         repo=camunda_camunda
+      helm-extra-args: |
+        --helm-set global.preview.ingress.internalAuthBypass.enabled=true
+  
+  test:
+    name: Run Smoke Tests
+    needs:
+    - deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Required for Teleport authentication
+      id-token: write
+    steps:
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          proxy: camunda.teleport.sh:443
+          version: auto
+
+      - name: Authenticate to Teleport
+        uses: teleport-actions/auth@v2
+        with:
+          # Required for tsh proxy app: allows the bot to reissue app-specific TLS certificates.
+          # Without this, the bot cert has "disallow-reissue" extension and tsh proxy app fails with:
+          # "access denied: identity is not allowed to reissue certificates"
+          # The bot's Teleport role also needs: rules: [{resources: [role], verbs: [read]}]
+          allow-reissue: true
+          certificate-ttl: 1h
+          proxy: camunda.teleport.sh:443
+          token: infra-ci-prod-github-action-preview-env-infra
+
+      - name: Start Teleport TCP Tunnel
+        shell: bash
+        env:
+          TELEPORT_APP: camunda-ci-ingress-gateway-443
+          PREVIEW_HOST: ${{ needs.deploy.outputs.host-name }}
+        run: |
+          # Start TCP proxy on port 443 (requires sudo for privileged port)
+          # Use full path since sudo doesn't inherit PATH
+          sudo -E "$(which tsh)" proxy app "${TELEPORT_APP}" --port 443 --debug &
+          sleep 5
+          
+          # Verify tunnel is running
+          if ! nc -z 127.0.0.1 443; then
+            echo "::error::Failed to start tsh proxy on port 443"
+            exit 1
+          fi
+          echo "✅ Teleport TCP tunnel running on port 443"
+
+          # Map preview hostname to localhost
+          echo "127.0.0.1 ${PREVIEW_HOST}" | sudo tee -a /etc/hosts
+          echo "✅ Added ${PREVIEW_HOST} to /etc/hosts"
+
+      - name: Generate GitHub Token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: c8-cross-component-e2e-tests
+
+      - name: Checkout Smoke Tests
+        uses: actions/checkout@v6
+        with:
+          repository: camunda/c8-cross-component-e2e-tests
+          token: ${{ steps.github-token.outputs.token }}
+          path: e2e-tests
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: e2e-tests/package-lock.json
+
+      - name: Install Dependencies
+        working-directory: e2e-tests
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: e2e-tests
+        run: npx playwright install chromium --with-deps
+
+      - name: Run Smoke Tests
+        working-directory: e2e-tests
+        env:
+          LOCAL_TEST: true
+          MINOR_VERSION: SM-8.9
+          PLAYWRIGHT_BASE_URL: https://${{ needs.deploy.outputs.host-name }}
+          PROJECT: chromium
+          CI: true
+          DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD: demo
+          DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET: admin
+          DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD: admin
+          TASKLIST_VERSION: v2
+        run: |
+          npx playwright test "tests/${MINOR_VERSION}/smoke-tests.spec.ts" \
+            --project=chromium \
+            --reporter=list,html \
+            --retries=2 \
+            --trace=on
+
+      - name: Upload Test Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-${{ github.run_number }}
+          path: |
+            e2e-tests/html-report/
+            e2e-tests/test-results/
+          retention-days: 7
 
   teardown-smoke-test:
     name: Teardown Smoke Test Preview Environment
-    # Only run if deploy didn't fail and teardown is not skipped (via workflow_dispatch)
+    # Only run if deploy and test didn't fail and teardown is not skipped (via workflow_dispatch)
     if: >
       !failure() && !cancelled() && !inputs.skip-teardown
     needs:
-    - deploy-smoke-test
+    - deploy
+    - test
     uses: ./.github/workflows/preview-env-teardown.yml
     secrets: inherit
     with:
@@ -44,10 +165,11 @@ jobs:
     # Notify on failure for scheduled runs only
     if: >
       always() &&
-        needs.deploy-smoke-test.result == 'failure' &&
-        github.event_name == 'schedule'
+      (needs.deploy.result == 'failure' || needs.test.result == 'failure') &&
+      github.event_name == 'schedule'
     needs:
-    - deploy-smoke-test
+    - deploy
+    - test
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/719.

This PR extends the `preview-env-smoke-test.yml` workflow to run Playwright tests from [camunda/c8-cross-component-e2e-tests](https://github.com/camunda/c8-cross-component-e2e-tests) against preview environments. Tests access the environment via Teleport TCP tunnel, bypassing Vouch/Okta through an internal IP whitelist.

It includes:
- **Helm chart**: add `internalAuthBypass.enabled` config to whitelist internal IPs on preview ingress
- **preview-env-build-and-deploy.yml**: add `helm-extra-args` input and `host-name` output to support smoke test integration
-  **preview-env-smoke-test.yml**: a new test job running [smoke-tests.spec.ts](https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/tests/SM-8.9/smoke-tests.spec.ts) for the corresponding minor version, accessing the deployed preview environment via a Teleport TCP tunnel (auth using existing infra-ci-dev-github-action-preview-env-infra bot)

Test: https://github.com/camunda/camunda/actions/runs/20763961226/job/59627554868

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
