### PR TITLE
refactor: replace metadata-store with useProcessInstanceElementSelection in listeners tab

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
@@ -17,6 +17,8 @@ import {EmptyMessage} from 'modules/components/EmptyMessage';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
 import {formatDate} from 'modules/utils/date';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 import {
   CellContainer,
@@ -64,14 +66,20 @@ const Listeners: React.FC<Props> = observer(
     hasNextPage,
     hasPreviousPage,
   }) => {
-    const {metaData} = flowNodeMetaDataStore.state;
-    const isUserTask = metaData?.instanceMetadata?.flowNodeType === 'USER_TASK';
+    const isUserTaskV1 =
+      flowNodeMetaDataStore.state.metaData?.instanceMetadata?.flowNodeType ===
+      'USER_TASK';
+
+    const {resolvedElementInstance} = useProcessInstanceElementSelection();
+    const hasUserTaskSelected = IS_ELEMENT_SELECTION_V2
+      ? resolvedElementInstance?.type === 'USER_TASK'
+      : isUserTaskV1;
 
     const [selectedOption, setSelectedOption] =
       useState<FilterLabelMappingKeys>('All listeners');
 
     const handleEmptyMessages = () => {
-      if (isUserTask) {
+      if (hasUserTaskSelected) {
         if (selectedOption === 'All listeners') {
           return 'This flow node has no execution listeners nor user task listeners';
         }
@@ -88,7 +96,7 @@ const Listeners: React.FC<Props> = observer(
 
     return (
       <Content>
-        {isUserTask && (
+        {hasUserTaskSelected && (
           <Dropdown
             id="listenerTypeFilter"
             data-testid="listener-type-filter"


### PR DESCRIPTION
## Description

Replaces the `flowNodeMetaDataStore` usage in the PI listeners tab with the `useProcessInstanceElementSelection` hook when the feature `ELEMENT_SELECTION_V2` is enabled.

I tried running the unit tests with the feature flag enabled, but it broke multiple unrelated test-suites as well. So I just made sure that the tests still work without the feature flag for now.

## Related issues

closes #41820 
