### PR TITLE
fix: increase worker replicas

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -56,6 +56,7 @@ jobs:
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       load-test-load: >
         --set starter.rate=50
+        --set workers.worker.replicas=6
         --set starter.bpmnXmlPath="bpmn/typical_process.bpmn"
   setup-realistic-test:
     name: Realistic load test


### PR DESCRIPTION
## Description

 * As discovered in a recent [investigation](https://github.com/camunda/camunda/issues/42244#issuecomment-3728352534), we need to increase the worker replicas to keep up with the load
 
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/42244
