### PR TITLE
Deduplicate audit logs in the Camunda Exporter

### DIFF
--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -105,6 +105,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
       <scope>test</scope>

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -68,6 +68,12 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-exporter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/camunda/exporter/SchemaWithExporter.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/camunda/exporter/SchemaWithExporter.java
@@ -14,7 +14,7 @@ import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
 
 public class SchemaWithExporter {
 
@@ -35,7 +35,7 @@ public class SchemaWithExporter {
     provider.init(
         config,
         clientAdapter.getExporterEntityCacheProvider(),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(clientAdapter.objectMapper()),
         clientAdapter.objectMapper());
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -250,7 +250,7 @@ public class CamundaExporter implements Exporter {
     provider.init(
         configuration,
         clientAdapter.getExporterEntityCacheProvider(),
-        context.getMeterRegistry(),
+        context,
         metadata,
         clientAdapter.objectMapper());
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -15,10 +15,10 @@ import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -28,7 +28,7 @@ public interface ExporterResourceProvider {
   void init(
       final ExporterConfiguration configuration,
       final ExporterEntityCacheProvider entityCacheProvider,
-      final MeterRegistry meterRegistry,
+      final Context context,
       final ExporterMetadata exporterMetadata,
       final ObjectMapper objectMapper);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -54,7 +54,6 @@ import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -266,7 +265,7 @@ final class CamundaExporterIT {
     resourceProvider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
     final var expectedHandlers =
@@ -331,7 +330,7 @@ final class CamundaExporterIT {
     resourceProvider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
@@ -366,7 +365,7 @@ final class CamundaExporterIT {
     resourceProvider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
@@ -444,7 +443,7 @@ final class CamundaExporterIT {
     defaultExporterResourceProvider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -174,7 +174,7 @@ public class DefaultExporterResourceProviderTest {
     final var context = new ExporterTestContext();
     context.setPartitionId(partitionId);
 
-    // when)
+    // when
     final var provider = new DefaultExporterResourceProvider();
     provider.init(
         config,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import static io.camunda.exporter.DefaultExporterResourceProvider.PROCESS_DEFINITION_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -43,8 +44,8 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.TenantEntityAuditL
 import io.camunda.zeebe.exporter.common.auditlog.transformers.UserAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.UserTaskAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.VariableAddUpdateAuditLogTransformer;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
@@ -53,6 +54,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class DefaultExporterResourceProviderTest {
@@ -64,7 +66,7 @@ public class DefaultExporterResourceProviderTest {
     provider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
@@ -100,7 +102,7 @@ public class DefaultExporterResourceProviderTest {
     provider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
@@ -123,7 +125,7 @@ public class DefaultExporterResourceProviderTest {
     provider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
@@ -146,7 +148,7 @@ public class DefaultExporterResourceProviderTest {
     provider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        new ExporterTestContext(),
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
@@ -163,62 +165,27 @@ public class DefaultExporterResourceProviderTest {
                 handlersExcludingAuditLog.stream().map(ExportHandler::getClass).distinct().count());
   }
 
-  @Test
-  void shouldAddAuditLogHandlersFromAddAuditLogHandlersMethod() {
+  @ParameterizedTest
+  @MethodSource("expectedAuditLogTransformers")
+  void shouldAddAuditLogHandlersFromAddAuditLogHandlersMethod(
+      final int partitionId, final Map<Class<?>, ValueType> expectedTransformers) {
     // given
     final var config = new ExporterConfiguration();
+    final var context = new ExporterTestContext();
+    context.setPartitionId(partitionId);
 
-    // when
+    // when)
     final var provider = new DefaultExporterResourceProvider();
     provider.init(
         config,
         mock(ExporterEntityCacheProvider.class),
-        new SimpleMeterRegistry(),
+        context,
         new ExporterMetadata(TestObjectMapper.objectMapper()),
         TestObjectMapper.objectMapper());
 
     // then
     final var auditLogHandlers =
         provider.getExportHandlers().stream().filter(AuditLogHandler.class::isInstance).toList();
-
-    final Map<Class<?>, ValueType> expectedTransformers =
-        Map.ofEntries(
-            Map.entry(AuthorizationAuditLogTransformer.class, ValueType.AUTHORIZATION),
-            Map.entry(
-                BatchOperationCreationAuditLogTransformer.class,
-                ValueType.BATCH_OPERATION_CREATION),
-            Map.entry(
-                BatchOperationLifecycleManagementAuditLogTransformer.class,
-                ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
-            Map.entry(DecisionAuditLogTransformer.class, ValueType.DECISION),
-            Map.entry(DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
-            Map.entry(
-                DecisionRequirementsRecordAuditLogTransformer.class,
-                ValueType.DECISION_REQUIREMENTS),
-            Map.entry(FormAuditLogTransformer.class, ValueType.FORM),
-            Map.entry(GroupAuditLogTransformer.class, ValueType.GROUP),
-            Map.entry(GroupEntityAuditLogTransformer.class, ValueType.GROUP),
-            Map.entry(IncidentResolutionAuditLogTransformer.class, ValueType.INCIDENT),
-            Map.entry(MappingRuleAuditLogTransformer.class, ValueType.MAPPING_RULE),
-            Map.entry(ProcessAuditLogTransformer.class, ValueType.PROCESS),
-            Map.entry(ProcessInstanceCancelAuditLogTransformer.class, ValueType.PROCESS_INSTANCE),
-            Map.entry(
-                ProcessInstanceCreationAuditLogTransformer.class,
-                ValueType.PROCESS_INSTANCE_CREATION),
-            Map.entry(
-                ProcessInstanceMigrationAuditLogTransformer.class,
-                ValueType.PROCESS_INSTANCE_MIGRATION),
-            Map.entry(
-                ProcessInstanceModificationAuditLogTransformer.class,
-                ValueType.PROCESS_INSTANCE_MODIFICATION),
-            Map.entry(ResourceAuditLogTransformer.class, ValueType.RESOURCE),
-            Map.entry(RoleAuditLogTransformer.class, ValueType.ROLE),
-            Map.entry(RoleEntityAuditLogTransformer.class, ValueType.ROLE),
-            Map.entry(TenantAuditLogTransformer.class, ValueType.TENANT),
-            Map.entry(TenantEntityAuditLogTransformer.class, ValueType.TENANT),
-            Map.entry(UserAuditLogTransformer.class, ValueType.USER),
-            Map.entry(UserTaskAuditLogTransformer.class, ValueType.USER_TASK),
-            Map.entry(VariableAddUpdateAuditLogTransformer.class, ValueType.VARIABLE));
 
     // Verify that all expected AuditLogHandler transformers are present
     assertThat(
@@ -282,5 +249,72 @@ public class DefaultExporterResourceProviderTest {
     }
 
     return String.join("-", expectedName);
+  }
+
+  private static Stream<Arguments> expectedAuditLogTransformers() {
+    return Stream.of(
+        Arguments.arguments(
+            PROCESS_DEFINITION_PARTITION,
+            Map.ofEntries(
+                Map.entry(AuthorizationAuditLogTransformer.class, ValueType.AUTHORIZATION),
+                Map.entry(
+                    BatchOperationCreationAuditLogTransformer.class,
+                    ValueType.BATCH_OPERATION_CREATION),
+                Map.entry(
+                    BatchOperationLifecycleManagementAuditLogTransformer.class,
+                    ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
+                Map.entry(DecisionAuditLogTransformer.class, ValueType.DECISION),
+                Map.entry(
+                    DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
+                Map.entry(
+                    DecisionRequirementsRecordAuditLogTransformer.class,
+                    ValueType.DECISION_REQUIREMENTS),
+                Map.entry(FormAuditLogTransformer.class, ValueType.FORM),
+                Map.entry(GroupAuditLogTransformer.class, ValueType.GROUP),
+                Map.entry(GroupEntityAuditLogTransformer.class, ValueType.GROUP),
+                Map.entry(IncidentResolutionAuditLogTransformer.class, ValueType.INCIDENT),
+                Map.entry(MappingRuleAuditLogTransformer.class, ValueType.MAPPING_RULE),
+                Map.entry(ProcessAuditLogTransformer.class, ValueType.PROCESS),
+                Map.entry(
+                    ProcessInstanceCancelAuditLogTransformer.class, ValueType.PROCESS_INSTANCE),
+                Map.entry(
+                    ProcessInstanceCreationAuditLogTransformer.class,
+                    ValueType.PROCESS_INSTANCE_CREATION),
+                Map.entry(
+                    ProcessInstanceMigrationAuditLogTransformer.class,
+                    ValueType.PROCESS_INSTANCE_MIGRATION),
+                Map.entry(
+                    ProcessInstanceModificationAuditLogTransformer.class,
+                    ValueType.PROCESS_INSTANCE_MODIFICATION),
+                Map.entry(ResourceAuditLogTransformer.class, ValueType.RESOURCE),
+                Map.entry(RoleAuditLogTransformer.class, ValueType.ROLE),
+                Map.entry(RoleEntityAuditLogTransformer.class, ValueType.ROLE),
+                Map.entry(TenantAuditLogTransformer.class, ValueType.TENANT),
+                Map.entry(TenantEntityAuditLogTransformer.class, ValueType.TENANT),
+                Map.entry(UserAuditLogTransformer.class, ValueType.USER),
+                Map.entry(UserTaskAuditLogTransformer.class, ValueType.USER_TASK),
+                Map.entry(VariableAddUpdateAuditLogTransformer.class, ValueType.VARIABLE))),
+        Arguments.arguments(
+            2,
+            Map.ofEntries(
+                Map.entry(
+                    BatchOperationLifecycleManagementAuditLogTransformer.class,
+                    ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT),
+                Map.entry(
+                    DecisionEvaluationAuditLogTransformer.class, ValueType.DECISION_EVALUATION),
+                Map.entry(IncidentResolutionAuditLogTransformer.class, ValueType.INCIDENT),
+                Map.entry(
+                    ProcessInstanceCancelAuditLogTransformer.class, ValueType.PROCESS_INSTANCE),
+                Map.entry(
+                    ProcessInstanceCreationAuditLogTransformer.class,
+                    ValueType.PROCESS_INSTANCE_CREATION),
+                Map.entry(
+                    ProcessInstanceMigrationAuditLogTransformer.class,
+                    ValueType.PROCESS_INSTANCE_MIGRATION),
+                Map.entry(
+                    ProcessInstanceModificationAuditLogTransformer.class,
+                    ValueType.PROCESS_INSTANCE_MODIFICATION),
+                Map.entry(UserTaskAuditLogTransformer.class, ValueType.USER_TASK),
+                Map.entry(VariableAddUpdateAuditLogTransformer.class, ValueType.VARIABLE))));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
@@ -18,10 +18,10 @@ import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -38,7 +38,7 @@ public class TestExporterResourceProvider implements ExporterResourceProvider {
   public void init(
       final ExporterConfiguration configuration,
       final ExporterEntityCacheProvider entityCacheProvider,
-      final MeterRegistry meterRegistry,
+      final Context context,
       final ExporterMetadata exporterMetadata,
       final ObjectMapper objectMapper) {}
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Only add audit log transformers that process events from distributed Zeebe commands in the Camunda Exporter on partition 1.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43680
