### PR TITLE
feat: create JobMetricsBatch templates and models for ES/OS/RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobMetricsBatchDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobMetricsBatchDbModel.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+
+public record JobMetricsBatchDbModel(
+    String key,
+    OffsetDateTime startTime,
+    OffsetDateTime endTime,
+    boolean incompleteBatch,
+    String tenantId,
+    int failedCount,
+    OffsetDateTime lastFailedAt,
+    int completedCount,
+    OffsetDateTime lastCompletedAt,
+    int createdCount,
+    OffsetDateTime lastCreatedAt,
+    String jobType,
+    String worker) {
+
+  public static class Builder implements ObjectBuilder<JobMetricsBatchDbModel> {
+
+    private String key;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
+    private boolean incompleteBatch;
+    private String tenantId;
+    private int failedCount;
+    private OffsetDateTime lastFailedAt;
+    private int completedCount;
+    private OffsetDateTime lastCompletedAt;
+    private int createdCount;
+    private OffsetDateTime lastCreatedAt;
+    private String jobType;
+    private String worker;
+
+    public Builder key(final String key) {
+      this.key = key;
+      return this;
+    }
+
+    public Builder startTime(final OffsetDateTime startTime) {
+      this.startTime = startTime;
+      return this;
+    }
+
+    public Builder endTime(final OffsetDateTime endTime) {
+      this.endTime = endTime;
+      return this;
+    }
+
+    public Builder incompleteBatch(final boolean incompleteBatch) {
+      this.incompleteBatch = incompleteBatch;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder failedCount(final int failedCount) {
+      this.failedCount = failedCount;
+      return this;
+    }
+
+    public Builder lastFailedAt(final OffsetDateTime lastFailedAt) {
+      this.lastFailedAt = lastFailedAt;
+      return this;
+    }
+
+    public Builder completedCount(final int completedCount) {
+      this.completedCount = completedCount;
+      return this;
+    }
+
+    public Builder lastCompletedAt(final OffsetDateTime lastCompletedAt) {
+      this.lastCompletedAt = lastCompletedAt;
+      return this;
+    }
+
+    public Builder createdCount(final int createdCount) {
+      this.createdCount = createdCount;
+      return this;
+    }
+
+    public Builder lastCreatedAt(final OffsetDateTime lastCreatedAt) {
+      this.lastCreatedAt = lastCreatedAt;
+      return this;
+    }
+
+    public Builder jobType(final String jobType) {
+      this.jobType = jobType;
+      return this;
+    }
+
+    public Builder worker(final String worker) {
+      this.worker = worker;
+      return this;
+    }
+
+    @Override
+    public JobMetricsBatchDbModel build() {
+      return new JobMetricsBatchDbModel(
+          key,
+          startTime,
+          endTime,
+          incompleteBatch,
+          tenantId,
+          failedCount,
+          lastFailedAt,
+          completedCount,
+          lastCompletedAt,
+          createdCount,
+          lastCreatedAt,
+          jobType,
+          worker);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -42,6 +42,7 @@ import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.DraftTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -145,7 +146,8 @@ public class BackupPriorityConfiguration {
             // AUDIT LOG
             new AuditLogTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
-            new ClusterVariableIndex(indexPrefix, isElasticsearch));
+            new ClusterVariableIndex(indexPrefix, isElasticsearch),
+            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch));
 
     LOG.debug("Prio1 are {}", prio1);
     LOG.debug("Prio2 are {}", prio2);

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -177,7 +177,8 @@ class BackupPrioritiesTest {
             "camunda-usage-metric-8.8.0_",
             "camunda-usage-metric-tu-8.8.0_",
             "camunda-audit-log-8.9.0_",
-            "camunda-cluster-variable-8.9.0_");
+            "camunda-cluster-variable-8.9.0_",
+            "camunda-job-metrics-batch-8.9.0_");
 
     for (final var indexList : indices) {
       assertThat(indexList.allIndices())

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1000,6 +1000,7 @@ public class SchemaManagerIT {
         // we verify the names hard coded on purpose
         // to make sure no index will be accidentally dropped, names are changed or added
         .containsExactlyInAnyOrder(
+            newPrefix + "-camunda-job-metrics-batch-8.9.0_",
             newPrefix + "-camunda-authorization-8.8.0_",
             newPrefix + "-camunda-cluster-variable-8.9.0_",
             newPrefix + "-camunda-correlated-message-subscription-8.8.0_",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -30,6 +30,7 @@ import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.DraftTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -88,7 +89,8 @@ public class IndexDescriptors {
                 new UsageMetricTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
                 new AuditLogTemplate(indexPrefix, isElasticsearch),
-                new HistoryDeletionIndex(indexPrefix, isElasticsearch))
+                new HistoryDeletionIndex(indexPrefix, isElasticsearch),
+                new JobMetricsBatchTemplate(indexPrefix, isElasticsearch))
             .collect(Collectors.toMap(Object::getClass, Function.identity()));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobMetricsBatchTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobMetricsBatchTemplate.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.template;
+
+import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import java.util.Optional;
+
+public class JobMetricsBatchTemplate extends AbstractTemplateDescriptor implements Prio5Backup {
+
+  public static final String INDEX_NAME = "job-metrics-batch";
+  public static final String INDEX_VERSION = "8.9.0";
+
+  public static final String ID = "id";
+  public static final String START_TIME = "startTime";
+  public static final String END_TIME = "endTime";
+  public static final String INCOMPLETE_BATCH = "incompleteBatch";
+  public static final String TENANT_ID = "tenantId";
+  public static final String FAILED_COUNT = "failedCount";
+  public static final String LAST_FAILED_AT = "lastFailedAt";
+  public static final String COMPLETED_COUNT = "completedCount";
+  public static final String LAST_COMPLETED_AT = "lastCompletedAt";
+  public static final String CREATED_COUNT = "createdCount";
+  public static final String LAST_CREATED_AT = "lastCreatedAt";
+  public static final String JOB_TYPE = "jobType";
+  public static final String WORKER = "worker";
+
+  public JobMetricsBatchTemplate(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public Optional<String> getTenantIdField() {
+    return Optional.of(TENANT_ID);
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return ComponentNames.CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/jobmetricsbatch/JobMetricsBatchEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/jobmetricsbatch/JobMetricsBatchEntity.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.jobmetricsbatch;
+
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public final class JobMetricsBatchEntity
+    implements ExporterEntity<JobMetricsBatchEntity>, TenantOwned {
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String id;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private OffsetDateTime startTime;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private OffsetDateTime endTime;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private boolean incompleteBatch;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String tenantId;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private int failedCount;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private OffsetDateTime lastFailedAt;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private int completedCount;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private OffsetDateTime lastCompletedAt;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private int createdCount;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private OffsetDateTime lastCreatedAt;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String jobType;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String worker;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public JobMetricsBatchEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public OffsetDateTime getStartTime() {
+    return startTime;
+  }
+
+  public JobMetricsBatchEntity setStartTime(final OffsetDateTime startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public OffsetDateTime getEndTime() {
+    return endTime;
+  }
+
+  public JobMetricsBatchEntity setEndTime(final OffsetDateTime endTime) {
+    this.endTime = endTime;
+    return this;
+  }
+
+  public boolean isIncompleteBatch() {
+    return incompleteBatch;
+  }
+
+  public JobMetricsBatchEntity setIncompleteBatch(final boolean incompleteBatch) {
+    this.incompleteBatch = incompleteBatch;
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public JobMetricsBatchEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public int getFailedCount() {
+    return failedCount;
+  }
+
+  public JobMetricsBatchEntity setFailedCount(final int failedCount) {
+    this.failedCount = failedCount;
+    return this;
+  }
+
+  public OffsetDateTime getLastFailedAt() {
+    return lastFailedAt;
+  }
+
+  public JobMetricsBatchEntity setLastFailedAt(final OffsetDateTime lastFailedAt) {
+    this.lastFailedAt = lastFailedAt;
+    return this;
+  }
+
+  public int getCompletedCount() {
+    return completedCount;
+  }
+
+  public JobMetricsBatchEntity setCompletedCount(final int completedCount) {
+    this.completedCount = completedCount;
+    return this;
+  }
+
+  public OffsetDateTime getLastCompletedAt() {
+    return lastCompletedAt;
+  }
+
+  public JobMetricsBatchEntity setLastCompletedAt(final OffsetDateTime lastCompletedAt) {
+    this.lastCompletedAt = lastCompletedAt;
+    return this;
+  }
+
+  public int getCreatedCount() {
+    return createdCount;
+  }
+
+  public JobMetricsBatchEntity setCreatedCount(final int createdCount) {
+    this.createdCount = createdCount;
+    return this;
+  }
+
+  public OffsetDateTime getLastCreatedAt() {
+    return lastCreatedAt;
+  }
+
+  public JobMetricsBatchEntity setLastCreatedAt(final OffsetDateTime lastCreatedAt) {
+    this.lastCreatedAt = lastCreatedAt;
+    return this;
+  }
+
+  public String getJobType() {
+    return jobType;
+  }
+
+  public JobMetricsBatchEntity setJobType(final String jobType) {
+    this.jobType = jobType;
+    return this;
+  }
+
+  public String getWorker() {
+    return worker;
+  }
+
+  public JobMetricsBatchEntity setWorker(final String worker) {
+    this.worker = worker;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        startTime,
+        endTime,
+        incompleteBatch,
+        tenantId,
+        failedCount,
+        lastFailedAt,
+        completedCount,
+        lastCompletedAt,
+        createdCount,
+        lastCreatedAt,
+        jobType,
+        worker);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final var that = (JobMetricsBatchEntity) obj;
+    return Objects.equals(id, that.id)
+        && Objects.equals(startTime, that.startTime)
+        && Objects.equals(endTime, that.endTime)
+        && incompleteBatch == that.incompleteBatch
+        && Objects.equals(tenantId, that.tenantId)
+        && failedCount == that.failedCount
+        && Objects.equals(lastFailedAt, that.lastFailedAt)
+        && completedCount == that.completedCount
+        && Objects.equals(lastCompletedAt, that.lastCompletedAt)
+        && createdCount == that.createdCount
+        && Objects.equals(lastCreatedAt, that.lastCreatedAt)
+        && Objects.equals(jobType, that.jobType)
+        && Objects.equals(worker, that.worker);
+  }
+
+  @Override
+  public String toString() {
+    return "JobMetricsBatchEntity[id=%s, startTime=%s, endTime=%s, incompleteBatch=%s, tenantId=%s, failedCount=%d, lastFailedAt=%s, completedCount=%d, lastCompletedAt=%s, createdCount=%d, lastCreatedAt=%s, jobType=%s, worker=%s]"
+        .formatted(
+            id,
+            startTime,
+            endTime,
+            incompleteBatch,
+            tenantId,
+            failedCount,
+            lastFailedAt,
+            completedCount,
+            lastCompletedAt,
+            createdCount,
+            lastCreatedAt,
+            jobType,
+            worker);
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-job-metrics-batch.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-job-metrics-batch.json
@@ -1,0 +1,51 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "startTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "incompleteBatch": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "failedCount": {
+        "type": "integer"
+      },
+      "lastFailedAt": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "completedCount": {
+        "type": "integer"
+      },
+      "lastCompletedAt": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "createdCount": {
+        "type": "integer"
+      },
+      "lastCreatedAt": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "jobType": {
+        "type": "keyword"
+      },
+      "worker": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-job-metrics-batch.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-job-metrics-batch.json
@@ -1,0 +1,51 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "startTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "incompleteBatch": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "failedCount": {
+        "type": "integer"
+      },
+      "lastFailedAt": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "completedCount": {
+        "type": "integer"
+      },
+      "lastCompletedAt": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "createdCount": {
+        "type": "integer"
+      },
+      "lastCreatedAt": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "jobType": {
+        "type": "keyword"
+      },
+      "worker": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -834,13 +834,13 @@ final class ElasticsearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        indicesClientSpy, times(19) // number of index templates
+                        indicesClientSpy, times(20) // number of index templates
                         )
                     .putSettings(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
-        .hasSize(19)
+        .hasSize(20)
         .allSatisfy(
             request -> {
               assertThat(request.index()).hasSize(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -84,7 +84,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 final class OpenSearchArchiverRepositoryIT {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OpenSearchArchiverRepositoryIT.class);
-  @RegisterExtension private static SearchDBExtension searchDB = create();
+  @RegisterExtension private static final SearchDBExtension SEARCH_DB = create();
   private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -810,13 +810,13 @@ final class OpenSearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        genericClientSpy, times(19) // number of index templates
+                        genericClientSpy, times(20) // number of index templates
                         )
                     .executeAsync(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
-        .hasSize(19)
+        .hasSize(20)
         .allSatisfy(
             request -> {
               final var indexPattern =
@@ -874,7 +874,7 @@ final class OpenSearchArchiverRepositoryIT {
     final var searchEngineClient = new OpensearchEngineClient(testClient, objectMapper);
     final var connectConfig = new ConnectConfiguration();
     connectConfig.setIndexPrefix(indexPrefix);
-    connectConfig.setUrl(searchDB.esUrl());
+    connectConfig.setUrl(SEARCH_DB.esUrl());
     connectConfig.setType(DatabaseType.OPENSEARCH.toString());
     final var schemaManagerConfig = new SchemaManagerConfiguration();
     schemaManagerConfig.getRetry().setMaxRetries(1);
@@ -1094,7 +1094,7 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   private RestClientTransport createRestClient() {
-    final var restClient = RestClient.builder(HttpHost.create(searchDB.osUrl())).build();
+    final var restClient = RestClient.builder(HttpHost.create(SEARCH_DB.osUrl())).build();
     return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 


### PR DESCRIPTION
## Description

[Solution design.](https://docs.google.com/document/d/14PNu8-wPPGTizJVRAmGdYwDD9x-hTGC_43ao8sc9ww0/edit?tab=t.0#heading=h.hj27khdz8woa)

This pull request introduces support for "Job Metrics Batch" data throughout the application stack. It adds a new database model, entity, schema templates, and search index mappings to enable storage and search of job metrics batch information, including counts and timestamps for job metrics grouped by type, worker, and tenant.

The most important changes are:

**Database and Data Model Support:**
* Added the `JobMetricsBatchDbModel` record and builder to represent job metrics batch data in the database layer.

**Schema and Entity Layer:**
* Introduced the `JobMetricsBatchEntity` class to model job metrics batch records as entities, including fields for job type, worker, counts, timestamps, and tenant information.

**Index and Template Integration:**
* Created the `JobMetricsBatchTemplate` class, defining the schema template for job metrics batch indices, and registered it in `IndexDescriptors` so it is included in the application's index management. [[1]](diffhunk://#diff-8393a539512124f0c22ac37a0d0f75c4c20c9a386571ac6552fcd1d12fa32fcaR1-R57) [[2]](diffhunk://#diff-2c004f64242ed2ee844a610f60a507322c648e081a630994b56eae67511cd49cR33) [[3]](diffhunk://#diff-2c004f64242ed2ee844a610f60a507322c648e081a630994b56eae67511cd49cL91-R93)

**Search Index Mappings:**
* Added Elasticsearch and OpenSearch index mapping templates (`camunda-job-metrics-batch.json`) to define the structure and types for job metrics batch documents, ensuring strict typing and compatibility with search backends.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/43653
