### PR TITLE
deps: minimize gateway mapper dependencies

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -55,12 +55,10 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.15.3</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-observation</artifactId>
-      <version>1.15.3</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/gateways/gateway-mapping-http/pom.xml
+++ b/gateways/gateway-mapping-http/pom.xml
@@ -33,6 +33,13 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-authentication</artifactId>
+      <!-- we only need the entities which need security-core and search-domain -->
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

Excludes all dependencies of the camunda-authentication module in the gateway mapper module. The authentication module brings a lot of spring security-related dependencies we don't want to expose. We only need the DTOs from that module and bring all required dependencies for them in the mapping module.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

n/a
