### PR TITLE
[Backport stable/8.6] [Backport stable/8.7] [Backport stable/8.8] ci: update codeowner file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,3 +30,12 @@
 /.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team
+
+##########################
+## Reliability Testing  ##
+##########################
+
+# Performance + Load testing
+/load-tests/ @camunda/reliability-testing
+/zeebe/benchmarks/ @camunda/reliability-testing
+/.github/workflows/*load-test*.yml @camunda/reliability-testing


### PR DESCRIPTION
# Description
Backport of #43555 to `stable/8.6`.

relates to #43551 #43500

closes https://github.com/camunda/camunda/pull/43554