### PR TITLE
ci: flaky test summary from forks lacks permission, disable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -935,7 +935,7 @@ jobs:
 
   utils-flaky-tests-summary:
     name: flaky tests summary comment
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     needs:
       - archunit-tests
       - docker-checks


### PR DESCRIPTION
## Description

While troubleshooting the CI experience from forked repositories of `camunda/camunda` via https://github.com/cmur2/camunda in hopes to make external contributions smoother, I noticed that the feature we built in https://github.com/camunda/camunda/issues/28981 does not work from forks: the flaky test summary logic is executed in context of the forked repo, but tries to update PR comments in `camunda/camunda` itself which it lacks permission for.

Thus disabling the logic for now since the CI job will always fail, example: https://github.com/camunda/camunda/actions/runs/20786279373/job/59698381209?pr=43579

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
