### PR TITLE
feat: add root process instance key to batch operation items

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -633,10 +633,19 @@
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
       <column name="PROCESSED_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="ERROR_MESSAGE" type="VARCHAR(${errorMessageSize})"/>
       <column name="STATE" type="VARCHAR(20)" defaultValue="ACTIVE"/>
     </createTable>
+
+    <createIndex tableName="${prefix}BATCH_OPERATION_ITEM" indexName="${prefix}IDX_BATCH_OPERATION_ITEM_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+
+    <createIndex tableName="${prefix}BATCH_OPERATION_ITEM" indexName="${prefix}IDX_BATCH_OPERATION_ITEM_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
 
     <createTable tableName="${prefix}BATCH_OPERATION_ERROR">
       <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -18,7 +18,7 @@ public record BatchOperationItemDbModel(
     String batchOperationKey,
     long itemKey,
     long processInstanceKey,
-    long rootProcessInstanceKey,
+    Long rootProcessInstanceKey,
     BatchOperationEntity.BatchOperationItemState state,
     OffsetDateTime processedDate,
     String errorMessage) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 public record BatchOperationItemDbModel(
     String batchOperationKey,
     long itemKey,
-    long processInstanceKey,
+    Long processInstanceKey,
     Long rootProcessInstanceKey,
     BatchOperationEntity.BatchOperationItemState state,
     OffsetDateTime processedDate,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -18,6 +18,7 @@ public record BatchOperationItemDbModel(
     String batchOperationKey,
     long itemKey,
     long processInstanceKey,
+    long rootProcessInstanceKey,
     BatchOperationEntity.BatchOperationItemState state,
     OffsetDateTime processedDate,
     String errorMessage) {
@@ -41,6 +42,12 @@ public record BatchOperationItemDbModel(
     }
 
     return new BatchOperationItemDbModel(
-        batchOperationKey, itemKey, processInstanceKey, state, processedDate, truncatedValue);
+        batchOperationKey,
+        itemKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        state,
+        processedDate,
+        truncatedValue);
   }
 }

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -36,6 +36,7 @@
       <arg column="OPERATION_TYPE" javaType="io.camunda.search.entities.BatchOperationType"/>
       <arg column="ITEM_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="STATE"
         javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemState"/>
       <arg column="PROCESSED_DATE" javaType="java.time.OffsetDateTime"/>
@@ -68,10 +69,10 @@
 
   <insert id="insertItems"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto">
-    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE)
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, STATE)
     VALUES
     <foreach collection="items" item="item" separator=",">
