### PR TITLE
Update known node versions in the node lease

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -9,15 +9,15 @@ package io.camunda.zeebe.restore;
 
 import io.camunda.application.MainSupport;
 import io.camunda.application.Profile;
-import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration;
+import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.RestorePropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.RestoreProperties;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.broker.NodeIdProviderConfiguration;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -42,9 +42,6 @@ import org.springframework.context.annotation.Import;
       UnifiedConfigurationHelper.class,
       UnifiedConfiguration.class,
       BrokerBasedPropertiesOverride.class,
-      // ---
-      NodeIdProviderConfiguration.class,
-      BrokerBasedConfiguration.class,
       RestorePropertiesOverride.class,
       WorkingDirectoryConfiguration.class
     })
@@ -63,14 +60,16 @@ public class RestoreApp implements ApplicationRunner {
 
   @Autowired
   public RestoreApp(
-      final BrokerBasedConfiguration configuration,
+      final BrokerBasedProperties configuration,
       final BackupStore backupStore,
       final RestoreProperties restoreConfiguration,
+      final WorkingDirectory workingDirectory,
       final MeterRegistry meterRegistry) {
-    this.configuration = configuration.config();
+    this.configuration = configuration;
     this.backupStore = backupStore;
     this.restoreConfiguration = restoreConfiguration;
     this.meterRegistry = meterRegistry;
+    configuration.init(workingDirectory.path().toAbsolutePath().toString());
   }
 
   public static void main(final String[] args) {

--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -113,6 +113,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -92,7 +93,8 @@ public record Lease(
     return now <= timestamp;
   }
 
-  public Lease renew(final long now, final Duration leaseDuration) {
+  public Lease renew(
+      final long now, final Duration leaseDuration, final VersionMappings knownVersionMappings) {
     if (!isStillValid(now)) {
       throw new IllegalStateException(
           "Lease is not valid anymore("
@@ -121,6 +123,14 @@ public record Lease(
     public static VersionMappings of(final NodeInstance... nodeInstance) {
       final var map = new TreeMap<Integer, Version>();
       for (final var node : nodeInstance) {
+        map.put(node.id(), node.version());
+      }
+      return new VersionMappings(Collections.unmodifiableSortedMap(map));
+    }
+
+    public static VersionMappings of(final Collection<NodeInstance> nodeInstances) {
+      final var map = new TreeMap<Integer, Version>();
+      for (final var node : nodeInstances) {
         map.put(node.id(), node.version());
       }
       return new VersionMappings(Collections.unmodifiableSortedMap(map));

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.nodeid;
 
+import io.atomix.cluster.Member;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public interface NodeIdProvider extends AutoCloseable {
@@ -26,6 +28,20 @@ public interface NodeIdProvider extends AutoCloseable {
    *     within a predefined time.
    */
   CompletableFuture<Boolean> isValid();
+
+  /**
+   * Sets the current known cluster members.
+   *
+   * @param currentMembers the current members of the cluster
+   */
+  void setMembers(Set<Member> currentMembers);
+
+  /**
+   * Awaits until the NodeIdProvider is ready and other services can start safely.
+   *
+   * @return A CompletableFuture completed with true when the provider is ready.
+   */
+  CompletableFuture<Boolean> awaitReadiness();
 
   /**
    * NodeIdProvider to be used when the nodeId is static, i.e. it's defined in the configuration.
@@ -53,6 +69,16 @@ public interface NodeIdProvider extends AutoCloseable {
 
       @Override
       public CompletableFuture<Boolean> isValid() {
+        return CompletableFuture.completedFuture(true);
+      }
+
+      @Override
+      public void setMembers(final Set<Member> currentMembers) {
+        // no-op
+      }
+
+      @Override
+      public CompletableFuture<Boolean> awaitReadiness() {
         return CompletableFuture.completedFuture(true);
       }
     };

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -42,7 +42,7 @@ public class LeaseTest {
     final var renewalDuration = Duration.ofSeconds(5);
 
     // when
-    final var renewedLease = lease.renew(currentTime, renewalDuration);
+    final var renewedLease = lease.renew(currentTime, renewalDuration, VersionMappings.empty());
 
     // then
     assertThat(renewedLease.taskId()).isEqualTo("task1");
@@ -62,7 +62,7 @@ public class LeaseTest {
         String.format(
             "Lease is not valid anymore(%s), it expired at %s",
             Instant.ofEpochMilli(currentTime), Instant.ofEpochMilli(lease.timestamp()));
-    assertThatThrownBy(() -> lease.renew(currentTime, renewalDuration))
+    assertThatThrownBy(() -> lease.renew(currentTime, renewalDuration, VersionMappings.empty()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(expectedMessage);
   }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -53,7 +53,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 @Testcontainers
 @Timeout(value = 120)
-public class RepositoryNodeIdProviderIT {
+class RepositoryNodeIdProviderIT {
 
   private static final Duration EXPIRY_DURATION = Duration.ofSeconds(5);
 
@@ -73,7 +73,7 @@ public class RepositoryNodeIdProviderIT {
   private volatile boolean leaseFailed = false;
 
   @BeforeAll
-  public static void setUpAll() {
+  static void setUpAll() {
     client =
         S3NodeIdRepository.buildClient(
             new S3ClientConfig(
@@ -83,7 +83,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     final var bucketName = UUID.randomUUID().toString();
     taskId = UUID.randomUUID().toString();
     config = new Config(bucketName, EXPIRY_DURATION, Duration.ofMinutes(2));
@@ -95,8 +95,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldAcquireALease()
-      throws ExecutionException, InterruptedException, TimeoutException {
+  void shouldAcquireALease() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -117,7 +116,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldAcquireAnExpiredLease()
+  void shouldAcquireAnExpiredLease()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
@@ -154,7 +153,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldBlockInitializationIfAllLeasesAreTaken()
+  void shouldBlockInitializationIfAllLeasesAreTaken()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
@@ -192,7 +191,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldRenewTheLeaseBeforeExpiration()
+  void shouldRenewTheLeaseBeforeExpiration()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
@@ -255,7 +254,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldInvokeFailureListenerWhenFailsToRenew()
+  void shouldInvokeFailureListenerWhenFailsToRenew()
       throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
@@ -276,7 +275,7 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldReleaseGracefullyWhenClosed() {
+  void shouldReleaseGracefullyWhenClosed() {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -298,15 +297,15 @@ public class RepositoryNodeIdProviderIT {
         .isEqualTo(lease.lease().nodeInstance().nextVersion());
   }
 
-  public void assertLeaseIsReady() {
+  private void assertLeaseIsReady() {
     assertLeaseIs(true);
   }
 
-  public void assertLeaseIsNotReady() {
+  private void assertLeaseIsNotReady() {
     assertLeaseIs(false);
   }
 
-  public void assertLeaseIs(final boolean status) {
+  private void assertLeaseIs(final boolean status) {
     Awaitility.await("Until the lease is acquired")
         .untilAsserted(
             () ->


### PR DESCRIPTION
## Description

This pull request introduces support for tracking and updating known cluster member versions within the dynamic node ID provider. NodeIdProvider keeps tracks of the known members and the version is notified of membership changes from SWIM. The known members and versions is updated in the lease everytime it is renewed. 

In preparation to the follow up issue where we want to await readiness of the node id provider based on the known member version mappings, the interface is extended with `awaitReadiness` method. An intermediate bean `NodeIdReadinessAwaiter` is added that waits for it to be ready. The data  directory provider is only initialized after the node id provider is ready. 

## Related issues

closes #43665 
