### PR TITLE
feat: export rootProcessInstanceKey to ES/OS user task entity

### DIFF
--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
@@ -477,11 +477,14 @@ class VariableServiceTest {
     // given
     final String taskId = "taskId_557";
     final var flowNodeInstanceId = 456L;
+    final var processInstanceKey = 123L;
+    final var rootProcessInstanceKey = 789L;
     final TaskEntity task =
         new TaskEntity()
             .setId(taskId)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceId))
-            .setProcessInstanceId("123")
+            .setProcessInstanceId(String.valueOf(processInstanceKey))
+            .setRootProcessInstanceKey(rootProcessInstanceKey)
             .setTenantId("tenant_b");
     when(taskStore.getTask(taskId)).thenReturn(task);
     final ImportProperties importProperties = mock(ImportProperties.class);
@@ -492,9 +495,21 @@ class VariableServiceTest {
     mockReturnOriginalVariables(
         List.of(
             createVariableEntity(
-                flowNodeInstanceId, "varA", "\"originalA\"", variableSizeThreshold, "tenant_b"),
+                flowNodeInstanceId,
+                "varA",
+                "\"originalA\"",
+                variableSizeThreshold,
+                "tenant_b",
+                processInstanceKey,
+                rootProcessInstanceKey),
             createVariableEntity(
-                flowNodeInstanceId, "varB", "\"originalB\"", variableSizeThreshold, "tenant_b")));
+                flowNodeInstanceId,
+                "varB",
+                "\"originalB\"",
+                variableSizeThreshold,
+                "tenant_b",
+                processInstanceKey,
+                rootProcessInstanceKey)));
 
     // when
     instance.persistTaskVariables(
@@ -510,11 +525,35 @@ class VariableServiceTest {
     verify(variableStore).persistTaskVariables(taskVariableCaptor.capture());
     final var variablesToPersist = taskVariableCaptor.getValue();
     assertThat(variablesToPersist)
-        .extracting("name", "value", "fullValue", "tenantId")
+        .extracting(
+            "name",
+            "value",
+            "fullValue",
+            "tenantId",
+            "processInstanceKey",
+            "rootProcessInstanceKey")
         .containsExactlyInAnyOrder(
-            tuple("varA", "\"originalA\"", "\"originalA\"", "tenant_b"),
-            tuple("varB", "\"changedB\"", "\"changedB\"", "tenant_b"),
-            tuple("varC", "\"changedC\"", "\"changedC\"", "tenant_b"));
+            tuple(
+                "varA",
+                "\"originalA\"",
+                "\"originalA\"",
+                "tenant_b",
+                processInstanceKey,
+                rootProcessInstanceKey),
+            tuple(
+                "varB",
+                "\"changedB\"",
+                "\"changedB\"",
+                "tenant_b",
+                processInstanceKey,
+                rootProcessInstanceKey),
+            tuple(
+                "varC",
+                "\"changedC\"",
+                "\"changedC\"",
+                "tenant_b",
+                processInstanceKey,
+                rootProcessInstanceKey));
   }
 
   @Test
@@ -522,11 +561,14 @@ class VariableServiceTest {
     // given
     final String taskId = "taskId_557";
     final var flowNodeInstanceId = 456L;
+    final var processInstanceKey = 123L;
+    final var rootProcessInstanceKey = 789L;
     final TaskEntity task =
         new TaskEntity()
             .setId(taskId)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceId))
-            .setProcessInstanceId("123")
+            .setProcessInstanceId(String.valueOf(processInstanceKey))
+            .setRootProcessInstanceKey(rootProcessInstanceKey)
             .setTenantId("tenant_c");
     when(taskStore.getTask(taskId)).thenReturn(task);
     final ImportProperties importProperties = mock(ImportProperties.class);
