### PR TITLE
refactor: restructure s3 backups directory

### DIFF
--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCredentialsIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCredentialsIT.java
@@ -22,12 +22,11 @@ import com.azure.storage.common.sas.AccountSasSignatureValues;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -70,7 +69,7 @@ public class AzureBackupStoreContainerCredentialsIT {
   // Further explanation along the description of the manual tests to replace this can be found in
   // the PR: https://github.com/camunda/camunda/pull/31494
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void shouldLoginWithAccountSasToken(final Backup backup) {
     // we create an azure client initially so that we can generate a sas token.
     final BlobServiceClient blobServiceClient =
@@ -97,7 +96,7 @@ public class AzureBackupStoreContainerCredentialsIT {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void shouldLoginWithServiceSasToken(final Backup backup) {
     // we create an azure client initially so that we can generate a sas token.
     final BlobServiceClient blobServiceClient =

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCredentialsIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCredentialsIT.java
@@ -22,10 +22,13 @@ import com.azure.storage.common.sas.AccountSasSignatureValues;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -162,5 +165,9 @@ public class AzureBackupStoreContainerCredentialsIT {
     store.save(backup).join();
     final var status = store.getStatus(backup.id()).join();
     assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
+  }
+
+  private static Stream<? extends Arguments> provideBackups() throws Exception {
+    return TestBackupProvider.provideArguments();
   }
 }

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.testkit.BackupStoreTestKit;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -35,7 +34,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -79,7 +78,7 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void backupShouldExistAfterStoreIsClosed(final Backup backup) {
     // given
     getStore().save(backup).join();
@@ -96,7 +95,7 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void cannotDeleteUploadingBlock(final Backup backup) {
 
     // given when
@@ -115,7 +114,7 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void cannotRestoreUploadingBackup(final Backup backup, @TempDir final Path targetDir) {
     // when
     uploadInProgressManifest(backup);

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.testkit.BackupStoreTestKit;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -31,7 +30,7 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class FilesystemBackupStoreIT implements BackupStoreTestKit {
 
@@ -70,7 +69,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void backupShouldExistAfterStoreIsClosed(final Backup backup) {
     // given
     getStore().save(backup).join();
@@ -87,7 +86,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void cannotDeleteUploadingBlock(final Backup backup) {
 
     // given when
@@ -106,7 +105,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   void cannotRestoreUploadingBackup(final Backup backup, @TempDir final Path targetDir) {
     // when
     uploadInProgressManifest(backup);

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -102,6 +102,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <classifier>tests</classifier>
       <type>test-jar</type>

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -259,14 +259,16 @@ public final class S3BackupStore implements BackupStore {
                 return manifest;
               }
             })
-        .thenComposeAsync(this::listBackupObjects)
-        .thenCombine(
-            readManifestObject(id).thenComposeAsync(this::listBackupManifestObjects),
-            (contentsObjects, manifestObjects) -> {
-              final var allObjects = new ArrayList<>(contentsObjects);
-              allObjects.addAll(manifestObjects);
-              return allObjects;
-            })
+        .thenComposeAsync(
+            manifest ->
+                listBackupObjects(manifest)
+                    .thenCombine(
+                        readManifestObject(id).thenComposeAsync(this::listBackupManifestObjects),
+                        (contentsObjects, manifestObjects) -> {
+                          final var allObjects = new ArrayList<>(contentsObjects);
+                          allObjects.addAll(manifestObjects);
+                          return allObjects;
+                        }))
         .thenComposeAsync(this::deleteBackupObjects);
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -130,9 +130,14 @@ public final class S3BackupStore implements BackupStore {
   }
 
   /**
-   * Tries to build the longest possible prefix based on the given wildcard. If the first component
-   * of prefix is not present in the wildcard, the prefix will be empty. If the second component of
-   * the prefix is empty, the prefix will only contain the first prefix component and so forth.
+   * Tries to build the longest possible prefix based on the given wildcard for the legacy backup
+   * structure. The legacy backup structure stores manifests and backup contents in the same path.
+   * Backups created prior to 8.9 use this structure so this is purely for maintaining backwards
+   * compatibility.
+   *
+   * <p>If the first component of prefix is not present in the wildcard, the prefix will be empty.
+   * If the second component of the prefix is empty, the prefix will only contain the first prefix
+   * component and so forth.
    *
    * <p>Using the resulting prefix to list objects does not guarantee that returned objects actually
    * match the wildcard, use {@link S3BackupStore#tryParseKeyAsId(String objectKey)} and {@link
@@ -144,6 +149,16 @@ public final class S3BackupStore implements BackupStore {
         + BackupIdentifierWildcard.asPrefix(wildcard);
   }
 
+  /**
+   * Tries to build the longest possible prefix based on the given wildcard. If the first component
+   * of prefix is not present in the wildcard, the prefix will be empty. If the second component of
+   * the prefix is empty, the prefix will only contain the first prefix component and so forth.
+   *
+   * <p>Using the resulting prefix to list objects does not guarantee that returned objects actually
+   * match the wildcard, use {@link S3BackupStore#tryParseKeyAsId(String objectKey)} and {@link
+   * BackupIdentifierWildcard#matches(BackupIdentifier id)} to ensure that the listed object
+   * matches.
+   */
   private String wildcardPrefix(final BackupIdentifierWildcard wildcard) {
     return config.basePath().map(base -> base + "/").orElse("")
         + Directory.MANIFESTS.name

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -263,7 +263,7 @@ public final class S3BackupStore implements BackupStore {
             manifest ->
                 listBackupObjects(manifest)
                     .thenCombine(
-                        readManifestObject(id).thenComposeAsync(this::listBackupManifestObjects),
+                        listBackupManifestObjects(manifest),
                         (contentsObjects, manifestObjects) -> {
                           final var allObjects = new ArrayList<>(contentsObjects);
                           allObjects.addAll(manifestObjects);

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -346,21 +346,17 @@ public final class S3BackupStore implements BackupStore {
   private CompletableFuture<List<ObjectIdentifier>> listObjects(
       final Manifest manifest, final Directory directory) {
 
-    if (canDerivePathFromManifest(manifest)) {
-      return listObjectsBasedOnDescriptor(manifest, directory);
+    if (manifest instanceof final ValidBackupManifest validManifest
+        && validManifest.backupDescriptor().isPresent()) {
+      return listObjectsBasedOnDescriptor(
+          validManifest.backupDescriptor().get(), manifest.id(), directory);
     }
     return listObjectsBasedOnId(manifest, directory);
   }
 
-  private boolean canDerivePathFromManifest(final Manifest manifest) {
-    return manifest instanceof final ValidBackupManifest validManifest
-        && validManifest.backupDescriptor().isPresent();
-  }
-
   private CompletableFuture<List<ObjectIdentifier>> listObjectsBasedOnDescriptor(
-      final Manifest manifest, final Directory directory) {
-    final var descriptor = ((ValidBackupManifest) manifest).backupDescriptor().get();
-    final var prefix = derivePath(descriptor, manifest.id(), directory);
+      final BackupDescriptor descriptor, final BackupIdentifier id, final Directory directory) {
+    final var prefix = derivePath(descriptor, id, directory);
     return listBackupObjects(prefix);
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -466,7 +466,7 @@ public final class S3BackupStore implements BackupStore {
 
   private CompletableFuture<ResponseBytes<GetObjectResponse>> findManifestForBackup(
       final BackupIdentifier id) {
-    LOG.atTrace().addKeyValue("backup", id).setMessage("Reading manifest").log();
+    LOG.atTrace().addKeyValue("backup", id).setMessage("Finding manifest").log();
     return client
         .getObject(
             req ->
@@ -487,11 +487,11 @@ public final class S3BackupStore implements BackupStore {
   }
 
   CompletableFuture<Manifest> readManifestObject(final BackupIdentifier id) {
-    LOG.atTrace().addKeyValue("backup", id).setMessage("Reading manifest").log();
     return findManifestForBackup(id)
         .thenApply(
             response -> {
               try {
+                LOG.atTrace().addKeyValue("backup", id).setMessage("Reading manifest").log();
                 return (Manifest)
                     MAPPER.readValue(response.asInputStream(), ValidBackupManifest.class);
               } catch (final IOException e) {

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/CompletedBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/CompletedBackupManifest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.s3.manifest;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -51,5 +52,10 @@ public record CompletedBackupManifest(
         segmentFiles,
         createdAt,
         Instant.now());
+  }
+
+  @Override
+  public Optional<BackupDescriptor> backupDescriptor() {
+    return Optional.of(descriptor);
   }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.s3.manifest;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -46,5 +47,10 @@ public record FailedBackupManifest(
   @Override
   public FailedBackupManifest asFailed(final String failureReason) {
     return this;
+  }
+
+  @Override
+  public Optional<BackupDescriptor> backupDescriptor() {
+    return descriptor.map(Function.identity());
   }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.s3.manifest;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -30,9 +31,15 @@ public record InProgressBackupManifest(
     return BackupStatusCode.IN_PROGRESS;
   }
 
-  public CompletedBackupManifest asCompleted(final FileSet snapshot, final FileSet segments) {
-    return new CompletedBackupManifest(
-        id, descriptor, snapshot, segments, createdAt, Instant.now());
+  @Override
+  public BackupStatus toStatus() {
+    return new BackupStatusImpl(
+        id,
+        Optional.of(descriptor),
+        statusCode(),
+        Optional.empty(),
+        Optional.of(createdAt),
+        Optional.of(modifiedAt));
   }
 
   @Override
@@ -48,13 +55,12 @@ public record InProgressBackupManifest(
   }
 
   @Override
-  public BackupStatus toStatus() {
-    return new BackupStatusImpl(
-        id,
-        Optional.of(descriptor),
-        statusCode(),
-        Optional.empty(),
-        Optional.of(createdAt),
-        Optional.of(modifiedAt));
+  public Optional<BackupDescriptor> backupDescriptor() {
+    return Optional.of(descriptor);
+  }
+
+  public CompletedBackupManifest asCompleted(final FileSet snapshot, final FileSet segments) {
+    return new CompletedBackupManifest(
+        id, descriptor, snapshot, segments, createdAt, Instant.now());
   }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/ValidBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/ValidBackupManifest.java
@@ -12,8 +12,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import java.time.Instant;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = Id.NAME, property = "statusCode")
@@ -27,6 +29,8 @@ public sealed interface ValidBackupManifest extends Manifest
 
   @Override
   BackupIdentifier id();
+
+  Optional<BackupDescriptor> backupDescriptor();
 
   Instant createdAt();
 

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathIT.java
@@ -9,17 +9,19 @@ package io.camunda.zeebe.backup.s3;
 
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.util.S3TestBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.BackupAssert;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.junit.jupiter.Container;
@@ -52,7 +54,7 @@ final class CustomBasePathIT {
                     .withStartupTimeout(Duration.ofMinutes(1)));
 
     @ParameterizedTest
-    @ArgumentsSource(TestBackupProvider.class)
+    @MethodSource("provideBackups")
     void canBackupAndRestore(final Backup backup, @TempDir final Path target) {
       // given
       final var config =
@@ -81,6 +83,10 @@ final class CustomBasePathIT {
           .asInstanceOf(new InstanceOfAssertFactory<>(Backup.class, BackupAssert::assertThatBackup))
           .hasSameContentsAs(backup);
     }
+
+    static Stream<? extends Arguments> provideBackups() throws Exception {
+      return S3TestBackupProvider.provideArguments();
+    }
   }
 
   @Nested
@@ -101,7 +107,7 @@ final class CustomBasePathIT {
                     .withStartupTimeout(Duration.ofMinutes(1)));
 
     @ParameterizedTest
-    @ArgumentsSource(TestBackupProvider.class)
+    @MethodSource("provideBackups")
     void canBackupAndRestore(final Backup backup, @TempDir final Path target) {
       // given
       final var config =
@@ -128,6 +134,10 @@ final class CustomBasePathIT {
           .succeedsWithin(Duration.ofSeconds(30))
           .asInstanceOf(new InstanceOfAssertFactory<>(Backup.class, BackupAssert::assertThatBackup))
           .hasSameContentsAs(backup);
+    }
+
+    static Stream<? extends Arguments> provideBackups() throws Exception {
+      return S3TestBackupProvider.provideArguments();
     }
   }
 }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -144,13 +144,13 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
 
     final var prefix =
         brokerVersion.minor() <= 8
-            ? getStore().objectPrefix(backup.id())
-            : getStore().objectPrefixV2(backup.id(), Directory.CONTENTS);
+            ? getStore().legacyObjectPrefix(backup.id())
+            : getStore().objectPrefix(backup.id(), Directory.CONTENTS);
 
     final var manifestPrefix =
         brokerVersion.minor() <= 8
-            ? getStore().objectPrefix(backup.id())
-            : getStore().objectPrefixV2(backup.id(), Directory.MANIFESTS);
+            ? getStore().legacyObjectPrefix(backup.id())
+            : getStore().objectPrefix(backup.id(), Directory.MANIFESTS);
 
     final var manifest = manifestPrefix + S3BackupStore.MANIFEST_OBJECT_KEY;
     final var snapshotObjects =
@@ -205,7 +205,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
                       .listObjectsV2(
                           req ->
                               req.bucket(getConfig().bucketName())
-                                  .prefix(getStore().objectPrefix(backup.id())))
+                                  .prefix(getStore().legacyObjectPrefix(backup.id())))
                       .join();
               Assertions.assertThat(listed.contents()).isEmpty();
             });
@@ -248,7 +248,9 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
             delete ->
                 delete
                     .bucket(getConfig().bucketName())
-                    .key(getStore().objectPrefix(backup.id()) + S3BackupStore.MANIFEST_OBJECT_KEY))
+                    .key(
+                        getStore().legacyObjectPrefix(backup.id())
+                            + S3BackupStore.MANIFEST_OBJECT_KEY))
         .join();
 
     // then

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -85,7 +85,9 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   @MethodSource("provideBackups")
   default void snapshotFilesExist(final Backup backup) {
     // given
-    final var prefix = getStore().objectPrefix(backup.id()) + S3BackupStore.SNAPSHOT_PREFIX;
+    final var prefix =
+        getStore().derivePath(backup.descriptor(), backup.id(), Directory.CONTENTS)
+            + S3BackupStore.SNAPSHOT_PREFIX;
 
     final var expectedObjects =
         backup.snapshot().names().stream().map(name -> prefix + name).toList();
@@ -107,7 +109,9 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   @MethodSource("provideBackups")
   default void segmentFilesExist(final Backup backup) {
     // given
-    final var prefix = getStore().objectPrefix(backup.id()) + S3BackupStore.SEGMENTS_PREFIX;
+    final var prefix =
+        getStore().derivePath(backup.descriptor(), backup.id(), Directory.CONTENTS)
+            + S3BackupStore.SEGMENTS_PREFIX;
 
     final var expectedObjects =
         backup.segments().names().stream().map(name -> prefix + name).toList();

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
@@ -56,24 +56,6 @@ public class S3TestBackupProvider {
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }
 
-  public static Backup minimalBackupWithId(final BackupIdentifierImpl id) throws IOException {
-    final var tempDir = Files.createTempDirectory("backup");
-    Files.createDirectory(tempDir.resolve("segments/"));
-    final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
-    Files.write(seg1, RandomUtils.nextBytes(1));
-
-    return new BackupImpl(
-        id,
-        new BackupDescriptorImpl(
-            4,
-            5,
-            "test",
-            Instant.now().truncatedTo(ChronoUnit.MILLIS),
-            CheckpointType.MANUAL_BACKUP),
-        new NamedFileSetImpl(Map.of()),
-        new NamedFileSetImpl(Map.of("segment-file-1", seg1)));
-  }
-
   public static Backup simpleBackup(final boolean legacy) throws IOException {
     return simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), legacy);
   }

--- a/zeebe/backup-stores/testkit/pom.xml
+++ b/zeebe/backup-stores/testkit/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
@@ -18,8 +18,7 @@ public interface BackupStoreTestKit
         UpdatingBackupStatus,
         QueryingBackupStatus,
         ListingBackups,
-        StoringRangeMarkers,
-        StoringBackupIndex {
+        StoringRangeMarkers {
 
   static Stream<? extends Arguments> provideBackups() throws Exception {
     return TestBackupProvider.provideArguments();

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.zeebe.backup.testkit;
 
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
 public interface BackupStoreTestKit
     extends SavingBackup,
         DeletingBackup,
@@ -14,4 +18,10 @@ public interface BackupStoreTestKit
         UpdatingBackupStatus,
         QueryingBackupStatus,
         ListingBackups,
-        StoringRangeMarkers {}
+        StoringRangeMarkers,
+        StoringBackupIndex {
+
+  static Stream<? extends Arguments> provideBackups() throws Exception {
+    return TestBackupProvider.provideArguments();
+  }
+}

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/DeletingBackup.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/DeletingBackup.java
@@ -12,12 +12,11 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.time.Duration;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public interface DeletingBackup {
   BackupStore getStore();
@@ -32,7 +31,7 @@ public interface DeletingBackup {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void backupDoesNotExistAfterDeleting(final Backup backup) {
     // given
     getStore().save(backup).join();

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.backup.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider;
@@ -49,14 +51,13 @@ public interface ListingBackups {
   @ArgumentsSource(WildcardBackupProvider.class)
   default void canFindBackupByWildcard(final WildcardTestParameter parameter) {
     // given
-    final var provider = new TestBackupProvider();
 
     final var backups =
         Stream.concat(parameter.unexpectedIds().stream(), parameter.expectedIds().stream())
             .map(
                 id -> {
                   try {
-                    return provider.minimalBackupWithId(id);
+                    return getBackup(id);
                   } catch (final IOException e) {
                     throw new UncheckedIOException(e);
                   }
@@ -71,5 +72,9 @@ public interface ListingBackups {
     assertThat(result)
         .map(BackupStatus::id)
         .containsExactlyInAnyOrderElementsOf(parameter.expectedIds());
+  }
+
+  default Backup getBackup(final BackupIdentifierImpl id) throws IOException {
+    return TestBackupProvider.minimalBackupWithId(id);
   }
 }

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/QueryingBackupStatus.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/QueryingBackupStatus.java
@@ -12,19 +12,18 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.time.Duration;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public interface QueryingBackupStatus {
   BackupStore getStore();
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void canGetStatus(final Backup backup) {
     // given
     getStore().save(backup).join();
@@ -42,7 +41,7 @@ public interface QueryingBackupStatus {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void statusIsFailedAfterMarkingAsFailed(final Backup backup) {
     // given
     getStore().save(backup).join();

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/RestoringBackup.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/RestoringBackup.java
@@ -12,19 +12,18 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.testkit.support.BackupAssert;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.nio.file.Path;
 import java.time.Duration;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public interface RestoringBackup {
   BackupStore getStore();
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void canRestoreBackup(final Backup backup, @TempDir final Path targetDir) {
     // given
     getStore().save(backup).join();
@@ -37,7 +36,7 @@ public interface RestoringBackup {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void restoredBackupHasSameContents(
       final Backup originalBackup, @TempDir final Path targetDir) {
     // given
@@ -53,7 +52,7 @@ public interface RestoringBackup {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void savedContentDoesNotGetOverWritten(
       final Backup originalBackup, @TempDir final Path targetDir) {
     // given

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/SavingBackup.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/SavingBackup.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
@@ -20,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public interface SavingBackup {
   BackupStore getStore();
@@ -30,13 +29,13 @@ public interface SavingBackup {
   Class<? extends Exception> getFileNotFoundExceptionClass();
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void savingBackupIsSuccessful(final Backup backup) {
     Assertions.assertThat(getStore().save(backup)).succeedsWithin(Duration.ofSeconds(10));
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void backupFailsIfBackupAlreadyExists(final Backup backup) {
     // when
     getStore().save(backup).join();
@@ -49,7 +48,7 @@ public interface SavingBackup {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void backupFailsIfFilesAreMissing(final Backup backup) throws IOException {
     // when
     final var deletedFile = backup.segments().files().stream().findFirst().orElseThrow();
@@ -64,7 +63,7 @@ public interface SavingBackup {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void shouldNotOverwriteCompletedBackup(final Backup backup) {
     // given
     getStore().save(backup).join();

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/UpdatingBackupStatus.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/UpdatingBackupStatus.java
@@ -12,17 +12,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public interface UpdatingBackupStatus {
 
   BackupStore getStore();
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void backupIsMarkedAsCompleted(final Backup backup) {
     // when
     getStore().save(backup).join();
@@ -34,7 +33,7 @@ public interface UpdatingBackupStatus {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void backupCanBeMarkedAsFailed(final Backup backup) {
     // given
     getStore().save(backup).join();
@@ -50,7 +49,7 @@ public interface UpdatingBackupStatus {
   }
 
   @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
+  @MethodSource("provideBackups")
   default void markingAsFailedUpdatesTimestamp(final Backup backup) {
     // given
     getStore().save(backup).join();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Align S3 backup store structure with GCS/FS/Azure, moving `manifest.json` files under `basePath/manifests/` and respective backup contents under `basePath/contents/`.

Manifests are parsed from both legacy and new structure, but the actual contents path is extracted from the `brokerVersion` present in the Manifest's `backupDescriptor`. Overall, lookups are performed first on the updated structure and then falling back to the legacy one.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #11243 
