### PR TITLE
[Backport stable/8.8] Defer ZeebeClient deprecation warning until actual use

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -126,12 +126,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class ZeebeClientImpl implements ZeebeClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientImpl.class);
+  private static final AtomicBoolean DEPRECATION_WARNING_LOGGED = new AtomicBoolean(false);
   private static final String ZEEBE_DEPRECATION_WARNING =
       "{} is deprecated and will be removed in version 8.10. Please migrate to io.camunda.client.CamundaClient.";
   private static final String UNSUPPORTED_OPERATION_MSG =
@@ -190,7 +192,6 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final GatewayStub gatewayStub,
       final ExecutorResource executorResource,
       final HttpClient httpClient) {
-    LOG.warn(ZEEBE_DEPRECATION_WARNING, ZeebeClient.class.getSimpleName());
     this.config = config;
     jsonMapper = config.getJsonMapper();
     this.channel = channel;
@@ -302,7 +303,9 @@ public final class ZeebeClientImpl implements ZeebeClient {
           final MethodDescriptor<ReqT, RespT> methodDescriptor,
           final CallOptions callOptions,
           final Channel channel) {
-        LOG.warn(ZEEBE_DEPRECATION_WARNING, ZeebeClient.class.getSimpleName());
+        if (DEPRECATION_WARNING_LOGGED.compareAndSet(false, true)) {
+          LOG.warn(ZEEBE_DEPRECATION_WARNING, ZeebeClient.class.getSimpleName());
+        }
         return channel.newCall(methodDescriptor, callOptions);
       }
     };

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class HttpClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
+  private static final AtomicBoolean DEPRECATION_WARNING_LOGGED = new AtomicBoolean(false);
 
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
@@ -257,9 +259,11 @@ public final class HttpClient implements AutoCloseable {
       final ApiCallback<HttpT, RespT> callback) {
     final AtomicReference<ApiCallback<HttpT, RespT>> apiCallback = new AtomicReference<>(callback);
 
-    LOGGER.warn(
-        "{} is deprecated and will be removed in version 8.10. Please migrate to io.camunda.client.CamundaClient.",
-        ZeebeClient.class.getSimpleName());
+    if (DEPRECATION_WARNING_LOGGED.compareAndSet(false, true)) {
+      LOGGER.warn(
+          "{} is deprecated and will be removed in version 8.10. Please migrate to io.camunda.client.CamundaClient.",
+          ZeebeClient.class.getSimpleName());
+    }
 
     final URI target = buildRequestURI(path);
 


### PR DESCRIPTION
# Description
Backport of #41599 to `stable/8.8`.

relates to #26861 camunda/camunda#41274