### PR TITLE
feat: implement first root PI key exporter metadata

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
@@ -12,9 +12,21 @@ import static io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTra
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.function.Predicate;
 
 public class ProcessInstanceCancelAuditLogTransformer
     implements AuditLogTransformer<ProcessInstanceRecordValue> {
+
+  private final Predicate<Long> shouldIncludeRootProcessInstanceKey;
+
+  public ProcessInstanceCancelAuditLogTransformer() {
+    shouldIncludeRootProcessInstanceKey = key -> true;
+  }
+
+  public ProcessInstanceCancelAuditLogTransformer(
+      final Predicate<Long> shouldIncludeRootProcessInstanceKey) {
+    this.shouldIncludeRootProcessInstanceKey = shouldIncludeRootProcessInstanceKey;
+  }
 
   @Override
   public TransformerConfig config() {
@@ -28,7 +40,8 @@ public class ProcessInstanceCancelAuditLogTransformer
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessInstanceKey(value.getProcessInstanceKey());
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && shouldIncludeRootProcessInstanceKey.test(rootProcessInstanceKey)) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -246,13 +246,16 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(DecisionIndex.class).getFullQualifiedName(),
                 decisionRequirementsCache),
             new ListViewProcessInstanceFromProcessInstanceHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                processCache,
+                exporterMetadata),
             new ListViewFlowNodeFromIncidentHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromJobHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromProcessInstanceHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                exporterMetadata),
             new ListViewVariableFromVariableHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ClusterVariableCreatedHandler(
@@ -272,13 +275,16 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new FlowNodeInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
-                processCache),
+                processCache,
+                exporterMetadata),
             new IncidentHandler(
                 indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache),
             new SequenceFlowHandler(
-                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName(),
+                exporterMetadata),
             new SequenceFlowDeletedHandler(
-                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName(),
+                exporterMetadata),
             new DecisionEvaluationHandler(
                 indexDescriptors.get(DecisionInstanceTemplate.class).getFullQualifiedName()),
             new ProcessHandler(
@@ -303,7 +309,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 exporterMetadata,
                 objectMapper),
             new UserTaskProcessInstanceHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(), exporterMetadata),
             new UserTaskVariableHandler(
                 indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
@@ -336,16 +342,20 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new ProcessInstanceCancellationOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
-                batchOperationCache),
+                batchOperationCache,
+                exporterMetadata),
             new ProcessInstanceMigrationOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
-                batchOperationCache),
+                batchOperationCache,
+                exporterMetadata),
             new ProcessInstanceModificationOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
-                batchOperationCache),
+                batchOperationCache,
+                exporterMetadata),
             new ResolveIncidentOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
-                batchOperationCache),
+                batchOperationCache,
+                exporterMetadata),
             new ListViewFromProcessInstanceCancellationOperationHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
                 batchOperationCache),
@@ -370,7 +380,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                     .get(CorrelatedMessageSubscriptionTemplate.class)
                     .getFullQualifiedName())));
 
-    addAuditLogHandlers(configuration.getAuditLog());
+    addAuditLogHandlers(configuration.getAuditLog(), exporterMetadata);
 
     if (configuration.getBatchOperation().isExportItemsOnCreation()) {
       // only add this handler when the items are exported on creation
@@ -470,7 +480,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     return formCache;
   }
 
