### PR TITLE
refactor: migrate processInstanceVariables.spec.ts

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -68,7 +68,7 @@ class OperateProcessInstancePage {
     this.newVariableNameField = page.getByRole('textbox', {name: 'Name'});
     this.newVariableValueField = page.getByRole('textbox', {name: 'Value'});
     this.editVariableValueField = page.getByRole('textbox', {name: 'Value'});
-    this.variableSpinner = page.getByTestId('full-variable-loader');
+    this.variableSpinner = page.getByTestId('variable-operation-spinner');
     this.operationSpinner = page.getByTestId('operation-spinner');
     this.executionCountToggleOn = this.instanceHistory.getByLabel(
       'show execution count',
@@ -92,6 +92,50 @@ class OperateProcessInstancePage {
 
   async connectorResultVariableValue(variableName: string): Promise<Locator> {
     return this.page.getByTestId(variableName).locator('td').last();
+  }
+
+  async navigateToProcessInstance({id}: {id: string}): Promise<void> {
+    await this.page.goto(`/operate/processes/instances/${id}`);
+  }
+
+  async getProcessInstanceKey(): Promise<string> {
+    const url = this.page.url();
+    const matches = url.match(/instances\/(\d+)/);
+    return matches ? matches[1] : '';
+  }
+
+  async clickEditVariableButton(variableName: string): Promise<void> {
+    await this.page
+      .getByTestId(`variable-${variableName}`)
+      .getByRole('button', {
+        name: /edit variable/i,
+      })
+      .click();
+  }
+
+  async clickVariableValueInput(): Promise<void> {
+    await this.editVariableValueField.click();
+  }
+
+  async clearVariableValueInput(): Promise<void> {
+    await this.editVariableValueField.clear();
+  }
+
+  async fillVariableValueInput(value: string): Promise<void> {
+    await this.editVariableValueField.fill(value);
+  }
+
+  async clickAddVariableButton(): Promise<void> {
+    await this.addVariableButton.click();
+  }
+
+  async fillNewVariable(name: string, value: string): Promise<void> {
+    await this.newVariableNameField.fill(name);
+    await this.newVariableValueField.fill(value);
+  }
+
+  async clickSaveVariableButton(): Promise<void> {
+    await this.saveVariableButton.click();
   }
 
   async completedIconAssertion(): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -64,7 +64,9 @@ class TaskPanelPage {
           ? 'assigned-to-me'
           : option.toLowerCase().replace(/\s+/g, '-');
 
-    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`), {timeout: 30000});
+    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`), {
+      timeout: 30000,
+    });
 
     await this.collapseSidePanelButton.click();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/onlyIncidentsProcess_v_1.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="onlyIncidentsProcess" name="Only Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="onlyIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleServiceTaskProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleServiceTaskProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0">
+  <bpmn:process id="simpleServiceTaskProcess" name="simple service task process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
+    <bpmn:serviceTask id="Task_1" name="Simple Service Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="simple-service-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simpleServiceTaskProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hqza8q_di" bpmnElement="Task_1">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c9ld4u_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0tj3651_di" bpmnElement="Flow_1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11w1osn_di" bpmnElement="Flow_2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/variableScrollingProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/variableScrollingProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0">
+  <bpmn:process id="variableScrollingProcess" name="variable scrolling process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
+    <bpmn:serviceTask id="Task_1" name="Service Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="variableScrollingProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hqza8q_di" bpmnElement="Task_1">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c9ld4u_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0tj3651_di" bpmnElement="Flow_1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11w1osn_di" bpmnElement="Flow_2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -41,6 +41,8 @@ test.beforeAll(async () => {
     version: 1,
   };
 
+  await sleep(3000);
+
   await Promise.all(
     [...new Array(PROCESS_INSTANCE_COUNT)].map((_, index) =>
       createInstances(processV1.bpmnProcessId, processV1.version, 1, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -22,6 +22,7 @@ test.beforeAll(async () => {
     './resources/variableScrollingProcess.bpmn',
     './resources/simpleServiceTaskProcess.bpmn',
   ]);
+  await sleep(1500);
   const manyVariables = generateManyVariables();
   await createInstances('variableScrollingProcess', 1, 1, manyVariables);
   await createInstances('simpleServiceTaskProcess', 1, 1);
@@ -207,7 +208,7 @@ test.describe('Process Instance Variables', () => {
         operateProcessInstancePage.variablesList.getByRole('row'),
       ).toHaveCount(201);
 
-      await expect(page.getByText('aa', {exact: true})).not.toBeVisible();
+      await expect(page.getByText('aa', {exact: true})).toBeHidden();
       await expect(page.getByText('by', {exact: true})).toBeVisible();
       await expect(page.getByText('jp', {exact: true})).toBeVisible();
 
@@ -216,7 +217,7 @@ test.describe('Process Instance Variables', () => {
         operateProcessInstancePage.variablesList.getByRole('row'),
       ).toHaveCount(201);
 
-      await expect(page.getByText('jp', {exact: true})).not.toBeVisible();
+      await expect(page.getByText('jp', {exact: true})).toBeHidden();
       await expect(page.getByText('aa', {exact: true})).toBeVisible();
       await expect(page.getByText('by', {exact: true})).toBeVisible();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {
+  deploy,
+  createInstances,
+  generateManyVariables,
+} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/variableScrollingProcess.bpmn',
+    './resources/simpleServiceTaskProcess.bpmn',
+  ]);
+  const manyVariables = generateManyVariables();
+  await createInstances('variableScrollingProcess', 1, 1, manyVariables);
+  await createInstances('simpleServiceTaskProcess', 1, 1);
+});
+
+test.describe('Process Instance Variables', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Edit variables', async ({
+    page,
+    operateProcessInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName(
+        'variable scrolling process',
+      );
+      await sleep(100);
+      await operateProcessesPage.clickProcessInstanceLink();
+      await expect(operateProcessInstancePage.addVariableButton).toBeEnabled();
+    });
+
+    await test.step('Click edit variable button and verify Save Variable button is enabled', async () => {
+      await operateProcessInstancePage.clickEditVariableButton('aa');
+      await operateProcessInstancePage.clickVariableValueInput();
+      await operateProcessInstancePage.clearVariableValueInput();
+      await operateProcessInstancePage.fillVariableValueInput(
+        '"editedTestValue"',
+      );
+      await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Click Save Variable button and verify that both edit variable spinner and operation spinner are displayed', async () => {
+      await operateProcessInstancePage.saveVariableButton.click();
+      await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
+    });
+
+    await test.step('Verify that both spinners disappear after saving the variable', async () => {
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden({
+        timeout: 60000,
+      });
+      await expect(operateProcessInstancePage.operationSpinner).toBeHidden({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Refresh the page and verify the variable is still there', async () => {
+      await page.reload();
+      await expect(page.getByText('editedtestvalue')).toBeVisible();
+    });
+  });
+
+  test('Add variables', async ({
+    page,
+    operateProcessInstancePage,
+    operateHomePage,
+    operateFiltersPanelPage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName(
+        'simple service task process',
+      );
+      await operateProcessesPage.clickProcessInstanceLink();
+      await expect(operateProcessInstancePage.addVariableButton).toBeEnabled();
+    });
+
+    await test.step('Add a new variable', async () => {
+      await operateProcessInstancePage.clickAddVariableButton();
+      await operateProcessInstancePage.fillNewVariable(
+        'secondTestKey',
+        '"secondTestValue"',
+      );
+      await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled();
+    });
+
+    await test.step('Click Save Variable button and verify that variable spinner and toast are displayed', async () => {
+      await operateProcessInstancePage.clickSaveVariableButton();
+      await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
+      await expect(operateProcessInstancePage.variableAddedBanner).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Verify that the spinner disappears after saving the variable', async () => {
+      await expect(operateProcessInstancePage.variableSpinner).toBeHidden({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Refresh the page and verify the variable is still there', async () => {
+      await page.reload();
+      await expect(
+        page.getByText('secondTestKey', {exact: true}),
+      ).toBeVisible();
+      await expect(page.getByText('"secondTestValue"')).toBeVisible();
+    });
+
+    await test.step('Get the process instance key, navigate to Instances tab, and search using the added variable', async () => {
+      const processInstanceKey =
+        await operateProcessInstancePage.getProcessInstanceKey();
+
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.displayOptionalFilter('Variable');
+      await operateFiltersPanelPage.fillVariableNameFilter('secondTestKey');
+      await operateFiltersPanelPage.fillVariableValueFilter(
+        '"secondTestValue"',
+      );
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        processInstanceKey,
+      );
+
+      await expect(page.getByText('1 result')).toBeVisible();
+      await operateProcessesPage.assertProcessInstanceLink(processInstanceKey);
+    });
+  });
+
+  test('Infinite scrolling', async ({
+    page,
+    operateHomePage,
+    operateProcessesPage,
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName(
+        'variable scrolling process',
+      );
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Scroll through variables and verify row count increases progressively', async () => {
+      await expect(operateProcessInstancePage.variablesList).toBeVisible();
+      await expect(
+        operateProcessInstancePage.variablesList.getByRole('row'),
+      ).toHaveCount(51);
+
+      await expect(page.getByText('aa', {exact: true})).toBeVisible();
+      await expect(page.getByText('bx', {exact: true})).toBeVisible();
+
+      await page.getByText('bx', {exact: true}).scrollIntoViewIfNeeded();
+      await expect(
+        operateProcessInstancePage.variablesList.getByRole('row'),
+      ).toHaveCount(101);
+
+      await expect(page.getByText('dv', {exact: true})).toBeVisible();
+      await page.getByText('dv', {exact: true}).scrollIntoViewIfNeeded();
+      await expect(
+        operateProcessInstancePage.variablesList.getByRole('row'),
+      ).toHaveCount(151);
+
+      await expect(page.getByText('ft', {exact: true})).toBeVisible();
+      await page.getByText('ft', {exact: true}).scrollIntoViewIfNeeded();
+      await expect(
+        operateProcessInstancePage.variablesList.getByRole('row'),
+      ).toHaveCount(201);
+
+      await expect(page.getByText('hr', {exact: true})).toBeVisible();
+      await page.getByText('hr', {exact: true}).scrollIntoViewIfNeeded();
+
+      await expect(
+        operateProcessInstancePage.variablesList.getByRole('row'),
+      ).toHaveCount(201);
+
+      await expect(page.getByText('aa', {exact: true})).not.toBeVisible();
+      await expect(page.getByText('by', {exact: true})).toBeVisible();
+      await expect(page.getByText('jp', {exact: true})).toBeVisible();
+
+      await page.getByText('by', {exact: true}).scrollIntoViewIfNeeded();
+      await expect(
+        operateProcessInstancePage.variablesList.getByRole('row'),
+      ).toHaveCount(201);
+
+      await expect(page.getByText('jp', {exact: true})).not.toBeVisible();
+      await expect(page.getByText('aa', {exact: true})).toBeVisible();
+      await expect(page.getByText('by', {exact: true})).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/apiHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/apiHelpers.ts
@@ -7,7 +7,6 @@
  */
 
 import {APIRequestContext, request} from '@playwright/test';
-import {sleep} from './sleep';
 
 export async function authAPI(
   name: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -41,6 +41,19 @@ const createInstances = async (
   }
 };
 
+const createSingleInstance = async (
+  processDefinitionId: string,
+  version: number,
+  variables?: JSONDoc,
+) => {
+  const result = await zeebe.createProcessInstance({
+    processDefinitionId,
+    version,
+    variables: variables ?? {},
+  });
+  return result;
+};
+
 const publishMessage = async (messageName: string, correlationKey: string) => {
   try {
     await zeebe.publishMessage({
@@ -53,12 +66,26 @@ const publishMessage = async (messageName: string, correlationKey: string) => {
   }
 };
 
+const generateManyVariables = () => {
+  let variables: Record<string, string> = {};
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
+  alphabet.forEach((letter1) => {
+    alphabet.forEach((letter2) => {
+      variables[`${letter1}${letter2}`] = `${letter1}${letter2}`;
+    });
+  });
+
+  return variables;
+};
+
 async function checkUpdateOnVersion(
   targetVersion: string,
   processInstanceKey: string,
 ) {
   const res = await zeebe.searchProcessInstances({
     filter: {processInstanceKey},
+    sort: [],
   });
   const item = res?.items?.[0];
   console.log(
@@ -68,4 +95,11 @@ async function checkUpdateOnVersion(
   return !!item && item.processDefinitionVersion == targetVersion;
 }
 
-export {deploy, createInstances, publishMessage, checkUpdateOnVersion};
+export {
+  deploy,
+  createInstances,
+  createSingleInstance,
+  publishMessage,
+  generateManyVariables,
+  checkUpdateOnVersion,
+};


### PR DESCRIPTION
## Description

### ✅ Migrated Tests to New Test Suite Structure

This PR migrates the [**Process Instance Variables**](https://github.com/camunda/camunda/blob/8.7/operate/client/e2e-playwright/tests/processInstanceVariables.spec.ts) tests to the new test suite. The following changes were made:

#### 🔄 Changes:
- Removed the custom navigation helper in favor of consistent UI navigation that reflects the real user scenario:
  - Navigates to the **Processes** tab
  - Filters by process name
  - Clicks on the process instance link

#### ✅ Other Improvements:

- Added `beforeEach` and `afterEach` hooks in [`processInstanceVariables.spec.ts`](https://github.com/camunda/camunda/blob/migrate-Operate-processInstanceVariables.spec-to-core-applocation-test-suite/qa/core-application-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts):
  - Logs in before each test
  - Captures screenshots and failure videos

✅ Aligned test structure and flow with the Tasklist E2E tests to maintain consistency across Core Application test suites


🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/20775292387)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
