### PR TITLE
fix: do not retry on RESOURCE_EXHAUSTED

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -145,7 +145,7 @@ public final class RequestRetryHandler {
       return true;
     } else if (error instanceof BrokerErrorException) {
       final ErrorCode code = ((BrokerErrorException) error).getError().getCode();
-      return code == ErrorCode.PARTITION_LEADER_MISMATCH || code == ErrorCode.RESOURCE_EXHAUSTED;
+      return code == ErrorCode.PARTITION_LEADER_MISMATCH;
     }
     return false;
   }


### PR DESCRIPTION
## Description

 * Retrying other partitions on resource exhausted is likely to fail and causing additional load on the cluster, as we distribute load round-robin it is likely that other partition experience the same load and being close to the limit
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/43715