-  private void addAuditLogHandlers(final AuditLogConfiguration auditLog) {
+  private void addAuditLogHandlers(
+      final AuditLogConfiguration auditLog, final ExporterMetadata exporterMetadata) {
     if (auditLog.isEnabled()) {
       final var indexName = (indexDescriptors.get(AuditLogTemplate.class).getFullQualifiedName());
 
@@ -487,7 +498,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
           .addHandler(new IncidentResolutionAuditLogTransformer())
           .addHandler(new MappingRuleAuditLogTransformer())
           .addHandler(new ProcessAuditLogTransformer())
-          .addHandler(new ProcessInstanceCancelAuditLogTransformer())
+          .addHandler(
+              new ProcessInstanceCancelAuditLogTransformer(
+                  exporterMetadata::isKeyAfterFirstRootProcessInstanceKey))
           .addHandler(new ProcessInstanceCreationAuditLogTransformer())
           .addHandler(new ProcessInstanceMigrationAuditLogTransformer())
           .addHandler(new ProcessInstanceModificationAuditLogTransformer())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -283,8 +283,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName(),
                 exporterMetadata),
             new SequenceFlowDeletedHandler(
-                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName(),
-                exporterMetadata),
+                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
             new DecisionEvaluationHandler(
                 indexDescriptors.get(DecisionInstanceTemplate.class).getFullQualifiedName()),
             new ProcessHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
@@ -44,6 +44,7 @@ public final class ExporterMetadata {
         }
       };
   private long firstProcessMessageSubscriptionKey = UNSET_POSITION;
+  private long firstRootProcessInstanceKey = UNSET_POSITION;
 
   public ExporterMetadata(final ObjectMapper objectMapper) {
     // Specialized reader/writer for this class for efficiency
@@ -94,6 +95,20 @@ public final class ExporterMetadata {
         || key < getFirstProcessMessageSubscriptionKey();
   }
 
+  public long getFirstRootProcessInstanceKey() {
+    return firstRootProcessInstanceKey;
+  }
+
+  public void setFirstRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    if (firstRootProcessInstanceKey == UNSET_POSITION) {
+      firstRootProcessInstanceKey = rootProcessInstanceKey;
+    }
+  }
+
+  public boolean isKeyAfterFirstRootProcessInstanceKey(final long key) {
+    return firstRootProcessInstanceKey != UNSET_POSITION && key >= firstRootProcessInstanceKey;
+  }
+
   public void deserialize(final byte[] bytes) {
     try {
       objectReader.readValue(bytes);
@@ -114,7 +129,10 @@ public final class ExporterMetadata {
   @Override
   public int hashCode() {
     return Objects.hash(
-        lastIncidentUpdatePosition, firstUserTaskKeys, firstProcessMessageSubscriptionKey);
+        lastIncidentUpdatePosition,
+        firstUserTaskKeys,
+        firstProcessMessageSubscriptionKey,
+        firstRootProcessInstanceKey);
   }
 
   @Override
@@ -127,8 +145,9 @@ public final class ExporterMetadata {
     }
     final ExporterMetadata that = (ExporterMetadata) o;
     return lastIncidentUpdatePosition == that.lastIncidentUpdatePosition
-        && firstUserTaskKeys == that.firstUserTaskKeys
-        && firstProcessMessageSubscriptionKey == that.firstProcessMessageSubscriptionKey;
+        && firstProcessMessageSubscriptionKey == that.firstProcessMessageSubscriptionKey
+        && firstRootProcessInstanceKey == that.firstRootProcessInstanceKey
+        && Objects.equals(firstUserTaskKeys, that.firstUserTaskKeys);
   }
 
   @Override
@@ -140,6 +159,8 @@ public final class ExporterMetadata {
         + firstUserTaskKeys
         + ", firstProcessMessageSubscriptionKey="
         + firstProcessMessageSubscriptionKey
+        + ", firstRootProcessInstanceKey="
+        + firstRootProcessInstanceKey
         + '}';
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_MIGRATED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -48,11 +49,15 @@ public class FlowNodeInstanceFromProcessInstanceHandler
 
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ExporterMetadata exporterMetadata;
 
   public FlowNodeInstanceFromProcessInstanceHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+      final String indexName,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ExporterMetadata exporterMetadata) {
     this.indexName = indexName;
     this.processCache = processCache;
+    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -136,7 +141,8 @@ public class FlowNodeInstanceFromProcessInstanceHandler
                 ? null
                 : recordValue.getBpmnElementType().name()));
     final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
@@ -15,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.AC
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
@@ -41,9 +42,12 @@ public class ListViewFlowNodeFromProcessInstanceHandler
       Set.of(BpmnElementType.PROCESS, BpmnElementType.SEQUENCE_FLOW);
 
   private final String indexName;
+  private final ExporterMetadata exporterMetadata;
 
-  public ListViewFlowNodeFromProcessInstanceHandler(final String indexName) {
+  public ListViewFlowNodeFromProcessInstanceHandler(
+      final String indexName, final ExporterMetadata exporterMetadata) {
     this.indexName = indexName;
+    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -116,7 +120,8 @@ public class ListViewFlowNodeFromProcessInstanceHandler
     final long processInstanceKey = recordValue.getProcessInstanceKey();
     entity.getJoinRelation().setParent(processInstanceKey);
     final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.exporter.handlers;
 
-import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
@@ -23,12 +22,9 @@ public class SequenceFlowDeletedHandler
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;
-  private final ExporterMetadata exporterMetadata;
 
-  public SequenceFlowDeletedHandler(
-      final String indexName, final ExporterMetadata exporterMetadata) {
+  public SequenceFlowDeletedHandler(final String indexName) {
     this.indexName = indexName;
-    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -68,11 +64,6 @@ public class SequenceFlowDeletedHandler
         .setBpmnProcessId(recordValue.getBpmnProcessId())
         .setActivityId(recordValue.getElementId())
         .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
-    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0
-        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
-      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
@@ -22,9 +23,12 @@ public class SequenceFlowDeletedHandler
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;
+  private final ExporterMetadata exporterMetadata;
 
-  public SequenceFlowDeletedHandler(final String indexName) {
+  public SequenceFlowDeletedHandler(
+      final String indexName, final ExporterMetadata exporterMetadata) {
     this.indexName = indexName;
+    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -65,7 +69,8 @@ public class SequenceFlowDeletedHandler
         .setActivityId(recordValue.getElementId())
         .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
     final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
@@ -21,9 +22,11 @@ public class SequenceFlowHandler
 
   private static final String ID_PATTERN = "%s_%s";
   private final String indexName;
+  private final ExporterMetadata exporterMetadata;
 
-  public SequenceFlowHandler(final String indexName) {
+  public SequenceFlowHandler(final String indexName, final ExporterMetadata exporterMetadata) {
     this.indexName = indexName;
+    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -64,7 +67,8 @@ public class SequenceFlowHandler
         .setActivityId(recordValue.getElementId())
         .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
     final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
@@ -23,9 +24,12 @@ public class UserTaskProcessInstanceHandler
     implements ExportHandler<TaskProcessInstanceEntity, ProcessInstanceRecordValue> {
 
   private final String indexName;
+  private final ExporterMetadata exporterMetadata;
 
-  public UserTaskProcessInstanceHandler(final String indexName) {
+  public UserTaskProcessInstanceHandler(
+      final String indexName, final ExporterMetadata exporterMetadata) {
     this.indexName = indexName;
+    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -65,7 +69,8 @@ public class UserTaskProcessInstanceHandler
 
     entity.setJoin(join);
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.batchoperation;
 
 import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
@@ -43,14 +44,17 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractOperationStatusHandler.class);
   protected final ValueType handledValueType;
+  private final ExporterMetadata exporterMetadata;
 
   public AbstractOperationStatusHandler(
       final String indexName,
       final ValueType handledValueType,
       final OperationType relevantOperationType,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final ExporterMetadata exporterMetadata) {
     super(indexName, batchOperationCache, relevantOperationType);
     this.handledValueType = handledValueType;
+    this.exporterMetadata = exporterMetadata;
   }
 
   @Override
@@ -88,7 +92,8 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
         .setItemKey(getItemKey(record))
         .setProcessInstanceKey(getProcessInstanceKey(record));
     final var rootProcessInstanceKey = getRootProcessInstanceKey(record);
-    if (rootProcessInstanceKey > 0) {
+    if (rootProcessInstanceKey > 0
+        && exporterMetadata.isKeyAfterFirstRootProcessInstanceKey(rootProcessInstanceKey)) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
@@ -27,12 +28,14 @@ public class ProcessInstanceCancellationOperationHandler
 
   public ProcessInstanceCancellationOperationHandler(
       final String indexName,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final ExporterMetadata exporterMetadata) {
     super(
         indexName,
         ValueType.PROCESS_INSTANCE,
         OperationType.CANCEL_PROCESS_INSTANCE,
-        batchOperationCache);
+        batchOperationCache,
+        exporterMetadata);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
@@ -26,18 +27,19 @@ public class ProcessInstanceMigrationOperationHandler
 
   public ProcessInstanceMigrationOperationHandler(
       final String indexName,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final ExporterMetadata exporterMetadata) {
     super(
         indexName,
         ValueType.PROCESS_INSTANCE_MIGRATION,
         OperationType.MIGRATE_PROCESS_INSTANCE,
-        batchOperationCache);
+        batchOperationCache,
+        exporterMetadata);
   }
 
   @Override
   long getRootProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
-    return -1; // TODO implement when available in the record
-    // https://github.com/camunda/camunda/pull/43315
+    return record.getValue().getRootProcessInstanceKey();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
@@ -26,12 +27,14 @@ public class ProcessInstanceModificationOperationHandler
 
   public ProcessInstanceModificationOperationHandler(
       final String indexName,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final ExporterMetadata exporterMetadata) {
     super(
         indexName,
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         OperationType.MODIFY_PROCESS_INSTANCE,
-        batchOperationCache);
+        batchOperationCache,
+        exporterMetadata);
   }
 
   @Override
@@ -41,8 +44,7 @@ public class ProcessInstanceModificationOperationHandler
 
   @Override
   long getRootProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
-    return -1; // TODO implement when available in the record
-    // https://github.com/camunda/camunda/pull/43315
+    return record.getValue().getRootProcessInstanceKey();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
@@ -25,14 +26,19 @@ public class ResolveIncidentOperationHandler
 
   public ResolveIncidentOperationHandler(
       final String indexName,
-      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
-    super(indexName, ValueType.INCIDENT, OperationType.RESOLVE_INCIDENT, batchOperationCache);
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final ExporterMetadata exporterMetadata) {
+    super(
+        indexName,
+        ValueType.INCIDENT,
+        OperationType.RESOLVE_INCIDENT,
+        batchOperationCache,
+        exporterMetadata);
   }
 
   @Override
   long getRootProcessInstanceKey(final Record<IncidentRecordValue> record) {
-    return -1; // TODO implement when available in the record
-    // https://github.com/camunda/camunda/pull/43320
+    return record.getValue().getRootProcessInstanceKey();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
@@ -10,7 +10,10 @@ package io.camunda.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 final class ExporterMetadataTest {
   @Test
@@ -19,6 +22,9 @@ final class ExporterMetadataTest {
     final var source = new ExporterMetadata(TestObjectMapper.objectMapper());
     final var destination = new ExporterMetadata(TestObjectMapper.objectMapper());
     source.setLastIncidentUpdatePosition(3);
+    source.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 4);
+    source.setFirstProcessMessageSubscriptionKey(5);
+    source.setFirstRootProcessInstanceKey(6);
     destination.setLastIncidentUpdatePosition(-1);
 
     // when
@@ -27,6 +33,9 @@ final class ExporterMetadataTest {
 
     // then
     assertThat(destination.getLastIncidentUpdatePosition()).isEqualTo(3);
+    assertThat(destination.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK)).isEqualTo(4);
+    assertThat(destination.getFirstProcessMessageSubscriptionKey()).isEqualTo(5);
+    assertThat(destination.getFirstRootProcessInstanceKey()).isEqualTo(6);
   }
 
   @Test
@@ -40,5 +49,50 @@ final class ExporterMetadataTest {
 
     // then
     assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldNotUpdateFirstRootProcessInstanceKeyWithADifferentValue() {
+    // given
+    final var metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+    metadata.setFirstRootProcessInstanceKey(5);
+
+    // when
+    metadata.setFirstRootProcessInstanceKey(3);
+
+    // then
+    assertThat(metadata.getFirstRootProcessInstanceKey()).isEqualTo(5);
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {5, 6})
+  void shouldIsKeyAfterFirstRootProcessInstanceKeyReturnTrue(final long key) {
+    // given
+    final var metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+    metadata.setFirstRootProcessInstanceKey(5);
+
+    // when - then
+    assertThat(metadata.isKeyAfterFirstRootProcessInstanceKey(key)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {-1, 4})
+  void shouldIsKeyAfterFirstRootProcessInstanceKeyReturnFalse(final long key) {
+    // given
+    final var metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+    metadata.setFirstRootProcessInstanceKey(5);
+
+    // when - then
+    assertThat(metadata.isKeyAfterFirstRootProcessInstanceKey(key)).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {-1, Long.MAX_VALUE})
+  void shouldIsKeyAfterFirstRootProcessInstanceKeyReturnFalseWhenMetadataIsUnset(final long key) {
+    // given
+    final var metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+
+    // when - then
+    assertThat(metadata.isKeyAfterFirstRootProcessInstanceKey(key)).isFalse();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -12,7 +12,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -22,11 +24,16 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SequenceFlowDeletedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "sequence-flow";
-  private final SequenceFlowDeletedHandler underTest = new SequenceFlowDeletedHandler(indexName);
+  private final ExporterMetadata exporterMetadata =
+      new ExporterMetadata(TestObjectMapper.objectMapper());
+  private final SequenceFlowDeletedHandler underTest =
+      new SequenceFlowDeletedHandler(indexName, exporterMetadata);
 
   @Test
   void testGetHandledValueType() {
@@ -123,16 +130,19 @@ public class SequenceFlowDeletedHandlerTest {
             .from(factory.generateObject(ProcessInstanceRecordValue.class))
             .build();
 
-    final Record<ProcessInstanceRecordValue> variableRecord =
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
         factory.generateRecord(
             ValueType.PROCESS_INSTANCE,
             r ->
                 r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED)
                     .withValue(processInstanceRecordValue));
 
+    exporterMetadata.setFirstRootProcessInstanceKey(
+        processInstanceRecordValue.getRootProcessInstanceKey());
+
     // when
     final SequenceFlowEntity sequenceFlowEntity = new SequenceFlowEntity();
-    underTest.updateEntity(variableRecord, sequenceFlowEntity);
+    underTest.updateEntity(processInstanceRecord, sequenceFlowEntity);
 
     // then
     assertThat(sequenceFlowEntity.getId())
@@ -153,5 +163,24 @@ public class SequenceFlowDeletedHandlerTest {
     assertThat(sequenceFlowEntity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(processInstanceRecordValue.getRootProcessInstanceKey());
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {Long.MAX_VALUE, -1L})
+  void shouldNotSetRootProcessInstanceKey(final long metadataValue) {
+    // given
+    exporterMetadata.setFirstRootProcessInstanceKey(metadataValue);
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r -> r.withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_DELETED));
+
+    // when
+    final SequenceFlowEntity sequenceFlowEntity = new SequenceFlowEntity();
+    underTest.updateEntity(processInstanceRecord, sequenceFlowEntity);
+
+    // then
+    assertThat(sequenceFlowEntity.getRootProcessInstanceKey()).isNull();
+    assertThat(processInstanceRecord.getValue().getRootProcessInstanceKey()).isPositive();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We must ensure that child process instances created on 8.9+ but whose root was started before 8.9 are treated as legacy by the archiver and follow per‑process‑instance retention.

To achieve this:

- Maintain an ExporterMetadata entry (per partition) to store firstRootProcessInstanceKey, the smallest root process instance key created with the new (8.9+) engine that supports rootProcessInstanceKey.

- When exporting records with a rootProcessInstanceKey:

If rootProcessInstanceKey >= firstRootProcessInstanceKey, export the field normally.
If rootProcessInstanceKey < firstRootProcessInstanceKey (i.e. the record belongs to a hierarchy whose root PI was created before 8.9), do not export rootProcessInstanceKey for that document, so that this hierarchy is treated as legacy by the archiver and follows per‑process‑instance retention.

This ensures that:

- Child process instances created in 8.9, but whose root PI started in 8.8, are archived via the legacy per‑process‑instance archiver.
- Only hierarchies fully "owned" by the 8.9+ engine (root created after upgrade) are visible to the hierarchy‑based retention logic.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41658 
