### PR TITLE
feat: add `deleteHistory` to ResourceDeletionRecord

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
@@ -24,6 +24,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "deleteHistory": {
+              "type": "boolean"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
@@ -24,6 +24,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "deleteHistory": {
+              "type": "boolean"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.resource;
 
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -20,17 +21,17 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   // Static StringValue keys to avoid memory waste
   private static final StringValue RESOURCE_KEY_KEY = new StringValue("resourceKey");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue DELETE_HISTORY_KEY = new StringValue("deleteHistory");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY_KEY);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
+  private final BooleanProperty deleteHistoryProp = new BooleanProperty(DELETE_HISTORY_KEY, false);
 
   public ResourceDeletionRecord() {
-    super(2);
-    declareProperty(resourceKeyProp).declareProperty(tenantIdProp);
-  }
-
-  public void wrap(final ResourceDeletionRecord record) {
-    resourceKeyProp.setValue(record.getResourceKey());
+    super(3);
+    declareProperty(resourceKeyProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(deleteHistoryProp);
   }
 
   @Override
@@ -40,6 +41,16 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   public ResourceDeletionRecord setResourceKey(final long resourceKey) {
     resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+
+  @Override
+  public boolean isDeleteHistory() {
+    return deleteHistoryProp.getValue();
+  }
+
+  public ResourceDeletionRecord setDeleteHistory(final boolean deleteHistory) {
+    deleteHistoryProp.setValue(deleteHistory);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2530,12 +2530,32 @@ final class JsonSerializableToJsonTest {
 
               return new ResourceDeletionRecord()
                   .setResourceKey(resourceKey)
+                  .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+                  .setDeleteHistory(true);
+            },
+        """
+                {
+                  "resourceKey":1,
+                  "tenantId": "<default>",
+                  "deleteHistory": true
+                }
+                """
+      },
+      {
+        "Empty ResourceDeletionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var resourceKey = 1L;
+
+              return new ResourceDeletionRecord()
+                  .setResourceKey(resourceKey)
                   .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
             },
         """
                 {
                   "resourceKey":1,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "deleteHistory": false
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceDeletionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceDeletionRecord.golden
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.resource;
 
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -20,17 +21,17 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   // Static StringValue keys to avoid memory waste
   private static final StringValue RESOURCE_KEY_KEY = new StringValue("resourceKey");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue DELETE_HISTORY_KEY = new StringValue("deleteHistory");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY_KEY);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
+  private final BooleanProperty deleteHistoryProp = new BooleanProperty(DELETE_HISTORY_KEY, false);
 
   public ResourceDeletionRecord() {
-    super(2);
-    declareProperty(resourceKeyProp).declareProperty(tenantIdProp);
-  }
-
-  public void wrap(final ResourceDeletionRecord record) {
-    resourceKeyProp.setValue(record.getResourceKey());
+    super(3);
+    declareProperty(resourceKeyProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(deleteHistoryProp);
   }
 
   @Override
@@ -40,6 +41,16 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   public ResourceDeletionRecord setResourceKey(final long resourceKey) {
     resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+
+  @Override
+  public boolean isDeleteHistory() {
+    return deleteHistoryProp.getValue();
+  }
+
+  public ResourceDeletionRecord setDeleteHistory(final boolean deleteHistory) {
+    deleteHistoryProp.setValue(deleteHistory);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceDeletionRecordValue.java
@@ -33,4 +33,9 @@ public interface ResourceDeletionRecordValue extends RecordValue, TenantOwned {
    * @return the key of the resource that will be deleted
    */
   long getResourceKey();
+
+  /**
+   * @return whether resource history should be deleted
+   */
+  boolean isDeleteHistory();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add flag to determine weather history should be deleted for a ResourceDeletionRecord.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/41951
