### PR TITLE
ci: add korthout to the always green engineer list

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -65,7 +65,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       (github.actor == 'eamonnmoloney' || github.actor == 'remcowesterhoud' || github.actor == 'korthout') &&
+       (github.actor == 'eamonnmoloney' || github.actor == 'remcowesterhoud' || github.actor == 'korthout' || github.actor == 'fabiopaini-camunda') &&
        !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
     steps:
       - run: echo "Workflow conditions met, proceeding with build"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -65,7 +65,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       (github.actor == 'eamonnmoloney' || github.actor == 'remcowesterhoud') &&
+       (github.actor == 'eamonnmoloney' || github.actor == 'remcowesterhoud' || github.actor == 'korthout') &&
        !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
     steps:
       - run: echo "Workflow conditions met, proceeding with build"


### PR DESCRIPTION
This pull request updates the workflow conditions in `.github/workflows/docker-build-helm-integration.yml` to allow additional users to trigger the build for pull requests. This is a minor change focused on expanding the list of authorized actors.

* Workflow trigger condition: Added `korthout` and `fabiopaini-camunda` to the list of GitHub actors permitted to trigger the build for pull requests.## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
