### PR TITLE
43662 enhance authorization wildcard resource id handling

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -225,8 +224,6 @@ public class AuditLogAuthorizationsIT {
     assertGetByKeyAccess(client, logs.items().getFirst());
   }
 
-  // TODO: this one fails, due to the wildcard shortcut in the authorization checks
-  @Disabled("https://github.com/camunda/camunda/issues/43662")
   @Test
   void shouldAuthorizeByProcessIdWildcard(
       @Authenticated(USER_B_USERNAME) final CamundaClient client) {
@@ -267,8 +264,6 @@ public class AuditLogAuthorizationsIT {
     assertGetByKeyAccess(client, logs.items().getFirst());
   }
 
-  // TODO: this one fails, due to the wildcard shortcut in the authorization checks
-  @Disabled("https://github.com/camunda/camunda/issues/43662")
   @Test
   void shouldAuthorizeByUserTaskProcessIdWildcard(
       @Authenticated(USER_C_USERNAME) final CamundaClient client) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -20,7 +20,6 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -49,9 +48,6 @@ public class AuditLogSearchClientIT {
     utils.await();
   }
 
-  // TODO: this one fails, because r/n the authorizations fail if the resourceId supplier returns
-  // null, which is the case for ADMIN audit log entries
-  @Disabled("https://github.com/camunda/camunda/issues/43662")
   @Test
   void shouldGetAuditLogByKey(@Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  * Test is disabled on RDBMS until https://github.com/camunda/camunda/issues/43323 is implemented.
  */
 @MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class AuditLogSearchClientIT {
 

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -34,6 +34,41 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -46,11 +46,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>

--- a/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
@@ -171,6 +171,11 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
       final T document,
       final SingleAuthorizationCondition single) {
     final Authorization authorization = single.authorization();
+
+    if (!authorization.appliesTo(document)) {
+      return;
+    }
+
     final var resourceAccess =
         getResourceAccessProvider()
             .hasResourceAccess(securityContext.authentication(), authorization, document);
@@ -183,7 +188,8 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
       final SecurityContext securityContext,
       final T document,
       final AnyOfAuthorizationCondition anyOf) {
-    final var authorizations = anyOf.authorizations();
+    final var authorizations = anyOf.applicableAuthorizations(document);
+
     for (final Authorization authorization : authorizations) {
       final var resourceAccess =
           getResourceAccessProvider()

--- a/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
@@ -173,7 +173,9 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
     final Authorization authorization = single.authorization();
 
     if (!authorization.appliesTo(document)) {
-      return;
+      throw new ResourceAccessDeniedException(
+          authorization,
+          "Authorization is not applicable - which does not make sense for single authorizations.");
     }
 
     final var resourceAccess =

--- a/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
@@ -88,9 +88,10 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
 
   private AuthorizationCheck createSingleAuthorizationCheck(
       final CamundaAuthentication authentication, final SingleAuthorizationCondition single) {
-    final var resourceAccess = resolveResourceAccess(authentication, single.authorization());
+    final var authorization = single.authorization();
+    final var resourceAccess = resolveResourceAccess(authentication, authorization);
 
-    if (resourceAccess.wildcard()) {
+    if (resourceAccess.wildcard() && !authorization.transitive()) {
       return AuthorizationCheck.disabled();
     }
 
@@ -103,8 +104,7 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
     for (final Authorization authorization : anyOf.authorizations()) {
       final var resourceAccess = resolveResourceAccess(authentication, authorization);
 
-      if (resourceAccess.wildcard()) {
-        // here is the culprit for audit log authorizations
+      if (resourceAccess.wildcard() && !authorization.transitive()) {
         return AuthorizationCheck.disabled();
       }
 

--- a/search/search-client/src/test/java/io/camunda/search/clients/auth/AbstractResourceAccessControllerTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/auth/AbstractResourceAccessControllerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.auth.condition.AuthorizationConditions;
+import io.camunda.security.reader.ResourceAccess;
+import io.camunda.security.reader.ResourceAccessController;
+import io.camunda.security.reader.ResourceAccessProvider;
+import io.camunda.security.reader.TenantAccess;
+import io.camunda.security.reader.TenantAccessProvider;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AbstractResourceAccessControllerTest {
+
+  @Mock private ResourceAccessProvider resourceAccessProvider;
+  @Mock private TenantAccessProvider tenantAccessProvider;
+
+  private ResourceAccessController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new DummyResourceAccessController(resourceAccessProvider, tenantAccessProvider);
+  }
+
+  @Nested
+  class DoGetWithConditionalAuthorizations {
+
+    @Test
+    void withSingleAuthorization() {
+      // given
+      final var resource = new Object();
+      final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
+      final var authorization =
+          Authorization.of(a -> a.processDefinition().readProcessDefinition())
+              .withCondition(o -> false);
+
+      final var securityContext =
+          SecurityContext.of(
+              s -> s.withAuthentication(authentication).withAuthorization(authorization));
+
+      when(tenantAccessProvider.hasTenantAccess(authentication, resource))
+          .thenReturn(TenantAccess.allowed(List.of("baz")));
+
+      // when
+      controller.doGet(securityContext, a -> resource);
+
+      // then
+      verify(resourceAccessProvider, never()).hasResourceAccess(any(), any(), any());
+    }
+
+    @Test
+    void withAnyOfAuthorization() {
+      // given
+      final var resource = new Object();
+      final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
+      final var enabledAuthorization = Authorization.of(a -> a.processDefinition().readUserTask());
+      final var disabledAuthorization =
+          Authorization.of(a -> a.processDefinition().readProcessDefinition())
+              .withCondition(o -> false);
+
+      // it's important to have the disabled one first, otherwise the controller would skip checking
+      final var securityContext =
+          SecurityContext.of(
+              s ->
+                  s.withAuthentication(authentication)
+                      .withAuthorizationCondition(
+                          AuthorizationConditions.anyOf(
+                              disabledAuthorization, enabledAuthorization)));
+
+      when(resourceAccessProvider.hasResourceAccess(authentication, enabledAuthorization, resource))
+          .thenReturn(ResourceAccess.allowed(enabledAuthorization));
+      when(tenantAccessProvider.hasTenantAccess(authentication, resource))
+          .thenReturn(TenantAccess.allowed(List.of("baz")));
+
+      // when
+      controller.doGet(securityContext, a -> resource);
+
+      // then
+      verify(resourceAccessProvider, times(1))
+          .hasResourceAccess(authentication, enabledAuthorization, resource);
+    }
+  }
+
+  private class DummyResourceAccessController extends AbstractResourceAccessController {
+
+    ResourceAccessProvider resourceAccessProvider;
+    TenantAccessProvider tenantAccessProvider;
+
+    public DummyResourceAccessController(
+        final ResourceAccessProvider resourceAccessProvider,
+        final TenantAccessProvider tenantAccessProvider) {
+      this.resourceAccessProvider = resourceAccessProvider;
+      this.tenantAccessProvider = tenantAccessProvider;
+    }
+
+    @Override
+    protected ResourceAccessProvider getResourceAccessProvider() {
+      return resourceAccessProvider;
+    }
+
+    @Override
+    protected TenantAccessProvider getTenantAccessProvider() {
+      return tenantAccessProvider;
+    }
+  }
+}

--- a/search/search-client/src/test/java/io/camunda/search/clients/auth/AbstractResourceAccessControllerTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/auth/AbstractResourceAccessControllerTest.java
@@ -8,12 +8,14 @@
 package io.camunda.search.clients.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
@@ -65,10 +67,10 @@ public class AbstractResourceAccessControllerTest {
       when(tenantAccessProvider.hasTenantAccess(authentication, resource))
           .thenReturn(TenantAccess.allowed(List.of("baz")));
 
-      // when
-      controller.doGet(securityContext, a -> resource);
-
       // then
+      assertThatThrownBy(() -> controller.doGet(securityContext, a -> resource))
+          .isInstanceOf(ResourceAccessDeniedException.class)
+          .hasMessageContaining("not applicable");
       verify(resourceAccessProvider, never()).hasResourceAccess(any(), any(), any());
     }
 

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ResourceAccessDeniedException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ResourceAccessDeniedException.java
@@ -18,12 +18,22 @@ public class ResourceAccessDeniedException extends CamundaSearchException {
   private final List<MissingAuthorization> missingAuthorizations;
 
   public ResourceAccessDeniedException(final MissingAuthorization missingAuthorization) {
-    super(missingSingleAuthMessage(missingAuthorization), Reason.FORBIDDEN);
-    this.missingAuthorizations = List.of(missingAuthorization);
+    this(missingAuthorization, "");
+  }
+
+  public ResourceAccessDeniedException(
+      final MissingAuthorization missingAuthorization, final String customMessage) {
+    super(missingSingleAuthMessage(missingAuthorization) + customMessage, Reason.FORBIDDEN);
+    missingAuthorizations = List.of(missingAuthorization);
   }
 
   public ResourceAccessDeniedException(final Authorization<?> authorization) {
     this(MissingAuthorization.from(authorization));
+  }
+
+  public ResourceAccessDeniedException(
+      final Authorization<?> authorization, final String customMessage) {
+    this(MissingAuthorization.from(authorization), customMessage);
   }
 
   /**
@@ -32,7 +42,7 @@ public class ResourceAccessDeniedException extends CamundaSearchException {
    */
   public ResourceAccessDeniedException(final List<Authorization<?>> authorizations) {
     super(missingMultipleAuthMessage(MissingAuthorization.from(authorizations)), Reason.FORBIDDEN);
-    this.missingAuthorizations = MissingAuthorization.from(authorizations);
+    missingAuthorizations = MissingAuthorization.from(authorizations);
   }
 
   public List<MissingAuthorization> getMissingAuthorizations() {

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -41,13 +41,16 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record Authorization<T>(
     @JsonProperty("resource_type") AuthorizationResourceType resourceType,
     @JsonProperty("permission_type") PermissionType permissionType,
     @JsonProperty("resource_ids") List<String> resourceIds,
-    @JsonIgnore Function<T, String> resourceIdSupplier) {
+    @JsonIgnore Function<T, String> resourceIdSupplier,
+    @JsonIgnore Predicate<T> condition,
+    @JsonProperty("transitive") boolean transitive) {
 
   public boolean hasAnyResourceIds() {
     return resourceIds != null && !resourceIds.isEmpty();
@@ -55,24 +58,60 @@ public record Authorization<T>(
 
   public static <T> Authorization<T> withAuthorization(
       final Authorization<T> authorization, final String resourceId) {
-    return of(
-        b ->
-            b.resourceType(authorization.resourceType())
-                .permissionType(authorization.permissionType())
-                .resourceIds(List.of(resourceId)));
+    return authorization.with(resourceId);
   }
 
   public static <T> Authorization<T> withAuthorization(
       final Authorization<T> authorization, final Function<T, String> resourceIdSupplier) {
-    return of(
-        b ->
-            b.resourceType(authorization.resourceType())
-                .permissionType(authorization.permissionType())
-                .resourceIdSupplier(resourceIdSupplier));
+    return authorization.with(resourceIdSupplier);
+  }
+
+  public Authorization<T> with(final String resourceId) {
+    return new Authorization<>(
+        resourceType(),
+        permissionType(),
+        List.of(resourceId),
+        resourceIdSupplier(),
+        condition(),
+        transitive());
+  }
+
+  public Authorization<T> with(final List<String> resourceIds) {
+    return new Authorization<>(
+        resourceType(),
+        permissionType(),
+        List.copyOf(resourceIds),
+        resourceIdSupplier(),
+        condition(),
+        transitive());
+  }
+
+  public Authorization<T> with(final Function<T, String> resourceIdSupplier) {
+    return new Authorization<>(
+        resourceType(),
+        permissionType(),
+        resourceIds(),
+        resourceIdSupplier,
+        condition(),
+        transitive());
+  }
+
+  public Authorization<T> withCondition(final Predicate<T> condition) {
+    return new Authorization<>(
+        resourceType(),
+        permissionType(),
+        resourceIds(),
+        resourceIdSupplier(),
+        condition,
+        transitive());
   }
 
   public static <T> Authorization<T> of(final Function<Builder<T>, Builder<T>> builderFunction) {
     return builderFunction.apply(new Builder<>()).build();
+  }
+
+  public boolean appliesTo(final T document) {
+    return condition.test(document);
   }
 
   public static class Builder<T> {
@@ -80,6 +119,8 @@ public record Authorization<T>(
     private PermissionType permissionType;
     private List<String> resourceIds;
     private Function<T, String> resourceIdSupplier;
+    private Predicate<T> condition = t -> true;
+    private boolean transitive = false;
 
     public Builder<T> resourceType(final AuthorizationResourceType resourceType) {
       this.resourceType = resourceType;
@@ -88,6 +129,16 @@ public record Authorization<T>(
 
     public Builder<T> permissionType(final PermissionType permissionType) {
       this.permissionType = permissionType;
+      return this;
+    }
+
+    public Builder<T> condition(final Predicate<T> condition) {
+      this.condition = condition;
+      return this;
+    }
+
+    public Builder<T> transitive() {
+      transitive = true;
       return this;
     }
 
@@ -210,7 +261,8 @@ public record Authorization<T>(
     }
 
     public Authorization<T> build() {
-      return new Authorization<>(resourceType, permissionType, resourceIds, resourceIdSupplier);
+      return new Authorization<>(
+          resourceType, permissionType, resourceIds, resourceIdSupplier, condition, transitive);
     }
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -22,6 +22,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.S
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.TENANT;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.CREATE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.DELETE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
@@ -112,6 +113,12 @@ public record Authorization<T>(
 
   public boolean appliesTo(final T document) {
     return condition.test(document);
+  }
+
+  @JsonIgnore
+  public boolean isWildcard() {
+    return resourceIds != null
+        && resourceIds.stream().anyMatch(id -> WILDCARD.getResourceId().equals(id));
   }
 
   public static class Builder<T> {

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -112,7 +112,7 @@ public record Authorization<T>(
   }
 
   public boolean appliesTo(final T document) {
-    return condition.test(document);
+    return condition == null || condition.test(document);
   }
 
   @JsonIgnore
@@ -126,7 +126,7 @@ public record Authorization<T>(
     private PermissionType permissionType;
     private List<String> resourceIds;
     private Function<T, String> resourceIdSupplier;
-    private Predicate<T> condition = t -> true;
+    private Predicate<T> condition = null;
     private boolean transitive = false;
 
     public Builder<T> resourceType(final AuthorizationResourceType resourceType) {

--- a/security/security-core/src/main/java/io/camunda/security/auth/condition/AnyOfAuthorizationCondition.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/condition/AnyOfAuthorizationCondition.java
@@ -27,4 +27,15 @@ public record AnyOfAuthorizationCondition(List<Authorization<?>> authorizations)
     }
     authorizations = List.copyOf(authorizations);
   }
+
+  public <T> List<Authorization<?>> applicableAuthorizations(final T document) {
+    return authorizations().stream()
+        .filter(
+            auth -> {
+              @SuppressWarnings("unchecked")
+              final Authorization<T> typedAuth = (Authorization<T>) auth;
+              return typedAuth.appliesTo(document);
+            })
+        .toList();
+  }
 }

--- a/service/src/main/java/io/camunda/service/AuditLogServices.java
+++ b/service/src/main/java/io/camunda/service/AuditLogServices.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.service;
 
-import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.AUDIT_LOG_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.AUDIT_LOG_READ_PROCESS_INSTANCE_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.AUDIT_LOG_READ_USER_TASK_AUTHORIZATION;
@@ -18,6 +17,7 @@ import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.condition.AuthorizationCondition;
 import io.camunda.security.auth.condition.AuthorizationConditions;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -25,6 +25,16 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 
 public class AuditLogServices
     extends SearchQueryService<AuditLogServices, AuditLogQuery, AuditLogEntity> {
+
+  private static final AuthorizationCondition AUDIT_LOG_AUTHORIZATIONS =
+      AuthorizationConditions.anyOf(
+          AUDIT_LOG_READ_AUTHORIZATION.with(al -> al.category().name()),
+          AUDIT_LOG_READ_PROCESS_INSTANCE_AUTHORIZATION
+              .with(AuditLogEntity::processDefinitionId)
+              .withCondition(al -> al.processDefinitionId() != null),
+          AUDIT_LOG_READ_USER_TASK_AUTHORIZATION
+              .with(AuditLogEntity::processDefinitionId)
+              .withCondition(al -> al.processDefinitionId() != null));
 
   private final AuditLogSearchClient auditLogSearchClient;
 
@@ -51,11 +61,7 @@ public class AuditLogServices
             auditLogSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication,
-                        AuthorizationConditions.anyOf(
-                            AUDIT_LOG_READ_AUTHORIZATION,
-                            AUDIT_LOG_READ_PROCESS_INSTANCE_AUTHORIZATION,
-                            AUDIT_LOG_READ_USER_TASK_AUTHORIZATION)))
+                        authentication, AUDIT_LOG_AUTHORIZATIONS))
                 .searchAuditLogs(query));
   }
 
@@ -76,16 +82,7 @@ public class AuditLogServices
             auditLogSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication,
-                        AuthorizationConditions.anyOf(
-                            withAuthorization(
-                                AUDIT_LOG_READ_PROCESS_INSTANCE_AUTHORIZATION,
-                                AuditLogEntity::processDefinitionId),
-                            withAuthorization(
-                                AUDIT_LOG_READ_AUTHORIZATION, al -> al.category().name()),
-                            withAuthorization(
-                                AUDIT_LOG_READ_USER_TASK_AUTHORIZATION,
-                                AuditLogEntity::processDefinitionId))))
+                        authentication, AUDIT_LOG_AUTHORIZATIONS))
                 .getAuditLog(auditLogKey));
   }
 }

--- a/service/src/main/java/io/camunda/service/AuditLogServices.java
+++ b/service/src/main/java/io/camunda/service/AuditLogServices.java
@@ -13,6 +13,7 @@ import static io.camunda.service.authorization.Authorizations.AUDIT_LOG_READ_USE
 
 import io.camunda.search.clients.AuditLogSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -34,7 +35,10 @@ public class AuditLogServices
               .withCondition(al -> al.processDefinitionId() != null),
           AUDIT_LOG_READ_USER_TASK_AUTHORIZATION
               .with(AuditLogEntity::processDefinitionId)
-              .withCondition(al -> al.processDefinitionId() != null));
+              .withCondition(
+                  al ->
+                      al.processDefinitionId() != null
+                          && al.category() == AuditLogOperationCategory.USER_TASKS));
 
   private final AuditLogSearchClient auditLogSearchClient;
 

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -101,10 +101,10 @@ public abstract class Authorizations {
       Authorization.of(a -> a.auditLog().read());
 
   public static final Authorization<AuditLogEntity> AUDIT_LOG_READ_PROCESS_INSTANCE_AUTHORIZATION =
-      Authorization.of(a -> a.processDefinition().readProcessInstance());
+      Authorization.of(a -> a.processDefinition().readProcessInstance().transitive());
 
   public static final Authorization<AuditLogEntity> AUDIT_LOG_READ_USER_TASK_AUTHORIZATION =
-      Authorization.of(a -> a.processDefinition().readUserTask());
+      Authorization.of(a -> a.processDefinition().readUserTask().transitive());
 
   public static final Authorization<ClusterVariableEntity> CLUSTER_VARIABLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.clusterVariable().read());


### PR DESCRIPTION
## Description

The current authorization capabilities were not able to cover the audit log requirements, thus within this PR 2 new concepts are introduced

**1. conditional authorizations**

Some auditlog authorizations a based on `processDefinitionId` and require the usage a `resourceIdSupplier`. But some audit logs, e.g. admin logs, don't have `processDefinitionId` therefore the corresponding check should be skipped.

Unfortunately the current implementation would throw a `NullPointerException` and the whole request would be aborted. 

Impact: The client could not fetch any admin audit logs by key.


**2. transitive authorizations**

The audit logs authorizations are also kinda unique as they described nested/transitive authorizations, e.g. someone can access all audit logs of a specific process instance, when they have access to the process (this permission targets the process entity, not the audit log directly - hence transitive).

Unfortunately the wildcard handling in the `AbstractResourceAccessController` has a short-circuit if any of the authorizations return a wildcard permission. This wildcard does not refer to all audit logs - just to all processes, but with the short-circuit be interpreted like that.

Impact: a user with wildcard permissions to read all process instances for all (wildcard) processes, would gain access to **all** audit logs (which is not intended!)


⚠️ **RDBMS still needs to be implemented in another PR/Issue**

## Related issues

closes #43662 
