### PR TITLE
[Backport stable/8.6] fix: disable posix_fallocate if there's a LinkageError

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
@@ -40,7 +40,7 @@ final class PosixSegmentAllocator implements SegmentAllocator {
 
     try {
       posixFs.posixFallocate(fileDescriptor, 0, segmentSize);
-    } catch (final UnsupportedOperationException e) {
+    } catch (final LinkageError | UnsupportedOperationException e) {
       LOGGER.warn(
           "Failed to use native system call to pre-allocate file, will use fallback from now on {}",
           fallback,

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.journal.fs;
 
 import io.camunda.zeebe.util.Loggers;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Map;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.LibraryOption;
@@ -36,11 +37,14 @@ public interface LibC {
    * @return an instance of this library
    */
   static LibC ofNativeLibrary() {
+    return ofNativeLibrary(Platform.getNativePlatform().getStandardCLibraryName());
+  }
+
+  @VisibleForTesting
+  static LibC ofNativeLibrary(final String libraryName) {
     try {
       return LibraryLoader.loadLibrary(
-          LibC.class,
-          Map.of(LibraryOption.LoadNow, true),
-          Platform.getNativePlatform().getStandardCLibraryName());
+          LibC.class, Map.of(LibraryOption.LoadNow, true), libraryName);
     } catch (final UnsatisfiedLinkError e) {
       Loggers.FILE_LOGGER.warn(
           "Failed to load C library; any native calls will not be available", e);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/LibCTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/LibCTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal.fs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import io.camunda.zeebe.journal.fs.LibC.InvalidLibC;
+import org.junit.jupiter.api.Test;
+
+public class LibCTest {
+
+  @Test
+  void shouldLoadSystemLibC() {
+    assertThatNoException().isThrownBy(LibC::ofNativeLibrary);
+  }
+
+  @Test
+  void shouldReturnInvalidLibCWhenNotFound() {
+    // given
+    final var libraryName = "dzz";
+    // when
+    final var loaded = LibC.ofNativeLibrary(libraryName);
+    // then
+    assertThat(loaded).isInstanceOf(InvalidLibC.class);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #43767 to `stable/8.6`.

relates to 