### PR TITLE
feat: auto override c8run release versions for alpha tags

### DIFF
--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -17,7 +17,7 @@ on:
         required: true
         default: ""
       camundaAppsRelease:
-        description: "Name of the Camunda apps GitHub release page (e.g., 8.7.1, 8.8.0-alpha4, etc.)"
+        description: "Target Camunda apps version (matches release page name, e.g., 8.7.1 or 8.8.0-alpha4)"
         type: string
         required: true
         default: ""
@@ -116,6 +116,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+
+      - name: Resolve runtime versions
+        run: |
+          release_name='${{ inputs.camundaAppsRelease }}'
+          branch='${{ inputs.branch }}'
+          if [[ "$branch" == "main" && "$release_name" == *alpha* ]]; then
+            echo "Overriding runtime versions to ${release_name}"
+            {
+              echo "CAMUNDA_VERSION=${release_name}"
+              echo "CONNECTORS_VERSION=${release_name}"
+            } >> "$GITHUB_ENV"
+          fi
 
       - name: Import Secrets
         id: secrets


### PR DESCRIPTION
## Description
It allows to use of SNAPSHOT versions in main branch c8run/.env and for alphas releases, so we use dynamic version from CI vars instead of c8run/.env hardcoded values.

## Related issues
#40501 

