### PR TITLE
Refactor Auditlog Integration Tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthenticationIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auditlog;
+
+import static io.camunda.it.auditlog.AuditLogUtils.DEFAULT_USERNAME;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_A;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_A_ID;
+import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.AuditLogActorTypeEnum;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/*
+ * Test is disabled on RDBMS until https://github.com/camunda/camunda/issues/43323 is implemented.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class AuditLogAuthenticationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthorizationsEnabled()
+          .withAuthenticatedAccess();
+
+  private static CamundaClient adminClient;
+
+  @BeforeAll
+  static void setup() {
+    new AuditLogUtils(adminClient, true).init();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldSetActorAndTenantBasedOnAuthenticatedUser(
+      final boolean useRestApi, @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    final var utils = new AuditLogUtils(client, useRestApi);
+    final var deployment = utils.deployResource("a.bpmn", PROCESS_A, TENANT_A);
+    final var instance = utils.startProcessInstance(PROCESS_A_ID, TENANT_A);
+    utils.await();
+
+    final var auditLogs =
+        client
+            .newAuditLogSearchRequest()
+            .filter(f -> f.processInstanceKey("" + instance.getProcessInstanceKey()))
+            .send()
+            .join();
+
+    assertThat(auditLogs.items())
+        .hasSize(1)
+        .allSatisfy(
+            log -> {
+              assertThat(log.getProcessInstanceKey())
+                  .isEqualTo("" + instance.getProcessInstanceKey());
+              assertThat(log.getActorId()).isEqualTo(DEFAULT_USERNAME);
+              assertThat(log.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
+              assertThat(log.getTenantId()).isEqualTo(TENANT_A);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -197,6 +198,7 @@ public class AuditLogAuthorizationsIT {
   }
 
   // TODO: this one fails, due to the wildcard shortcut in the authorization checks
+  @Disabled("https://github.com/camunda/camunda/issues/43662")
   @Test
   void shouldAuthorizeByProcessIdWildcard(
       @Authenticated(USER_B_USERNAME) final CamundaClient client) {
@@ -236,6 +238,7 @@ public class AuditLogAuthorizationsIT {
   }
 
   // TODO: this one fails, due to the wildcard shortcut in the authorization checks
+  @Disabled("https://github.com/camunda/camunda/issues/43662")
   @Test
   void shouldAuthorizeByUserTaskProcessIdWildcard(
       @Authenticated(USER_C_USERNAME) final CamundaClient client) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -7,33 +7,30 @@
  */
 package io.camunda.it.auditlog;
 
-import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.READ;
 import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.READ_USER_TASK;
 import static io.camunda.client.api.search.enums.ResourceType.AUDIT_LOG;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
-import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_ID_A;
-import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_ID_B;
-import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_ID_DEPLOYED_RESOURCES;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_A_ID;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_B_ID;
+import static io.camunda.it.auditlog.AuditLogUtils.PROCESS_C_ID;
 import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
 import static io.camunda.it.auditlog.AuditLogUtils.TENANT_B;
