### PR TITLE
feat: Add Option to Install Load Tests with OpenSearch

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -46,10 +46,11 @@ on:
         required: false
         default: false
       secondary-storage-type:
-        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch" or "postgresql"'
+        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
         type: choice
         options:
         - elasticsearch
+        - opensearch
         - postgresql
         default: elasticsearch
   workflow_call:
@@ -98,7 +99,7 @@ on:
         required: false
         default: false
       secondary-storage-type:
-        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch" or "postgresql"'
+        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch" or "postgresql"'
         # type choice is invalid here
         type: string
         required: false

--- a/load-tests/camunda-platform-values-opensearch.yaml
+++ b/load-tests/camunda-platform-values-opensearch.yaml
@@ -1,16 +1,25 @@
-# We need to explictly enable ELS as per default this is disabled now
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
 global:
   elasticsearch:
+    enabled: false
+
+  opensearch:
     enabled: true
+    url:
+      protocol: http
+      host: "opensearch"
+      port: 9200
 
 ########################################################################################
 ################################################### Orchestration cluster configuration
 ########################################################################################
 orchestration:
-  # We need to explicity set the secondary storage type to ELS
+  # We need to explicitly set the secondary storage type to OpenSearch
   data:
     secondaryStorage:
-      type: elasticsearch
+      type: opensearch
   # We set extra configuration to configure additional settings for Broker and Gateway, that are part
   # of the orchestration cluster.
   # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
@@ -25,7 +34,7 @@ orchestration:
       zeebe.broker.data.disk.freeSpace.replication: "2GB"
       # Configure index suffix with hour pattern, so we create every hour a new index
       # such that ILM can clean it up quickly
-      # We need to configure it for the ES exporter AND the CamundaExporter
+      # We need to configure it for the CamundaExporter
       zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
       zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
       zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
@@ -37,13 +46,9 @@ orchestration:
       # Disable the importers
       camunda.tasklist.importerEnabled: "false"
       camunda.operate.importerEnabled: "false"
-      camunda.operate.elasticsearch.numberOfShards: 3
-      # Schema management has been moved out of exporter - to be bootstrap at start; once
       camunda.data.secondary-storage.retention.enabled: "true"
-      # 0s causes ILM to move data asap - it is normally the default
-      # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
       camunda.data.secondary-storage.retention.minimum-age: "70m"
-      camunda.data.secondary-storage.elasticsearch.history.policy-name: "camunda-retention-policy"
+      camunda.data.secondary-storage.opensearch.history.policy-name: "camunda-retention-policy"
       camunda.database.retention.policyName: "camunda-retention-policy"
       zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
       #Metrics:
@@ -52,32 +57,9 @@ orchestration:
       # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
       zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
 
-########################################################################################
-################################################### Elasticsearch cluster configuration
-########################################################################################
+
+#################################################################################################
+################################################### Disable Elasticsearch when using OpenSearch
+#################################################################################################
 elasticsearch:
-  enabled: true
-  clusterName: "elasticsearch"
-  master:
-    fullnameOverride: elastic
-    nameOverride: elastic
-    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
-    replicaCount: 3
-    pdb:
-      minAvailable: 2
-    ## @param elasticsearch.master.heapSize
-    heapSize: 3g
-    persistence:
-      ## @param elasticsearch.master.persistence.size
-      size: 128Gi
-      storageClass: "ssd"
-      accessModes: ["ReadWriteOnce"]
-    resources:
-      requests:
-        cpu: 3
-        memory: 3Gi
-      limits:
-        cpu: 3
-        memory: 6Gi
-  extraConfig:
-    logger.org.elasticsearch.deprecation: "OFF"
+  enabled: false

--- a/load-tests/secondary-storage-values-opensearch.yaml
+++ b/load-tests/secondary-storage-values-opensearch.yaml
@@ -1,0 +1,50 @@
+###########################################################################
+#######
+#     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #
+#     # #    # #      ##   # #      #       #  #  #    # #    # #    #
+#     # #####  #####  # #  #  ####  #####  #    # #    # #      ######
+#     # #      #      #  # #      # #      ###### #####  #      #    #
+#     # #      #      #   ## #    # #      #    # #   #  #    # #    #
+####### #      ###### #    #  ####  ###### #    # #    #  ####  #    #
+###########################################################################
+
+# Override values for https://github.com/opensearch-project/helm-charts
+
+clusterName: "opensearch"
+nameOverride: "opensearch"
+masterService: "opensearch"
+
+majorVersion: "2.19.0"
+
+config:
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins.security.disabled: true
+
+extraEnvs:
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    value: "yourStrongPassword123!"
+
+opensearchJavaOpts: "-Xms1024m -Xmx1024m"
+
+resources:
+  requests:
+    cpu: 3
+    memory: 4Gi
+  limits:
+    cpu: 6
+    memory: 10Gi
+
+persistence:
+  enabled: true
+  size: 128Gi
+  storageClass: "ssd"
+
+antiAffinity: "hard"
+
+protocol: http
+
+securityConfig:
+  enabled: false
+

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -17,6 +17,8 @@ additional_load_test_configuration ?=
 # Conditional values file based on secondary_storage
 ifeq ($(secondary_storage),postgresql)
 storage_values_file := camunda-platform-values-rdbms.yaml