@@ -537,9 +579,21 @@ class VariableServiceTest {
     mockReturnOriginalVariables(
         List.of(
             createVariableEntity(
-                flowNodeInstanceId, "varA", "\"originalA\"", variableSizeThreshold, "tenant_c"),
+                flowNodeInstanceId,
+                "varA",
+                "\"originalA\"",
+                variableSizeThreshold,
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey),
             createVariableEntity(
-                flowNodeInstanceId, "varB", "\"originalB\"", variableSizeThreshold, "tenant_c")));
+                flowNodeInstanceId,
+                "varB",
+                "\"originalB\"",
+                variableSizeThreshold,
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey)));
 
     when(draftVariableStore.getVariablesByTaskIdAndVariableNames(taskId, emptyList()))
         .thenReturn(
@@ -575,17 +629,49 @@ class VariableServiceTest {
     verify(variableStore).persistTaskVariables(taskVariableCaptor.capture());
     final var variablesToPersist = taskVariableCaptor.getValue();
     assertThat(variablesToPersist)
-        .extracting("name", "value", "fullValue", "tenantId")
+        .extracting(
+            "name",
+            "value",
+            "fullValue",
+            "tenantId",
+            "processInstanceKey",
+            "rootProcessInstanceKey")
         .containsExactlyInAnyOrder(
-            tuple("varA", "\"originalA\"", "\"originalA\"", "tenant_c"),
-            tuple("varB", "\"draftB\"", "\"draftB\"", "tenant_c"),
-            tuple("varC", "\"draftC\"", "\"draftC\"", "tenant_c"),
+            tuple(
+                "varA",
+                "\"originalA\"",
+                "\"originalA\"",
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey),
+            tuple(
+                "varB",
+                "\"draftB\"",
+                "\"draftB\"",
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey),
+            tuple(
+                "varC",
+                "\"draftC\"",
+                "\"draftC\"",
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey),
             tuple(
                 "varD",
                 "\"changedD_longValueThatExceedL",
                 "\"changedD_longValueThatExceedLimit\"",
-                "tenant_c"),
-            tuple("varE", "\"changedE\"", "\"changedE\"", "tenant_c"));
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey),
+            tuple(
+                "varE",
+                "\"changedE\"",
+                "\"changedE\"",
+                "tenant_c",
+                processInstanceKey,
+                rootProcessInstanceKey));
   }
 
   @Test
@@ -600,7 +686,9 @@ class VariableServiceTest {
       final String name,
       final String value,
       final int variableSizeThreshold,
-      final String tenantId) {
+      final String tenantId,
+      final Long processInstanceKey,
+      final Long rootProcessInstanceKey) {
     final VariableEntity entity =
         new VariableEntity()
             .setId(String.format("%s-%s", flowNodeInstanceId, name))
@@ -618,6 +706,8 @@ class VariableServiceTest {
       entity.setIsPreview(false);
     }
     entity.setTenantId(tenantId);
+    entity.setProcessInstanceKey(processInstanceKey);
+    entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     return entity;
   }
 
@@ -627,6 +717,12 @@ class VariableServiceTest {
       final String value,
       final int variableSizeThreshold) {
     return createVariableEntity(
-        flowNodeInstanceId, name, value, variableSizeThreshold, DEFAULT_TENANT_IDENTIFIER);
+        flowNodeInstanceId,
+        name,
+        value,
+        variableSizeThreshold,
+        DEFAULT_TENANT_IDENTIFIER,
+        123L,
+        123L);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -129,6 +129,10 @@ public class UserTaskCompletionVariableHandler
     } else {
       snapshotVariableEntity.setValue(variableValueAsString).setIsPreview(false);
     }
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      snapshotVariableEntity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
     return snapshotVariableEntity;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -272,6 +272,10 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           .get(formKey)
           .ifPresent(c -> entity.setFormId(c.formId()).setFormVersion(c.formVersion()));
     }
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   private boolean refersToPreviousVersionRecord(final long key) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Exports rootProcessInstanceKey from User task records, to ES/OS task entity on `CREATING` intent
- Exports rootProcessInstanceKey from User task records, to ES/OS task snapshot variable on task completion
- Cascades rootProcessInstanceKey in V1 complete task API when persisting snapshot variables

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41658