-import static io.camunda.it.auditlog.AuditLogUtils.USER_TASKS_PROCESS_ID;
-import static io.camunda.it.auditlog.AuditLogUtils.assignUserToTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
-import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -55,327 +52,249 @@ public class AuditLogAuthorizationsIT {
           .withAuthorizationsEnabled()
           .withAuthenticatedAccess();
 
+  private static final String USER_UNAUTHORIZED_NAME = "UnauthorizedUser";
   private static final String USER_A_USERNAME = "userA";
+  private static final String USER_AA_USERNAME = "userAA";
   private static final String USER_B_USERNAME = "userB";
+  private static final String USER_BB_USERNAME = "userBB";
   private static final String USER_C_USERNAME = "userC";
+  private static final String USER_CC_USERNAME = "userCC";
   private static final String USER_D_USERNAME = "userD";
-  private static final String USER_E_USERNAME = "userE";
-  private static final String USER_F_USERNAME = "userF";
   private static final String PASSWORD = "password";
+  private static final List WILDCARD = List.of(AuthorizationScope.WILDCARD.getResourceId());
 
-  /*
-   * User A has AUDIT_LOG READ permission for PROCESS_ID_A only. User A is only assigned to
-   * TENANT_A. They should only see audit logs related to that process definition and belonging to
-   * TENANT_A.
-   */
+  @UserDefinition
+  private static final TestUser USER_UNAUTHORIZED =
+      new TestUser(USER_UNAUTHORIZED_NAME, PASSWORD, List.of());
+
+  // With AUDIT_LOG#READ permissions
   @UserDefinition
   private static final TestUser USER_A =
-      new TestUser(
-          USER_A_USERNAME,
-          PASSWORD,
-          List.of(
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of(PROCESS_ID_A)),
-              new Permissions(
-                  AUDIT_LOG, READ, List.of(AuditLogCategoryEnum.DEPLOYED_RESOURCES.name()))));
+      new TestUser(USER_A_USERNAME, PASSWORD, List.of(new Permissions(AUDIT_LOG, READ, WILDCARD)));
 
-  /*
-   * User B has AUDIT_LOG READ permission for PROCESS_ID_B only. User B is only assigned to
-   * TENANT_B. They should only see audit logs related to that process definition and belonging to
-   * TENANT_B.
-   */
+  @UserDefinition
+  private static final TestUser USER_AA =
+      new TestUser(
+          USER_AA_USERNAME,
+          PASSWORD,
+          List.of(new Permissions(AUDIT_LOG, READ, List.of(AuditLogCategoryEnum.ADMIN.name()))));
+
+  // With PROCESS_DEFINITION#READ_PROCESS_INSTANCE permission
   @UserDefinition
   private static final TestUser USER_B =
       new TestUser(
           USER_B_USERNAME,
           PASSWORD,
-          List.of(
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of(PROCESS_ID_B)),
-              new Permissions(
-                  AUDIT_LOG, READ, List.of(AuditLogCategoryEnum.DEPLOYED_RESOURCES.name()))));
+          List.of(new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, WILDCARD)));
 
-  /*
-   * User C has READ permission for USER_TASKS audit log category only. They should only see
-   * audit logs related to user tasks.
-   */
+  @UserDefinition
+  private static final TestUser USER_BB =
+      new TestUser(
+          USER_BB_USERNAME,
+          PASSWORD,
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_A_ID))));
+
   @UserDefinition
   private static final TestUser USER_C =
       new TestUser(
           USER_C_USERNAME,
           PASSWORD,
-          List.of(
-              new Permissions(AUDIT_LOG, READ, List.of(AuditLogCategoryEnum.USER_TASKS.name()))));
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, WILDCARD)));
 
