### PR TITLE
[Backport main] Create authorization for user API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertBadRequest,
+  assertInvalidArgument,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  encode,
+  assertStatusCode,
+  assertRequiredFields,
+  assertForbiddenRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  CREATE_CUSTOM_AUTHORIZATION_BODY,
+  authorizedComponentRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+
+const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
+
+test.describe.serial('Create Authorization API - Success and Conflict', () => {
+  let successUser: {username: string; name: string; email: string; password: string};
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create user for Authorization tests', async () => {
+      successUser = await createUser(request);
+      console.log('Created user with username:', successUser.username);
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step(
+      'Teardown - Delete user with username ' +
+        successUser.username +
+        ' created for Authorization tests',
+      async () => {
+        await cleanupUsers(request, [successUser.username]);
+      },
+    );
+  });
+
+  test('Create Authorization for user - Success', async ({request}) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      successUser.username,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertStatusCode(authRes, 201);
+
+      await validateResponse(
+        {
+          path: CREATE_AUTHORIZATION_ENDPOINT,
+          method: 'POST',
+          status: '201',
+        },
+        authRes,
+      );
+
+      const authBody = await authRes.json();
+      assertRequiredFields(authBody, authorizedComponentRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - Multiple permissionTypes - Success', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      successUser.username,
+      'USER',
+      '*',
+      'BATCH',
+      [
+        'CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE',
+        'CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE',
+      ],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertStatusCode(authRes, 201);
+
+      await validateResponse(
+        {
+          path: CREATE_AUTHORIZATION_ENDPOINT,
+          method: 'POST',
+          status: '201',
+        },
+        authRes,
+      );
+
+      const authBody = await authRes.json();
+      assertRequiredFields(authBody, authorizedComponentRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 409 Conflict', async ({request}) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      successUser.username,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertConflictRequest(
+        authRes,
+        `Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to create authorization for owner '${successUser.username}' for resource identifier '*', but an authorization for this resource identifier already exists.`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+});
+
+test.describe.parallel('Create Authorization API - Unhappy paths', () => {
+  let user: {username: string; name: string; email: string; password: string};
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create user for Authorization tests', async () => {
+      user = await createUser(request);
+      console.log('Created user with username:', user.username);
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step(
+      'Teardown - Delete user with username ' +
+        user.username +
+        ' created for Authorization tests',
+      async () => {
+        await cleanupUsers(request, [user.username]);
+      },
+    );
+  });
+
+  test('Create Authorization for user - 400 Bad Request - wrong value for ownerType', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'WRONG_VALUE_FOR_TEST',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertBadRequest(
+        authRes,
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'ownerType'. Use any of the following values: [USER, CLIENT, ROLE, GROUP, MAPPING_RULE, UNSPECIFIED]",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 400 Bad Request - wrong value for resourceType', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'WRONG_VALUE_FOR_TEST',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertBadRequest(
+        authRes,
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 400 Invalid Argument - invalid resourceId', async ({
+    request,
+  }) => {
+    const invalidResourceId = ';;;;';
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      invalidResourceId,
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertInvalidArgument(
+        authRes,
+        400,
+        `The provided resourceId contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'.`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 401 Unauthorized', async ({
+    request,
+  }) => {
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      user.username,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: authorizationBody,
+        },
+      );
+      await assertUnauthorizedRequest(authRes);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Authorization for user - 404 Not Found - not existing ownerId', async ({
+    request,
+  }) => {
+    const notExistingOwnerId = 'nonExistingOwnerId12345';
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      notExistingOwnerId,
+      'USER',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: authorizationBody,
+        },
+      );
+      await assertNotFoundRequest(
+        authRes,
+        `Command 'CREATE' rejected with code 'NOT_FOUND': Expected to create or update authorization with ownerId or resourceId '${notExistingOwnerId}', but a user with this ID does not exist.`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+});
+
+test.describe('Create Authorization for User - Forbidden', () => {
+  let userToGrantAuthorization: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+
+  test.beforeAll(
+    'Setup - Create test user with Resource Authorization and user for granting Authorization',
+    async ({request}) => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+
+      userToGrantAuthorization = await createUser(request);
+    },
+  );
+
+  test.afterAll(
+    'Teardown - Delete test users created for Authorization Forbidden tests',
+    async ({request}) => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+        userToGrantAuthorization.username,
+      ]);
+    },
+  );
+  test('Create Authorization for user - 403 Forbidden', async ({request}) => {
+    await test.step('Test - Create Authorization with user credentials', async () => {
+      const token = encode(
+        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+      );
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        userToGrantAuthorization.username,
+        'USER',
+        '*',
+        'PROCESS_DEFINITION',
+        ['CREATE_PROCESS_INSTANCE'],
+      );
+
+      await expect(async () => {
+        const authRes = await request.post(
+          buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: authorizationBody,
+          },
+        );
+        await assertForbiddenRequest(
+          authRes,
+          "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'",
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -11,6 +11,7 @@ import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
   assertConflictRequest,
+  assertInvalidState,
   assertNotFoundRequest,
   assertStatusCode,
   assertUnauthorizedRequest,
@@ -74,7 +75,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
 
     await test.step('Suspend already suspended batch operation', async () => {
       const doubleRes = await suspendBatchOperation(request, key, 409);
-      await assertConflictRequest(doubleRes, 'INVALID_STATE');
+      await assertInvalidState(doubleRes);
     });
 
     await test.step('resume batch operation', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -580,6 +580,46 @@ export function CREATE_COMPONENT_AUTHORIZATION(
   };
 }
 
+export function CREATE_CUSTOM_AUTHORIZATION_BODY(
+  ownerId: string,
+  ownerType:
+    | 'USER'
+    | 'CLIENT'
+    | 'ROLE'
+    | 'GROUP'
+    | 'MAPPING_RULE'
+    | 'WRONG_VALUE_FOR_TEST',
+  resourceId: string,
+  resourceType:
+    | 'AUDIT_LOG'
+    | 'AUTHORIZATION'
+    | 'MAPPING_RULE'
+    | 'MESSAGE'
+    | 'BATCH'
+    | 'COMPONENT'
+    | 'SYSTEM'
+    | 'TENANT'
+    | 'RESOURCE'
+    | 'PROCESS_DEFINITION'
+    | 'DECISION_REQUIREMENTS_DEFINITION'
+    | 'DECISION_DEFINITION'
+    | 'GROUP'
+    | 'USER'
+    | 'ROLE'
+    | 'DOCUMENT'
+    | 'USER_TASK'
+    | 'WRONG_VALUE_FOR_TEST',
+  permissionTypes: string[],
+) {
+  return {
+    ownerId: ownerId,
+    ownerType: ownerType,
+    resourceType: resourceType,
+    resourceId: resourceId,
+    permissionTypes: permissionTypes,
+  };
+}
+
 export function GET_CURRENT_USER_EXPECTED_BODY(
   username: string,
   name: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -133,8 +133,11 @@ export async function assertConflictRequest(
 ) {
   await assertStatusCode(response, 409);
   const json = await response.json();
-  assertRequiredFields(json, ['title']);
-  expect(json['title']).toContain(detail || 'ALREADY_EXISTS');
+  assertRequiredFields(json, ['title', 'detail']);
+  expect(json.title).toBe('ALREADY_EXISTS');
+  if (detail) {
+    expect(json.detail).toContain(detail);
+  }
 }
 
 export async function assertInvalidState(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
@@ -25,3 +25,27 @@ export async function createComponentAuthorization(
   const json = await res.json();
   assertRequiredFields(json, authorizedComponentRequiredFields);
 }
+
+export async function grantUserResourceAuthorization(
+  request: APIRequestContext,
+  user: {username: string; password: string; name: string; email: string},
+) {
+  const USER_RESOURCE_AUTHORIZATION = {
+    ownerId: user.username,
+    ownerType: 'USER',
+    resourceId: '*',
+    resourceType: 'RESOURCE',
+    permissionTypes: ['READ'],
+  };
+
+  const authRes = await request.post(buildUrl('/authorizations'), {
+    headers: jsonHeaders(),
+    data: USER_RESOURCE_AUTHORIZATION,
+  });
+  expect(authRes.status()).toBe(201);
+  const authBody = await authRes.json();
+  assertRequiredFields(authBody, ['authorizationKey']);
+  return {
+    authorizationKey: authBody.authorizationKey,
+  };
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -75,7 +75,7 @@ export async function createCompletedBatchOperation(
     expect(json.state).toBe('COMPLETED');
   }).toPass({
     intervals: [5_000, 10_000, 10_000, 15_000, 20_000],
-    timeout: 60_000,
+    timeout: 90_000,
   });
 
   return key;
@@ -98,7 +98,7 @@ export async function expectBatchState(
     expect(body.state).toBe(expectedState);
   }).toPass({
     intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
-    timeout: 90_000,
+    timeout: 120_000,
   });
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -38,7 +38,10 @@ export {assertUserNameInResponse} from './user-requestHelpers';
 export {createUser} from './user-requestHelpers';
 export {assignRoleToUsers} from './user-requestHelpers';
 export {createUsersAndStoreResponseFields} from './user-requestHelpers';
-export {createComponentAuthorization} from './authorization-requestHelpers';
+export {
+  createComponentAuthorization,
+  grantUserResourceAuthorization
+} from './authorization-requestHelpers';
 export {assertRoleInResponse} from './role-requestHelpers';
 export {assertClientsInResponse} from './clients-requestHelpers';
 export {setupProcessInstanceForTests} from './job-requestHelpers';


### PR DESCRIPTION
## Description
Backport of #43765 to `main`.

## Related issue
relates to #37204

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/20914238300)