-      (#{batchOperationKey}, #{item.itemKey}, #{item.processInstanceKey}, #{item.state})
+      (#{batchOperationKey}, #{item.itemKey}, #{item.processInstanceKey}, #{item.rootProcessInstanceKey}, #{item.state})
     </foreach>
   </insert>
 
@@ -98,10 +99,11 @@
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
     databaseId="postgresql">
     INSERT INTO ${prefix}BATCH_OPERATION_ITEM
-    (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
+    (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
     VALUES (#{batchOperationKey},
     #{itemKey},
     #{processInstanceKey},
+    #{rootProcessInstanceKey},
     #{processedDate},
     #{state})
     ON CONFLICT (BATCH_OPERATION_KEY, ITEM_KEY) DO UPDATE SET
@@ -117,6 +119,7 @@
     USING (SELECT #{batchOperationKey}   AS BATCH_OPERATION_KEY,
                   #{itemKey}            AS ITEM_KEY,
                   #{processInstanceKey} AS PROCESS_INSTANCE_KEY,
+                  #{rootProcessInstanceKey} AS ROOT_PROCESS_INSTANCE_KEY,
                   #{processedDate}      AS PROCESSED_DATE,
                   #{state}              AS STATE,
                   #{errorMessage}       AS ERROR_MESSAGE) AS source
@@ -127,18 +130,19 @@
                  PROCESSED_DATE = source.PROCESSED_DATE,
                  ERROR_MESSAGE = source.ERROR_MESSAGE
     WHEN NOT MATCHED THEN
-      INSERT (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE, ERROR_MESSAGE)
-      VALUES (source.BATCH_OPERATION_KEY, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY,
+      INSERT (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE, ERROR_MESSAGE)
+      VALUES (source.BATCH_OPERATION_KEY, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY, source.ROOT_PROCESS_INSTANCE_KEY,
               source.PROCESSED_DATE, source.STATE, source.ERROR_MESSAGE);  </insert>
 
   <insert id="upsertItem"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
     databaseId="mariadb">
     INSERT INTO ${prefix}BATCH_OPERATION_ITEM
-    (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
+    (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
     VALUES (#{batchOperationKey},
     #{itemKey},
     #{processInstanceKey},
+    #{rootProcessInstanceKey},
     #{processedDate},
     #{state})
     ON DUPLICATE KEY UPDATE
@@ -149,10 +153,11 @@
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto"
     databaseId="mysql">
     INSERT INTO ${prefix}BATCH_OPERATION_ITEM
-    (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
+    (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE)
     VALUES (#{batchOperationKey},
     #{itemKey},
     #{processInstanceKey},
+    #{rootProcessInstanceKey},
     #{processedDate},
     #{state})
     ON DUPLICATE KEY UPDATE
@@ -166,6 +171,7 @@
     USING (SELECT #{batchOperationKey}   AS BATCH_OPERATION_KEY,
     #{itemKey}            AS ITEM_KEY,
     #{processInstanceKey} AS PROCESS_INSTANCE_KEY,
+    #{rootProcessInstanceKey} AS ROOT_PROCESS_INSTANCE_KEY,
     #{processedDate}      AS PROCESSED_DATE,
     #{state}              AS STATE,
     #{errorMessage}       AS ERROR_MESSAGE
@@ -177,9 +183,9 @@
     PROCESSED_DATE = source.PROCESSED_DATE,
     ERROR_MESSAGE  = source.ERROR_MESSAGE
     WHEN NOT MATCHED THEN
-    INSERT (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE,
+    INSERT (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE,
     ERROR_MESSAGE)
-    VALUES (source.BATCH_OPERATION_KEY, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY,
+    VALUES (source.BATCH_OPERATION_KEY, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY, source.ROOT_PROCESS_INSTANCE_KEY,
     source.PROCESSED_DATE, source.STATE, source.ERROR_MESSAGE)
   </insert>
 
@@ -190,6 +196,7 @@
     USING (SELECT CAST(#{batchOperationKey} AS VARCHAR)   AS BATCH_OPERATION_KEY,
     CAST(#{itemKey} AS BIGINT)            AS ITEM_KEY,
     CAST(#{processInstanceKey} AS BIGINT) AS PROCESS_INSTANCE_KEY,
+    CAST(#{rootProcessInstanceKey} AS BIGINT) AS ROOT_PROCESS_INSTANCE_KEY,
     CAST(#{processedDate} AS TIMESTAMP)   AS PROCESSED_DATE,
     CAST(#{state} AS VARCHAR)            AS STATE,
     CAST(#{errorMessage} AS VARCHAR)     AS ERROR_MESSAGE) source
@@ -200,9 +207,9 @@
     PROCESSED_DATE = source.PROCESSED_DATE,
     ERROR_MESSAGE  = source.ERROR_MESSAGE
     WHEN NOT MATCHED THEN
-    INSERT (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE,
+    INSERT (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESSED_DATE, STATE,
     ERROR_MESSAGE)
-    VALUES (source.BATCH_OPERATION_KEY, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY,
+    VALUES (source.BATCH_OPERATION_KEY, source.ITEM_KEY, source.PROCESS_INSTANCE_KEY, source.ROOT_PROCESS_INSTANCE_KEY,
     source.PROCESSED_DATE, source.STATE, source.ERROR_MESSAGE)
   </insert>
 
@@ -347,6 +354,7 @@
     bo.OPERATION_TYPE,
     bi.ITEM_KEY,
     bi.PROCESS_INSTANCE_KEY,
+    bi.ROOT_PROCESS_INSTANCE_KEY,
     bi.STATE,
     bi.PROCESSED_DATE,
     bi.ERROR_MESSAGE

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModelTest.java
@@ -18,7 +18,7 @@ class BatchOperationItemDbModelTest {
   void shouldTruncateErrorMessage() {
     final BatchOperationItemDbModel truncatedMessage =
         new BatchOperationItemDbModel(
-                "batchId", 123L, 456L, BatchOperationItemState.ACTIVE, null, "errorMessage")
+                "batchId", 123L, 456L, 789L, BatchOperationItemState.ACTIVE, null, "errorMessage")
             .truncateErrorMessage(10, null);
 
     assertThat(truncatedMessage.errorMessage().length()).isEqualTo(10);
@@ -29,7 +29,7 @@ class BatchOperationItemDbModelTest {
   void shouldTruncateErrorMessageBytes() {
     final BatchOperationItemDbModel truncatedMessage =
         new BatchOperationItemDbModel(
-                "batchId", 123L, 456L, BatchOperationItemState.ACTIVE, null, "ääääääääää")
+                "batchId", 123L, 456L, 789L, BatchOperationItemState.ACTIVE, null, "ääääääääää")
             .truncateErrorMessage(50, 5);
 
     assertThat(truncatedMessage.errorMessage().length()).isEqualTo(2);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
@@ -49,7 +49,13 @@ class BatchOperationWriterTest {
                 .map(
                     i ->
                         new BatchOperationItemDbModel(
-                            "42", i, i, BatchOperationItemState.ACTIVE, OffsetDateTime.now(), null))
+                            "42",
+                            i,
+                            i,
+                            i,
+                            BatchOperationItemState.ACTIVE,
+                            OffsetDateTime.now(),
+                            null))
                 .toList());
 
     // when

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -29,6 +29,7 @@ class SearchQueryResponseMapperTest {
             BatchOperationType.MIGRATE_PROCESS_INSTANCE,
             1234L,
             4321L,
+            4320L,
             BatchOperationItemState.COMPLETED,
             OffsetDateTime.parse("2025-01-15T11:53:00Z"),
             "errorMessage");
@@ -52,7 +53,7 @@ class SearchQueryResponseMapperTest {
   void shouldHandleNullFieldsInBatchOperationItemEntity() {
     // given
     final BatchOperationItemEntity item =
-        new BatchOperationItemEntity(null, null, null, null, null, null, null);
+        new BatchOperationItemEntity(null, null, null, null, null, null, null, null);
 
     // when
     final BatchOperationItemResponse response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -138,6 +138,7 @@ public class BatchOperationIT {
                 batchOperation.batchOperationKey(),
                 items.getFirst().itemKey(),
                 items.getFirst().processInstanceKey(),
+                items.getFirst().rootProcessInstanceKey(),
                 BatchOperationItemState.COMPLETED,
                 NOW,
                 null));
@@ -205,6 +206,7 @@ public class BatchOperationIT {
                 batchOperation.batchOperationKey(),
                 item.itemKey(),
                 item.processInstanceKey(),
+                item.rootProcessInstanceKey(),
                 BatchOperationItemState.COMPLETED,
                 NOW,
                 "x".repeat(9000)));
@@ -256,6 +258,7 @@ public class BatchOperationIT {
                 batchOperation.batchOperationKey(),
                 items.getFirst().itemKey(),
                 items.getFirst().processInstanceKey(),
+                items.getFirst().rootProcessInstanceKey(),
                 BatchOperationItemState.COMPLETED,
                 NOW,
                 null));
@@ -309,6 +312,7 @@ public class BatchOperationIT {
                 batchOperation.batchOperationKey(),
                 items.getFirst().itemKey(),
                 items.getFirst().processInstanceKey(),
+                items.getFirst().rootProcessInstanceKey(),
                 BatchOperationItemState.FAILED,
                 NOW,
                 "error"));
@@ -373,6 +377,7 @@ public class BatchOperationIT {
                 batchOperation.batchOperationKey(),
                 items.getFirst().itemKey(),
                 items.getFirst().processInstanceKey(),
+                items.getFirst().rootProcessInstanceKey(),
                 BatchOperationItemState.SKIPPED,
                 NOW,
                 null));
@@ -431,6 +436,7 @@ public class BatchOperationIT {
                 batchOperation.batchOperationKey(),
                 items.getFirst().itemKey(),
                 items.getFirst().processInstanceKey(),
+                items.getFirst().rootProcessInstanceKey(),
                 BatchOperationItemState.COMPLETED,
                 NOW,
                 null));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -97,6 +97,7 @@ public final class BatchOperationFixtures {
                         batchOperationKey,
                         itemKey,
                         itemKey,
+                        itemKey,
                         BatchOperationItemState.ACTIVE,
                         NOW,
                         null))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -19,6 +19,10 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
@@ -31,6 +35,8 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.filter.UserFilter.Builder;
 import io.camunda.search.query.AuditLogQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.security.reader.AuthorizationCheck;
@@ -45,6 +51,8 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -60,9 +68,14 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableEvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
@@ -769,7 +782,6 @@ class RdbmsExporterIT {
         ImmutableRecord.<ProcessMessageSubscriptionRecordValue>builder()
             .from(RecordFixtures.FACTORY.generateRecord(ValueType.PROCESS_MESSAGE_SUBSCRIPTION))
             .withIntent(ProcessMessageSubscriptionIntent.CREATED)
-            .withPosition(2L)
             .withTimestamp(System.currentTimeMillis())
             .build();
 
@@ -794,7 +806,6 @@ class RdbmsExporterIT {
         ImmutableRecord.builder()
             .from(RecordFixtures.FACTORY.generateRecord(ValueType.PROCESS_MESSAGE_SUBSCRIPTION))
             .withIntent(ProcessMessageSubscriptionIntent.CREATED)
-            .withPosition(2L)
             .withTimestamp(System.currentTimeMillis())
             .build();
 
@@ -805,7 +816,6 @@ class RdbmsExporterIT {
         ImmutableRecord.builder()
             .from(messageSubscriptionRecord)
             .withIntent(ProcessMessageSubscriptionIntent.DELETED)
-            .withPosition(3L)
             .withTimestamp(System.currentTimeMillis())
             .build());
 
@@ -824,7 +834,6 @@ class RdbmsExporterIT {
         ImmutableRecord.<ProcessMessageSubscriptionRecordValue>builder()
             .from(RecordFixtures.FACTORY.generateRecord(ValueType.PROCESS_MESSAGE_SUBSCRIPTION))
             .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
-            .withPosition(2L)
             .withTimestamp(System.currentTimeMillis())
             .build();
 
@@ -1013,13 +1022,149 @@ class RdbmsExporterIT {
   }
 
   @Test
+  public void shouldExportBatchOperationCreatedRecord() {
+    // given
+    final var batchOperationCreationRecord =
+        givenBatchOperationCreationExported(
+            io.camunda.zeebe.protocol.record.value.BatchOperationType.MIGRATE_PROCESS_INSTANCE);
+
+    final var batchOperation =
+        rdbmsService
+            .getBatchOperationReader()
+            .findOne(String.valueOf(batchOperationCreationRecord.getKey()));
+    assertThat(batchOperation).isNotEmpty();
+    assertThat(batchOperation.get().operationType())
+        .isEqualTo(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
+    assertThat(batchOperation.get().state()).isEqualTo(BatchOperationState.ACTIVE);
+    assertThat(batchOperation.get().operationsTotalCount()).isEqualTo(0L);
+    assertThat(batchOperation.get().operationsCompletedCount()).isEqualTo(0L);
+    assertThat(batchOperation.get().operationsFailedCount()).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldExportBatchOperationChunkRecord() {
+    final var batchOperationCreationRecord =
+        givenBatchOperationCreationExported(
+            io.camunda.zeebe.protocol.record.value.BatchOperationType.MODIFY_PROCESS_INSTANCE);
+
+    final var itemKey = 9043L;
+    final var processInstanceKey = 9044L;
+
+    final Record<BatchOperationChunkRecordValue> record =
+        RecordFixtures.FACTORY.generateRecord(ValueType.BATCH_OPERATION_CHUNK);
+    final var batchOperationChunkedRecord =
+        ImmutableRecord.<BatchOperationChunkRecordValue>builder()
+            .from(record)
+            .withIntent(BatchOperationChunkIntent.CREATE)
+            .withTimestamp(System.currentTimeMillis())
+            .withBatchOperationReference(batchOperationCreationRecord.getKey())
+            .withValue(
+                ImmutableBatchOperationChunkRecordValue.builder()
+                    .from(record.getValue())
+                    .withBatchOperationKey(batchOperationCreationRecord.getKey())
+                    .withItems(
+                        List.of(
+                            ImmutableBatchOperationItemValue.builder()
+                                .withItemKey(itemKey)
+                                .withProcessInstanceKey(processInstanceKey)
+                                .build()))
+                    .build())
+            .build();
+    // when
+    exporter.export(batchOperationChunkedRecord);
+
+    // then
+    final var batchOperation =
+        rdbmsService
+            .getBatchOperationReader()
+            .findOne(String.valueOf(batchOperationCreationRecord.getKey()));
+    assertThat(batchOperation).isNotEmpty();
+    assertThat(batchOperation.get().operationType())
+        .isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
+    assertThat(batchOperation.get().state()).isEqualTo(BatchOperationState.ACTIVE);
+    assertThat(batchOperation.get().operationsTotalCount()).isEqualTo(1L);
+    assertThat(batchOperation.get().operationsCompletedCount()).isEqualTo(0L);
+    assertThat(batchOperation.get().operationsFailedCount()).isEqualTo(0L);
+
+    final var results = searchBatchOperationItems(itemKey);
+    final var items = results.items();
+    assertThat(items).hasSize(1);
+    final var item = items.getFirst();
+    assertThat(item.itemKey()).isEqualTo(itemKey);
+    assertThat(item.processInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(item.rootProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(item.operationType()).isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
+    assertThat(item.state()).isEqualTo(BatchOperationItemState.ACTIVE);
+  }
+
+  @Test
+  public void shouldUpsertBatchOperationItemForResolvedIncidentThatRelatesToBatchOperation() {
+    // given
+    final var batchOperationCreationRecord =
+        givenBatchOperationCreationExported(
+            io.camunda.zeebe.protocol.record.value.BatchOperationType.RESOLVE_INCIDENT);
+
+    final var incidentKey = 1142L;
+    final var processInstanceKey = 1151L;
+    final var rootProcessInstanceKey = 1162L;
+    final var elementInstanceKey = 1173L;
+    final var incidentRecord =
+        withBatchOperationReference(
+            FIXTURES.getIncidentRecord(
+                IncidentIntent.RESOLVED,
+                incidentKey,
+                processInstanceKey,
+                rootProcessInstanceKey,
+                elementInstanceKey),
+            batchOperationCreationRecord.getKey());
+
+    // when
+    exporter.export(incidentRecord);
+
+    // then
+    final var results = searchBatchOperationItems(incidentKey);
+    final var items = results.items();
+    assertThat(items).hasSize(1);
+    final var item = items.getFirst();
+    assertThat(item.itemKey()).isEqualTo(incidentKey);
+    assertThat(item.processInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(item.rootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+    assertThat(item.operationType()).isEqualTo(BatchOperationType.RESOLVE_INCIDENT);
+    assertThat(item.state()).isEqualTo(BatchOperationItemState.COMPLETED);
+  }
+
+  @Test
+  public void
+      shouldNotUpsertBatchOperationItemForResolvedIncidentThatDoesNotRelateBatchOperation() {
+    // given
+    final var incidentKey = 1042L;
+    final var processInstanceKey = 1051L;
+    final var rootProcessInstanceKey = 1062L;
+    final var elementInstanceKey = 1073L;
+    final var incidentRecord =
+        FIXTURES.getIncidentRecord(
+            IncidentIntent.RESOLVED,
+            incidentKey,
+            processInstanceKey,
+            rootProcessInstanceKey,
+            elementInstanceKey);
+
+    // when
+    exporter.export(incidentRecord);
+
+    // then
+    final var results = searchBatchOperationItems(incidentKey);
+    final var items = results.items();
+    assertThat(items).isEmpty();
+  }
+
+  @Test
   public void shouldExportJob() {
     // given
     final Record<RecordValue> jobCreatedRecord =
         ImmutableRecord.builder()
             .from(RecordFixtures.FACTORY.generateRecord(ValueType.JOB))
             .withIntent(JobIntent.CREATED)
-            .withPosition(2L)
             .withTimestamp(System.currentTimeMillis())
             .build();
 
@@ -1093,5 +1238,41 @@ class RdbmsExporterIT {
 
   private static long getProcessInstanceRootProcessInstanceKey(final Record<RecordValue> record) {
     return ((ProcessInstanceRecordValue) record.getValue()).getRootProcessInstanceKey();
+  }
+
+  private ImmutableRecord<BatchOperationCreationRecordValue> givenBatchOperationCreationExported(
+      final io.camunda.zeebe.protocol.record.value.BatchOperationType batchOperationType) {
+    final Record<BatchOperationCreationRecordValue> record =
+        RecordFixtures.FACTORY.generateRecord(ValueType.BATCH_OPERATION_CREATION);
+    final var batchOperationCreationRecord =
+        ImmutableRecord.<BatchOperationCreationRecordValue>builder()
+            .from(record)
+            .withIntent(BatchOperationIntent.CREATED)
+            .withTimestamp(System.currentTimeMillis())
+            .withValue(
+                ImmutableBatchOperationCreationRecordValue.builder()
+                    .from(record.getValue())
+                    .withBatchOperationKey(record.getKey())
+                    .withBatchOperationType(batchOperationType)
+                    .build())
+            .build();
+
+    exporter.export(batchOperationCreationRecord);
+    return batchOperationCreationRecord;
+  }
+
+  private <T extends RecordValue> Record<T> withBatchOperationReference(
+      final Record<T> record, final long batchOperationKey) {
+    return ImmutableRecord.<T>builder()
+        .from(record)
+        .withBatchOperationReference(batchOperationKey)
+        .build();
+  }
+
+  private SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      final long itemKey) {
+    return rdbmsService
+        .getBatchOperationItemReader()
+        .search(BatchOperationItemQuery.of(b -> b.filter(f -> f.itemKeys(itemKey))));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -1092,7 +1092,7 @@ class RdbmsExporterIT {
     final var item = items.getFirst();
     assertThat(item.itemKey()).isEqualTo(itemKey);
     assertThat(item.processInstanceKey()).isEqualTo(processInstanceKey);
-    assertThat(item.rootProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(item.rootProcessInstanceKey()).isNull();
     assertThat(item.operationType()).isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
     assertThat(item.state()).isEqualTo(BatchOperationItemState.ACTIVE);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -45,6 +46,7 @@ import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
@@ -53,6 +55,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleMa
 import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableDecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableHistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
@@ -526,6 +529,28 @@ public class RecordFixtures {
                 .withProcessInstanceKey(processInstanceKey)
                 .withRootProcessInstanceKey(rootProcessInstanceKey)
                 .withElementInstancePath(List.of(List.of(processInstanceKey, elementInstanceKey)))
+                .build())
+        .build();
+  }
+
+  public ImmutableRecord<RecordValue> getHistoryDeletionRecord(
+      final HistoryDeletionIntent intent,
+      final long resourceKey,
+      final HistoryDeletionType deletionType) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.HISTORY_DELETION);
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withKey(resourceKey)
+        .withIntent(intent)
+        .withPosition(nextPosition())
+        .withPartitionId(1)
+        .withTimestamp(System.currentTimeMillis())
+        .withValue(
+            ImmutableHistoryDeletionRecordValue.builder()
+                .from((ImmutableHistoryDeletionRecordValue) recordValueRecord.getValue())
+                .withResourceKey(resourceKey)
+                .withResourceType(deletionType)
                 .build())
         .build();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformer.java
@@ -48,6 +48,7 @@ public class BatchOperationItemEntityTransformer
         source.getType() != null ? BatchOperationType.valueOf(source.getType().name()) : null,
         source.getItemKey(),
         source.getProcessInstanceKey(),
+        source.getRootProcessInstanceKey(),
         map(source.getState()),
         source.getCompletedDate(),
         source.getErrorMessage());
@@ -61,6 +62,7 @@ public class BatchOperationItemEntityTransformer
         // in legacy items only one of the following is set (processInstanceKey as default)
         ObjectUtils.firstNonNull(source.getIncidentKey(), source.getProcessInstanceKey()),
         source.getProcessInstanceKey(),
+        source.getRootProcessInstanceKey(),
         map(source.getState()),
         source.getCompletedDate(),
         source.getErrorMessage());

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -67,6 +67,7 @@ public record BatchOperationEntity(
       BatchOperationType operationType,
       Long itemKey,
       Long processInstanceKey,
+      Long rootProcessInstanceKey,
       BatchOperationItemState state,
       OffsetDateTime processedDate,
       String errorMessage) {}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -54,7 +54,7 @@ public class BatchOperationChunkExportHandler
         Long.toString(batchOperationKey),
         value.getItemKey(),
         value.getProcessInstanceKey(),
-        -1L, // TODO root process instance key is not currently available in chunk record
+        null, // TODO root process instance key is not currently available in chunk record
         BatchOperationItemState.ACTIVE,
         null,
         null);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -54,6 +54,7 @@ public class BatchOperationChunkExportHandler
         Long.toString(batchOperationKey),
         value.getItemKey(),
         value.getProcessInstanceKey(),
+        -1L, // TODO root process instance key is not currently available in chunk record
         BatchOperationItemState.ACTIVE,
         null,
         null);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/HistoryDeletionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/HistoryDeletionBatchOperationExportHandler.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import java.util.Optional;
 
 public class HistoryDeletionBatchOperationExportHandler
     extends RdbmsBatchOperationStatusExportHandler<HistoryDeletionRecordValue> {
@@ -44,8 +45,8 @@ public class HistoryDeletionBatchOperationExportHandler
   }
 
   @Override
-  long getRootProcessInstanceKey(final Record<HistoryDeletionRecordValue> record) {
-    return -1L;
+  Optional<Long> getRootProcessInstanceKey(final Record<HistoryDeletionRecordValue> record) {
+    return Optional.empty();
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/HistoryDeletionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/HistoryDeletionBatchOperationExportHandler.java
@@ -40,8 +40,8 @@ public class HistoryDeletionBatchOperationExportHandler
   }
 
   @Override
-  long getProcessInstanceKey(final Record<HistoryDeletionRecordValue> record) {
-    return -1L;
+  Optional<Long> getProcessInstanceKey(final Record<HistoryDeletionRecordValue> record) {
+    return Optional.empty();
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/HistoryDeletionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/HistoryDeletionBatchOperationExportHandler.java
@@ -40,7 +40,12 @@ public class HistoryDeletionBatchOperationExportHandler
 
   @Override
   long getProcessInstanceKey(final Record<HistoryDeletionRecordValue> record) {
-    return -1;
+    return -1L;
+  }
+
+  @Override
+  long getRootProcessInstanceKey(final Record<HistoryDeletionRecordValue> record) {
+    return -1L;
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
@@ -36,8 +36,8 @@ public class IncidentBatchOperationExportHandler
   }
 
   @Override
-  long getProcessInstanceKey(final Record<IncidentRecordValue> record) {
-    return record.getValue().getProcessInstanceKey();
+  Optional<Long> getProcessInstanceKey(final Record<IncidentRecordValue> record) {
+    return Optional.of(record.getValue().getProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
@@ -40,6 +40,11 @@ public class IncidentBatchOperationExportHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<IncidentRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<IncidentRecordValue> record) {
     return record.getIntent().equals(IncidentIntent.RESOLVED);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.Optional;
 
 /**
  * This handles the batch operation status item of batch operations of type RESOLVE_INCIDENT. It
@@ -40,8 +41,8 @@ public class IncidentBatchOperationExportHandler
   }
 
   @Override
-  long getRootProcessInstanceKey(final Record<IncidentRecordValue> record) {
-    return record.getValue().getRootProcessInstanceKey();
+  Optional<Long> getRootProcessInstanceKey(final Record<IncidentRecordValue> record) {
+    return Optional.of(record.getValue().getRootProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -47,6 +47,11 @@ public class ProcessInstanceCancellationBatchOperationExportHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
     return record.getValue().getBpmnElementType() == BpmnElementType.PROCESS
         && record.getIntent().equals(ProcessInstanceIntent.ELEMENT_TERMINATED);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -43,8 +43,8 @@ public class ProcessInstanceCancellationBatchOperationExportHandler
   }
 
   @Override
-  long getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
-    return record.getValue().getProcessInstanceKey();
+  Optional<Long> getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return Optional.of(record.getValue().getProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.Optional;
 
 /**
  * This handles the batch operation item status of batch operations of type CANCEL_PROCESS_INSTANCE.
@@ -47,8 +48,8 @@ public class ProcessInstanceCancellationBatchOperationExportHandler
   }
 
   @Override
-  long getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
-    return record.getValue().getRootProcessInstanceKey();
+  Optional<Long> getRootProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return Optional.of(record.getValue().getRootProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+import java.util.Optional;
 
 /**
  * This handles the batch operation item status of batch operations of type
@@ -41,8 +42,9 @@ public class ProcessInstanceMigrationBatchOperationExportHandler
   }
 
   @Override
-  long getRootProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
-    return record.getValue().getRootProcessInstanceKey();
+  Optional<Long> getRootProcessInstanceKey(
+      final Record<ProcessInstanceMigrationRecordValue> record) {
+    return Optional.of(record.getValue().getRootProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -41,6 +41,11 @@ public class ProcessInstanceMigrationBatchOperationExportHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATED);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -37,8 +37,8 @@ public class ProcessInstanceMigrationBatchOperationExportHandler
   }
 
   @Override
-  long getProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
-    return record.getValue().getProcessInstanceKey();
+  Optional<Long> getProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return Optional.of(record.getValue().getProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -41,6 +41,11 @@ public class ProcessInstanceModificationBatchOperationExportHandler
   }
 
   @Override
+  long getRootProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
+    return record.getValue().getRootProcessInstanceKey();
+  }
+
+  @Override
   protected boolean isCompleted(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFIED);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+import java.util.Optional;
 
 /**
  * This handles the batch operation item status of batch operations of type MODIFY_PROCESS_INSTANCE.
@@ -41,8 +42,9 @@ public class ProcessInstanceModificationBatchOperationExportHandler
   }
 
   @Override
-  long getRootProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
-    return record.getValue().getRootProcessInstanceKey();
+  Optional<Long> getRootProcessInstanceKey(
+      final Record<ProcessInstanceModificationRecordValue> record) {
+    return Optional.of(record.getValue().getRootProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -37,8 +37,9 @@ public class ProcessInstanceModificationBatchOperationExportHandler
   }
 
   @Override
-  long getProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
-    return record.getValue().getProcessInstanceKey();
+  Optional<Long> getProcessInstanceKey(
+      final Record<ProcessInstanceModificationRecordValue> record) {
+    return Optional.of(record.getValue().getProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -77,7 +77,7 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
         new BatchOperationItemDbModel(
             String.valueOf(record.getBatchOperationReference()),
             getItemKey(record),
-            getProcessInstanceKey(record),
+            getProcessInstanceKey(record).orElse(null),
             getRootProcessInstanceKey(record).orElse(null),
             state,
             DateUtil.toOffsetDateTime(record.getTimestamp()),
@@ -123,7 +123,7 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
    * @param record the record
    * @return the process instance key
    */
-  abstract long getProcessInstanceKey(Record<T> record);
+  abstract Optional<Long> getProcessInstanceKey(Record<T> record);
 
   /**
    * Extract the root process instance key from the record.

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.DateUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Optional;
 
 /**
  * Abstract base class for handling the status of batch operation items. Subclasses of this class
@@ -77,7 +78,7 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
             String.valueOf(record.getBatchOperationReference()),
             getItemKey(record),
             getProcessInstanceKey(record),
-            getRootProcessInstanceKey(record),
+            getRootProcessInstanceKey(record).orElse(null),
             state,
             DateUtil.toOffsetDateTime(record.getTimestamp()),
             errorMessage));
@@ -130,7 +131,7 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
    * @param record the record
    * @return the root process instance key
    */
-  abstract long getRootProcessInstanceKey(Record<T> record);
+  abstract Optional<Long> getRootProcessInstanceKey(Record<T> record);
 
   /** Checks if the batch operation item is completed */
   abstract boolean isCompleted(Record<T> record);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -77,6 +77,7 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
             String.valueOf(record.getBatchOperationReference()),
             getItemKey(record),
             getProcessInstanceKey(record),
+            getRootProcessInstanceKey(record),
             state,
             DateUtil.toOffsetDateTime(record.getTimestamp()),
             errorMessage));
@@ -122,6 +123,14 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
    * @return the process instance key
    */
   abstract long getProcessInstanceKey(Record<T> record);
+
+  /**
+   * Extract the root process instance key from the record.
+   *
+   * @param record the record
+   * @return the root process instance key
+   */
+  abstract long getRootProcessInstanceKey(Record<T> record);
 
   /** Checks if the batch operation item is completed */
   abstract boolean isCompleted(Record<T> record);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -152,6 +152,7 @@ class BatchOperationItemControllerTest extends RestControllerTest {
         BatchOperationType.CANCEL_PROCESS_INSTANCE,
         11L,
         12L,
+        13L,
         BatchOperationItemState.FAILED,
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         "error");


### PR DESCRIPTION
so we can use it for search later.

As with the ES/OS version we only store the root process instance key when the final processing is done.  We do not currently have access to the root process instance key when we receive `BatchOperationChunkRecordValue`.  Adding that would need some changes to the Zeebe protocol.

Refs: #41660