-  /*
-   * User D has READ_PROCESS_INSTANCE permission for PROCESS_ID only. They should only see
-   * audit logs related to that process definition.
-   */
+  @UserDefinition
+  private static final TestUser USER_CC =
+      new TestUser(
+          USER_CC_USERNAME,
+          PASSWORD,
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_C_ID))));
+
   @UserDefinition
   private static final TestUser USER_D =
       new TestUser(
           USER_D_USERNAME,
           PASSWORD,
           List.of(
-              new Permissions(
-                  PROCESS_DEFINITION,
-                  READ_PROCESS_INSTANCE,
-                  List.of(PROCESS_ID_DEPLOYED_RESOURCES))));
-
-  /*
-   * User E has READ_USER_TASK permission for USER_TASKS_PROCESS_ID only. They should only see
-   * audit logs related to the user tasks of that process definition.
-   */
-  @UserDefinition
-  private static final TestUser USER_E =
-      new TestUser(
-          USER_E_USERNAME,
-          PASSWORD,
-          List.of(
-              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(USER_TASKS_PROCESS_ID))));
-
-  /*
-   * User F has AUDIT_LOG READ permission for ADMIN category and READ_PROCESS_INSTANCE permission
-   * for PROCESS_ID_DEPLOYED_RESOURCES and READ_USER_TASK permission for USER_TASKS_PROCESS_ID.
-   * They should see audit logs related to ADMIN category as well as audit logs related to those
-   * process definitions.
-   */
-  @UserDefinition
-  private static final TestUser USER_F =
-      new TestUser(
-          USER_F_USERNAME,
-          PASSWORD,
-          List.of(
-              new Permissions(AUDIT_LOG, READ, List.of(AuditLogCategoryEnum.ADMIN.name())),
-              new Permissions(
-                  PROCESS_DEFINITION,
-                  READ_PROCESS_INSTANCE,
-                  List.of(PROCESS_ID_DEPLOYED_RESOURCES)),
-              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(USER_TASKS_PROCESS_ID))));
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_A_ID)),
+              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_B_ID))));
 
   private static CamundaClient adminClient;
 
   @BeforeAll
   static void setUp() {
-    AuditLogUtils.generateData(adminClient, USE_REST_API);
-
-    assignUserToTenant(adminClient, USER_A_USERNAME, TENANT_A);
-    assignUserToTenant(adminClient, USER_B_USERNAME, TENANT_B);
-    assignUserToTenant(adminClient, USER_C_USERNAME, TENANT_A);
-    assignUserToTenant(adminClient, USER_D_USERNAME, TENANT_A);
-    assignUserToTenant(adminClient, USER_E_USERNAME, TENANT_B);
-    assignUserToTenant(adminClient, USER_F_USERNAME, TENANT_A);
-    assignUserToTenant(adminClient, USER_F_USERNAME, TENANT_B);
+    final var utils = new AuditLogUtils(adminClient);
+    utils.generateDefaults();
+    utils.assignUserToTenant(USER_UNAUTHORIZED_NAME, TENANT_A);
+    utils.assignUserToTenant(USER_A_USERNAME, TENANT_A);
+    utils.assignUserToTenant(USER_AA_USERNAME, TENANT_A);
+    utils.assignUserToTenant(USER_B_USERNAME, TENANT_B);
+    utils.assignUserToTenant(USER_BB_USERNAME, TENANT_B);
+    utils.assignUserToTenant(USER_C_USERNAME, TENANT_A);
+    utils.assignUserToTenant(USER_CC_USERNAME, TENANT_A);
+    utils.assignUserToTenant(USER_C_USERNAME, TENANT_B);
+    utils.assignUserToTenant(USER_CC_USERNAME, TENANT_B);
+    utils.assignUserToTenant(USER_D_USERNAME, TENANT_A);
+    utils.await();
   }
 
   @Test
