### PR TITLE
Increase database IT timeouts to 20 minutes

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -40,7 +40,7 @@ jobs:
   integration-tests:
     name: "${{inputs.database-type}}"
     permissions: { }  # GITHUB_TOKEN unused in this job
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: gcp-perf-core-8-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The P90 of the ES IT jobs is 14.3 minutes. This means that ~10% of the runs is timing out, causing quite some merge queue evictions. This temporarily increases the timeout to resolve this until we've improved the performance of these
 tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

N/A
