### PR TITLE
fix: enable audit log acceptance tests for RDBMS

### DIFF
--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -68,10 +68,10 @@
     <where>
       <!-- authorization filters -->
       <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
-        AND TENANT_ID IN
+        AND (TENANT_SCOPE = 'GLOBAL' OR TENANT_ID IN
         <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
           #{tenantId}
-        </foreach>
+        </foreach>)
       </if>
       <!-- basic filters -->
       <if test="filter.auditLogKeyOperations != null and !filter.auditLogKeyOperations.isEmpty()">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthenticationIT.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Test is disabled on RDBMS until https://github.com/camunda/camunda/issues/43323 is implemented.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogAuthenticationIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * Test is disabled on RDBMS until https://github.com/camunda/camunda/issues/43323 is implemented.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogIdentityOperationsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * Test is disabled on RDBMS until https://github.com/camunda/camunda/issues/43323 is implemented.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogSearchClientIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuditLogFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuditLogFixtures.java
@@ -64,6 +64,44 @@ public final class AuditLogFixtures extends CommonFixtures {
     return builderFunction.apply(builder).build();
   }
 
+  public static AuditLogDbModel createRandomProcessInstance() {
+    final var builder =
+        new AuditLogDbModel.Builder()
+            .auditLogKey("audit-" + generateRandomString(15))
+            .entityKey(String.valueOf(nextKey()))
+            .entityType(AuditLogEntityType.PROCESS_INSTANCE)
+            .operationType(AuditLogOperationType.CREATE)
+            .entityVersion(RANDOM.nextInt(100))
+            .entityValueType((short) RANDOM.nextInt(10))
+            .entityOperationIntent((short) RANDOM.nextInt(10))
+            .batchOperationKey(nextKey())
+            .batchOperationType(randomEnum(BatchOperationType.class))
+            .timestamp(OffsetDateTime.now())
+            .actorType(randomEnum(AuditLogActorType.class))
+            .actorId("actor-" + generateRandomString(10))
+            .tenantId("tenant-" + generateRandomString(10))
+            .tenantScope(AuditLogTenantScope.TENANT)
+            .result(randomEnum(AuditLogOperationResult.class))
+            .annotation("annotation-" + generateRandomString(20))
+            .category(randomEnum(AuditLogOperationCategory.class))
+            .processDefinitionId("process-" + generateRandomString(10))
+            .decisionRequirementsId("decision-req-" + generateRandomString(10))
+            .decisionDefinitionId("decision-" + generateRandomString(10))
+            .processDefinitionKey(nextKey())
+            .processInstanceKey(nextKey())
+            .elementInstanceKey(nextKey())
+            .jobKey(nextKey())
+            .userTaskKey(nextKey())
+            .decisionRequirementsKey(nextKey())
+            .decisionDefinitionKey(nextKey())
+            .decisionEvaluationKey(nextKey())
+            .deploymentKey(nextKey())
+            .formKey(nextKey())
+            .resourceKey(nextKey());
+
+    return builder.build();
+  }
+
   public static void createAndSaveRandomAuditLogs(final RdbmsWriters rdbmsWriters) {
     createAndSaveRandomAuditLogs(rdbmsWriters, b -> b);
   }


### PR DESCRIPTION
## Description

Enables acceptance tests for RDBMS; fixes mapping query.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to: #43323