-  void shouldIsolateAuditLogsByTenant(
-      @Authenticated(USER_A_USERNAME) final CamundaClient tenantAUserClient,
-      @Authenticated(USER_B_USERNAME) final CamundaClient tenantBUserClient) {
+  void shouldNotAuthorizeWithoutPermissions(
+      @Authenticated(USER_UNAUTHORIZED_NAME) final CamundaClient client) {
     // when
-    final var userAAuditLogs = tenantAUserClient.newAuditLogSearchRequest().send().join();
-    final var userBAuditLogs = tenantBUserClient.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().send().join();
 
     // then
-    // User A should only see audit logs from TENANT_A and PROCESS_ID_A
-    assertThat(userAAuditLogs.items()).isNotEmpty();
-    assertThat(userAAuditLogs.items().stream().allMatch(log -> TENANT_A.equals(log.getTenantId())))
-        .isTrue();
-    assertThat(
-            userAAuditLogs.items().stream()
-                .anyMatch(log -> PROCESS_ID_A.equals(log.getProcessDefinitionId())))
-        .isTrue();
-    assertThat(
-            userAAuditLogs.items().stream()
-                .noneMatch(log -> PROCESS_ID_B.equals(log.getProcessDefinitionId())))
-        .isTrue();
-
-    // User B should only see audit logs from TENANT_B and PROCESS_ID_B
-    assertThat(userBAuditLogs.items()).isNotEmpty();
-    assertThat(userBAuditLogs.items().stream().allMatch(log -> TENANT_B.equals(log.getTenantId())))
-        .isTrue();
-    assertThat(
-            userBAuditLogs.items().stream()
-                .anyMatch(log -> PROCESS_ID_B.equals(log.getProcessDefinitionId())))
-        .isTrue();
-    assertThat(
-            userBAuditLogs.items().stream()
-                .noneMatch(log -> PROCESS_ID_A.equals(log.getProcessDefinitionId())))
-        .isTrue();
+    assertThat(logs.items()).isEmpty();
   }
 
   @Test
-  void shouldNotSeeDeployedResourceAuditLogsWithOnlyUserTasksCategoryPermission(
-      @Authenticated(USER_C_USERNAME) final CamundaClient userTaskUserClient) {
+  void shouldAuthorizeByTenant(@Authenticated(USER_A_USERNAME) final CamundaClient client) {
     // when
-    final var userCAuditLogs =
-        userTaskUserClient
-            .newAuditLogSearchRequest()
-            .filter(f -> f.category(AuditLogCategoryEnum.DEPLOYED_RESOURCES))
-            .send()
-            .join();
+    final var logs = client.newAuditLogSearchRequest().send().join();
 
     // then
-    assertThat(userCAuditLogs.items()).isEmpty();
-
-    // Admin should see the DEPLOYED_RESOURCES category audit log
-    final var adminAuditLogs =
-        adminClient
-            .newAuditLogSearchRequest()
-            .filter(fn -> fn.category(AuditLogCategoryEnum.DEPLOYED_RESOURCES))
-            .send()
-            .join();
-    assertThat(adminAuditLogs.items()).isNotEmpty();
-    assertThat(adminAuditLogs.items().get(0).getCategory())
-        .isEqualTo(AuditLogCategoryEnum.DEPLOYED_RESOURCES);
-  }
-
-  @Test
-  void shouldOnlySeeAllowedAuditLogsForMultipleAuditLogPermissions(
-      @Authenticated(USER_F_USERNAME) final CamundaClient multiPermissionUserClient) {
-    // when
-    final var userFAuditLogs = multiPermissionUserClient.newAuditLogSearchRequest().send().join();
-
-    // then
-    // User F should see audit logs from ADMIN category, DEPLOYED_RESOURCES process instances,
-    // and USER_TASKS from USER_TASKS_PROCESS_ID
-    assertThat(userFAuditLogs.items()).isNotEmpty();
-
-    // Verify User F can see ADMIN category audit logs
+    assertThat(logs.items()).isNotEmpty();
     assertThat(
-            userFAuditLogs.items().stream()
-                .anyMatch(log -> AuditLogCategoryEnum.ADMIN.equals(log.getCategory())))
-        .isTrue();
-
-    // Verify User F can see DEPLOYED_RESOURCES process instance audit logs
-    assertThat(
-            userFAuditLogs.items().stream()
-                .anyMatch(
-                    log ->
-                        PROCESS_ID_DEPLOYED_RESOURCES.equals(log.getProcessDefinitionId())
-                            && AuditLogCategoryEnum.DEPLOYED_RESOURCES.equals(log.getCategory())))
-        .isTrue();
-
-    // Verify User F can see USER_TASKS audit logs from USER_TASKS_PROCESS_ID
-    assertThat(
-            userFAuditLogs.items().stream()
-                .anyMatch(
-                    log ->
-                        USER_TASKS_PROCESS_ID.equals(log.getProcessDefinitionId())
-                            && AuditLogCategoryEnum.USER_TASKS.equals(log.getCategory())))
-        .isTrue();
-
-    // Verify User F cannot see audit logs from PROCESS_ID_A
-    assertThat(
-            userFAuditLogs.items().stream()
-                .noneMatch(log -> PROCESS_ID_A.equals(log.getProcessDefinitionId())))
-        .isTrue();
-
-    // Verify User F cannot see audit logs from PROCESS_ID_B
-    assertThat(
-            userFAuditLogs.items().stream()
-                .noneMatch(log -> PROCESS_ID_B.equals(log.getProcessDefinitionId())))
-        .isTrue();
-
-    // Verify that admin can see all these audit logs
-    final var adminAuditLogs = adminClient.newAuditLogSearchRequest().send().join();
-    assertThat(adminAuditLogs.items()).hasSizeGreaterThan(userFAuditLogs.items().size());
-
-    // Verify admin can see all the categories and process definitions
-    assertThat(
-            adminAuditLogs.items().stream()
-                .anyMatch(log -> AuditLogCategoryEnum.ADMIN.equals(log.getCategory())))
-        .isTrue();
-    assertThat(
-            adminAuditLogs.items().stream()
-                .anyMatch(log -> PROCESS_ID_A.equals(log.getProcessDefinitionId())))
-        .isTrue();
-    assertThat(
-            adminAuditLogs.items().stream()
-                .anyMatch(log -> PROCESS_ID_B.equals(log.getProcessDefinitionId())))
-        .isTrue();
-  }
-
-  @Test
-  void shouldOnlySeeAuditLogsForAuthorizedProcessDefinition(
-      @Authenticated(USER_D_USERNAME) final CamundaClient processDefinitionOnlyClient) {
-    // when
-    final var userDAuditLogs =
-        processDefinitionOnlyClient
-            .newAuditLogSearchRequest()
-            .filter(fn -> fn.operationType(AuditLogOperationTypeEnum.CREATE))
-            .send()
-            .join();
-
-    // then
-    // User D should only see audit logs from PROCESS_ID
-    assertThat(userDAuditLogs.items().size()).isOne();
-    assertThat(
-            userDAuditLogs.items().stream()
+            logs.items().stream()
                 .allMatch(
-                    log -> PROCESS_ID_DEPLOYED_RESOURCES.equals(log.getProcessDefinitionId())))
+                    log -> Objects.isNull(log.getTenantId()) || TENANT_A.equals(log.getTenantId())))
         .isTrue();
-
-    // Verify they cannot see audit logs from PROCESS_ID_A
-    assertThat(
-            userDAuditLogs.items().stream()
-                .noneMatch(log -> PROCESS_ID_A.equals(log.getProcessDefinitionId())))
-        .isTrue();
-
-    // Verify that the audit log entry for PROCESS_ID exists for admin
-    final var adminAuditLogs =
-        adminClient
-            .newAuditLogSearchRequest()
-            .filter(
-                fn ->
-                    fn.category(AuditLogCategoryEnum.DEPLOYED_RESOURCES)
-                        .operationType(AuditLogOperationTypeEnum.CREATE))
-            .send()
-            .join();
-
-    // Admin should see both audit logs
-    assertThat(adminAuditLogs.items().size()).isGreaterThanOrEqualTo(2);
-    assertThat(
-            adminAuditLogs.items().stream()
-                .map(log -> log.getProcessDefinitionId())
-                .collect(Collectors.toSet()))
-        .containsExactlyInAnyOrder(
-            PROCESS_ID_DEPLOYED_RESOURCES, PROCESS_ID_A, PROCESS_ID_B, USER_TASKS_PROCESS_ID);
   }
 
   @Test
