### PR TITLE
feat: write root process instance key to db for exported incidents

### DIFF
--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/IncidentDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/IncidentDbModelTest.java
@@ -20,6 +20,7 @@ class IncidentDbModelTest {
         new IncidentDbModel.Builder()
             .incidentKey(123L)
             .processInstanceKey(456L)
+            .rootProcessInstanceKey(654L)
             .processDefinitionKey(789L)
             .errorMessage("errorMessage")
             .state(IncidentState.ACTIVE)
@@ -28,7 +29,18 @@ class IncidentDbModelTest {
             .truncateErrorMessage(10, null);
 
     assertThat(truncatedMessage.errorMessage().length()).isEqualTo(10);
-    assertThat(truncatedMessage.errorMessage()).isEqualTo("errorMessa");
+
+    assertThat(truncatedMessage)
+        .isEqualTo(
+            new IncidentDbModel.Builder()
+                .incidentKey(123L)
+                .processInstanceKey(456L)
+                .rootProcessInstanceKey(654L)
+                .processDefinitionKey(789L)
+                .errorMessage("errorMessa")
+                .state(IncidentState.ACTIVE)
+                .tenantId("tenantId")
+                .build());
   }
 
   @Test
@@ -37,6 +49,7 @@ class IncidentDbModelTest {
         new IncidentDbModel.Builder()
             .incidentKey(123L)
             .processInstanceKey(456L)
+            .rootProcessInstanceKey(654L)
             .processDefinitionKey(789L)
             .errorMessage("ääääääääää")
             .state(IncidentState.ACTIVE)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -652,6 +652,8 @@ class RdbmsExporterIT {
     final var processInstanceRecord = getProcessInstanceStartedRecord(1L);
     final var processInstanceKey =
         ((ProcessInstanceRecordValue) processInstanceRecord.getValue()).getProcessInstanceKey();
+    final var rootProcessInstanceKey =
+        getProcessInstanceRootProcessInstanceKey(processInstanceRecord);
     exporter.export(processInstanceRecord);
     final var elementRecord = getElementActivatingRecord(1L, processInstanceKey);
     final var elementInstanceKey = elementRecord.getKey();
@@ -661,7 +663,11 @@ class RdbmsExporterIT {
     final var incidentKey = 42L;
     final var incidentRecord =
         getIncidentRecord(
-            IncidentIntent.CREATED, incidentKey, processInstanceKey, elementInstanceKey);
+            IncidentIntent.CREATED,
+            incidentKey,
+            processInstanceKey,
+            rootProcessInstanceKey,
+            elementInstanceKey);
     exporter.export(incidentRecord);
 
     // then
@@ -669,18 +675,26 @@ class RdbmsExporterIT {
     assertThat(element).isNotEmpty();
     assertThat(element.get().incidentKey()).isEqualTo(incidentKey);
     assertThat(element.get().hasIncident()).isTrue();
+
     final var processInstance = rdbmsService.getProcessInstanceReader().findOne(processInstanceKey);
     assertThat(processInstance).isNotEmpty();
     assertThat(processInstance.get().hasIncident()).isTrue();
+
     final var incident = rdbmsService.getIncidentReader().findOne(incidentKey);
     assertThat(incident).isNotEmpty();
     assertThat(incident.get().incidentKey()).isEqualTo(incidentKey);
     assertThat(incident.get().state()).isEqualTo(IncidentState.ACTIVE);
+    assertThat(incident.get().processInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(incident.get().rootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
 
     // given
     final var incidentResolvedRecord =
         getIncidentRecord(
-            IncidentIntent.RESOLVED, incidentKey, processInstanceKey, elementInstanceKey);
+            IncidentIntent.RESOLVED,
+            incidentKey,
+            processInstanceKey,
+            rootProcessInstanceKey,
+            elementInstanceKey);
 
     // when
     exporter.export(incidentResolvedRecord);
@@ -690,12 +704,16 @@ class RdbmsExporterIT {
     assertThat(element2).isNotEmpty();
     assertThat(element2.get().incidentKey()).isNull();
     assertThat(element2.get().hasIncident()).isFalse();
+
     final var processInstance2 =
         rdbmsService.getProcessInstanceReader().findOne(processInstanceKey);
     assertThat(processInstance2).isNotEmpty();
     assertThat(processInstance2.get().hasIncident()).isFalse();
+
     final var incident2 = rdbmsService.getIncidentReader().findOne(incidentKey).orElseThrow();
     assertThat(incident2.state()).isEqualTo(IncidentState.RESOLVED);
+    assertThat(incident2.processInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(incident2.rootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -472,6 +472,7 @@ public class RecordFixtures {
       final IncidentIntent intent,
       final long incidentKey,
       final long processInstanceKey,
+      final long rootProcessInstanceKey,
       final long elementInstanceKey) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.INCIDENT);
     return ImmutableRecord.builder()
@@ -485,6 +486,7 @@ public class RecordFixtures {
                 .from((IncidentRecordValue) recordValueRecord.getValue())
                 .withElementInstanceKey(elementInstanceKey)
                 .withProcessInstanceKey(processInstanceKey)
+                .withRootProcessInstanceKey(rootProcessInstanceKey)
                 .withElementInstancePath(List.of(List.of(processInstanceKey, elementInstanceKey)))
                 .build())
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentExportHandler.java
@@ -76,6 +76,7 @@ public class IncidentExportHandler implements RdbmsExportHandler<IncidentRecordV
         .flowNodeInstanceKey(value.getElementInstanceKey())
         .flowNodeId(value.getElementId())
         .processInstanceKey(mapIfGreaterZero(value.getProcessInstanceKey()))
+        .rootProcessInstanceKey(mapIfGreaterZero(value.getRootProcessInstanceKey()))
         .processDefinitionKey(mapIfGreaterZero(value.getProcessDefinitionKey()))
         .processDefinitionId(value.getBpmnProcessId())
         .state(IncidentState.ACTIVE)
@@ -89,7 +90,7 @@ public class IncidentExportHandler implements RdbmsExportHandler<IncidentRecordV
         .build();
   }
 
-  private Long mapIfGreaterZero(final Long key) {
+  private Long mapIfGreaterZero(final long key) {
     return key > 0 ? key : null;
   }
 


### PR DESCRIPTION
so we can ue it for cleanup later

Refs: #41660