### PR TITLE
ci: use public images on fork PRs as best effort

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: 'Path to the dockerfile, that should be used; defaults to Dockerfile'
     required: false
     default: 'Dockerfile'
+  publicBaseImage:
+    description: 'Base image from DockerHub to use when running on fork PRs without Minimus access'
+    required: false
+    default: 'eclipse-temurin:21-jre-noble'
+  publicBaseDigest:
+    description: 'Base image digest from DockerHub to use when running on fork PRs without Minimus access'
+    required: false
+    default: 'sha256:67fc762eabacb56e5444b367889e04ce8c839b8f4b3d8ef3e459c5579fbefd8a'
   debug:
     description: 'Enable debug logging for BuildKit daemon'
     required: false
@@ -63,6 +71,10 @@ runs:
         IS_MAIN_OR_STABLE_BRANCH: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
       run: |
         echo is-main-or-stable-branch="$IS_MAIN_OR_STABLE_BRANCH" | tee -a $GITHUB_OUTPUT
+
+    - name: Check for Fork
+      uses: ./.github/actions/is-fork
+      id: is-fork
 
     - name: Set up multi-platform support
       uses: docker/setup-qemu-action@v3
@@ -117,6 +129,23 @@ runs:
       shell: bash
       run: echo "result=$(realpath --relative-to="${PWD}" ${{ inputs.distball }})" >> $GITHUB_OUTPUT
 
+    - name: Set additional build args dynamically based on workflow run context
+      id: get-additional-build-args
+      shell: bash
+      run: |
+        # Check if current workflow run is related to a fork PR
+        if [[ "${{ steps.is-fork.outputs.is-fork }}" == "true" ]]; then
+          echo "The current workflow run is related to a fork PR."
+          echo "As a result, private Minimus hardened base images will be replaced with public images."
+
+          {
+            echo 'result<<EOF'
+            echo 'BASE_IMAGE=${{ inputs.publicBaseImage }}'
+            echo 'BASE_DIGEST=${{ inputs.publicBaseDigest }}'
+            echo 'EOF'
+          } | tee -a $GITHUB_OUTPUT
+        fi
+
     - name: Build Docker image
       uses: docker/build-push-action@v6
       env:
@@ -135,4 +164,5 @@ runs:
           DATE=${{ steps.get-date.outputs.result }}
           REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
           VERSION=${{ inputs.version != '' && inputs.version || steps.get-version.outputs.result }}
+          ${{ steps.get-additional-build-args.outputs.result }}
         target: app

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -366,6 +366,8 @@ jobs:
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
       - name: Verify Docker image
+        # Skip verification on fork PRs as there public base images are used that don't match our golden labels
+        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         uses: ./.github/actions/verify-platform-docker
         with:
           imageName: ${{ env.LOCAL_DOCKER_IMAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,6 +881,8 @@ jobs:
         run: docker system prune -af
 
       - name: Verify Docker image
+        # Skip verification on fork PRs as there public base images are used that don't match our golden labels
+        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         uses: ./.github/actions/verify-platform-docker
         with:
           imageName: ${{ env.LOCAL_DOCKER_IMAGE }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ docker build \
   --tag camunda/zeebe:local \
   --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' \
   --build-arg BASE_IMAGE='eclipse-temurin:21-jre-noble' \
-  --build-arg BASE_DIGEST='sha256:20e7f7288e1c18eebe8f06a442c9f7183342d9b022d3b9a9677cae2b558ddddd' \
+  --build-arg BASE_DIGEST='sha256:67fc762eabacb56e5444b367889e04ce8c839b8f4b3d8ef3e459c5579fbefd8a' \
   --target app \
   --file ./camunda.Dockerfile
   .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:
 #ARG BASE_IMAGE="eclipse-temurin:21-jre-noble"
-#ARG BASE_DIGEST="sha256:20e7f7288e1c18eebe8f06a442c9f7183342d9b022d3b9a9677cae2b558ddddd"
+#ARG BASE_DIGEST="sha256:67fc762eabacb56e5444b367889e04ce8c839b8f4b3d8ef3e459c5579fbefd8a"
 
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -12,7 +12,7 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk:
 #ARG BASE_IMAGE="eclipse-temurin:21-jre-noble"
-#ARG BASE_DIGEST="sha256:20e7f7288e1c18eebe8f06a442c9f7183342d9b022d3b9a9677cae2b558ddddd"
+#ARG BASE_DIGEST="sha256:67fc762eabacb56e5444b367889e04ce8c839b8f4b3d8ef3e459c5579fbefd8a"
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"


### PR DESCRIPTION
## Description

With #43685 and the subsequent PRs, we adjusted our Docker images to use private Minimus base images that are hardened. External contributors do not have access to them, as the service is limited to paid customers (Camunda). Externals cannot build the exact same Docker images that Camundi can, which we deem acceptable for now and document how to work around it.

The problem is that the CI and automation also relies on having access to Minimus which is not possible for Pull Requests from forks of `camunda/camunda`.

As a best effort stop-gap solution this PR:

* detect if a PR is from a fork and use public images instead of Minimus -> [required status checks](https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci) are green for external contributors so they are technically unblocked to merge, but less accurate CI results
* disables steps related to Docker image verification that don't make sense when using public images

Proof:

* This PR shows that the logic still works in `camunda/camunda` for Camundi (no change, green required status checks)
* [Demo PR](https://github.com/camunda/camunda/pull/43579) on a forked repository to show that this logic works on forks (green CI)

⚠️ I only adjusted CI jobs part of https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci which are required status checks. If they fail, they technically block the merge of PRs of externals in GHA. We have several legacy jobs that also fail for externals but are out of scope of my changes.

⚠️ We have to be aware that this solution is best effort as public images and Minimus images differ in several aspects, thus it could stop working with future changes.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) -- no, Minimus is not backported yet outside of `main`

## Related issues

None