-  void shouldOnlySeeAuditLogsForAuthorizedUserTaskProcessDefinition(
-      @Authenticated(USER_E_USERNAME) final CamundaClient userTaskPDOnlyClient) {
+  void shouldAuthorizeByCategoryWildcard(
+      @Authenticated(USER_A_USERNAME) final CamundaClient client) {
     // when
-    final var userEAuditLogs = userTaskPDOnlyClient.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().send().join();
 
     // then
-    // User E should only see audit logs from PROCESS_ID_C
-    assertThat(userEAuditLogs.items()).hasSize(1);
+    assertThat(logs.items()).isNotEmpty();
     assertThat(
-            userEAuditLogs.items().stream()
-                .allMatch(log -> USER_TASKS_PROCESS_ID.equals(log.getProcessDefinitionId())))
+            logs.items().stream()
+                .anyMatch(log -> AuditLogCategoryEnum.ADMIN.equals(log.getCategory())))
         .isTrue();
-
-    // Verify they cannot see audit logs from PROCESS_ID
     assertThat(
-            userEAuditLogs.items().stream()
-                .noneMatch(
-                    log -> PROCESS_ID_DEPLOYED_RESOURCES.equals(log.getProcessDefinitionId())))
+            logs.items().stream()
+                .anyMatch(log -> AuditLogCategoryEnum.DEPLOYED_RESOURCES.equals(log.getCategory())))
         .isTrue();
