### PR TITLE
Create authorization for user API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -1,0 +1,358 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect, APIResponse} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertBadRequest,
+  assertInvalidArgument,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  encode,
+  assertStatusCode,
+  assertRequiredFields,
+  assertForbiddenRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {createUser} from '@requestHelpers';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  CREATE_CUSTOM_AUTHORIZATION_BODY,
+  authorizedComponentRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+import {grantUserResourceAuthorization} from 'utils/grantUserAuthorization';
+
+const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
+
+test.describe('Create Authorization API', () => {
+  let user: {username: string; name: string; email: string; password: string};
+  let createdAutorizationKeys: string[] = [];
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create user for Authorization tests', async () => {
+      user = await createUser(request);
+      console.log('Created user with username:', user.username);
+      let userSearchRes = await request.post(buildUrl('/users/search', {}), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            username: user.name,
+          },
+        },
+      });
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step(
+      'Teardown - Delete user with username ' +
+        user.username +
+        ' created for Authorization tests',
+      async () => {
+        await cleanupUsers(request, [user.username]);
+      },
+    );
+  });
+  test('Create Authorization for user - Success', async ({request}) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertStatusCode(authRes, 201);
+
+      await validateResponse(
+        {
+          path: CREATE_AUTHORIZATION_ENDPOINT,
+          method: 'POST',
+          status: '201',
+        },
+        authRes,
+      );
+
+      const authBody = await authRes.json();
+      assertRequiredFields(authBody, authorizedComponentRequiredFields);
+      createdAutorizationKeys.push(authBody.authorizationKey);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - Multiple permissionTypes - Success', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'BATCH',
+      [
+        'CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE',
+        'CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE',
+      ],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertStatusCode(authRes, 201);
+
+      await validateResponse(
+        {
+          path: CREATE_AUTHORIZATION_ENDPOINT,
+          method: 'POST',
+          status: '201',
+        },
+        authRes,
+      );
+
+      const authBody = await authRes.json();
+      assertRequiredFields(authBody, authorizedComponentRequiredFields);
+      createdAutorizationKeys.push(authBody.authorizationKey);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 400 Bad Request - wrong value for ownerType', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'WRONG_VALUE_FOR_TEST',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertBadRequest(
+        authRes,
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'ownerType'. Use any of the following values: [USER, CLIENT, ROLE, GROUP, MAPPING_RULE, UNSPECIFIED]",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 400 Bad Request - wrong value for resourceType', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'WRONG_VALUE_FOR_TEST',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertBadRequest(
+        authRes,
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUTHORIZATION, MAPPING_RULE, MESSAGE, BATCH, COMPONENT, SYSTEM, TENANT, RESOURCE, PROCESS_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DECISION_DEFINITION, GROUP, USER, ROLE, DOCUMENT]",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 400 Invalid Argument - invalid resourceId', async ({
+    request,
+  }) => {
+    const invalidResourceId = ';;;;';
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      invalidResourceId,
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertInvalidArgument(
+        authRes,
+        400,
+        `The provided resourceId contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 401 Unauthorized', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      await assertUnauthorizedRequest(authRes);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 404 Not Found - not existing ownerId', async ({
+    request,
+  }) => {
+    const notExistingOwnerId = 'nonExistingOwnerId12345';
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      notExistingOwnerId,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertNotFoundRequest(
+        authRes,
+        `Command 'CREATE' rejected with code 'NOT_FOUND': Expected to create or update authorization with ownerId or resourceId '${notExistingOwnerId}', but a user with this ID does not exist.`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 409 Conflict', async ({request}) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertConflictRequest(
+        authRes,
+        `Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to create authorization for owner '${user.username}' for resource identifier '*', but an authorization for this resource identifier already exists.`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+});
+
+test.describe('Create Authorization for User - Forbidden', () => {
+  let userToGrantAuthorization: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let authorizationKey: string;
+
+  test.beforeAll(
+    'Setup - Create test user with Resource Authorization and user for granting Authorization',
+    async ({request}) => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      const obj = await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+      authorizationKey = obj.authorizationKey;
+
+      userToGrantAuthorization = await createUser(request);
+    },
+  );
+
+  test.afterAll(
+    'Teardown - Delete test users created for Authorization Forbidden tests',
+    async ({request}) => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+        userToGrantAuthorization.username,
+      ]);
+    },
+  );
+  test('Create Authorization for user - 403 Forbidden', async ({request}) => {
+    await test.step('Test - Create Authorization with limited user credentials', async ({}) => {
+      const token = encode(
+        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+      );
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        userToGrantAuthorization.username,
+        'USER',
+        '*',
+        'PROCESS_DEFINITION',
+        ['CREATE_PROCESS_INSTANCE'],
+      );
+
+      await expect(async () => {
+        const authRes = await request.post(
+          buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: authorizationBody,
+          },
+        );
+        await assertForbiddenRequest(
+          authRes,
+          "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'",
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -578,6 +578,44 @@ export function CREATE_COMPONENT_AUTHORIZATION(
   };
 }
 
+export function CREATE_CUSTOM_AUTHORIZATION_BODY(
+  ownerId: string,
+  ownerType:
+    | 'USER'
+    | 'CLIENT'
+    | 'ROLE'
+    | 'GROUP'
+    | 'MAPPING_RULE'
+    | 'WRONG_VALUE_FOR_TEST',
+  resourceId: string,
+  resourceType:
+    | 'AUTHORIZATION'
+    | 'MAPPING_RULE'
+    | 'MESSAGE'
+    | 'BATCH'
+    | 'COMPONENT'
+    | 'SYSTEM'
+    | 'TENANT'
+    | 'RESOURCE'
+    | 'PROCESS_DEFINITION'
+    | 'DECISION_REQUIREMENTS_DEFINITION'
+    | 'DECISION_DEFINITION'
+    | 'GROUP'
+    | 'USER'
+    | 'ROLE'
+    | 'DOCUMENT'
+    | 'WRONG_VALUE_FOR_TEST',
+  permissionTypes: string[],
+) {
+  return {
+    ownerId: ownerId,
+    ownerType: ownerType,
+    resourceType: resourceType,
+    resourceId: resourceId,
+    permissionTypes: permissionTypes,
+  };
+}
+
 export function GET_CURRENT_USER_EXPECTED_BODY(
   username: string,
   name: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/grantUserAuthorization.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/grantUserAuthorization.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect} from '@playwright/test';
+import {assertRequiredFields, buildUrl, jsonHeaders} from './http';
+
+export async function grantUserResourceAuthorization(
+  request: APIRequestContext,
+  user: {username: string; password: string; name: string; email: string},
+) {
+  const USER_RESOURCE_AUTHORIZATION = {
+    ownerId: user.username,
+    ownerType: 'USER',
+    resourceId: '*',
+    resourceType: 'RESOURCE',
+    permissionTypes: ['READ'],
+  };
+
+  const authRes = await request.post(buildUrl('/authorizations'), {
+    headers: jsonHeaders(),
+    data: USER_RESOURCE_AUTHORIZATION,
+  });
+  expect(authRes.status()).toBe(201);
+  const authBody = await authRes.json();
+  assertRequiredFields(authBody, ['authorizationKey']);
+  return {
+    authorizationKey: authBody.authorizationKey,
+  };
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -130,7 +130,7 @@ export async function assertConflictRequest(
   await assertStatusCode(response, 409);
   const json = await response.json();
   assertRequiredFields(json, ['title']);
-  expect(json['title']).toContain(detail || 'ALREADY_EXISTS');
+  expect(json['detail']).toContain(detail || 'ALREADY_EXISTS');
 }
 
 export async function assertInvalidState(


### PR DESCRIPTION
## Description

This PR covers Create Authorization API, covering `ownerType` USER. There are happy path tests: 

- Create Authorization for user - Success
- Create Authorization for user - Multiple permissionTypes - Success

And unhappy path tests:

- Create Authorization for user - 400 Bad Request - wrong value for ownerType
- Create Authorization for user - 400 Bad Request - wrong value for resourceType
- Create Authorization for user - 400 Invalid Argument - invalid resourceId
- Create Authorization for user - 401 Unauthorized
- Create Authorization for user - 404 Not Found - not existing ownerId – here was found inconsistency between API docs and Concept docs, which was reported in the issue for Documentation Team [here](https://github.com/camunda/camunda-docs/issues/7686)
- Create Authorization for user - 409 Conflict
- Create Authorization for user - 403 Forbidden

Also the PR introduces new function: `grantUserAuthorization`, which accepts user as parameter and grants him resource authorization. This is required for forbidden access test. 

One additional change – change in `http.ts` file in function `assertConflictResponse`, as it expected to contain `detail` parameter in `title` field of response.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related #37204

## On demand workflow
[Was successul](url)