### PR TITLE
fix: remove transitive Spring Boot 3 dependency

### DIFF
--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -36,6 +36,8 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
+      <!-- this dependency will be shaded into this artifact -->
+      <optional>true</optional>
       <exclusions>
         <!-- Exclude Spring Boot 3.x starter - we use 4.x version -->
         <exclusion>
@@ -50,6 +52,97 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-4-starter</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      Original dependencies of the shaded module, except `camunda-spring-boot-starter`.
+      This is done as the shaded module is declared as provided
+      and we cannot use the shade plugin's feature to promoteTransitiveDependencies
+      as this would reintroduce the dependency on `camunda-spring-boot-starter`.
+    -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->
@@ -124,9 +217,9 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <createSourcesJar>true</createSourcesJar>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
                   <!-- Only include the base module in the shaded jar -->
@@ -157,10 +250,13 @@
           <ignoredNonTestScopedDependencies>
             <dependency>*</dependency>
           </ignoredNonTestScopedDependencies>
-          <!-- Ignore all unused, we inherit all from base -->
+          <!-- Ignore all unused, we duplicate all from the base module -->
           <ignoredUsedUndeclaredDependencies>
             <dependency>*</dependency>
           </ignoredUsedUndeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>*</dependency>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Description

The [effective pom of camunda-process-test-spring-4](https://repo1.maven.org/maven2/io/camunda/camunda-process-test-spring-4/8.8.9/camunda-process-test-spring-4-8.8.9.pom) still contained the Spring Boot 3 based camunda-spring-boot-starter module as dependency, potentially causing runtime conflicts with camunda-spring-boot-4-starter. The cause is that the shade plugin is not taking into account exclusions when adding transitive dependencies (limitation).

This change adds all original transitive dependencies of camunda-process-test-spring, except camunda-spring-boot-starter, to camunda-process-test-spring-4 and disables the pom creation by the shade plugin. For the stable branch I don't expect dependency changes, so I consider this an acceptable workaround.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #42077
