### PR TITLE
feat: add process instance deletion to CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -50,6 +50,7 @@ import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
+import io.camunda.client.api.command.DeleteProcessInstanceCommandStep1;
 import io.camunda.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.client.api.command.DeleteRoleCommandStep1;
 import io.camunda.client.api.command.DeleteTenantCommandStep1;
@@ -398,6 +399,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   CancelProcessInstanceCommandStep1 newCancelInstanceCommand(long processInstanceKey);
+
+  /**
+   * Command to delete a process instance history.
+   *
+   * <pre>
+   * camundaClient
+   *  .newDeleteInstanceCommand(processInstanceKey)
+   *  .send();
+   * </pre>
+   *
+   * @param processInstanceKey the key which identifies the corresponding process instance
+   * @return a builder for the command
+   */
+  DeleteProcessInstanceCommandStep1 newDeleteInstanceCommand(long processInstanceKey);
 
   /**
    * Command to set and/or update the variables of a given flow element (e.g. process instance,

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteProcessInstanceCommandStep1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DeleteProcessInstanceResponse;
+
+public interface DeleteProcessInstanceCommandStep1
+    extends CommandWithOperationReferenceStep<DeleteProcessInstanceCommandStep1>,
+        FinalCommandStep<DeleteProcessInstanceResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteProcessInstanceResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import io.camunda.client.api.search.enums.BatchOperationType;
+
+public interface DeleteProcessInstanceResponse {
+  /**
+   * @return the unique key of the batch operation that was created.
+   */
+  String getBatchOperationKey();
+
+  /**
+   * @return the type of the batch operation that was created.
+   */
+  BatchOperationType getBatchOperationType();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -58,6 +58,7 @@ import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
+import io.camunda.client.api.command.DeleteProcessInstanceCommandStep1;
 import io.camunda.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.client.api.command.DeleteRoleCommandStep1;
 import io.camunda.client.api.command.DeleteTenantCommandStep1;
@@ -220,6 +221,7 @@ import io.camunda.client.impl.command.DeleteAuthorizationCommandImpl;
 import io.camunda.client.impl.command.DeleteDocumentCommandImpl;
 import io.camunda.client.impl.command.DeleteGroupCommandImpl;
 import io.camunda.client.impl.command.DeleteMappingRuleCommandImpl;
+import io.camunda.client.impl.command.DeleteProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.DeleteResourceCommandImpl;
 import io.camunda.client.impl.command.DeleteRoleCommandImpl;
 import io.camunda.client.impl.command.DeleteTenantCommandImpl;
@@ -692,6 +694,11 @@ public final class CamundaClientImpl implements CamundaClient {
         httpClient,
         config,
         jsonMapper);