+else ifeq ($(secondary_storage),opensearch)
+storage_values_file := camunda-platform-values-opensearch.yaml
 else # default is elasticsearch
 storage_values_file := camunda-platform-values-elasticsearch.yaml
 endif
@@ -30,7 +32,7 @@ install: install-storage install-platform install-load-test install-elasticsearc
 .PHONY: install-stable
 install-stable: install-storage install-platform-stable install-load-test install-elasticsearch-exporter
 
-# Install PostgreSQL database if secondary_storage is postgresql
+# Install PostgreSQL database if secondary_storage is postgresql, or OpenSearch if secondary_storage is opensearch
 .PHONY: install-storage
 install-storage:
 ifeq ($(secondary_storage),postgresql)
@@ -40,7 +42,6 @@ ifeq ($(secondary_storage),postgresql)
 	# - additional extension pg_stat_statements for advanced query performance monitoring (must be activated with postgres user before use)
 	helm upgrade --install postgres oci://registry-1.docker.io/bitnamicharts/postgresql \
 		--namespace $(namespace) \
-		--wait --timeout 5m0s \
 		--set global.postgresql.auth.database=camunda \
 		--set global.postgresql.auth.username=camunda \
 		--set global.postgresql.auth.password=camunda \
@@ -51,6 +52,12 @@ ifeq ($(secondary_storage),postgresql)
 		--set primary.resources.limits.memory=6Gi \
 		--set primary.resources.limits.cpu=6000m \
 		--set primary.persistence.size=128Gi
+else ifeq ($(secondary_storage),opensearch)
+	@echo "Installing OpenSearch cluster for namespace $(namespace)..."
+	helm upgrade --install opensearch opensearch/opensearch \
+		--version "2.31.0" \
+		--namespace $(namespace) \
+		-f secondary-storage-values-opensearch.yaml
 else
 	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
 endif
@@ -147,4 +154,8 @@ ifeq ($(secondary_storage),postgresql)
 	@echo "Cleaning up PostgreSQL database for namespace $(namespace)..."
 	-helm --namespace $(namespace) uninstall postgres
 	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/name=postgresql
+else ifeq ($(secondary_storage),opensearch)
+	@echo "Cleaning up OpenSearch cluster for namespace $(namespace)..."
+	-helm --namespace $(namespace) uninstall opensearch
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/name=opensearch
 endif

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -20,9 +20,9 @@ namespace="$1"
 
 # Validate secondaryStorage value
 secondaryStorage="${2:-elasticsearch}"
-if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "postgresql" ]]; then
+if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" ]]; then
   echo "Error: Invalid secondary storage type '$secondaryStorage'"
-  echo "Allowed values are: elasticsearch, postgresql"
+  echo "Allowed values are: elasticsearch, opensearch, postgresql"
   exit 1
 fi
 
@@ -81,6 +81,7 @@ cp -rv default/ $namespace
 
 # Copy camunda-platform-values*.yaml files to the new folder
 cp -v ../camunda-platform-values*.yaml $namespace/
+cp -v ../secondary-storage-values*.yaml $namespace/
 
 # Copy Prometheus ElasticSearch Exporter values.yaml to the new folder
 cp -v ../prometheus-elasticsearch-exporter-values.yaml $namespace/
@@ -94,6 +95,7 @@ sed_inplace "s/elasticsearch/$secondaryStorage/" Makefile
 # Add/update helm repositories
 helm repo add camunda https://helm.camunda.io/ --force-update
 helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/ --force-update
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
 helm repo update
 
 # Clone Platform Helm so we can run the latest chart


### PR DESCRIPTION
## Description

This creates an OpenSearch container and sets it up similarly to how an RDBMS is set up, so that we can run load tests with OpenSearch as the secondary storage.

Given OpenSearch requires extensive config options, have moved the values to a dedicated opensearch-cluster-values file rather than setting via command line args.

Attempting to add it similarly to: https://github.com/camunda/camunda/pull/43005


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
