### PR TITLE
[Backport stable/8.6] refactor: migrate processInstancesTable.spec to OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -79,7 +79,7 @@ export class OperateFiltersPanelPage {
       name: 'Process Instance Key(s)',
     });
     this.processInstanceKeysFilter = page.getByRole('textbox', {
-      name: 'process instance key',
+      name: 'Process Instance Key(s)',
     });
     this.parentProcessInstanceKey = page.getByRole('textbox', {
       name: 'parent process instance key',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessA.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessA.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+  <bpmn:process id="instancesTableProcessA" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="instancesTableProcessA">
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessB_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessB_v_1.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+  <bpmn:process id="instancesTableProcessB" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="instancesTableProcessB">
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessB_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessB_v_2.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+  <bpmn:process id="instancesTableProcessB" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="Activity_1g4x7d7" />
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>Flow_15gc1ec</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="Activity_1g4x7d7" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_15gc1ec</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_15gc1ec" sourceRef="Activity_1g4x7d7" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="instancesTableProcessB">
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="420" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15gc1ec_di" bpmnElement="Flow_15gc1ec">
+        <di:waypoint x="520" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1g4x7d7_di" bpmnElement="Activity_1g4x7d7">
+        <dc:Bounds x="420" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessForInfiniteScroll.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/instancesTableProcessForInfiniteScroll.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.10.0">
+  <bpmn:process id="instancesTableProcessForInfiniteScroll" name="Process For Infinite Scroll" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="instancesTableProcessForInfiniteScroll">
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -23,6 +23,7 @@ test.beforeAll(async () => {
     './resources/Start_Form_Process.bpmn',
     './resources/Zeebe_Priority_User_Task_Process.bpmn',
   ]);
+  await sleep(1000);
   await createInstances('Job_Worker_Process', 1, 1);
   await createInstances('Zeebe_User_Task_Process', 1, 1);
   await createInstances('Variable_Process', 1, 1, {
@@ -31,6 +32,7 @@ test.beforeAll(async () => {
   await createInstances('Form_User_Task', 1, 1);
   await createInstances('Start_Form_Process', 1, 1);
   await createInstances('Zeebe_Priority_User_Task_Process', 1, 1);
+  await sleep(1000);
 });
 
 test.describe('HTO User Flow Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -34,7 +34,7 @@ test.beforeAll(async () => {
         .processInstanceKey,
     ),
   };
-  await sleep(500);
+  await sleep(1000);
 
   processB_v_1 = {
     processInstanceKey: Number(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {processInstanceKey: number};
+
+let processA: ProcessInstance;
+let processB_v_1: ProcessInstance;
+let processB_v_2: ProcessInstance;
+let scrollingInstances: ProcessInstance[];
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/instancesTableProcessA.bpmn',
+    './resources/instancesTableProcessB_v_1.bpmn',
+    './resources/instancesTableProcessForInfiniteScroll.bpmn',
+  ]);
+
+  processA = {
+    processInstanceKey: Number(
+      (await createSingleInstance('instancesTableProcessA', 1))
+        .processInstanceKey,
+    ),
+  };
+  await sleep(500);
+
+  processB_v_1 = {
+    processInstanceKey: Number(
+      (await createSingleInstance('instancesTableProcessB', 1))
+        .processInstanceKey,
+    ),
+  };
+
+  await deploy(['./resources/instancesTableProcessB_v_2.bpmn']);
+  await sleep(1000);
+
+  processB_v_2 = {
+    processInstanceKey: Number(
+      (await createSingleInstance('instancesTableProcessB', 2))
+        .processInstanceKey,
+    ),
+  };
+
+  // Create scrolling instances
+  const createdInstances = [];
+  for (let i = 0; i < 300; i++) {
+    const instance = await createSingleInstance(
+      'instancesTableProcessForInfiniteScroll',
+      1,
+    );
+    createdInstances.push(instance);
+  }
+  scrollingInstances = createdInstances.map((instance) => ({
+    processInstanceKey: Number(instance.processInstanceKey),
+  }));
+});
+
+test.describe('Process Instances Table', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Sorting of process instances', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+  }) => {
+    test.slow();
+    let instanceIds: number[] = [
+      processA.processInstanceKey,
+      processB_v_1.processInstanceKey,
+      processB_v_2.processInstanceKey,
+    ];
+
+    await test.step('Extract process instance keys and filter by the extracted values', async () => {
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instanceIds.join(),
+      );
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('3 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Check default sorting of processes', async () => {
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(0).innerText(),
+        )
+        .toContain(instanceIds[2].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(1).innerText(),
+        )
+        .toContain(instanceIds[1].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(2).innerText(),
+        )
+        .toContain(instanceIds[0].toString());
+    });
+
+    await test.step('Check sorting of processes by start date ASC', async () => {
+      await operateProcessesPage.clickStartDateSortButton();
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(0).innerText(),
+        )
+        .toContain(instanceIds[0].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(1).innerText(),
+        )
+        .toContain(instanceIds[1].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(2).innerText(),
+        )
+        .toContain(instanceIds[2].toString());
+    });
+
+    await test.step('Check sorting of processes by process instance key DESC', async () => {
+      instanceIds.sort();
+      await operateProcessesPage.clickProcessInstanceKeySortButton();
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(0).innerText(),
+        )
+        .toContain(instanceIds[2].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(1).innerText(),
+        )
+        .toContain(instanceIds[1].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(2).innerText(),
+        )
+        .toContain(instanceIds[0].toString());
+    });
+
+    await test.step('Check sorting of processes by process instance key ASC', async () => {
+      await operateProcessesPage.clickProcessInstanceKeySortButton();
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(0).innerText(),
+        )
+        .toContain(instanceIds[0].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(1).innerText(),
+        )
+        .toContain(instanceIds[1].toString());
+      await expect
+        .poll(() =>
+          operateProcessesPage.processInstancesTable.nth(2).innerText(),
+        )
+        .toContain(instanceIds[2].toString());
+    });
+  });
+
+  test('Scrolling of process instances', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+  }) => {
+    test.slow();
+    const descendingInstanceIds = [...scrollingInstances]
+      .map((instance) => instance.processInstanceKey)
+      .sort((a, b) => b - a);
+    const instanceRows = page.getByTestId('data-list').getByRole('row');
+
+    await test.step('Select process and sort by instance key DESC', async () => {
+      await operateFiltersPanelPage.selectProcess(
+        'Process For Infinite Scroll',
+      );
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('300 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await operateProcessesPage.clickProcessInstanceKeySortButton();
+      await expect(instanceRows).toHaveCount(50);
+      await expect
+        .poll(() => instanceRows.nth(0).innerText())
+        .toContain(descendingInstanceIds[0].toString());
+      await expect
+        .poll(() => instanceRows.nth(49).innerText())
+        .toContain(descendingInstanceIds[49].toString());
+    });
+
+    await test.step('Scroll to 100th instance', async () => {
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[49]}`})
+        .scrollIntoViewIfNeeded();
+
+      await expect(instanceRows).toHaveCount(100);
+    });
+
+    await test.step('Scroll to 150th instance', async () => {
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[99]}`})
+        .scrollIntoViewIfNeeded();
+      await expect(instanceRows).toHaveCount(150);
+    });
+
+    await test.step('Scroll to 200th instance', async () => {
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[149]}`})
+        .scrollIntoViewIfNeeded();
+      await sleep(500);
+      await expect(instanceRows).toHaveCount(200);
+      await expect
+        .poll(() => instanceRows.nth(0).innerText())
+        .toContain(descendingInstanceIds[0].toString());
+      await expect
+        .poll(() => instanceRows.nth(199).innerText())
+        .toContain(descendingInstanceIds[199].toString());
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[199]}`})
+        .scrollIntoViewIfNeeded();
+      await expect(instanceRows).toHaveCount(200);
+    });
+
+    await test.step('Scroll to 250th instance', async () => {
+      await expect
+        .poll(() => instanceRows.nth(0).innerText())
+        .toContain(descendingInstanceIds[50].toString());
+      await expect
+        .poll(() => instanceRows.nth(199).innerText())
+        .toContain(descendingInstanceIds[249].toString());
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -10,11 +10,18 @@ import {Camunda8} from '@camunda8/sdk';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types';
 
 const c8 = new Camunda8({
-  CAMUNDA_AUTH_STRATEGY: process.env.CAMUNDA_AUTH_STRATEGY,
+  CAMUNDA_AUTH_STRATEGY: process.env.CAMUNDA_AUTH_STRATEGY as
+    | 'BASIC'
+    | 'OAUTH'
+    | 'BEARER'
+    | 'COOKIE'
+    | 'NONE'
+    | undefined,
   CAMUNDA_BASIC_AUTH_USERNAME: process.env.CAMUNDA_BASIC_AUTH_USERNAME,
   CAMUNDA_BASIC_AUTH_PASSWORD: process.env.CAMUNDA_BASIC_AUTH_PASSWORD,
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
 });
+
 const zeebe = c8.getCamundaRestClient();
 const deploy = async (processFilePaths: string[]) => {
   try {
@@ -28,17 +35,30 @@ const deploy = async (processFilePaths: string[]) => {
 
 const createInstances = async (
   processDefinitionId: string,
-  version: number,
+  processDefinitionVersion: number,
   numberOfInstances: number,
   variables?: JSONDoc,
 ) => {
   for (let i = 0; i < numberOfInstances; i++) {
     await zeebe.createProcessInstance({
       processDefinitionId,
-      version,
-      variables: variables ?? {}, // Ensure it's never undefined
+      processDefinitionVersion,
+      variables: variables ?? {},
     });
   }
+};
+
+const createSingleInstance = async (
+  processDefinitionId: string,
+  processDefinitionVersion: number,
+  variables?: JSONDoc,
+) => {
+  const result = await zeebe.createProcessInstance({
+    processDefinitionId,
+    processDefinitionVersion,
+    variables: variables ?? {},
+  });
+  return result;
 };
 
 const publishMessage = async (messageName: string, correlationKey: string) => {
@@ -66,6 +86,16 @@ const generateManyVariables = () => {
   return variables;
 };
 
+const cancelProcessInstance = async (processInstanceKey: string) => {
+  return zeebe.cancelProcessInstance({processInstanceKey});
+};
+
+async function searchByProcessInstanceKey(processInstanceKey: string) {
+  return zeebe.searchProcessInstances({
+    filter: {processInstanceKey},
+    sort: [],
+  });
+}
 async function checkUpdateOnVersion(
   targetVersion: string,
   processInstanceKey: string,
@@ -85,7 +115,10 @@ async function checkUpdateOnVersion(
 export {
   deploy,
   createInstances,
+  createSingleInstance,
   publishMessage,
   generateManyVariables,
+  cancelProcessInstance,
+  searchByProcessInstanceKey,
   checkUpdateOnVersion,
 };


### PR DESCRIPTION
# Description
Backport of #43557 to `stable/8.6`.

🧪[successful test run ](https://github.com/camunda/camunda/actions/runs/20781371661)

relates to #34106
closes [#34124](https://github.com/camunda/camunda/issues/34124)