+  }
+
+  @Override
+  public DeleteProcessInstanceCommandStep1 newDeleteInstanceCommand(final long processInstanceKey) {
+    return new DeleteProcessInstanceCommandImpl(processInstanceKey, config, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteProcessInstanceCommandImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.DeleteProcessInstanceCommandStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.DeleteProcessInstanceResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteProcessInstanceResponseImpl;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.client.protocol.rest.DeleteProcessInstanceRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteProcessInstanceCommandImpl implements DeleteProcessInstanceCommandStep1 {
+
+  private final long processInstanceKey;
+  private final DeleteProcessInstanceRequest httpRequestObject;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteProcessInstanceCommandImpl(
+      final long processInstanceKey,
+      final CamundaClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
+    this.processInstanceKey = processInstanceKey;
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    httpRequestObject = new DeleteProcessInstanceRequest();
+    requestTimeout(config.getDefaultRequestTimeout());
+  }
+
+  @Override
+  public DeleteProcessInstanceCommandStep1 operationReference(final long operationReference) {
+    httpRequestObject.setOperationReference(operationReference);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<DeleteProcessInstanceResponse> requestTimeout(
+      final Duration requestTimeout) {
+    ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeleteProcessInstanceResponse> send() {
+    final HttpCamundaFuture<DeleteProcessInstanceResponse> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/process-instances/" + processInstanceKey + "/deletion",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        BatchOperationCreatedResult.class,
+        DeleteProcessInstanceResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteProcessInstanceResponseImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.DeleteProcessInstanceResponse;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+
+public class DeleteProcessInstanceResponseImpl implements DeleteProcessInstanceResponse {
+  private final String batchOperationKey;
+  private final BatchOperationType batchOperationType;
+
+  public DeleteProcessInstanceResponseImpl(final BatchOperationCreatedResult response) {
+    batchOperationKey = response.getBatchOperationKey();
+    batchOperationType =
+        EnumUtil.convert(response.getBatchOperationType(), BatchOperationType.class);
+  }
+
+  @Override
+  public String getBatchOperationKey() {
+    return batchOperationKey;
+  }
+
+  @Override
+  public BatchOperationType getBatchOperationType() {
+    return batchOperationType;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/process/rest/DeleteProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/DeleteProcessInstanceRestTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.process.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.client.protocol.rest.DeleteProcessInstanceRequest;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+public class DeleteProcessInstanceRestTest extends ClientRestTest {
+
+  private static final BatchOperationCreatedResult DUMMY_RESPONSE =
+      Instancio.create(BatchOperationCreatedResult.class)
+          .batchOperationKey("1")
+          .batchOperationType(BatchOperationTypeEnum.DELETE_PROCESS_INSTANCE);
+  private static final long PROCESS_INSTANCE_KEY = 123L;
+
+  @Test
+  public void shouldSendDeleteCommand() {
+    // given
+    gatewayService.onDeleteProcessInstanceRequest(PROCESS_INSTANCE_KEY, DUMMY_RESPONSE);
+
+    // when
+    client.newDeleteInstanceCommand(PROCESS_INSTANCE_KEY).send().join();
+
+    // then
+    final DeleteProcessInstanceRequest request =
+        gatewayService.getLastRequest(DeleteProcessInstanceRequest.class);
+    assertThat(request).isNotNull();
+  }
+
+  @Test
+  public void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getDeleteProcessInstanceUrl(PROCESS_INSTANCE_KEY),
+        () -> new ProblemDetail().title("Invalid request").status(400));
+
+    assertThatThrownBy(() -> client.newDeleteInstanceCommand(PROCESS_INSTANCE_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    gatewayService.onDeleteProcessInstanceRequest(PROCESS_INSTANCE_KEY, DUMMY_RESPONSE);
+    final int operationReference = 456;
+
+    // when
+    client
+        .newDeleteInstanceCommand(PROCESS_INSTANCE_KEY)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final DeleteProcessInstanceRequest request =
+        gatewayService.getLastRequest(DeleteProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -62,6 +62,8 @@ public class RestGatewayPaths {
   private static final String URL_PROCESS_INSTANCE = REST_API_PATH + "/process-instances/%s";
   private static final String URL_PROCESS_INSTANCE_CANCELLATION =
       REST_API_PATH + "/process-instances/%s/cancellation";
+  private static final String URL_PROCESS_INSTANCE_DELETION =
+      REST_API_PATH + "/process-instances/%s/deletion";
   private static final String URL_PROCESS_INSTANCE_CALL_HIERARCHY =
       REST_API_PATH + "/process-instances/%s/call-hierarchy";
   private static final String URL_PROCESS_INSTANCE_SEQUENCE_FLOWS =
@@ -192,6 +194,10 @@ public class RestGatewayPaths {
 
   public static String getCancelProcessUrl(final long processInstanceKey) {
     return String.format(URL_PROCESS_INSTANCE_CANCELLATION, processInstanceKey);
+  }
+
+  public static String getDeleteProcessInstanceUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE_DELETION, processInstanceKey);
   }
 
   public static String getBroadcastSignalUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -267,6 +267,11 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getProcessInstancesCancelUrl(), response);
   }
 
+  public void onDeleteProcessInstanceRequest(
+      final long processInstanceKey, final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getDeleteProcessInstanceUrl(processInstanceKey), response);
+  }
+
   public void onDeleteProcessInstancesRequest(final BatchOperationCreatedResult response) {
     registerPost(RestGatewayPaths.getProcessInstancesDeletionUrl(), response);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -609,19 +609,16 @@ public final class TestHelper {
   }
 
   public static void waitForProcessInstancesToBeCompleted(
-      final CamundaClient camundaClient, final int expectedCount) {
+      final CamundaClient camundaClient,
+      final Consumer<ProcessInstanceFilter> fn,
+      final int expectedCount) {
     Awaitility.await("should wait until process instances are completed")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
               final var result =
-                  camundaClient
-                      .newProcessInstanceSearchRequest()
-                      .filter(f -> f.state(ProcessInstanceState.COMPLETED))
-                      .send()
-                      .join()
-                      .items();
+                  camundaClient.newProcessInstanceSearchRequest().filter(fn).send().join().items();
               assertThat(result).hasSize(expectedCount);
             });
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -493,8 +493,12 @@ paths:
             schema:
               $ref: '#/components/schemas/DeleteProcessInstanceRequest'
       responses:
-        "204":
-          description: The process instance will be deleted.
+        "200":
+          description: The operation to delete the process instance was created.
+          content:
+            application/json:
+              schema:
+                $ref: 'batch-operations.yaml#/components/schemas/BatchOperationCreatedResult'
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding a command for deleting the history of single process instances

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/41753
