### PR TITLE
Update runTests.js with API test option

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
@@ -17,6 +17,7 @@ const browser = await select({
     {name: 'Chrome', value: 'chromium'},
     {name: 'Firefox', value: 'firefox'},
     {name: 'Edge', value: 'msedge'},
+    {name: 'API', value: 'api-tests'},
   ],
 });
 
@@ -38,6 +39,8 @@ if (browser === 'chromium') {
   args.push('--project=firefox');
 } else if (browser === 'msedge') {
   args.push('--project=msedge');
+} else if (browser === 'api-tests') {
+  args.push('--project=api-tests');
 }
 
 if (runMode === 'headed') {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
@@ -11,40 +11,50 @@ import {spawn} from 'node:child_process';
 
 const IS_LOCAL = Boolean(process.env.LOCAL_TEST);
 
-const browser = await select({
-  message: 'Select the browser to run the tests on:',
+const category = await select({
+  message: "Which tests would you like to run?",
   choices: [
-    {name: 'Chrome', value: 'chromium'},
-    {name: 'Firefox', value: 'firefox'},
-    {name: 'Edge', value: 'msedge'},
-    {name: 'API', value: 'api-tests'},
+    { name: "E2E tests", value: "e2e" },
+    { name: "API tests", value: "api" },
   ],
 });
 
 const baseURL = getBaseURL();
 
-const runMode = await select({
-  message: 'Which mode would like to run Playwright:',
-  choices: [
-    {name: 'Headless', value: 'headless'},
-    {name: 'Headed', value: 'headed'},
-  ],
-});
-
 let args = ['run', 'test', '--'];
 
-if (browser === 'chromium') {
-  args.push('--project=chromium');
-} else if (browser === 'firefox') {
-  args.push('--project=firefox');
-} else if (browser === 'msedge') {
-  args.push('--project=msedge');
-} else if (browser === 'api-tests') {
-  args.push('--project=api-tests');
-}
+if (category === "api") {
+  args.push("--project=api-tests");
+} else {
+  const browser = await select({
+    message: 'Select the browser to run the E2E tests on:',
+    choices: [
+      {name: 'Chrome', value: 'chromium'},
+      {name: 'Firefox', value: 'firefox'},
+      {name: 'Edge', value: 'msedge'},
+    ],
+  });
+  const runMode = await select({
+    message: 'Which mode would like to run Playwright:',
+    choices: [
+      {name: 'Headless', value: 'headless'},
+      {name: 'Headed', value: 'headed'},
+    ],
+  });
 
-if (runMode === 'headed') {
-  args.push('--headed');
+  if (runMode === 'headed') {
+    args.push('--headed');
+  }
+
+  if (browser === 'chromium') {
+    args.push('--project=chromium');
+  } else if (browser === 'firefox') {
+    args.push('--project=firefox');
+  } else if (browser === 'msedge') {
+    args.push('--project=msedge');
+  } else if (browser === 'api-tests') {
+    args.push('--project=api-tests');
+  }
 }
 
 spawn('npm', args, {


### PR DESCRIPTION
## Description

This PR separates E2E tests from API tests during `npm run test:local` command.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/43)

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/20811435483)