-
-    // Verify they cannot see audit logs from PROCESS_ID_A
     assertThat(
-            userEAuditLogs.items().stream()
-                .noneMatch(log -> PROCESS_ID_A.equals(log.getProcessDefinitionId())))
+            logs.items().stream()
+                .anyMatch(log -> AuditLogCategoryEnum.USER_TASKS.equals(log.getCategory())))
         .isTrue();
+  }
 
-    // Verify that the audit log entry for PROCESS_ID_C exists for admin
-    final var adminAuditLogs = adminClient.newAuditLogSearchRequest().send().join();
+  @Test
+  void shouldAuthorizeByCategory(@Authenticated(USER_AA_USERNAME) final CamundaClient client) {
+    // when
+    final var logs = client.newAuditLogSearchRequest().send().join();
 
-    // Admin should see the PROCESS_ID_C audit log
-    assertThat(adminAuditLogs.items()).hasSizeGreaterThan(1);
+    // then
+    assertThat(logs.items()).isNotEmpty();
     assertThat(
-            adminAuditLogs.items().stream()
-                .anyMatch(log -> USER_TASKS_PROCESS_ID.equals(log.getProcessDefinitionId())))
+            logs.items().stream()
+                .allMatch(log -> AuditLogCategoryEnum.ADMIN.equals(log.getCategory())))
+        .isTrue();
+  }
+
+  // TODO: this one fails, due to the wildcard shortcut in the authorization checks
+  @Test
+  void shouldAuthorizeByProcessIdWildcard(
+      @Authenticated(USER_B_USERNAME) final CamundaClient client) {
+    // when
+    final var logs = client.newAuditLogSearchRequest().send().join();
+
+    // then
+    assertThat(logs.items()).isNotEmpty();
+    assertThat(
+            logs.items().stream()
+                .allMatch(
+                    log ->
+                        AuditLogCategoryEnum.DEPLOYED_RESOURCES.equals(log.getCategory())
+                            || AuditLogCategoryEnum.USER_TASKS.equals(log.getCategory())))
+        .isTrue();
+    assertThat(
+            logs.items().stream()
+                .anyMatch(log -> PROCESS_A_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+    assertThat(
+            logs.items().stream()
+                .anyMatch(log -> PROCESS_C_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+  }
+
+  @Test
+  void shouldAuthorizeByProcessId(@Authenticated(USER_BB_USERNAME) final CamundaClient client) {
+    // when
+    final var logs = client.newAuditLogSearchRequest().send().join();
+
+    // then
+    assertThat(logs.items()).isNotEmpty();
+    assertThat(
+            logs.items().stream()
+                .allMatch(log -> PROCESS_A_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+  }
+
+  // TODO: this one fails, due to the wildcard shortcut in the authorization checks
+  @Test
+  void shouldAuthorizeByUserTaskProcessIdWildcard(
+      @Authenticated(USER_C_USERNAME) final CamundaClient client) {
+    // when
+    final var logs = client.newAuditLogSearchRequest().send().join();
+
+    // then
+    assertThat(logs.items()).isNotEmpty();
+    assertThat(
+            logs.items().stream()
+                .allMatch(log -> AuditLogCategoryEnum.USER_TASKS.equals(log.getCategory())))
+        .isTrue();
+    assertThat(
+            logs.items().stream()
+                .anyMatch(log -> PROCESS_B_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+    assertThat(
+            logs.items().stream()
+                .anyMatch(log -> PROCESS_C_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+  }
+
+  @Test
+  void shouldAuthorizeByUserTaskProcessId(
+      @Authenticated(USER_CC_USERNAME) final CamundaClient client) {
+    // when
+    final var logs = client.newAuditLogSearchRequest().send().join();
+
+    // then
+    assertThat(logs.items()).isNotEmpty();
+    assertThat(
+            logs.items().stream()
+                .allMatch(log -> AuditLogCategoryEnum.USER_TASKS.equals(log.getCategory())))
+        .isTrue();
+    assertThat(
+            logs.items().stream()
+                .allMatch(log -> PROCESS_C_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+  }
+
+  @Test
+  void shouldAuthorizeWithCompositePermissions(
+      @Authenticated(USER_D_USERNAME) final CamundaClient client) {
+    // when
+    final var logs = client.newAuditLogSearchRequest().send().join();
+
+    // then
+    assertThat(logs.items()).isNotEmpty();
+    assertThat(
+            logs.items().stream()
+                .allMatch(
+                    log ->
+                        PROCESS_A_ID.equals(log.getProcessDefinitionId())
+                            || PROCESS_B_ID.equals(log.getProcessDefinitionId())))
+        .isTrue();
+    assertThat(
+            logs.items().stream()
+                .filter(log -> PROCESS_B_ID.equals(log.getProcessDefinitionId()))
+                .allMatch(log -> AuditLogCategoryEnum.USER_TASKS.equals(log.getCategory())))
         .isTrue();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -20,6 +20,7 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -51,6 +52,7 @@ public class AuditLogSearchClientIT {
 
   // TODO: this one fails, because r/n the authorizations fail if the resourceId supplier returns
   // null, which is the case for ADMIN audit log entries
+  @Disabled("https://github.com/camunda/camunda/issues/43662")
   @Test
   void shouldGetAuditLogByKey(@Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
     // given

--- a/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
@@ -71,9 +71,9 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
     final var authentication = securityContext.authentication();
     final var condition = securityContext.authorizationCondition();
     return switch (condition) {
-      case SingleAuthorizationCondition single ->
+      case final SingleAuthorizationCondition single ->
           createSingleAuthorizationCheck(authentication, single);
-      case AnyOfAuthorizationCondition anyOf ->
+      case final AnyOfAuthorizationCondition anyOf ->
           createAnyOfAuthorizationCheck(authentication, anyOf);
       default ->
           throw new IllegalStateException(
@@ -104,6 +104,7 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
       final var resourceAccess = resolveResourceAccess(authentication, authorization);
 
       if (resourceAccess.wildcard()) {
+        // here is the culprit for audit log authorizations
         return AuthorizationCheck.disabled();
       }
 
@@ -155,9 +156,9 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
     final var condition = securityContext.authorizationCondition();
 
     switch (condition) {
-      case SingleAuthorizationCondition single ->
+      case final SingleAuthorizationCondition single ->
           ensureSingleAuthorizationAccessOrThrow(securityContext, document, single);
-      case AnyOfAuthorizationCondition anyOf ->
+      case final AnyOfAuthorizationCondition anyOf ->
           ensureAnyOfAuthorizationAccessOrThrow(securityContext, document, anyOf);
       default ->
           throw new IllegalStateException(


### PR DESCRIPTION
- extracts a dedicated test class to check the proper setup of the authorization claims/actor for both REST and GRPC
- extracts a dedicated test class to check all possible authorization patterns
- extracts a dedicated test class for the e2e testing of identity operations (other types should be added in follow ups)
- extracts a dedicated test class to for search related e2e/IT tests (very minimal, needs extension in follow ups)
- refactor the `AuditLogUtils` for more convenience

Identified a few bugs in the setup, see https://github.com/camunda/camunda/issues/43662
