### PR TITLE
[Backport stable/8.7] Fix 500 error when querying non-existing backup state

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -381,6 +381,9 @@ public class BackupManagerElasticSearch extends BackupManager {
 
   private GetBackupStateResponseDto getBackupResponse(
       final Long backupId, final List<SnapshotInfo> snapshots, final boolean isBackupInProgress) {
+    if (snapshots.isEmpty()) {
+      throw new NotFoundApiException(String.format("No backup with id [%s] found.", backupId));
+    }
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
 
     final Metadata metadata =

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -509,6 +509,9 @@ public class BackupManagerOpenSearch extends BackupManager {
 
   private GetBackupStateResponseDto getBackupResponse(
       final Long backupId, final List<SnapshotInfo> snapshots, final boolean isBackupInProgress) {
+    if (snapshots.isEmpty()) {
+      throw new NotFoundApiException(String.format("No backup with id [%s] found.", backupId));
+    }
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
 
     final Map<String, JsonData> jsonDataMap = snapshots.get(0).metadata();


### PR DESCRIPTION
# Description
Backport of #43518 to `stable/8.7`.

relates to camunda/camunda#37591