### PR TITLE
feat: migrate variable scope-key to element-instance v2 API

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesContent.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesContent.tsx
@@ -17,10 +17,14 @@ import {useVariables} from 'modules/queries/variables/useVariables';
 import {VariablesFinalForm} from './VariablesFinalForm';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {isRequestError} from 'modules/request';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
+import {useVariableScopeKey} from 'modules/hooks/variables';
 
 const VariablesContent: React.FC = observer(() => {
   const {displayStatus, error} = useVariables();
-  const scopeId = getScopeId();
+  const scopeKey = IS_ELEMENT_SELECTION_V2
+    ? useVariableScopeKey()
+    : getScopeId();
 
   if (displayStatus === 'error') {
     return (
@@ -57,8 +61,8 @@ const VariablesContent: React.FC = observer(() => {
   if (displayStatus === 'no-variables') {
     return (
       <Content>
-        {scopeId !== null ? (
-          <VariablesFinalForm scopeId={scopeId} />
+        {scopeKey !== null ? (
+          <VariablesFinalForm scopeKey={scopeKey} />
         ) : (
           <EmptyMessageContainer>
             <EmptyMessage message="The Flow Node has no Variables" />
@@ -73,7 +77,7 @@ const VariablesContent: React.FC = observer(() => {
       {displayStatus === 'spinner' && (
         <Loading data-testid="variables-spinner" />
       )}
-      {scopeId !== null && <VariablesFinalForm scopeId={scopeId} />}
+      {scopeKey !== null && <VariablesFinalForm scopeKey={scopeKey} />}
     </Content>
   );
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesFinalForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesFinalForm.tsx
@@ -19,14 +19,14 @@ import {useElementInstanceVariables} from 'modules/mutations/elementInstances/us
 import {handleMutationError} from 'modules/utils/notifications';
 
 type Props = {
-  scopeId: string;
+  scopeKey: string;
 };
 
-const VariablesFinalForm: React.FC<Props> = ({scopeId}) => {
+const VariablesFinalForm: React.FC<Props> = ({scopeKey}) => {
   const queryClient = useQueryClient();
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {mutateAsync: mutateAsyncVariables} = useElementInstanceVariables(
-    scopeId,
+    scopeKey,
     processInstanceId,
   );
 
@@ -40,7 +40,7 @@ const VariablesFinalForm: React.FC<Props> = ({scopeId}) => {
           });
         },
       }}
-      key={scopeId}
+      key={scopeKey}
       render={(props) => <VariablesForm {...props} />}
       onSubmit={async (values, form) => {
         const {initialValues} = form.getState();

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -27,6 +27,8 @@ import {getScopeId} from 'modules/utils/variables';
 import type {Variable} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useVariable} from 'modules/queries/variables/useVariable';
 import {notificationsStore} from 'modules/stores/notifications';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 type Props = {
   id?: string;
@@ -102,6 +104,9 @@ const ExistingVariableValue: React.FC<Props> = observer(
     } = useVariable(id!, {
       enabled: isPreview && id !== undefined,
     });
+    const variableScopeKey = IS_ELEMENT_SELECTION_V2
+      ? useVariableScopeKey()
+      : getScopeId();
 
     useEffect(() => {
       if (error) {
@@ -179,7 +184,7 @@ const ExistingVariableValue: React.FC<Props> = observer(
               }}
               onBlur={(event) => {
                 createModification({
-                  scopeId: getScopeId(),
+                  scopeId: variableScopeKey,
                   name: variableName,
                   oldValue: getInitialValue(variable),
                   newValue: input.value ?? '',
@@ -214,7 +219,7 @@ const ExistingVariableValue: React.FC<Props> = observer(
               });
 
               createModification({
-                scopeId: getScopeId(),
+                scopeId: variableScopeKey,
                 name: variableName,
                 oldValue: getInitialValue(variable),
                 newValue: value ?? '',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Operation.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Operation.tsx
@@ -16,6 +16,8 @@ import {TrashCan} from '@carbon/react/icons';
 import {Operations} from '../Operations';
 import {useNewScopeIdForFlowNode} from 'modules/hooks/modifications';
 import {getScopeId} from 'modules/utils/variables';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
+import {useVariableScopeKey} from 'modules/hooks/variables';
 
 type Props = {
   variableName: string;
@@ -29,7 +31,10 @@ const Operation: React.FC<Props> = ({variableName, onRemove}) => {
   const newScopeIdForFlowNode = useNewScopeIdForFlowNode(
     flowNodeSelectionStore.state.selection?.flowNodeId,
   );
-  const scopeId = getScopeId() ?? newScopeIdForFlowNode;
+  const scopeKey = IS_ELEMENT_SELECTION_V2
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useVariableScopeKey(newScopeIdForFlowNode)
+    : (getScopeId() ?? newScopeIdForFlowNode);
 
   return (
     <Operations>
@@ -43,7 +48,7 @@ const Operation: React.FC<Props> = ({variableName, onRemove}) => {
         onClick={() => {
           onRemove();
           modificationsStore.removeVariableModification(
-            scopeId!,
+            scopeKey!,
             currentId,
             'ADD_VARIABLE',
             'variables',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/OnLastVariableModificationRemoved.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/OnLastVariableModificationRemoved.tsx
@@ -15,9 +15,13 @@ import {reaction} from 'mobx';
 import {type VariableFormValues} from 'modules/types/variables';
 import {useFieldArray} from 'react-final-form-arrays';
 import {getScopeId} from 'modules/utils/variables';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
+import {useVariableScopeKey} from 'modules/hooks/variables';
 
 const OnLastVariableModificationRemoved: React.FC = observer(() => {
-  const scopeId = getScopeId();
+  const scopeKey = IS_ELEMENT_SELECTION_V2
+    ? useVariableScopeKey()
+    : getScopeId();
   const form = useForm();
   const formState = useFormState<VariableFormValues>();
   const fieldArray = useFieldArray('newVariables');
@@ -39,13 +43,13 @@ const OnLastVariableModificationRemoved: React.FC = observer(() => {
         if (payload.operation === 'EDIT_VARIABLE') {
           const {scopeId: removedVariableScopeId, id, name, oldValue} = payload;
 
-          if (removedVariableScopeId !== scopeId) {
+          if (removedVariableScopeId !== scopeKey) {
             return;
           }
 
           const lastEditModification =
             modificationsStore.getLastVariableModification(
-              scopeId,
+              scopeKey,
               id,
               'EDIT_VARIABLE',
             );
@@ -60,7 +64,7 @@ const OnLastVariableModificationRemoved: React.FC = observer(() => {
           const {scopeId: removedVariableScopeId, id} = payload;
 
           if (
-            removedVariableScopeId !== scopeId ||
+            removedVariableScopeId !== scopeKey ||
             newVariables === undefined
           ) {
             return;
@@ -68,7 +72,7 @@ const OnLastVariableModificationRemoved: React.FC = observer(() => {
 
           const lastAddModification =
             modificationsStore.getLastVariableModification(
-              scopeId,
+              scopeKey,
               id,
               'ADD_VARIABLE',
             );
@@ -93,7 +97,7 @@ const OnLastVariableModificationRemoved: React.FC = observer(() => {
     return () => {
       disposer();
     };
-  }, [scopeId, form, fieldArray, newVariables]);
+  }, [scopeKey, form, fieldArray, newVariables]);
 
   return null;
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/index.tsx
@@ -27,6 +27,7 @@ import {getScopeId} from 'modules/utils/variables';
 import {useVariables} from 'modules/queries/variables/useVariables';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useVariableScopeKey} from 'modules/hooks/variables';
 
 type Props = {
   isVariableModificationAllowed?: boolean;
@@ -45,7 +46,9 @@ const Variables: React.FC<Props> = observer(
     const [footerVariant, setFooterVariant] =
       useState<FooterVariant>('initial');
 
-    const scopeId = getScopeId() ?? newScopeIdForFlowNode;
+    const scopeKey = IS_ELEMENT_SELECTION_V2
+      ? useVariableScopeKey(newScopeIdForFlowNode)
+      : (getScopeId() ?? newScopeIdForFlowNode);
 
     const {isModificationModeEnabled} = modificationsStore;
 
@@ -70,7 +73,7 @@ const Variables: React.FC<Props> = observer(
 
     const isViewMode = isModificationModeEnabled
       ? fieldArray.fields.length === 0 &&
-        modificationsStore.getAddVariableModifications(scopeId).length === 0
+        modificationsStore.getAddVariableModifications(scopeKey).length === 0
       : initialValues === undefined ||
         Object.values(initialValues).length === 0;
 
@@ -122,7 +125,7 @@ const Variables: React.FC<Props> = observer(
         )}
         {(!isViewMode || displayStatus === 'variables') && (
           <VariablesTable
-            scopeId={scopeId}
+            scopeId={scopeKey}
             isVariableModificationAllowed={isVariableModificationAllowed}
           />
         )}

--- a/operate/client/src/modules/hooks/useElementSelectionInstanceKey.test.tsx
+++ b/operate/client/src/modules/hooks/useElementSelectionInstanceKey.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {Paths} from 'modules/Routes';
+import {searchResult} from 'modules/testUtils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {useElementSelectionInstanceKey} from './useElementSelectionInstanceKey';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+
+const PROCESS_INSTANCE_KEY = '123';
+const mockElementInstance: ElementInstance = {
+  elementInstanceKey: '2251799813699889',
+  elementId: 'service-task-1',
+  elementName: 'Service Task',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  processDefinitionId: 'process-def-1',
+  processInstanceKey: PROCESS_INSTANCE_KEY,
+  processDefinitionKey: '2',
+  hasIncident: false,
+  tenantId: '<default>',
+};
+
+const getWrapper = (initialSearchParams?: Record<string, string>) => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    const searchParams = new URLSearchParams(initialSearchParams);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter
+          initialEntries={[
+            `${Paths.processInstance(PROCESS_INSTANCE_KEY)}?${searchParams.toString()}`,
+          ]}
+        >
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('useElementSelectionInstanceKey', () => {
+  it('should return the process instance key if no element is selected', () => {
+    const {result} = renderHook(() => useElementSelectionInstanceKey(), {
+      wrapper: getWrapper(),
+    });
+
+    expect(result.current).toBe('123');
+  });
+
+  it('should return the selected element instance key when an instance is selected', () => {
+    mockFetchElementInstance(':key').withSuccess(mockElementInstance);
+
+    const {result} = renderHook(() => useElementSelectionInstanceKey(), {
+      wrapper: getWrapper({elementInstanceKey: '456'}),
+    });
+
+    expect(result.current).toBe('456');
+  });
+
+  it('should return the resolved instance key when an element is selected', async () => {
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockElementInstance]),
+    );
+
+    const {result} = renderHook(() => useElementSelectionInstanceKey(), {
+      wrapper: getWrapper({elementId: '789'}),
+    });
+
+    await waitFor(() =>
+      expect(result.current).toBe(mockElementInstance.elementInstanceKey),
+    );
+  });
+
+  it('should null when a selected instance key cannot be resolved', async () => {
+    mockSearchElementInstances().withServerError(404);
+
+    const {result} = renderHook(() => useElementSelectionInstanceKey(), {
+      wrapper: getWrapper({elementId: '789'}),
+    });
+
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+});

--- a/operate/client/src/modules/hooks/useElementSelectionInstanceKey.ts
+++ b/operate/client/src/modules/hooks/useElementSelectionInstanceKey.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
+
+/**
+ * Returns the currently selected instance key in a process instance.
+ * If an element is selected, it returns the resolved element instance key.
+ * Otherwise, it returns the process instance key.
+ *
+ * _Note: The key is `null` if multiple instances exist for a selected element id._
+ */
+function useElementSelectionInstanceKey(): string | null {
+  const {processInstanceId: processInstanceKey} =
+    useProcessInstancePageParams();
+  const {
+    resolvedElementInstance,
+    selectedElementInstanceKey,
+    selectedElementId,
+  } = useProcessInstanceElementSelection();
+
+  if (!selectedElementId && !selectedElementInstanceKey) {
+    return processInstanceKey ?? null;
+  }
+
+  switch (true) {
+    case !selectedElementId && !selectedElementInstanceKey:
+      return processInstanceKey ?? null;
+    case !!selectedElementInstanceKey:
+      return selectedElementInstanceKey;
+    case !!resolvedElementInstance:
+      return resolvedElementInstance.elementInstanceKey;
+    default:
+      return null;
+  }
+}
+
+export {useElementSelectionInstanceKey};

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -18,7 +18,7 @@ import {useHasMultipleInstances} from './flowNodeMetadata';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
 import {TOKEN_OPERATIONS} from 'modules/constants';
-import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useElementSelectionInstanceKey} from './useElementSelectionInstanceKey';
 
 const useHasNoContent = () => {
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
@@ -33,18 +33,9 @@ const useHasNoContent = () => {
 };
 
 const useVariableScopeKey = (fallback?: string | null) => {
-  const {
-    resolvedElementInstance,
-    selectedElementInstanceKey,
-    selectedElementId,
-    isFetchingElement,
-  } = useProcessInstanceElementSelection();
-  const {processInstanceId: processInstanceKey = null} =
-    useProcessInstancePageParams();
+  const selectedInstanceKey = useElementSelectionInstanceKey();
+  const {selectedElementId} = useProcessInstanceElementSelection();
 
-  // First try to get actual instance ID
-  const selectedInstanceKey =
-    selectedElementInstanceKey ?? resolvedElementInstance?.elementInstanceKey;
   if (selectedInstanceKey) {
     return selectedInstanceKey;
   }
@@ -62,7 +53,7 @@ const useVariableScopeKey = (fallback?: string | null) => {
     }
   }
 
-  return fallback ?? (!isFetchingElement ? processInstanceKey : null);
+  return fallback ?? null;
 };
 
 const useDisplayStatus = ({

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -15,7 +15,6 @@ import {
   useNewTokenCountForSelectedNode,
 } from './flowNodeSelection';
 import {useHasMultipleInstances} from './flowNodeMetadata';
-import {getScopeId} from 'modules/utils/variables';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
 import {TOKEN_OPERATIONS} from 'modules/constants';
@@ -63,6 +62,7 @@ const useVariableScopeKey = (fallback?: string | null) => {
 };
 
 const useDisplayStatus = ({
+  scopeKey,
   isLoading,
   isFetchingNextPage,
   isFetchingPreviousPage,
@@ -70,6 +70,7 @@ const useDisplayStatus = ({
   isError,
   hasItems,
 }: {
+  scopeKey: string | null;
   isLoading: boolean;
   isFetchingNextPage: boolean;
   isFetchingPreviousPage: boolean;
@@ -100,10 +101,10 @@ const useDisplayStatus = ({
     return 'no-variables';
   }
 
-  if (modificationsStore.isModificationModeEnabled && getScopeId() === null) {
+  if (modificationsStore.isModificationModeEnabled && scopeKey === null) {
     return 'no-variables';
   }
-  if (isLoading || getScopeId() === null) {
+  if (isLoading || scopeKey === null) {
     return 'spinner';
   }
   if (!hasItems) {

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -18,6 +18,7 @@ import {useHasMultipleInstances} from './flowNodeMetadata';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
 import {TOKEN_OPERATIONS} from 'modules/constants';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 
 const useHasNoContent = () => {
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
@@ -36,13 +37,16 @@ const useVariableScopeKey = (fallback?: string | null) => {
     resolvedElementInstance,
     selectedElementInstanceKey,
     selectedElementId,
+    isFetchingElement,
   } = useProcessInstanceElementSelection();
+  const {processInstanceId: processInstanceKey = null} =
+    useProcessInstancePageParams();
 
   // First try to get actual instance ID
-  const actualInstanceKey =
+  const selectedInstanceKey =
     selectedElementInstanceKey ?? resolvedElementInstance?.elementInstanceKey;
-  if (actualInstanceKey) {
-    return actualInstanceKey;
+  if (selectedInstanceKey) {
+    return selectedInstanceKey;
   }
 
   // In modification mode, if selecting from diagram, check for pending ADD_TOKEN
@@ -58,7 +62,7 @@ const useVariableScopeKey = (fallback?: string | null) => {
     }
   }
 
-  return fallback ?? null;
+  return fallback ?? (!isFetchingElement ? processInstanceKey : null);
 };
 
 const useDisplayStatus = ({

--- a/operate/client/src/modules/queries/variables/useVariables.ts
+++ b/operate/client/src/modules/queries/variables/useVariables.ts
@@ -11,14 +11,18 @@ import {useInfiniteQuery} from '@tanstack/react-query';
 import {searchVariables} from 'modules/api/v2/variables/searchVariables';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import {getScopeId} from 'modules/utils/variables';
-import {useDisplayStatus} from 'modules/hooks/variables';
+import {useDisplayStatus, useVariableScopeKey} from 'modules/hooks/variables';
 import {queryKeys} from '../queryKeys';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 const MAX_VARIABLES_PER_REQUEST = 50;
 
 function useVariables(options?: {refetchInterval?: number | false}) {
   const {processInstanceId = ''} = useProcessInstancePageParams();
-  const scopeKey = getScopeId();
+  const scopeKey = IS_ELEMENT_SELECTION_V2
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useVariableScopeKey()
+    : getScopeId();
   const {refetchInterval = false} = options ?? {};
   const result = useInfiniteQuery({
     queryKey: queryKeys.variables.searchWithFilter({
@@ -67,6 +71,7 @@ function useVariables(options?: {refetchInterval?: number | false}) {
     refetchInterval,
   });
   const displayStatus = useDisplayStatus({
+    scopeKey,
     isLoading: result.isLoading,
     isFetchingNextPage: result.isFetchingNextPage,
     isFetchingPreviousPage: result.isFetchingPreviousPage,

--- a/operate/client/src/modules/utils/variables.ts
+++ b/operate/client/src/modules/utils/variables.ts
@@ -13,6 +13,7 @@ import {modificationsStore} from 'modules/stores/modifications';
 import {TOKEN_OPERATIONS} from 'modules/constants';
 import type {InfiniteData} from '@tanstack/react-query';
 
+/** @deprecated Use the `useVariableScopeKey` hook instead. */
 const getScopeId = () => {
   const {selection} = flowNodeSelectionStore.state;
   const {metaData} = flowNodeMetaDataStore.state;


### PR DESCRIPTION
## Description

This PR refactored the existing `getScopeId` utility into a `useVariableScopeKey` hook that uses `useProcessInstanceElementSelection` under the hood.

The other areas mentioned in the related issue have already been migrated and do not seem to require further action.

## Related issues

closes #41822
