### PR TITLE
Include audit log entries to the RDBMS history cleanup mechanism

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -9,10 +9,15 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.domain.Copyable;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
-public interface AuditLogMapper extends ProcessInstanceDependantMapper {
+public interface AuditLogMapper extends ProcessInstanceDependantMapper, HistoryCleanupMapper {
 
   void insert(BatchInsertDto<AuditLogDbModel> dto);
 
@@ -22,5 +27,60 @@ public interface AuditLogMapper extends ProcessInstanceDependantMapper {
 
   int deleteProcessDefinitionRelatedData(List<Long> processDefinitionKeys, int limit);
 
+  @Override
   int cleanupHistory(HistoryCleanupMapper.CleanupHistoryDto dto);
+
+  int updateAuditLogEntityHistoryCleanupDate(UpdateHistoryCleanupDateDto dto);
+
+  record UpdateHistoryCleanupDateDto(
+      List<String> entityKeys, String entityType, OffsetDateTime historyCleanupDate)
+      implements Copyable<UpdateHistoryCleanupDateDto> {
+
+    @Override
+    public UpdateHistoryCleanupDateDto copy(
+        final Function<
+                ObjectBuilder<UpdateHistoryCleanupDateDto>,
+                ObjectBuilder<UpdateHistoryCleanupDateDto>>
+            copyFunction) {
+      return copyFunction
+          .apply(
+              new Builder()
+                  .entityKeys(new ArrayList<>(entityKeys))
+                  .entityType(entityType)
+                  .historyCleanupDate(historyCleanupDate))
+          .build();
+    }
+
+    public static class Builder implements ObjectBuilder<UpdateHistoryCleanupDateDto> {
+
+      private List<String> entityKeys = new ArrayList<>();
+      private String entityType;
+      private OffsetDateTime historyCleanupDate;
+
+      public Builder entityKey(final String entityKey) {
+        entityKeys.add(entityKey);
+        return this;
+      }
+
+      public Builder entityKeys(final List<String> entityKeys) {
+        this.entityKeys = entityKeys;
+        return this;
+      }
+
+      public Builder entityType(final String entityType) {
+        this.entityType = entityType;
+        return this;
+      }
+
+      public Builder historyCleanupDate(final OffsetDateTime historyCleanupDate) {
+        this.historyCleanupDate = historyCleanupDate;
+        return this;
+      }
+
+      @Override
+      public UpdateHistoryCleanupDateDto build() {
+        return new UpdateHistoryCleanupDateDto(entityKeys, entityType, historyCleanupDate);
+      }
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
@@ -131,6 +132,8 @@ public class HistoryCleanupService {
         batchOperationKey,
         historyCleanupDate);
     batchOperationWriter.scheduleForHistoryCleanup(batchOperationKey, historyCleanupDate);
+    auditLogWriter.scheduleEntityRelatedAuditLogsHistoryCleanupTime(
+        batchOperationKey, AuditLogEntityType.BATCH, historyCleanupDate);
   }
 
   @VisibleForTesting

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -392,6 +392,16 @@
     </foreach>
   </insert>
 
+  <update id="updateAuditLogEntityHistoryCleanupDate">
+    UPDATE ${prefix}AUDIT_LOG SET
+    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE ENTITY_KEY IN
+    <foreach collection="entityKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+    AND ENTITY_TYPE = #{entityType}
+  </update>
+
   <delete id="deleteRootProcessInstanceRelatedData">
     <bind name="tableName" value="'AUDIT_LOG'"/>
     <bind name="primaryKeyColumn" value="'AUDIT_LOG_KEY'"/>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -410,7 +410,6 @@ class DefaultExecutionQueueTest {
   @CsvSource({
     // statementId, expectedResult
     "foo.updateHistoryCleanupDate,true",
-    "foo.updateProcessHistoryCleanupDate,true",
     "io.camunda.db.rdbms.sql.SequenceFlowMapper.updateHistoryCleanupDate,true",
     "io.camunda.db.rdbms.sql.SequenceFlowMapper.createIfNotExists,true",
     "some.other.Statement,false"

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -200,39 +200,6 @@ public class HistoryCleanupIT {
   }
 
   @Test
-  public void shouldSetHistoryCleanupDateForStandaloneDecisionAuditLog() {
-    // GIVEN
-    // Create a standalone decision audit log.
-    // Use a deterministic evaluation date for predictable cleanup date calculation
-    final var evaluationDate = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
-    final var auditLog =
-        AuditLogFixtures.createRandomized(
-            b ->
-                b.entityType(AuditLogEntityType.DECISION)
-                    .processInstanceKey(-1L)
-                    .timestamp(evaluationDate)
-                    .historyCleanupDate(null));
-    AuditLogFixtures.createAndSaveAuditLog(rdbmsWriters, auditLog);
-
-    // THEN - verify cleanup date is calculated correctly
-    final OffsetDateTime cleanupDate =
-        jdbcTemplate.queryForObject(
-            "SELECT HISTORY_CLEANUP_DATE FROM AUDIT_LOG "
-                + "WHERE DECISION_DEFINITION_KEY = "
-                + auditLog.decisionDefinitionKey(),
-            OffsetDateTime.class);
-
-    // The cleanup date should be evaluationDate + decisionInstanceTTL (default 30 days)
-    final var expectedCleanupDate = evaluationDate.plusDays(30);
-    assertThat(cleanupDate)
-        .describedAs(
-            "should have cleanup date set to evaluationDate + decisionInstanceTTL for decision"
-                + " instance without process instance")
-        .isNotNull()
-        .isEqualTo(expectedCleanupDate);
-  }
-
-  @Test
   public void shouldDeleteStandaloneDecisionInstanceDuringCleanup() {
     // GIVEN - Create a standalone decision instance with an expired cleanup date
     final var evaluationDate = OffsetDateTime.now().minusDays(40);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogHistoryCleanupIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.auditlog;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryConfig;
+import io.camunda.db.rdbms.write.service.HistoryCleanupService;
+import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AuditLogHistoryCleanupIT {
+
+  @TestTemplate
+  public void shouldCleanupAuditLogOperations(final CamundaRdbmsTestApplication testApplication) {
+    // GIVEN
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
+    final var rdbmsWriter = rdbmsService.createWriter(config);
+    final var historyCleanupService =
+        new HistoryCleanupService(config, rdbmsWriter, rdbmsService.getProcessInstanceReader());
+    final var auditLogReader = rdbmsService.getAuditLogReader();
+
+    final OffsetDateTime now = OffsetDateTime.now();
+    final OffsetDateTime scheduledCleanupDate = now.plus(HistoryConfig.DEFAULT_HISTORY_TTL);
+    final var auditLog =
+        AuditLogFixtures.createAndSaveAuditLog(
+            rdbmsWriter,
+            b -> b.entityType(AuditLogEntityType.GROUP).historyCleanupDate(scheduledCleanupDate));
+
+    // WHEN we do the history cleanup (partition doesn't matter here)
+    final OffsetDateTime cleanupDate = scheduledCleanupDate.plusSeconds(1);
+    historyCleanupService.cleanupHistory(0, cleanupDate);
+
+    // THEN
+    assertThat(auditLogReader.getById(auditLog.auditLogKey(), ResourceAccessChecks.disabled()))
+        .isNull();
+  }
+
+  @TestTemplate
+  public void shouldNotCleanupAuditLogOperations(
+      final CamundaRdbmsTestApplication testApplication) {
+    // GIVEN
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var config = new RdbmsWriterConfig.Builder().partitionId(0).build();
+    final var rdbmsWriter = rdbmsService.createWriter(config);
+    final var historyCleanupService =
+        new HistoryCleanupService(config, rdbmsWriter, rdbmsService.getProcessInstanceReader());
+    final var auditLogReader = rdbmsService.getAuditLogReader();
+
+    final OffsetDateTime now = OffsetDateTime.now();
+    final OffsetDateTime scheduledCleanupDate = now.plus(HistoryConfig.DEFAULT_HISTORY_TTL);
+    final var auditLog =
+        AuditLogFixtures.createAndSaveAuditLog(
+            rdbmsWriter,
+            b -> b.entityType(AuditLogEntityType.GROUP).historyCleanupDate(scheduledCleanupDate));
+
+    // AND we schedule history cleanup
+    final OffsetDateTime cleanupDate = OffsetDateTime.now();
+    rdbmsWriter.flush();
+
+    // WHEN we do the history cleanup too early (partition doesn't matter here)
+    historyCleanupService.cleanupHistory(0, cleanupDate);
+
+    // THEN
+    assertThat(auditLogReader.getById(auditLog.auditLogKey(), ResourceAccessChecks.disabled()))
+        .isNotNull();
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformer.java
@@ -63,35 +63,65 @@ public interface AuditLogTransformer<R extends RecordValue> {
     return config().supports(record);
   }
 
-  record TransformerConfig(
+  default boolean triggersCleanUp(final Record<R> record) {
+    return config().dataCleanupIntents().contains(record.getIntent());
+  }
+
+  public record TransformerConfig(
       ValueType valueType,
       Set<Intent> supportedIntents,
       Set<Intent> supportedRejections,
-      Set<RejectionType> supportedRejectionTypes) {
+      Set<RejectionType> supportedRejectionTypes,
+      Set<Intent> dataCleanupIntents) {
 
     public static TransformerConfig with(final ValueType valueType) {
-      return new TransformerConfig(valueType, Set.of(), Set.of(), Set.of());
+      return new TransformerConfig(valueType, Set.of(), Set.of(), Set.of(), Set.of());
     }
 
     public TransformerConfig withIntents(final Intent... intents) {
       return new TransformerConfig(
-          valueType(), Set.of(intents), supportedRejections(), supportedRejectionTypes);
+          valueType(),
+          Set.of(intents),
+          supportedRejections(),
+          supportedRejectionTypes,
+          dataCleanupIntents());
     }
 
     public TransformerConfig withRejections(
         final Intent rejectionIntent, final RejectionType... rejectionTypes) {
       return new TransformerConfig(
-          valueType(), supportedIntents(), Set.of(rejectionIntent), Set.of(rejectionTypes));
+          valueType(),
+          supportedIntents(),
+          Set.of(rejectionIntent),
+          Set.of(rejectionTypes),
+          dataCleanupIntents());
     }
 
     public TransformerConfig withRejections(final Intent... rejectionIntents) {
       return new TransformerConfig(
-          valueType(), supportedIntents(), Set.of(rejectionIntents), supportedRejectionTypes());
+          valueType(),
+          supportedIntents(),
+          Set.of(rejectionIntents),
+          supportedRejectionTypes(),
+          dataCleanupIntents());
     }
 
     public TransformerConfig withRejectionTypes(final RejectionType... rejectionTypes) {
       return new TransformerConfig(
-          valueType(), supportedIntents(), supportedRejections(), Set.of(rejectionTypes));
+          valueType(),
+          supportedIntents(),
+          supportedRejections(),
+          Set.of(rejectionTypes),
+          dataCleanupIntents());
+    }
+
+    public TransformerConfig withDataCleanupIntents(final Intent... dataCleanupIntents) {
+      return new TransformerConfig(
+          valueType(),
+          supportedIntents(),
+          supportedRejections(),
+          supportedRejectionTypes(),
+          Set.of(dataCleanupIntents));
     }
 
     boolean supports(final Record<?> record) {

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -56,9 +56,8 @@ public class AuditLogTransformerConfigs {
   public static final TransformerConfig AUTHORIZATION_CONFIG =
       TransformerConfig.with(AUTHORIZATION)
           .withIntents(
-              AuthorizationIntent.CREATED,
-              AuthorizationIntent.UPDATED,
-              AuthorizationIntent.DELETED);
+              AuthorizationIntent.CREATED, AuthorizationIntent.UPDATED, AuthorizationIntent.DELETED)
+          .withDataCleanupIntents(AuthorizationIntent.DELETED);
 
   public static final TransformerConfig BATCH_OPERATION_CREATION_CONFIG =
       TransformerConfig.with(BATCH_OPERATION_CREATION).withIntents(BatchOperationIntent.CREATED);
@@ -77,7 +76,9 @@ public class AuditLogTransformerConfigs {
 
   public static final TransformerConfig DECISION_EVALUATION_CONFIG =
       TransformerConfig.with(DECISION_EVALUATION)
-          .withIntents(DecisionEvaluationIntent.EVALUATED, DecisionEvaluationIntent.FAILED);
+          .withIntents(DecisionEvaluationIntent.EVALUATED, DecisionEvaluationIntent.FAILED)
+          .withDataCleanupIntents(
+              DecisionEvaluationIntent.EVALUATED, DecisionEvaluationIntent.FAILED);
 
   public static final TransformerConfig DECISION_CONFIG =
       TransformerConfig.with(DECISION).withIntents(DecisionIntent.CREATED, DecisionIntent.DELETED);
@@ -87,11 +88,14 @@ public class AuditLogTransformerConfigs {
           .withIntents(DecisionRequirementsIntent.CREATED, DecisionRequirementsIntent.DELETED);
 
   public static final TransformerConfig FORM_CONFIG =
-      TransformerConfig.with(ValueType.FORM).withIntents(FormIntent.CREATED, FormIntent.DELETED);
+      TransformerConfig.with(ValueType.FORM)
+          .withIntents(FormIntent.CREATED, FormIntent.DELETED)
+          .withDataCleanupIntents(FormIntent.DELETED);
 
   public static final TransformerConfig GROUP_CONFIG =
       TransformerConfig.with(GROUP)
-          .withIntents(GroupIntent.CREATED, GroupIntent.UPDATED, GroupIntent.DELETED);
+          .withIntents(GroupIntent.CREATED, GroupIntent.UPDATED, GroupIntent.DELETED)
+          .withDataCleanupIntents(GroupIntent.DELETED);
 
   public static final TransformerConfig GROUP_ENTITY_CONFIG =
       TransformerConfig.with(GROUP)
@@ -105,7 +109,8 @@ public class AuditLogTransformerConfigs {
   public static final TransformerConfig MAPPING_RULE_CONFIG =
       TransformerConfig.with(MAPPING_RULE)
           .withIntents(
-              MappingRuleIntent.CREATED, MappingRuleIntent.UPDATED, MappingRuleIntent.DELETED);
+              MappingRuleIntent.CREATED, MappingRuleIntent.UPDATED, MappingRuleIntent.DELETED)
+          .withDataCleanupIntents(MappingRuleIntent.DELETED);
 
   public static final TransformerConfig PROCESS_CONFIG =
       TransformerConfig.with(PROCESS).withIntents(ProcessIntent.CREATED, ProcessIntent.DELETED);
@@ -136,7 +141,8 @@ public class AuditLogTransformerConfigs {
 
   public static final TransformerConfig TENANT_CONFIG =
       TransformerConfig.with(TENANT)
-          .withIntents(TenantIntent.CREATED, TenantIntent.UPDATED, TenantIntent.DELETED);
+          .withIntents(TenantIntent.CREATED, TenantIntent.UPDATED, TenantIntent.DELETED)
+          .withDataCleanupIntents(TenantIntent.DELETED);
 
   public static final TransformerConfig TENANT_ENTITY_CONFIG =
       TransformerConfig.with(TENANT)
@@ -144,14 +150,16 @@ public class AuditLogTransformerConfigs {
 
   public static final TransformerConfig ROLE_CONFIG =
       TransformerConfig.with(ROLE)
-          .withIntents(RoleIntent.CREATED, RoleIntent.UPDATED, RoleIntent.DELETED);
+          .withIntents(RoleIntent.CREATED, RoleIntent.UPDATED, RoleIntent.DELETED)
+          .withDataCleanupIntents(RoleIntent.DELETED);
 
   public static final TransformerConfig ROLE_ENTITY_CONFIG =
       TransformerConfig.with(ROLE).withIntents(RoleIntent.ENTITY_ADDED, RoleIntent.ENTITY_REMOVED);
 
   public static final TransformerConfig USER_CONFIG =
       TransformerConfig.with(USER)
-          .withIntents(UserIntent.CREATED, UserIntent.UPDATED, UserIntent.DELETED);
+          .withIntents(UserIntent.CREATED, UserIntent.UPDATED, UserIntent.DELETED)
+          .withDataCleanupIntents(UserIntent.DELETED);
 
   public static final TransformerConfig USER_TASK_CONFIG =
       TransformerConfig.with(USER_TASK)

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -151,6 +152,21 @@ class AuditLogTransformerTest {
 
     assertThat(config.supports(invalidStateRecord)).isTrue();
     assertThat(config.supports(invalidArgumentRecord)).isTrue();
+  }
+
+  @Test
+  void shouldSupportDataCleanupScheduling() {
+    final var config =
+        AuditLogTransformer.TransformerConfig.with(ValueType.GROUP)
+            .withIntents(GroupIntent.DELETED)
+            .withDataCleanupIntents(GroupIntent.DELETED);
+
+    final var record =
+        factory.generateRecord(
+            ValueType.GROUP,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(GroupIntent.DELETED));
+
+    assertThat(config.dataCleanupIntents().contains(record.getIntent())).isTrue();
   }
 
   @Nested

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -67,5 +68,16 @@ class AuthorizationAuditLogTransformerTest {
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
     assertThat(entity.getRelatedEntityKey()).isEqualTo("owner-id");
     assertThat(entity.getRelatedEntityType()).isEqualTo(expectedRelatedEntityType);
+  }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecord(
+            ValueType.AUTHORIZATION, r -> r.withIntent(AuthorizationIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class DecisionEvaluationAuditLogTransformerTest {
 
@@ -204,5 +206,18 @@ class DecisionEvaluationAuditLogTransformerTest {
     assertThat(entity.getResult())
         .isEqualTo(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
     assertThat(entity.getEntityDescription()).isEqualTo(RejectionType.INVALID_STATE.name());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = DecisionEvaluationIntent.class,
+      names = {"EVALUATED", "FAILED"})
+  void shouldScheduleCleanUp(final DecisionEvaluationIntent intent) {
+    // given
+    final Record<DecisionEvaluationRecordValue> record =
+        factory.generateRecord(ValueType.DECISION_EVALUATION, r -> r.withIntent(intent));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformerTest.java
@@ -49,4 +49,14 @@ class FormAuditLogTransformerTest {
     assertThat(entity.getFormKey()).isEqualTo(456L);
     assertThat(entity.getEntityDescription()).isEqualTo("formResource");
   }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<Form> record =
+        factory.generateRecord(ValueType.FORM, r -> r.withIntent(FormIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
+  }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformerTest.java
@@ -48,4 +48,14 @@ class GroupAuditLogTransformerTest {
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
     assertThat(entity.getEntityDescription()).isEqualTo("groupName");
   }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<GroupRecordValue> record =
+        factory.generateRecord(ValueType.GROUP, r -> r.withIntent(GroupIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
+  }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformerTest.java
@@ -51,4 +51,15 @@ class MappingRuleAuditLogTransformerTest {
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
     assertThat(entity.getEntityDescription()).isEqualTo("Engineering Mapping");
   }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<MappingRuleRecordValue> record =
+        factory.generateRecord(
+            ValueType.MAPPING_RULE, r -> r.withIntent(MappingRuleIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
+  }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleAuditLogTransformerTest.java
@@ -45,4 +45,14 @@ class RoleAuditLogTransformerTest {
     // then
     assertThat(entity.getEntityKey()).isEqualTo("role-123");
   }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<RoleRecordValue> record =
+        factory.generateRecord(ValueType.ROLE, r -> r.withIntent(RoleIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
+  }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformerTest.java
@@ -46,4 +46,14 @@ class TenantAuditLogTransformerTest {
     assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<TenantRecordValue> record =
+        factory.generateRecord(ValueType.TENANT, r -> r.withIntent(TenantIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
+  }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformerTest.java
@@ -46,4 +46,14 @@ class UserAuditLogTransformerTest {
     assertThat(entity.getEntityKey()).isEqualTo("testuser");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
+
+  @Test
+  void shouldScheduleCleanUp() {
+    // given
+    final Record<UserRecordValue> record =
+        factory.generateRecord(ValueType.USER, r -> r.withIntent(UserIntent.DELETED));
+
+    // then
+    assertThat(transformer.triggersCleanUp(record)).isTrue();
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
@@ -56,7 +56,12 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
 
   @Override
   public void export(final Record<R> record) {
-    auditLogWriter.create(map(record));
+    final var auditLogEntity = map(record);
+    auditLogWriter.create(auditLogEntity);
+    if (transformer.triggersCleanUp(record)) {
+      auditLogWriter.scheduleEntityRelatedAuditLogsHistoryCleanupByEndTime(
+          auditLogEntity.entityKey(), auditLogEntity.entityType(), auditLogEntity.timestamp());
+    }
   }
 
   private AuditLogDbModel map(final Record<R> record) {

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
@@ -210,4 +210,64 @@ class AuditLogExportHandlerTest {
     assertThat(entity.relatedEntityType()).isEqualTo(AuditLogEntityType.USER);
     assertThat(entity.entityDescription()).isEqualTo("entity-description");
   }
+
+  @Test
+  void shouldScheduleDataCleanup() {
+    // given
+    final var entry =
+        new io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry()
+            .setEntityKey(String.valueOf(record.getKey()))
+            .setEntityType(
+                io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.PROCESS_INSTANCE)
+            .setOperationType(
+                io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.MODIFY)
+            .setCategory(
+                io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory
+                    .DEPLOYED_RESOURCES)
+            .setActor(
+                io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo.AuditLogActor.of(record))
+            .setTenant(
+                io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo.AuditLogTenant.of(record))
+            .setBatchOperationKey(123L)
+            .setBatchOperationType(
+                io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE)
+            .setProcessInstanceKey(value.getProcessInstanceKey())
+            .setEntityVersion(record.getRecordVersion())
+            .setEntityValueType(
+                io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION.value())
+            .setEntityOperationIntent(
+                io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent.MODIFIED
+                    .value())
+            .setTimestamp(
+                java.time.OffsetDateTime.ofInstant(
+                    java.time.Instant.ofEpochMilli(record.getTimestamp()),
+                    java.time.ZoneOffset.UTC))
+            .setAnnotation("test annotation")
+            .setResult(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS)
+            .setProcessDefinitionId("process-def-id")
+            .setProcessDefinitionKey(456L)
+            .setElementInstanceKey(789L)
+            .setJobKey(101L)
+            .setUserTaskKey(202L)
+            .setDecisionEvaluationKey(303L)
+            .setDecisionRequirementsId("drg-id")
+            .setDecisionRequirementsKey(404L)
+            .setDecisionDefinitionId("decision-id")
+            .setDecisionDefinitionKey(505L)
+            .setDeploymentKey(606L)
+            .setFormKey(707L)
+            .setResourceKey(808L)
+            .setRootProcessInstanceKey(909L)
+            .setRelatedEntityKey("related-entity-key")
+            .setRelatedEntityType(AuditLogEntityType.USER)
+            .setEntityDescription("entity-description");
+    when(transformer.create(record)).thenReturn(entry);
+    when(transformer.triggersCleanUp(record)).thenReturn(true);
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).scheduleEntityRelatedAuditLogsHistoryCleanupByEndTime(any(), any(), any());
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add an audit log history cleanup scheduling API.

Include the following entities to history cleanup:
- Identity-related entities
- Form resources
- Batch operations

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43585
