### PR TITLE
fix: correct the datasource variable and visualisation for the Identity metrics dashboard

### DIFF
--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -9,24 +9,18 @@
       "pluginName": "Prometheus"
     }
   ],
-  "__elements": {},
+  "__elements": [],
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.1.0"
+      "version": ""
     },
     {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
       "version": ""
     }
   ],
@@ -165,14 +159,30 @@
           "useBackend": false
         }
       ],
-      "title": "Requests to the OIDC provider",
+      "title": "Increase in requests to IDP",
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "schemaVersion": 41,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "${DS_PROMETHEUS}"
+        },
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",
@@ -182,6 +192,5 @@
   "timezone": "browser",
   "title": "Identity",
   "uid": "identity",
-  "version": 10,
-  "weekStart": ""
+  "version": 11
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On deploy to the dev stages there seems to be an issue with the datasource, I noticed that we don't template that on the Identity board but do on others so I've added it in. Additionally I've tweaked the metric to be an increase to detect better the increase (I know right) of requests etc. The idea being that we can tie an alert to the increase and send messages when requests are getting too much etc.
