### PR TITLE
[Backport stable/8.6] Update runTests.js with API test option

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
@@ -20,6 +20,7 @@ const browser = await select({
     {name: 'Firefox', value: 'firefox'},
 
     {name: 'Edge', value: 'msedge'},
+    {name: 'API', value: 'api-tests'},
   ],
 });
 
@@ -35,7 +36,17 @@ const runMode = await select({
   ],
 });
 
-let args = ['run', 'test', '--', `--project=${browser}`];
+let args = ['run', 'test', '--'];
+
+if (browser === 'chromium') {
+  args.push('--project=chromium');
+} else if (browser === 'firefox') {
+  args.push('--project=firefox');
+} else if (browser === 'msedge') {
+  args.push('--project=msedge');
+} else if (browser === 'api-tests') {
+  args.push('--project=api-tests');
+}
 
 if (runMode === 'headed') {
   args.push('--headed');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/runTest.js
@@ -11,45 +11,50 @@ import {spawn} from 'node:child_process';
 
 const IS_LOCAL = Boolean(process.env.LOCAL_TEST);
 
-const browser = await select({
-  message: 'Select the browser to run the tests on:',
-
+const category = await select({
+  message: "Which tests would you like to run?",
   choices: [
-    {name: 'Chrome', value: 'chromium'},
-
-    {name: 'Firefox', value: 'firefox'},
-
-    {name: 'Edge', value: 'msedge'},
-    {name: 'API', value: 'api-tests'},
+    { name: "E2E tests", value: "e2e" },
+    { name: "API tests", value: "api" },
   ],
 });
 
 const baseURL = getBaseURL();
 
-const runMode = await select({
-  message: 'Which mode would like to run Playwright:',
-
-  choices: [
-    {name: 'Headless', value: 'headless'},
-
-    {name: 'Headed', value: 'headed'},
-  ],
-});
-
 let args = ['run', 'test', '--'];
 
-if (browser === 'chromium') {
-  args.push('--project=chromium');
-} else if (browser === 'firefox') {
-  args.push('--project=firefox');
-} else if (browser === 'msedge') {
-  args.push('--project=msedge');
-} else if (browser === 'api-tests') {
-  args.push('--project=api-tests');
-}
+if (category === "api") {
+  args.push("--project=api-tests");
+} else {
+  const browser = await select({
+    message: 'Select the browser to run the E2E tests on:',
+    choices: [
+      {name: 'Chrome', value: 'chromium'},
+      {name: 'Firefox', value: 'firefox'},
+      {name: 'Edge', value: 'msedge'},
+    ],
+  });
+  const runMode = await select({
+    message: 'Which mode would like to run Playwright:',
+    choices: [
+      {name: 'Headless', value: 'headless'},
+      {name: 'Headed', value: 'headed'},
+    ],
+  });
 
-if (runMode === 'headed') {
-  args.push('--headed');
+  if (runMode === 'headed') {
+    args.push('--headed');
+  }
+
+  if (browser === 'chromium') {
+    args.push('--project=chromium');
+  } else if (browser === 'firefox') {
+    args.push('--project=firefox');
+  } else if (browser === 'msedge') {
+    args.push('--project=msedge');
+  } else if (browser === 'api-tests') {
+    args.push('--project=api-tests');
+  }
 }
 
 spawn('npm', args, {


### PR DESCRIPTION
## Description
Backport of #43578 to `stable/8.6`.

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/43)

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/20827782673)