### PR TITLE
[Backport stable/8.7] [Operate] Fix backup state endpoint returning 400 instead of 404 for non-existing backup

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -399,6 +399,9 @@ public class ElasticsearchBackupRepository implements BackupRepository {
 
   private GetBackupStateResponseDto getBackupResponse(
       final Long backupId, final List<SnapshotInfo> snapshots, final boolean isBackupInProgress) {
+    if (snapshots.isEmpty()) {
+      throw new ResourceNotFoundException(String.format("No backup with id [%s] found.", backupId));
+    }
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
     final var firstSnapshot = snapshots.getFirst();
     final Metadata metadata =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -410,6 +410,9 @@ public class OpensearchBackupRepository implements BackupRepository {
       final Long backupId,
       final List<OpenSearchSnapshotInfo> snapshots,
       final boolean isBackupInProgress) {
+    if (snapshots.isEmpty()) {
+      throw new ResourceNotFoundException(format("No backup with id [%s] found.", backupId));
+    }
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
     final Metadata metadata =
         Metadata.extractFromMetadataOrName(

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -27,6 +27,7 @@ import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.store.opensearch.response.OpenSearchGetSnapshotResponse;
 import io.camunda.operate.store.opensearch.response.OpenSearchSnapshotInfo;
 import io.camunda.operate.store.opensearch.response.SnapshotState;
+import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.backup.BackupService;
 import io.camunda.operate.webapp.backup.Metadata;
 import io.camunda.operate.webapp.management.dto.BackupStateDto;
@@ -534,5 +535,20 @@ class OpensearchBackupRepositoryTest {
     // Test
     final var backupState = repository.getBackupState("repository-name", 5L, id -> false);
     assertThat(backupState.getState()).isEqualTo(BackupStateDto.FAILED);
+  }
+
+  @Test
+  void shouldThrowResourceNotFoundExceptionWhenSnapshotsListIsEmpty() {
+    // given
+    mockSynchronSnapshotOperations();
+    when(openSearchSnapshotOperations.get(any())).thenReturn(new OpenSearchGetSnapshotResponse());
+
+    // when & then
+    final var exception =
+        assertThrows(
+            ResourceNotFoundException.class,
+            () -> repository.getBackupState("repository-name", 5L, id -> false));
+
+    assertThat(exception.getMessage()).isEqualTo("No backup with id [5] found.");
   }
 }


### PR DESCRIPTION
# Description
Backport of #43570 to `stable/8.7`.

relates to #43518 #37724 camunda/camunda#37591 camunda/camunda#37593