### PR TITLE
feat: link all identity docs to the current app version

### DIFF
--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -29,7 +29,8 @@ export const isTenantsApiEnabled = getClientConfigBoolean(
   false,
 );
 
-export const docsUrl = "https://docs.camunda.io";
+// To automatically point to correct versioned docs, this needs to be adjusted when main branch changes to a new release.
+export const docsUrl = "https://docs.camunda.io/docs/8.9";
 
 export const isSaaS = Boolean(getClientConfigString("organizationId"));
 

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -29,8 +29,7 @@ export const isTenantsApiEnabled = getClientConfigBoolean(
   false,
 );
 
-// To automatically point to correct versioned docs, this needs to be adjusted when main branch changes to a new release.
-export const docsUrl = "https://docs.camunda.io/docs/8.9";
+export const docsUrl = "https://docs.camunda.io/docs/next";
 
 export const isSaaS = Boolean(getClientConfigString("organizationId"));
 

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -73,7 +73,7 @@ const List: FC = () => {
       <PageHeader
         title={t("authorizations")}
         linkText={t("authorizations").toLowerCase()}
-        docsLinkPath="/docs/components/concepts/access-control/authorizations/"
+        docsLinkPath="/components/concepts/access-control/authorizations/"
       />
       <TabsTitle>{t("resourceType")}</TabsTitle>
       <TabsContainer>

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -171,10 +171,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
       <div>
         <Translate i18nKey="createAuthorizationIntroduction">
           Grant an owner access to a resource with specific permissions.{" "}
-          <DocumentationLink
-            path="/components/identity/authorization/"
-            withIcon
-          >
+          <DocumentationLink path="/components/admin/authorization/" withIcon>
             Learn more
           </DocumentationLink>{" "}
           .

--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -172,7 +172,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
         <Translate i18nKey="createAuthorizationIntroduction">
           Grant an owner access to a resource with specific permissions.{" "}
           <DocumentationLink
-            path="/docs/components/identity/authorization/"
+            path="/components/identity/authorization/"
             withIcon
           >
             Learn more
@@ -311,7 +311,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
                   Select at least one permission. All available resource
                   permissions can be found{" "}
                   <DocumentationLink
-                    path="/docs/components/concepts/access-control/authorizations/#resources-and-permissions"
+                    path="/components/concepts/access-control/authorizations/#resources-and-permissions"
                     withIcon
                   >
                     here

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -54,7 +54,7 @@ const Selection: FC<SelectionProps> = ({
                 <Translate i18nKey="usernameDescription">
                   Check the documentation for{" "}
                   <DocumentationLink
-                    path="/docs/components/identity/authorization/#about-authorizations"
+                    path="/components/identity/authorization/#about-authorizations"
                     withIcon
                   >
                     how to reference users

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -54,7 +54,7 @@ const Selection: FC<SelectionProps> = ({
                 <Translate i18nKey="usernameDescription">
                   Check the documentation for{" "}
                   <DocumentationLink
-                    path="/components/identity/authorization/#about-authorizations"
+                    path="/components/admin/authorization/#about-authorizations"
                     withIcon
                   >
                     how to reference users

--- a/identity/client/src/pages/cluster-variables/List.tsx
+++ b/identity/client/src/pages/cluster-variables/List.tsx
@@ -95,7 +95,7 @@ export default function List() {
     <PageHeader
       title={t("clusterVariables")}
       linkText={t("clusterVariables").toLowerCase()}
-      docsLinkPath="/docs/next/components/modeler/feel/cluster-variable/cluster-variable-overview/"
+      docsLinkPath="/components/modeler/feel/cluster-variable/cluster-variable-overview/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -106,7 +106,7 @@ export default function List() {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"clusterVariable"}
-          docsLinkPath="/docs/next/components/modeler/feel/cluster-variable/cluster-variable-overview/"
+          docsLinkPath="/components/modeler/feel/cluster-variable/cluster-variable-overview/"
           handleClick={addClusterVariable}
         />
         {addClusterVariableModal}

--- a/identity/client/src/pages/global-task-listeners/List.tsx
+++ b/identity/client/src/pages/global-task-listeners/List.tsx
@@ -51,7 +51,7 @@ const List: FC = () => {
     <PageHeader
       title={t("globalTaskListeners")}
       linkText={t("globalTaskListeners").toLowerCase()}
-      docsLinkPath="/docs/components/concepts/global-user-task-listeners/"
+      docsLinkPath="/components/concepts/global-user-task-listeners/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -62,7 +62,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"globalTaskListener"}
-          docsLinkPath="/docs/components/concepts/global-user-task-listeners/"
+          docsLinkPath="/components/concepts/global-user-task-listeners/"
           handleClick={addGlobalTaskListener}
         />
         {addGlobalTaskListenerModal}

--- a/identity/client/src/pages/groups/List.tsx
+++ b/identity/client/src/pages/groups/List.tsx
@@ -47,7 +47,7 @@ const List: FC = () => {
     <PageHeader
       title={t("groups")}
       linkText={t("groups").toLowerCase()}
-      docsLinkPath="/docs/components/identity/group/"
+      docsLinkPath="/components/identity/group/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -58,7 +58,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"group"}
-          docsLinkPath="/docs/components/identity/group/"
+          docsLinkPath="/components/identity/group/"
           handleClick={addGroup}
         />
         {addModal}

--- a/identity/client/src/pages/groups/List.tsx
+++ b/identity/client/src/pages/groups/List.tsx
@@ -47,7 +47,7 @@ const List: FC = () => {
     <PageHeader
       title={t("groups")}
       linkText={t("groups").toLowerCase()}
-      docsLinkPath="/components/identity/group/"
+      docsLinkPath="/components/admin/group/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -58,7 +58,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"group"}
-          docsLinkPath="/components/identity/group/"
+          docsLinkPath="/components/admin/group/"
           handleClick={addGroup}
         />
         {addModal}

--- a/identity/client/src/pages/groups/detail/clients/index.tsx
+++ b/identity/client/src/pages/groups/detail/clients/index.tsx
@@ -62,7 +62,7 @@ const Clients: FC<ClientsProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"client"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/client/"
+          docsLinkPath="/components/admin/client/"
         />
         {assignClientModal}
       </>

--- a/identity/client/src/pages/groups/detail/clients/index.tsx
+++ b/identity/client/src/pages/groups/detail/clients/index.tsx
@@ -62,7 +62,7 @@ const Clients: FC<ClientsProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"client"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/client/"
+          docsLinkPath="/components/identity/client/"
         />
         {assignClientModal}
       </>

--- a/identity/client/src/pages/groups/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/groups/detail/mapping-rules/index.tsx
@@ -72,7 +72,7 @@ const MappingRules: FC<MappingRulesProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"mappingRule"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/mapping-rules/manage-mapping-rules/"
+          docsLinkPath="/components/identity/mapping-rules/"
         />
         {assignMappingRulesModal}
       </>

--- a/identity/client/src/pages/groups/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/groups/detail/mapping-rules/index.tsx
@@ -72,7 +72,7 @@ const MappingRules: FC<MappingRulesProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"mappingRule"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/mapping-rules/"
+          docsLinkPath="/components/admin/mapping-rules/"
         />
         {assignMappingRulesModal}
       </>

--- a/identity/client/src/pages/groups/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMemberModal.tsx
@@ -78,7 +78,7 @@ const AssignMemberModal: FC<
             <Translate i18nKey="usernameDescription">
               Check the documentation for{" "}
               <DocumentationLink
-                path="/components/identity/group/#assign-users-to-a-group"
+                path="/components/admin/group/#assign-users-to-a-group"
                 withIcon
               >
                 how to reference users

--- a/identity/client/src/pages/groups/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMemberModal.tsx
@@ -78,7 +78,7 @@ const AssignMemberModal: FC<
             <Translate i18nKey="usernameDescription">
               Check the documentation for{" "}
               <DocumentationLink
-                path="/docs/components/identity/group/#assign-users-to-a-group"
+                path="/components/identity/group/#assign-users-to-a-group"
                 withIcon
               >
                 how to reference users

--- a/identity/client/src/pages/groups/detail/members/index.tsx
+++ b/identity/client/src/pages/groups/detail/members/index.tsx
@@ -67,7 +67,7 @@ const Members: FC<MembersProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"user"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/user/"
+          docsLinkPath="/components/identity/user/"
         />
         {assignUsersModal}
       </>

--- a/identity/client/src/pages/groups/detail/members/index.tsx
+++ b/identity/client/src/pages/groups/detail/members/index.tsx
@@ -67,7 +67,7 @@ const Members: FC<MembersProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"user"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/user/"
+          docsLinkPath="/components/admin/user/"
         />
         {assignUsersModal}
       </>

--- a/identity/client/src/pages/groups/detail/roles/index.tsx
+++ b/identity/client/src/pages/groups/detail/roles/index.tsx
@@ -71,7 +71,7 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"role"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/role/"
+          docsLinkPath="/components/identity/role/"
         />
         {assignRolesModal}
       </>

--- a/identity/client/src/pages/groups/detail/roles/index.tsx
+++ b/identity/client/src/pages/groups/detail/roles/index.tsx
@@ -71,7 +71,7 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
           childResourceTypeTranslationKey={"role"}
           parentResourceTypeTranslationKey={"group"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/role/"
+          docsLinkPath="/components/admin/role/"
         />
         {assignRolesModal}
       </>

--- a/identity/client/src/pages/mapping-rules/List.tsx
+++ b/identity/client/src/pages/mapping-rules/List.tsx
@@ -48,7 +48,7 @@ const List: FC = () => {
     <PageHeader
       title={t("mappingRules")}
       linkText={t("mappingRules").toLowerCase()}
-      docsLinkPath="/docs/components/identity/mapping-rules/manage-mapping-rules/"
+      docsLinkPath="/components/identity/mapping-rules/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -59,7 +59,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"mappingRule"}
-          docsLinkPath="/docs/components/identity/mapping-rules/manage-mapping-rules/"
+          docsLinkPath="/components/identity/mapping-rules/"
           handleClick={addMappingRule}
         />
         {addMappingRuleModal}

--- a/identity/client/src/pages/mapping-rules/List.tsx
+++ b/identity/client/src/pages/mapping-rules/List.tsx
@@ -48,7 +48,7 @@ const List: FC = () => {
     <PageHeader
       title={t("mappingRules")}
       linkText={t("mappingRules").toLowerCase()}
-      docsLinkPath="/components/identity/mapping-rules/"
+      docsLinkPath="/components/admin/mapping-rules/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -59,7 +59,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"mappingRule"}
-          docsLinkPath="/components/identity/mapping-rules/"
+          docsLinkPath="/components/admin/mapping-rules/"
           handleClick={addMappingRule}
         />
         {addMappingRuleModal}

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -153,7 +153,7 @@ const List: FC = () => {
       <PageHeader
         title={t("operationsLog")}
         linkText={t("operationsLog").toLowerCase()}
-        docsLinkPath="/docs/components/concepts/audit-log/"
+        docsLinkPath="/components/admin/audit-operations/"
       />
       <Grid condensed fullWidth>
         <ColumnRightPadding sm={4} md={3} lg={4} xlg={3}>

--- a/identity/client/src/pages/roles/List.tsx
+++ b/identity/client/src/pages/roles/List.tsx
@@ -44,7 +44,7 @@ const List: FC = () => {
     <PageHeader
       title={t("roles")}
       linkText={t("roles").toLowerCase()}
-      docsLinkPath="/components/identity/role/"
+      docsLinkPath="/components/admin/role/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -55,7 +55,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"role"}
-          docsLinkPath="/components/identity/role/"
+          docsLinkPath="/components/admin/role/"
           handleClick={addRole}
         />
         {addRoleModal}

--- a/identity/client/src/pages/roles/List.tsx
+++ b/identity/client/src/pages/roles/List.tsx
@@ -44,7 +44,7 @@ const List: FC = () => {
     <PageHeader
       title={t("roles")}
       linkText={t("roles").toLowerCase()}
-      docsLinkPath="/docs/components/identity/role/"
+      docsLinkPath="/components/identity/role/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -55,7 +55,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"role"}
-          docsLinkPath="/docs/components/identity/role/"
+          docsLinkPath="/components/identity/role/"
           handleClick={addRole}
         />
         {addRoleModal}

--- a/identity/client/src/pages/roles/detail/clients/index.tsx
+++ b/identity/client/src/pages/roles/detail/clients/index.tsx
@@ -68,7 +68,7 @@ const Clients: FC<ClientsProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"client"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/client/"
+          docsLinkPath="/components/identity/client/"
         />
         {assignClientModal}
       </>

--- a/identity/client/src/pages/roles/detail/clients/index.tsx
+++ b/identity/client/src/pages/roles/detail/clients/index.tsx
@@ -68,7 +68,7 @@ const Clients: FC<ClientsProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"client"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/client/"
+          docsLinkPath="/components/admin/client/"
         />
         {assignClientModal}
       </>

--- a/identity/client/src/pages/roles/detail/groups/index.tsx
+++ b/identity/client/src/pages/roles/detail/groups/index.tsx
@@ -68,7 +68,7 @@ const Groups: FC<GroupsProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"group"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/group/"
+          docsLinkPath="/components/identity/group/"
         />
         {assignGroupsModal}
       </>

--- a/identity/client/src/pages/roles/detail/groups/index.tsx
+++ b/identity/client/src/pages/roles/detail/groups/index.tsx
@@ -68,7 +68,7 @@ const Groups: FC<GroupsProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"group"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/group/"
+          docsLinkPath="/components/admin/group/"
         />
         {assignGroupsModal}
       </>

--- a/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
@@ -72,7 +72,7 @@ const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"mappingRule"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/mapping-rules/manage-mapping-rules/"
+          docsLinkPath="/components/identity/mapping-rules/"
         />
         {assignMappingRulesModal}
       </>

--- a/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
@@ -72,7 +72,7 @@ const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"mappingRule"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/mapping-rules/"
+          docsLinkPath="/components/admin/mapping-rules/"
         />
         {assignMappingRulesModal}
       </>

--- a/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
@@ -71,7 +71,7 @@ const AssignMemberModal: FC<
             <Translate i18nKey="usernameDescription">
               Check the documentation for{" "}
               <DocumentationLink
-                path="/docs/components/identity/role/#assign-users-to-a-role"
+                path="/components/identity/role/#assign-users-to-a-role"
                 withIcon
               >
                 how to reference users

--- a/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
@@ -71,7 +71,7 @@ const AssignMemberModal: FC<
             <Translate i18nKey="usernameDescription">
               Check the documentation for{" "}
               <DocumentationLink
-                path="/components/identity/role/#assign-users-to-a-role"
+                path="/components/admin/role/#assign-users-to-a-role"
                 withIcon
               >
                 how to reference users

--- a/identity/client/src/pages/roles/detail/members/index.tsx
+++ b/identity/client/src/pages/roles/detail/members/index.tsx
@@ -68,7 +68,7 @@ const Members: FC<MembersProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"user"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/docs/components/identity/user/"
+          docsLinkPath="/components/identity/user/"
         />
         {assignUsersModal}
       </>

--- a/identity/client/src/pages/roles/detail/members/index.tsx
+++ b/identity/client/src/pages/roles/detail/members/index.tsx
@@ -68,7 +68,7 @@ const Members: FC<MembersProps> = ({ roleId }) => {
           childResourceTypeTranslationKey={"user"}
           parentResourceTypeTranslationKey={"role"}
           handleClick={openAssignModal}
-          docsLinkPath="/components/identity/user/"
+          docsLinkPath="/components/admin/user/"
         />
         {assignUsersModal}
       </>

--- a/identity/client/src/pages/tenants/List.tsx
+++ b/identity/client/src/pages/tenants/List.tsx
@@ -45,7 +45,7 @@ const List: FC = () => {
     <PageHeader
       title={t("tenants")}
       linkText={t("tenants").toLowerCase()}
-      docsLinkPath="/docs/components/identity/tenant/"
+      docsLinkPath="/components/identity/tenant/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -56,7 +56,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"tenant"}
-          docsLinkPath="/docs/components/identity/tenant/"
+          docsLinkPath="/components/identity/tenant/"
           handleClick={addTenant}
         />
         {addTenantModal}

--- a/identity/client/src/pages/tenants/List.tsx
+++ b/identity/client/src/pages/tenants/List.tsx
@@ -45,7 +45,7 @@ const List: FC = () => {
     <PageHeader
       title={t("tenants")}
       linkText={t("tenants").toLowerCase()}
-      docsLinkPath="/components/identity/tenant/"
+      docsLinkPath="/components/admin/tenant/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -56,7 +56,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"tenant"}
-          docsLinkPath="/components/identity/tenant/"
+          docsLinkPath="/components/admin/tenant/"
           handleClick={addTenant}
         />
         {addTenantModal}

--- a/identity/client/src/pages/tenants/detail/clients/index.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/index.tsx
@@ -69,7 +69,7 @@ const Clients: FC<ClientsProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/components/identity/client/"
+          docsLinkPath="/components/admin/client/"
         />
         {assignClientModal}
       </>

--- a/identity/client/src/pages/tenants/detail/clients/index.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/index.tsx
@@ -69,7 +69,7 @@ const Clients: FC<ClientsProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/docs/components/identity/client/"
+          docsLinkPath="/components/identity/client/"
         />
         {assignClientModal}
       </>

--- a/identity/client/src/pages/tenants/detail/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/index.tsx
@@ -69,7 +69,7 @@ const Groups: FC<GroupsProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/docs/components/identity/group/"
+          docsLinkPath="/components/identity/group/"
         />
         {assignGroupsModal}
       </>

--- a/identity/client/src/pages/tenants/detail/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/index.tsx
@@ -69,7 +69,7 @@ const Groups: FC<GroupsProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/components/identity/group/"
+          docsLinkPath="/components/admin/group/"
         />
         {assignGroupsModal}
       </>

--- a/identity/client/src/pages/tenants/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/tenants/detail/mapping-rules/index.tsx
@@ -73,7 +73,7 @@ const MappingRules: FC<MappingRulesProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/docs/components/identity/mapping-rules/manage-mapping-rules/"
+          docsLinkPath="/components/identity/mapping-rules/"
         />
         {assignMappingRulesModal}
       </>

--- a/identity/client/src/pages/tenants/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/tenants/detail/mapping-rules/index.tsx
@@ -73,7 +73,7 @@ const MappingRules: FC<MappingRulesProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/components/identity/mapping-rules/"
+          docsLinkPath="/components/admin/mapping-rules/"
         />
         {assignMappingRulesModal}
       </>

--- a/identity/client/src/pages/tenants/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/AssignMemberModal.tsx
@@ -70,7 +70,7 @@ const AssignMemberModal: FC<
             <Translate i18nKey="usernameDescription">
               Check the documentation for{" "}
               <DocumentationLink
-                path="/components/identity/tenant/#assign-users-to-a-tenant"
+                path="/components/admin/tenant/#assign-users-to-a-tenant"
                 withIcon
               >
                 how to reference users

--- a/identity/client/src/pages/tenants/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/AssignMemberModal.tsx
@@ -70,7 +70,7 @@ const AssignMemberModal: FC<
             <Translate i18nKey="usernameDescription">
               Check the documentation for{" "}
               <DocumentationLink
-                path="/docs/components/identity/tenant/#assign-users-to-a-tenant"
+                path="/components/identity/tenant/#assign-users-to-a-tenant"
                 withIcon
               >
                 how to reference users

--- a/identity/client/src/pages/tenants/detail/members/index.tsx
+++ b/identity/client/src/pages/tenants/detail/members/index.tsx
@@ -69,7 +69,7 @@ const Members: FC<MembersProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/docs/components/identity/user/"
+          docsLinkPath="/components/identity/user/"
         />
         {assignUsersModal}
       </>

--- a/identity/client/src/pages/tenants/detail/members/index.tsx
+++ b/identity/client/src/pages/tenants/detail/members/index.tsx
@@ -69,7 +69,7 @@ const Members: FC<MembersProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/components/identity/user/"
+          docsLinkPath="/components/admin/user/"
         />
         {assignUsersModal}
       </>

--- a/identity/client/src/pages/tenants/detail/roles/index.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/index.tsx
@@ -72,7 +72,7 @@ const Roles: FC<RolesProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/docs/components/identity/role/"
+          docsLinkPath="/components/identity/role/"
         />
         {assignRolesModal}
       </>

--- a/identity/client/src/pages/tenants/detail/roles/index.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/index.tsx
@@ -72,7 +72,7 @@ const Roles: FC<RolesProps> = ({ tenantId }) => {
           parentResourceTypeTranslationKey={"tenant"}
           handleClick={openAssignModal}
           description={t("emptyStateTenantAccessDisclaimer")}
-          docsLinkPath="/components/identity/role/"
+          docsLinkPath="/components/admin/role/"
         />
         {assignRolesModal}
       </>

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -140,7 +140,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
                         <Link
                           href={documentationHref(
                             docsUrl,
-                            "/docs/components/identity/tenant/",
+                            "/components/admin/tenant/",
                           )}
                           target="_blank"
                           inline

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -46,7 +46,7 @@ const List: FC = () => {
     <PageHeader
       title={t("users")}
       linkText={t("users").toLowerCase()}
-      docsLinkPath="/components/identity/user/"
+      docsLinkPath="/components/admin/user/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -57,7 +57,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"user"}
-          docsLinkPath="/components/identity/user/"
+          docsLinkPath="/components/admin/user/"
           handleClick={addUser}
         />
         {addUserModal}

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -46,7 +46,7 @@ const List: FC = () => {
     <PageHeader
       title={t("users")}
       linkText={t("users").toLowerCase()}
-      docsLinkPath="/docs/components/identity/user/"
+      docsLinkPath="/components/identity/user/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -57,7 +57,7 @@ const List: FC = () => {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"user"}
-          docsLinkPath="/docs/components/identity/user/"
+          docsLinkPath="/components/identity/user/"
           handleClick={addUser}
         />
         {addUserModal}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
All docs links within admin UI are now updated to the new admin naming (instead of identity).
All docs links within admin UI are now relative to a configured baseUrl including "/docs/next".

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

does preparation for #43252
relates https://github.com/camunda/camunda/issues/40382
