### PR TITLE
feat: track the first log position in a backup

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -208,6 +208,7 @@ public final class BackupEndpoint {
     partitionStatus.brokerId().ifPresent(partitionBackupInfo::setBrokerId);
     partitionStatus.brokerVersion().ifPresent(partitionBackupInfo::setBrokerVersion);
     partitionStatus.snapshotId().ifPresent(partitionBackupInfo::setSnapshotId);
+    partitionStatus.firstLogPosition().ifPresent(partitionBackupInfo::setFirstLogPosition);
     partitionStatus.checkpointPosition().ifPresent(partitionBackupInfo::setCheckpointPosition);
     return partitionBackupInfo;
   }

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -455,6 +455,12 @@ components:
           type: string
           readOnly: true
           example: 238632143-55-690906332-690905294
+        firstLogPosition:
+          description: The first log position included in this backup.
+          type: integer
+          format: int64
+          readOnly: true
+          example: 5
         checkpointPosition:
           description: The position of the checkpoint for this backup.
           type: integer

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -347,6 +347,7 @@ final class BackupEndpointTest {
                  "createdAt": "2022-09-19T14:44:17.340409393Z",
                  "lastUpdatedAt": "2022-09-20T14:44:17.340409393Z",
                  "snapshotId" : "1-1-1-1",
+                 "firstLogPosition": 5,
                  "checkpointPosition": 1,
                  "brokerId": 0,
                  "brokerVersion": "8.0.6"
@@ -357,6 +358,7 @@ final class BackupEndpointTest {
                  "createdAt": "2022-09-19T14:44:17.340409393Z",
                  "lastUpdatedAt": "2022-09-20T14:44:17.340409393Z",
                  "snapshotId" : "1-1-1-1",
+                 "firstLogPosition": 5,
                  "checkpointPosition": 1,
                  "brokerId": 0,
                  "brokerVersion": "8.0.6"
@@ -400,6 +402,7 @@ final class BackupEndpointTest {
                  "createdAt": "2022-09-19T14:44:17.340409393Z",
                  "lastUpdatedAt": "2022-09-20T14:44:17.340409393Z",
                  "snapshotId" : "1-1-1-1",
+                 "firstLogPosition": 5,
                  "checkpointPosition": 1,
                  "brokerId": 0,
                  "brokerVersion": "8.0.6"
@@ -441,6 +444,7 @@ final class BackupEndpointTest {
           Optional.of("2022-09-19T14:44:17.340409393Z"),
           Optional.of("2022-09-20T14:44:17.340409393Z"),
           Optional.of("1-1-1-1"),
+          OptionalLong.of(5),
           OptionalLong.of(1),
           OptionalInt.of(0),
           Optional.of("8.0.6"));
@@ -463,6 +467,7 @@ final class BackupEndpointTest {
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
+          OptionalLong.empty(),
           OptionalLong.empty(),
           OptionalInt.empty(),
           Optional.empty());
@@ -606,6 +611,7 @@ final class BackupEndpointTest {
           Optional.of("2022-09-19T14:44:17.340409393Z"),
           Optional.empty(),
           Optional.empty(),
+          OptionalLong.empty(),
           OptionalLong.empty(),
           OptionalInt.empty(),
           Optional.of("8.0.6"));

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -72,6 +72,7 @@ import io.atomix.raft.utils.StateUtil;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.CheckedRunnable;
@@ -81,10 +82,8 @@ import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
@@ -1322,12 +1321,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return snapshotChunkSize;
   }
 
-  public CompletableFuture<Collection<Path>> getTailSegments(final long index) {
-    final var fut = new CompletableFuture<Collection<Path>>();
+  public CompletableFuture<SegmentInfo> getTailSegments(final long index) {
+    final var fut = new CompletableFuture<SegmentInfo>();
     threadContext.execute(
         () -> {
           final var segments = raftLog.getTailSegments(index);
-          fut.complete(segments.values());
+          fut.complete(segments);
         });
     return fut;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -39,6 +39,7 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.utils.serializer.Serializer;
+import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
@@ -47,7 +48,6 @@ import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
@@ -336,7 +336,7 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.cluster().getMembers();
   }
 
-  public CompletableFuture<Collection<Path>> getTailSegments(final long index) {
+  public CompletableFuture<SegmentInfo> getTailSegments(final long index) {
     return server.getContext().getTailSegments(index);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -27,10 +27,9 @@ import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalRecord;
+import io.camunda.zeebe.journal.SegmentInfo;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
-import java.nio.file.Path;
-import java.util.SortedMap;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,7 +243,7 @@ public final class RaftLog implements Closeable {
         + '}';
   }
 
-  public SortedMap<Long, Path> getTailSegments(final long index) {
+  public SegmentInfo getTailSegments(final long index) {
     return journal.getTailSegments(index);
   }
 }

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateCastingTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateCastingTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ManifestStateCastingTest {
@@ -30,12 +29,7 @@ final class ManifestStateCastingTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -55,12 +49,7 @@ final class ManifestStateCastingTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 new NamedFileSetImpl(Map.of()),
                 new NamedFileSetImpl(Map.of())));
 
@@ -78,12 +67,7 @@ final class ManifestStateCastingTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateTransitionTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateTransitionTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ManifestStateTransitionTest {
@@ -32,12 +31,7 @@ final class ManifestStateTransitionTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -56,12 +50,7 @@ final class ManifestStateTransitionTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -85,12 +74,7 @@ final class ManifestStateTransitionTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -115,12 +99,7 @@ final class ManifestStateTransitionTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
-                    2345234L,
-                    3,
-                    "1.2.0-SNAPSHOT",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP),
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -169,7 +169,6 @@ class ManifestManagerTest {
     return new BackupImpl(
         backupIdentifier,
         new BackupDescriptorImpl(
-            Optional.of("snapshotId"),
             backupIdentifier.checkpointId(),
             1,
             "8.7.0",

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBucketIT.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBucketIT.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,8 +67,7 @@ public class GcsBucketIT {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of(
                     "snapshotFile1",
@@ -116,8 +114,7 @@ public class GcsBucketIT {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of(
                     "snapshotFile1",

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,8 +38,7 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of("snapshotFile1", Path.of("file1"), "snapshotFile2", Path.of("file2"))),
             new NamedFileSetImpl(Map.of("segmentFile1", Path.of("file3"))));
@@ -71,8 +69,7 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of("snapshotFile1", Path.of("file1"), "snapshotFile2", Path.of("file2"))),
             new NamedFileSetImpl(Map.of("segmentFile1", Path.of("file3"))));
@@ -112,8 +109,7 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 
@@ -136,8 +132,7 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 
@@ -160,8 +155,7 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 
@@ -193,8 +187,7 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(
-                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestSerializationTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestSerializationTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.backup.common.ManifestImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ManifestSerializationTest {
@@ -73,7 +72,6 @@ final class ManifestSerializationTest {
         new ManifestImpl(
             new BackupIdentifierImpl(1, 2, 43),
             new BackupDescriptorImpl(
-                Optional.empty(),
                 2345234L,
                 3,
                 "1.2.0-SNAPSHOT",
@@ -114,7 +112,6 @@ final class ManifestSerializationTest {
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
                 new BackupDescriptorImpl(
-                    Optional.empty(),
                     2345234L,
                     3,
                     "1.2.0-SNAPSHOT",
@@ -338,7 +335,6 @@ final class ManifestSerializationTest {
         new ManifestImpl(
             new BackupIdentifierImpl(1, 2, 43),
             new BackupDescriptorImpl(
-                Optional.empty(),
                 2345234L,
                 3,
                 "1.2.0-SNAPSHOT",

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -129,12 +128,7 @@ final class BackupUploadIT {
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
         new BackupDescriptorImpl(
-            Optional.of("test-snapshot-id"),
-            4,
-            5,
-            "test",
-            Instant.now(),
-            CheckpointType.MANUAL_BACKUP),
+            "test-snapshot-id", 4, 5, "test", Instant.now(), CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(largeNumberOfSegments),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
   }
@@ -156,12 +150,7 @@ final class BackupUploadIT {
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
         new BackupDescriptorImpl(
-            Optional.of("test-snapshot-id"),
-            4,
-            5,
-            "test",
-            Instant.now(),
-            CheckpointType.MANUAL_BACKUP),
+            "test-snapshot-id", 4, 5, "test", Instant.now(), CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
@@ -23,7 +23,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.ArrayUtils;
@@ -127,7 +126,7 @@ final class CompressionIT {
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
         new BackupDescriptorImpl(
-            Optional.of("test-snapshot-id"),
+            "test-snapshot-id",
             4,
             5,
             "test",

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -49,7 +48,6 @@ public final class TestBackupProvider implements ArgumentsProvider {
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
         new BackupDescriptorImpl(
-            Optional.empty(),
             4,
             5,
             "test",
@@ -80,7 +78,7 @@ public final class TestBackupProvider implements ArgumentsProvider {
     return new BackupImpl(
         id,
         new BackupDescriptorImpl(
-            Optional.of("test-snapshot-id"),
+            "test-snapshot-id",
             4,
             5,
             "test",
@@ -99,7 +97,6 @@ public final class TestBackupProvider implements ArgumentsProvider {
     return new BackupImpl(
         id,
         new BackupDescriptorImpl(
-            Optional.empty(),
             4,
             5,
             "test",

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -62,6 +62,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-journal</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.api;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Additional information about the backup that might be required for restoring or querying the
@@ -20,6 +21,13 @@ public interface BackupDescriptor {
    * @return id of the snapshot included in the backup
    */
   Optional<String> snapshotId();
+
+  /**
+   * @return the position of the first known log entry included in the backup. Because we back up
+   *     entire segments, the actual first log position might be lower. May be empty if the first
+   *     log position is not known.
+   */
+  OptionalLong firstLogPosition();
 
   /**
    * @return the checkpoint position of the checkpoint included in the backup

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -243,6 +243,7 @@ public final class BackupRequestHandler implements BackupApi {
                                 Optional.empty(),
                                 Optional.empty(),
                                 OptionalLong.empty(),
+                                OptionalLong.empty(),
                                 OptionalInt.empty(),
                                 Optional.ofNullable(status.brokerVersion()));
                           })

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/PartitionBackupStatus.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/PartitionBackupStatus.java
@@ -20,6 +20,7 @@ public record PartitionBackupStatus(
     Optional<String> createdAt,
     Optional<String> lastUpdatedAt,
     Optional<String> snapshotId,
+    OptionalLong firstLogPosition,
     OptionalLong checkpointPosition,
     OptionalInt brokerId,
     Optional<String> brokerVersion) {
@@ -43,6 +44,9 @@ public record PartitionBackupStatus(
         Optional.ofNullable(response.getCreatedAt()),
         Optional.ofNullable(response.getLastUpdated()),
         Optional.ofNullable(response.getSnapshotId()),
+        response.hasFirstLogPosition()
+            ? OptionalLong.of(response.getFirstLogPosition())
+            : OptionalLong.empty(),
         response.hasCheckpointPosition()
             ? OptionalLong.of(response.getCheckpointPosition())
             : OptionalLong.empty(),
@@ -59,6 +63,7 @@ public record PartitionBackupStatus(
         Optional.empty(),
         Optional.empty(),
         OptionalLong.empty(),
+        OptionalLong.empty(),
         OptionalInt.empty(),
         Optional.empty());
   }
@@ -71,6 +76,7 @@ public record PartitionBackupStatus(
         Optional.ofNullable(response.getCreatedAt()),
         Optional.ofNullable(response.getLastUpdated()),
         Optional.ofNullable(response.getSnapshotId()),
+        OptionalLong.empty(),
         OptionalLong.empty(),
         OptionalInt.empty(),
         Optional.empty());

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -260,6 +260,7 @@ final class InProgressBackupImpl implements InProgressBackup {
     final var backupDescriptor =
         new BackupDescriptorImpl(
             snapshotId,
+            backupDescriptor().firstLogPosition(),
             backupDescriptor().checkpointPosition(),
             backupDescriptor().numberOfPartitions(),
             VersionUtil.getVersion(),

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -60,6 +61,7 @@ final class InProgressBackupImpl implements InProgressBackup {
   private PersistedSnapshot reservedSnapshot;
   private NamedFileSet snapshotFileSet;
   private NamedFileSet segmentsFileSet;
+  private OptionalLong firstLogPosition = OptionalLong.empty();
 
   InProgressBackupImpl(
       final PersistedSnapshotStore snapshotStore,
@@ -205,7 +207,7 @@ final class InProgressBackupImpl implements InProgressBackup {
       journalInfoProvider
           .getTailSegments(maxIndex)
           .whenComplete(
-              (segments, throwable) -> {
+              (tailSegments, throwable) -> {
                 if (throwable != null) {
                   LOG.atError()
                       .addKeyValue("backup", backupId)
@@ -213,7 +215,7 @@ final class InProgressBackupImpl implements InProgressBackup {
                       .setMessage("Failed to retrieve journal segments for backup")
                       .log();
                   filesCollected.completeExceptionally(throwable);
-                } else if (segments.isEmpty()) {
+                } else if (tailSegments.segmentPaths().isEmpty()) {
                   LOG.atError()
                       .addKeyValue("backup", backupId)
                       .setMessage("No journal segments found for backup")
@@ -223,11 +225,13 @@ final class InProgressBackupImpl implements InProgressBackup {
                 } else {
                   LOG.atTrace()
                       .addKeyValue("backup", backupId)
-                      .addKeyValue("segments", segments::size)
+                      .addKeyValue("segments", tailSegments.segmentPaths()::size)
                       .setMessage("Collected journal segments for backup")
                       .log();
+                  firstLogPosition = tailSegments.firstAsqn();
+
                   final Map<String, Path> map =
-                      segments.stream()
+                      tailSegments.segmentPaths().stream()
                           .collect(
                               Collectors.toMap(
                                   path -> segmentsDirectory.relativize(path).toString(),
@@ -260,7 +264,7 @@ final class InProgressBackupImpl implements InProgressBackup {
     final var backupDescriptor =
         new BackupDescriptorImpl(
             snapshotId,
-            backupDescriptor().firstLogPosition(),
+            firstLogPosition,
             backupDescriptor().checkpointPosition(),
             backupDescriptor().numberOfPartitions(),
             VersionUtil.getVersion(),

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/JournalInfoProvider.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/JournalInfoProvider.java
@@ -7,24 +7,23 @@
  */
 package io.camunda.zeebe.backup.management;
 
-import java.nio.file.Path;
-import java.util.Collection;
+import io.camunda.zeebe.journal.SegmentInfo;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Get the some information from the journal from an outside thread. All APIs are thread safe and
- * can be safely used from a different thread then the one used by Raft.
+ * Get some information from the journal from an outside thread. All APIs are thread safe and can be
+ * safely used from a different thread then the one used by Raft.
  */
 public interface JournalInfoProvider {
 
   /**
    * Get the segment files that are after or equal to an index.
    *
-   * <p>As an example, it can Useful for getting all the segment files >= commit_index or
+   * <p>As an example, it can be useful for getting all the segment files >= commit_index or
    * checkpoint_index.
    *
    * @param index the index in the log to select the segments
-   * @return a future containing a collection of segment files
+   * @return a future containing the tail segments with paths and the first ASQN
    */
-  CompletableFuture<Collection<Path>> getTailSegments(long index);
+  CompletableFuture<SegmentInfo> getTailSegments(long index);
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -70,7 +70,9 @@ public final class CheckpointCreateProcessor {
     // Get current partition count from routing information if available
     final int currentPartitionCount = partitionCountSupplier.getCurrentPartitionCount();
     final long checkpointId = checkpointRecord.getCheckpointId();
-    final var descriptor = BackupDescriptorImpl.from(record, currentPartitionCount);
+    final var latestBackupPosition = checkpointState.getLatestBackupPosition();
+    final var descriptor =
+        BackupDescriptorImpl.from(record, latestBackupPosition, currentPartitionCount);
 
     // Create backup (either normal or failed based on scaling state)
     if (scalingInProgress) {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -518,8 +518,7 @@ class BackupServiceImplTest {
     ControllableInProgressBackup() {
       id = new BackupIdentifierImpl(1, 2, 3);
       checkpointDescriptor =
-          new BackupDescriptorImpl(
-              Optional.empty(), 1L, 2, "1.2.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
+          new BackupDescriptorImpl(1L, 2, "1.2.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
     }
 
     @Override

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -58,8 +57,7 @@ class InProgressBackupImplTest {
   void setup() throws IOException {
     metadataProvider = mock();
     final var checkpointDescriptor =
-        new BackupDescriptorImpl(
-            Optional.empty(), 10L, 1, "8.1.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
+        new BackupDescriptorImpl(10L, 1, "8.1.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
 
     inProgressBackup =
         new InProgressBackupImpl(

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -120,7 +120,7 @@ final class CheckpointRecordsProcessorTest {
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(
             checkpointPosition, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value);
-    final var backupDescriptor = BackupDescriptorImpl.from(record, dynamicPartitionCount.get());
+    final var backupDescriptor = BackupDescriptorImpl.from(record, -1, dynamicPartitionCount.get());
 
     // when
     final var result = (MockProcessingResult) processor.process(record, resultBuilder);
@@ -161,7 +161,7 @@ final class CheckpointRecordsProcessorTest {
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(
             checkpointPosition + 10, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value);
-    final var backupDescriptor = BackupDescriptorImpl.from(record, dynamicPartitionCount.get());
+    final var backupDescriptor = BackupDescriptorImpl.from(record, -1, dynamicPartitionCount.get());
 
     // when
     final var result = (MockProcessingResult) processor.process(record, resultBuilder);
@@ -198,7 +198,7 @@ final class CheckpointRecordsProcessorTest {
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(
             checkpointPosition + 10, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value);
-    final var backupDescriptor = BackupDescriptorImpl.from(record, dynamicPartitionCount.get());
+    final var backupDescriptor = BackupDescriptorImpl.from(record, -1, dynamicPartitionCount.get());
 
     // when
     final var result = (MockProcessingResult) processor.process(record, resultBuilder);
@@ -589,7 +589,7 @@ final class CheckpointRecordsProcessorTest {
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(
             checkpointPosition, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value, 1, 1);
-    final var backupDescriptor = BackupDescriptorImpl.from(record, dynamicPartitionCount.get());
+    final var backupDescriptor = BackupDescriptorImpl.from(record, -1, dynamicPartitionCount.get());
 
     // Set up scaling in progress supplier to return true
     scalingInProgress.set(true);
@@ -636,7 +636,7 @@ final class CheckpointRecordsProcessorTest {
     final MockTypedCheckpointRecord firstRecord =
         new MockTypedCheckpointRecord(
             firstCheckpointPosition, 0, CheckpointIntent.CREATE, RecordType.COMMAND, firstValue);
-    var backupDescriptor = BackupDescriptorImpl.from(firstRecord, firstPartitionCount);
+    var backupDescriptor = BackupDescriptorImpl.from(firstRecord, -1, firstPartitionCount);
 
     // when - first checkpoint creation
     processor.process(firstRecord, resultBuilder);
@@ -657,7 +657,7 @@ final class CheckpointRecordsProcessorTest {
     final MockTypedCheckpointRecord secondRecord =
         new MockTypedCheckpointRecord(
             secondCheckpointPosition, 0, CheckpointIntent.CREATE, RecordType.COMMAND, secondValue);
-    backupDescriptor = BackupDescriptorImpl.from(secondRecord, secondPartitionCount);
+    backupDescriptor = BackupDescriptorImpl.from(secondRecord, -1, secondPartitionCount);
 
     // when - second checkpoint creation
     processor.process(secondRecord, resultBuilder);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -269,12 +269,14 @@ public final class BackupApiRequestHandler
     status
         .descriptor()
         .ifPresent(
-            backupDescriptor ->
-                response
-                    .setCheckpointPosition(backupDescriptor.checkpointPosition())
-                    .setSnapshotId(backupDescriptor.snapshotId().orElse(""))
-                    .setNumberOfPartitions(backupDescriptor.numberOfPartitions())
-                    .setBrokerVersion(backupDescriptor.brokerVersion()));
+            backupDescriptor -> {
+              response
+                  .setCheckpointPosition(backupDescriptor.checkpointPosition())
+                  .setSnapshotId(backupDescriptor.snapshotId().orElse(""))
+                  .setNumberOfPartitions(backupDescriptor.numberOfPartitions())
+                  .setBrokerVersion(backupDescriptor.brokerVersion());
+              backupDescriptor.firstLogPosition().ifPresent(response::setFirstLogPosition);
+            });
     status.failureReason().ifPresent(response::setFailureReason);
     status.created().ifPresent(instant -> response.setCreatedAt(instant.toString()));
     status.lastModified().ifPresent(instant -> response.setLastUpdated(instant.toString()));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -47,7 +47,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -145,12 +144,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
     final var backupIdx = 3L;
     final var descriptor =
         new BackupDescriptorImpl(
-            Optional.of(snapshot.getId()),
-            3L,
-            1,
-            "1.0.0",
-            Instant.now(),
-            CheckpointType.MANUAL_BACKUP);
+            snapshot.getId(), 3L, 1, "1.0.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
     logCompactor.compactFromSnapshots(snapshotStore);
     Awaitility.await("compaction is done")
         .until(() -> logCompactor.getCompactableIndex() == snapshot.getIndex());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -124,7 +124,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
                 snapshotStore,
                 dataDirectory,
                 // RaftPartitions implements this interface, but the RaftServer is not started
-                index -> CompletableFuture.completedFuture(journal.getTailSegments(index).values()),
+                index -> CompletableFuture.completedFuture(journal.getTailSegments(index)),
                 meterRegistry,
                 (context, entries, source) -> Either.left(WriteFailure.CLOSED)));
     actorScheduler.submitActor(backupService);
@@ -178,8 +178,8 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
       assertThat(files.toList().size()).isEqualTo(4L);
     }
     // all segments needed are still in the file system
-    final var activeSegmentPaths = journal.getTailSegments(backupIdx);
-    activeSegmentPaths.values().forEach(p -> assertThat(p).exists());
+    final var tailSegments = journal.getTailSegments(backupIdx);
+    tailSegments.segmentPaths().forEach(path -> assertThat(path).exists());
 
     assertThat(backupResultFut.isDone()).isFalse();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -189,12 +189,7 @@ final class BackupApiRequestHandlerTest {
             new BackupIdentifierImpl(1, 1, checkpointId),
             Optional.of(
                 new BackupDescriptorImpl(
-                    Optional.of("s-id"),
-                    100,
-                    3,
-                    "test",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP)),
+                    "s-id", 100, 3, "test", Instant.now(), CheckpointType.MANUAL_BACKUP)),
             io.camunda.zeebe.backup.api.BackupStatusCode.COMPLETED,
             Optional.empty(),
             Optional.of(createdAt),
@@ -306,12 +301,7 @@ final class BackupApiRequestHandlerTest {
             new BackupIdentifierImpl(1, 1, 2),
             Optional.of(
                 new BackupDescriptorImpl(
-                    Optional.of("s-id"),
-                    100,
-                    3,
-                    "test",
-                    Instant.now(),
-                    CheckpointType.MANUAL_BACKUP)),
+                    "s-id", 100, 3, "test", Instant.now(), CheckpointType.MANUAL_BACKUP)),
             io.camunda.zeebe.backup.api.BackupStatusCode.COMPLETED,
             Optional.empty(),
             Optional.of(createdAt),

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -19,8 +19,6 @@ import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.nio.file.Path;
-import java.util.SortedMap;
 
 public interface Journal extends AutoCloseable {
 
@@ -138,5 +136,11 @@ public interface Journal extends AutoCloseable {
    */
   boolean isOpen();
 
-  SortedMap<Long, Path> getTailSegments(long index);
+  /**
+   * Returns the tail segments of the journal starting from the given index.
+   *
+   * @param index The index from which to get the tail segments.
+   * @return The tail segments including paths and the first ASQN in the first segment.
+   */
+  SegmentInfo getTailSegments(long index);
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -137,7 +137,8 @@ public interface Journal extends AutoCloseable {
   boolean isOpen();
 
   /**
-   * Returns the tail segments of the journal starting from the given index.
+   * Returns the tail segments of the journal starting from the given index. If the index is out of
+   * bounds, it will return the last segment.
    *
    * @param index The index from which to get the tail segments.
    * @return The tail segments including paths and the first ASQN in the first segment.

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/SegmentInfo.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/SegmentInfo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.journal;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.OptionalLong;
+
+/**
+ * Information about segments of a journal.
+ *
+ * @param segmentPaths The paths to the segment files.
+ * @param firstAsqn The first ASQN in the segments. Empty if no record with an ASQN exists.
+ */
+public record SegmentInfo(Collection<Path> segmentPaths, OptionalLong firstAsqn) {
+
+  /** An empty result with no segments and no first ASQN. */
+  public static final SegmentInfo EMPTY = new SegmentInfo(List.of(), OptionalLong.empty());
+}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -327,11 +327,13 @@ final class SegmentsManager implements AutoCloseable {
   }
 
   SortedMap<Long, Segment> getTailSegments(final long index) {
+    // First look for a segment that contains the index
     final var segment = getSegment(index);
     if (segment == null) {
       return Collections.emptySortedMap();
     }
-
+    // Then use its first index to get the tail map. We can't get the tail map directly using the
+    // given index, because it may be in the middle of a segment.
     return Collections.unmodifiableSortedMap(segments.tailMap(segment.index(), true)); // inclusive
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -35,6 +35,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
 
   private long checkpointPosition = BackupStatusResponseEncoder.checkpointPositionNullValue();
   private int numberOfPartitions = BackupStatusResponseEncoder.numberOfPartitionsNullValue();
+  private long firstLogPosition = BackupStatusResponseEncoder.firstLogPositionNullValue();
   private String snapshotId = "";
   private byte[] encodedSnapshotId = EMPTY_BYTE_ARRAY;
   private String failureReason = "";
@@ -112,6 +113,19 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     return numberOfPartitions != BackupStatusResponseEncoder.numberOfPartitionsNullValue();
   }
 
+  public long getFirstLogPosition() {
+    return firstLogPosition;
+  }
+
+  public BackupStatusResponse setFirstLogPosition(final long firstLogPosition) {
+    this.firstLogPosition = firstLogPosition;
+    return this;
+  }
+
+  public boolean hasFirstLogPosition() {
+    return firstLogPosition != BackupStatusResponseEncoder.firstLogPositionNullValue();
+  }
+
   public String getSnapshotId() {
     return snapshotId.isEmpty() ? null : snapshotId;
   }
@@ -177,6 +191,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     brokerId = bodyDecoder.brokerId();
     checkpointPosition = bodyDecoder.checkpointPosition();
     numberOfPartitions = bodyDecoder.numberOfPartitions();
+    firstLogPosition = bodyDecoder.firstLogPosition();
 
     encodedSnapshotId = new byte[bodyDecoder.snapshotIdLength()];
     bodyDecoder.getSnapshotId(encodedSnapshotId, 0, encodedSnapshotId.length);
@@ -241,6 +256,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         .partitionId(partitionId)
         .checkpointPosition(checkpointPosition)
         .numberOfPartitions(numberOfPartitions)
+        .firstLogPosition(firstLogPosition)
         .status(status)
         .putSnapshotId(encodedSnapshotId, 0, encodedSnapshotId.length)
         .putFailureReason(encodedFailureReason, 0, encodedFailureReason.length)

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -70,6 +70,8 @@
     <!-- Following fields will have a valid value if status == COMPLETED or status == INPROGRESS -->
     <field name="checkpointPosition" id="5" type="int64"/>
     <field name="numberOfPartitions" id="6" type="uint16"/>
+    <!-- The first log position included in this backup, may be null if unknown -->
+    <field name="firstLogPosition" id="12" type="int64"/>
     <data name="snapshotId" id="7" type="varDataEncoding"/>
     <!-- failure reason will have a valid value if status == FAILED -->
     <data name="failureReason" id="8" type="varDataEncoding"/>

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -120,7 +120,7 @@ class PartitionRestoreServiceTest {
             snapshotStore,
             dataDirectory,
             // RaftPartitions implements this interface, but the RaftServer is not started
-            index -> CompletableFuture.completedFuture(journal.getTailSegments(index).values()),
+            index -> CompletableFuture.completedFuture(journal.getTailSegments(index)),
             meterRegistry,
             (context, entries, source) -> Either.left(WriteFailure.CLOSED));
     actorScheduler.submitActor(backupService);

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -45,7 +45,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -254,7 +253,6 @@ class PartitionRestoreServiceTest {
         backupStore.waitForBackup(new BackupIdentifierImpl(nodeId, partitionId, backupId));
     final var descriptor =
         new BackupDescriptorImpl(
-            Optional.empty(),
             checkpointPosition,
             1, // Use partition count of 1 for tests
             "test",


### PR DESCRIPTION
This adds `firstLogPosition` to the backup descriptor and exposes it in the backup management API. The first log position is determined by the journal.

Tracking the first log position will allow us to determine whether backups are actually contiguous or not.

closes #40251