### PR TITLE
ci: report to release cluster when indentity bump completes

### DIFF
--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -82,6 +82,7 @@ jobs:
           operation: publishMessage
           messageName: 'identity-workflow-completed'
           correlationKey: 'identity-update-${{ inputs.identityVersion }}'
+          timeToLive: '240000'
           variables: |
             {
               "workflow_run": {

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -62,6 +62,24 @@ jobs:
       - name: Push Changes to the target branch
         if: ${{ steps.update-identity-version.outcome == 'success' && inputs.dryRun == false }}
         run: git push origin "${{ inputs.targetBranch }}"
+      - name: Notify Camunda of completion
+        if: success()
+        uses: camunda-community-hub/camunda-platform-8-github-action@787c775abd971a613cea6026a5525f504613f9ae
+        with:
+          clientConfig: ${{ secrets.MONOREPO_RELEASE_CLUSTER_CLIENT_CONFIG }}
+          operation: publishMessage
+          messageName: 'identity-workflow-completed'
+          correlationKey: 'identity-update-${{ inputs.identityVersion }}'
+          variables: |
+            {
+              "workflow_run": {
+                "name": "Update Identity Version",
+                "conclusion": "success",
+                "head_branch": "${{ github.head_ref || github.ref_name }}",
+                "target_branch": "${{ inputs.targetBranch }}"
+              },
+              "action": "completed"
+            }
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -62,11 +62,23 @@ jobs:
       - name: Push Changes to the target branch
         if: ${{ steps.update-identity-version.outcome == 'success' && inputs.dryRun == false }}
         run: git push origin "${{ inputs.targetBranch }}"
+      - name: Import Camunda Secrets
+        if: success()
+        id: camunda-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG;
       - name: Notify Camunda of completion
         if: success()
         uses: camunda-community-hub/camunda-platform-8-github-action@787c775abd971a613cea6026a5525f504613f9ae
         with:
-          clientConfig: ${{ secrets.MONOREPO_RELEASE_CLUSTER_CLIENT_CONFIG }}
+          clientConfig: ${{ steps.camunda-secrets.outputs.CLIENT_CONFIG }}
           operation: publishMessage
           messageName: 'identity-workflow-completed'
           correlationKey: 'identity-update-${{ inputs.identityVersion }}'


### PR DESCRIPTION
## Description

Problem:
- `update-identity-version` and `run-release` trigered workflows run concurrently
- Both make commits to the same repository causing git push conflicts
- Error: "[failed to push some refs" ](https://github.com/camunda/camunda/actions/runs/20721650956/job/59486723186)due to untracked commits from parallel execution

Solution:
- Add synchronization to wait for identity workflow completion before proceeding to run-release
- This is a combined solution with https://github.com/camunda/zeebe-engineering-processes/pull/782

Tests:
https://github.com/camunda/zeebe-engineering-processes/pull/782#issuecomment-3725760335

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
