### PR TITLE
feat: store exported root process instance key for jobs in DB

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -35,6 +35,7 @@ public class JobEntityMapper {
         .processDefinitionId(jobDbModel.processDefinitionId())
         .processDefinitionKey(jobDbModel.processDefinitionKey())
         .processInstanceKey(jobDbModel.processInstanceKey())
+        .rootProcessInstanceKey(jobDbModel.rootProcessInstanceKey())
         .elementId(jobDbModel.elementId())
         .elementInstanceKey(jobDbModel.elementInstanceKey())
         .tenantId(jobDbModel.tenantId())

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -161,6 +161,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jeasy</groupId>
+      <artifactId>easy-random-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -8,6 +8,8 @@
 package io.camunda.it.rdbms.exporter;
 
 import static java.util.Collections.emptyList;
+import static org.jeasy.random.FieldPredicates.inClass;
+import static org.jeasy.random.FieldPredicates.named;
 
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
@@ -49,6 +51,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleMa
 import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
@@ -80,7 +83,12 @@ public class RecordFixtures {
 
   protected static final long NO_PARENT_EXISTS_KEY = -1L;
 
-  protected static final ProtocolFactory FACTORY = new ProtocolFactory(System.nanoTime());
+  protected static final ProtocolFactory FACTORY =
+      new ProtocolFactory(System.nanoTime())
+          // retries field is SMALLINT, so need to limit range
+          .registerRandomizer(
+              named("retries").and(inClass(ImmutableJobRecordValue.class)),
+              random -> random.nextInt(1, 32_000));
 
   protected static ImmutableRecord<RecordValue> getProcessInstanceStartedRecord(
       final long position) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -34,6 +34,7 @@ public record JobEntity(
     String processDefinitionId,
     Long processDefinitionKey,
     Long processInstanceKey,
+    Long rootProcessInstanceKey,
     String elementId,
     Long elementInstanceKey,
     String tenantId,
@@ -60,6 +61,7 @@ public record JobEntity(
     private String processDefinitionId;
     private Long processDefinitionKey;
     private Long processInstanceKey;
+    private Long rootProcessInstanceKey;
     private String elementId;
     private Long elementInstanceKey;
     private String tenantId;
@@ -156,6 +158,11 @@ public record JobEntity(
       return this;
     }
 
+    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
+      this.rootProcessInstanceKey = rootProcessInstanceKey;
+      return this;
+    }
+
     public Builder elementId(final String elementId) {
       this.elementId = elementId;
       return this;
@@ -202,6 +209,7 @@ public record JobEntity(
           processDefinitionId,
           processDefinitionKey,
           processInstanceKey,
+          rootProcessInstanceKey,
           elementId,
           elementInstanceKey,
           tenantId,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
@@ -65,6 +65,7 @@ public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
             .jobKey(record.getKey())
             .partitionId(record.getPartitionId())
             .processInstanceKey(value.getProcessInstanceKey())
+            .rootProcessInstanceKey(value.getRootProcessInstanceKey())
             .elementInstanceKey(value.getElementInstanceKey())
             .processDefinitionId(value.getBpmnProcessId())
             .processDefinitionKey(value.getProcessDefinitionKey())

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -125,6 +125,12 @@ public final class ProtocolFactory {
     registerRandomizers();
   }
 
+  public ProtocolFactory registerRandomizer(
+      final Predicate<Field> predicate, final Function<EasyRandom, ?> randomizer) {
+    randomizerRegistry.registerRandomizer(predicate, () -> randomizer.apply(random));
+    return this;
+  }
+
   /**
    * @return a stream of random records
    */


### PR DESCRIPTION
Just changes things to store root process instance key for exported jobs

Refs #41660
