### PR TITLE
feat: migrate to useProcessInstanceElementSelection.isSelected

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -126,13 +126,21 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
         useElementInstanceHistoryTree();
       const isRoot = elementType === 'PROCESS';
       const {processInstance} = useElementInstanceHistoryTree();
+      const {isSelected} = useProcessInstanceElementSelection();
 
       const rootNode = useRootNode();
-      const isSelected = flowNodeSelectionStore.isSelected({
-        flowNodeId: isRoot ? undefined : elementId,
-        flowNodeInstanceId: scopeKey,
-        isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
-      });
+
+      const isElementSelected = IS_ELEMENT_SELECTION_V2
+        ? isSelected({
+            elementId: isRoot ? undefined : elementId,
+            elementInstanceKey: scopeKey,
+            isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
+          })
+        : flowNodeSelectionStore.isSelected({
+            flowNodeId: isRoot ? undefined : elementId,
+            flowNodeInstanceId: scopeKey,
+            isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
+          });
 
       const {selectElementInstance, clearSelection} =
         useProcessInstanceElementSelection();
@@ -179,8 +187,8 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
           {...rest}
           key={scopeKey}
           data-testid={`tree-node-${scopeKey}`}
-          selected={isSelected ? [scopeKey] : []}
-          active={isSelected ? scopeKey : undefined}
+          selected={isElementSelected ? [scopeKey] : []}
+          active={isElementSelected ? scopeKey : undefined}
           id={scopeKey}
           value={scopeKey}
           aria-label={elementName}
@@ -235,11 +243,19 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
       const businessObject = businessObjects[elementId];
 
       const rootNode = useRootNode();
-      const isSelected = flowNodeSelectionStore.isSelected({
-        flowNodeId: isRoot ? undefined : elementId,
-        flowNodeInstanceId: scopeKey,
-        isMultiInstance: isMultiInstance(businessObject),
-      });
+      const {isSelected} = useProcessInstanceElementSelection();
+
+      const isElementSelected = IS_ELEMENT_SELECTION_V2
+        ? isSelected({
+            elementId: isRoot ? undefined : elementId,
+            elementInstanceKey: scopeKey,
+            isMultiInstanceBody: isMultiInstance(businessObject),
+          })
+        : flowNodeSelectionStore.isSelected({
+            flowNodeId: isRoot ? undefined : elementId,
+            flowNodeInstanceId: scopeKey,
+            isMultiInstance: isMultiInstance(businessObject),
+          });
 
       const {selectElementInstance} = useProcessInstanceElementSelection();
 
@@ -279,8 +295,8 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
           {...rest}
           key={scopeKey}
           data-testid={`tree-node-${scopeKey}`}
-          selected={isSelected ? [scopeKey] : []}
-          active={isSelected ? scopeKey : undefined}
+          selected={isElementSelected ? [scopeKey] : []}
+          active={isElementSelected ? scopeKey : undefined}
           id={scopeKey}
           value={scopeKey}
           aria-label={elementName}
@@ -366,11 +382,21 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
       const isRoot = elementType === 'bpmn:Process';
 
       const rootNode = useRootNode();
-      const isSelected = flowNodeSelectionStore.isSelected({
-        flowNodeId: isRoot ? undefined : elementId,
-        flowNodeInstanceId: scopeKey,
-        isMultiInstance: isMultiInstance(businessObject),
-      });
+
+      const {isSelected} = useProcessInstanceElementSelection();
+
+      const isElementSelected = IS_ELEMENT_SELECTION_V2
+        ? isSelected({
+            elementId: isRoot ? undefined : elementId,
+            elementInstanceKey: scopeKey,
+            isMultiInstanceBody: isMultiInstance(businessObject),
+          })
+        : flowNodeSelectionStore.isSelected({
+            flowNodeId: isRoot ? undefined : elementId,
+            flowNodeInstanceId: scopeKey,
+            isMultiInstance: isMultiInstance(businessObject),
+          });
+
       const virtualChildren = convertToVirtualElementInstance({
         flowNodeInstances: getVisibleChildPlaceholders(
           scopeKey,
@@ -431,8 +457,8 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
       const elementProps = {
         ...carbonTreeNodeProps,
         'data-testid': `tree-node-${scopeKey}`,
-        selected: isSelected ? [scopeKey] : [],
-        active: isSelected ? scopeKey : undefined,
+        selected: isElementSelected ? [scopeKey] : [],
+        active: isElementSelected ? scopeKey : undefined,
         id: scopeKey,
         value: scopeKey,
         'aria-label': elementName,
@@ -536,11 +562,21 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
       const isRoot = elementType === 'PROCESS';
 
       const rootNode = useRootNode();
-      const isSelected = flowNodeSelectionStore.isSelected({
-        flowNodeId: isRoot ? undefined : elementId,
-        flowNodeInstanceId: scopeKey,
-        isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
-      });
+
+      const {isSelected} = useProcessInstanceElementSelection();
+
+      const isElementSelected = IS_ELEMENT_SELECTION_V2
+        ? isSelected({
+            elementId: isRoot ? undefined : elementId,
+            elementInstanceKey: scopeKey,
+            isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
+          })
+        : flowNodeSelectionStore.isSelected({
+            flowNodeId: isRoot ? undefined : elementId,
+            flowNodeInstanceId: scopeKey,
+            isMultiInstance: elementType === 'MULTI_INSTANCE_BODY',
+          });
+
       const isExpanded = elementInstancesTreeStore.isNodeExpanded(scopeKey);
 
       const virtualChildren = modificationsStore.isModificationModeEnabled
@@ -665,8 +701,8 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
       const elementProps = {
         ...carbonTreeNodeProps,
         'data-testid': `tree-node-${scopeKey}`,
-        selected: isSelected ? [scopeKey] : [],
-        active: isSelected ? scopeKey : undefined,
+        selected: isElementSelected ? [scopeKey] : [],
+        active: isElementSelected ? scopeKey : undefined,
         id: scopeKey,
         value: scopeKey,
         'aria-label': elementName,

--- a/operate/client/src/modules/hooks/incidents.ts
+++ b/operate/client/src/modules/hooks/incidents.ts
@@ -17,6 +17,8 @@ import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProc
 import {useSearchParams} from 'react-router-dom';
 import {parseSortParamsV2} from 'modules/utils/filter';
 import {useMemo} from 'react';
+import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 type EnhancedIncident = Incident & {
   processDefinitionName: string;
@@ -29,6 +31,7 @@ const useEnhancedIncidents = (incidents: Incident[]): EnhancedIncident[] => {
   const instancesWithIncident = Array.from(
     new Set(incidents.map((incident) => incident.processInstanceKey)),
   );
+  const {isSelected} = useProcessInstanceElementSelection();
 
   const {data: processDefinitionNames} = useProcessInstancesSearch(
     {
@@ -52,11 +55,17 @@ const useEnhancedIncidents = (incidents: Incident[]): EnhancedIncident[] => {
         businessObjects,
         flowNodeId: incident.elementId,
       }),
-      isSelected: flowNodeSelectionStore.isSelected({
-        flowNodeId: incident.elementId,
-        flowNodeInstanceId: incident.elementInstanceKey,
-        isMultiInstance: false,
-      }),
+      isSelected: IS_ELEMENT_SELECTION_V2
+        ? isSelected({
+            elementId: incident.elementId,
+            elementInstanceKey: incident.elementInstanceKey,
+            isMultiInstanceBody: false,
+          })
+        : flowNodeSelectionStore.isSelected({
+            flowNodeId: incident.elementId,
+            flowNodeInstanceId: incident.elementInstanceKey,
+            isMultiInstance: false,
+          }),
       processDefinitionName:
         processDefinitionNames?.[incident.processInstanceKey] ?? '',
     };

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -152,6 +152,22 @@ const useProcessInstanceElementSelection = () => {
     elementInstanceByKey ??
     (searchResult?.page.totalItems === 1 ? searchResult?.items[0] : null);
 
+  const isSelected = (element: {
+    elementId?: string;
+    elementInstanceKey?: string;
+    isMultiInstanceBody?: boolean;
+  }) => {
+    if (isMultiInstanceBody !== element.isMultiInstanceBody) {
+      return false;
+    }
+
+    if (elementInstanceKey === null) {
+      return elementId === element.elementId;
+    }
+
+    return elementInstanceKey === element.elementInstanceKey;
+  };
+
   return {
     selectElement,
     selectElementInstance,
@@ -174,6 +190,7 @@ const useProcessInstanceElementSelection = () => {
     selectedAnchorElementId: anchorElementId,
     isFetchingElement:
       isFetchingElementInstanceByKey || isFetchingElementInstancesSearch,
+    isSelected,
   };
 };
 

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -152,21 +152,24 @@ const useProcessInstanceElementSelection = () => {
     elementInstanceByKey ??
     (searchResult?.page.totalItems === 1 ? searchResult?.items[0] : null);
 
-  const isSelected = (element: {
-    elementId?: string;
-    elementInstanceKey?: string;
-    isMultiInstanceBody?: boolean;
-  }) => {
-    if (isMultiInstanceBody !== element.isMultiInstanceBody) {
-      return false;
-    }
+  const isSelected = useCallback(
+    (element: {
+      elementId?: string;
+      elementInstanceKey?: string;
+      isMultiInstanceBody?: boolean;
+    }) => {
+      if (isMultiInstanceBody !== element.isMultiInstanceBody) {
+        return false;
+      }
 
-    if (elementInstanceKey === null) {
-      return elementId === element.elementId;
-    }
+      if (elementInstanceKey === null) {
+        return elementId === element.elementId;
+      }
 
-    return elementInstanceKey === element.elementInstanceKey;
-  };
+      return elementInstanceKey === element.elementInstanceKey;
+    },
+    [isMultiInstanceBody, elementInstanceKey, elementId],
+  );
 
   return {
     selectElement,


### PR DESCRIPTION
## Description

Replace `flowNodeSelectionStore.state.selection.isSelected` by `useProcessInstanceElementSelection.isSelected`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #41829
