### PR TITLE
bug: add Elasticsearch Prometheus Exporter support in load tests

### DIFF
--- a/load-tests/camunda-platform-values-elasticsearch-exporter.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch-exporter.yaml
@@ -1,5 +1,9 @@
 fullnameOverride: "elasticsearch-exporter"
 
+image:
+  # Set your specific exporter version here
+  tag: 6.4.0
+
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator

--- a/load-tests/camunda-platform-values-elasticsearch-exporter.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch-exporter.yaml
@@ -1,0 +1,10 @@
+fullnameOverride: "elasticsearch-exporter"
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: true
+  # Labels used by the service monitor, specific to our prometheus installation
+  labels:
+    release: monitoring

--- a/load-tests/camunda-platform-values-elasticsearch-exporter.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch-exporter.yaml
@@ -2,7 +2,7 @@ fullnameOverride: "elasticsearch-exporter"
 
 image:
   # Set your specific exporter version here
-  tag: 6.4.0
+  tag: "v1.10.0"
 
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -1,4 +1,4 @@
-fullnameOverride: "elasticsearch-exporter"
+fullnameOverride: "prom-els-exporter"
 
 image:
   # Set your specific exporter version here

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -54,7 +54,7 @@ else
 	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
 endif
 
-# Install Elasticsearch prometheus exporter if secondary_storage is elasticsearch
+# Install Elasticsearch Prometheus exporter if secondary_storage is elasticsearch
 .PHONY: install-elasticsearch-exporter
 install-elasticsearch-exporter:
 ifeq ($(secondary_storage),elasticsearch)

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -24,10 +24,10 @@ endif
 all: install
 
 .PHONY: install
-install: install-storage install-platform install-load-test
+install: install-storage install-platform install-load-test install-elasticsearch-exporter
 
 .PHONY: install-stable
-install-stable: install-storage install-platform-stable install-load-test
+install-stable: install-storage install-platform-stable install-load-test install-elasticsearch-exporter
 
 # Install PostgreSQL database if secondary_storage is postgresql
 .PHONY: install-storage
@@ -52,6 +52,20 @@ ifeq ($(secondary_storage),postgresql)
 		--set primary.persistence.size=128Gi
 else
 	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
+endif
+
+# Install Elasticsearch prometheus exporter if secondary_storage is elasticsearch
+.PHONY: install-elasticsearch-exporter
+install-elasticsearch-exporter:
+ifeq ($(secondary_storage),elasticsearch)
+	@echo "Installing Elasticsearch Prometheus Exporter for namespace $(namespace)..."
+	helm upgrade --install elasticsearch-exporter oci://ghcr.io/prometheus-community/charts/prometheus-elasticsearch-exporter \
+    --namespace $(namespace) \
+    --wait --timeout 5m0s \
+    -f camunda-platform-values-elasticsearch-exporter.yaml \
+    --set es.uri="http://$(namespace)-elasticsearch:9200"
+else
+	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
 endif
 
 # Install/upgrade Camunda Platform helm chart
@@ -123,6 +137,7 @@ template-stable:
 clean:
 	-helm --namespace $(namespace) uninstall $(namespace)
 	-helm --namespace $(namespace) uninstall $(namespace)-test
+	-helm --namespace $(namespace) uninstall elasticsearch-exporter
 	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/instance=$(namespace)
 	-kubectl delete -n $(namespace) pvc -l app=elasticsearch-master
 	-kubectl delete -n $(namespace) cronjob leader-balancer

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -3,6 +3,7 @@ secondary_storage ?= elasticsearch
 helm_chart ?= camunda-platform-8.9
 curl_image ?= curlimages/curl:7.87.0
 camunda_management_url ?= http://camunda:9600
+prometheus_elasticsearch_exporter_chart_version ?= 7.2.1
 # Optional: additional Helm configuration for the Camunda Platform release.
 # Use this to pass extra `--set`/`-f` flags, for example:
 #   make install additional_platform_configuration="--set zeebeGateway.env[0].name=FOO --set zeebeGateway.env[0].value=bar"
@@ -61,8 +62,9 @@ ifeq ($(secondary_storage),elasticsearch)
 	@echo "Installing Elasticsearch Prometheus Exporter for namespace $(namespace)..."
 	helm upgrade --install elasticsearch-exporter oci://ghcr.io/prometheus-community/charts/prometheus-elasticsearch-exporter \
     --namespace $(namespace) \
+    --version $(prometheus_elasticsearch_exporter_chart_version) \
     --wait --timeout 5m0s \
-    -f camunda-platform-values-elasticsearch-exporter.yaml \
+    -f prometheus-elasticsearch-exporter-values.yaml \
     --set es.uri="http://$(namespace)-elasticsearch:9200"
 else
 	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -82,6 +82,9 @@ cp -rv default/ $namespace
 # Copy camunda-platform-values*.yaml files to the new folder
 cp -v ../camunda-platform-values*.yaml $namespace/
 
+# Copy Prometheus ElasticSearch Exporter values.yaml to the new folder
+cp -v ../prometheus-elasticsearch-exporter-values.yaml $namespace/
+
 cd $namespace
 
 # Update Makefile to use the namespace and secondary storage


### PR DESCRIPTION
## Description

This pull request adds support for deploying and managing the Elasticsearch Prometheus Exporter as part of the load test setup, specifically when Elasticsearch is used as secondary storage. The changes ensure that the exporter is installed, configured, and properly cleaned up, and that Prometheus monitoring is enabled for it.

Deployment and configuration of Elasticsearch Prometheus Exporter:

* Added a new Helm values file (`camunda-platform-values-elasticsearch-exporter.yaml`) to configure the Elasticsearch Prometheus Exporter, including enabling ServiceMonitor for Prometheus integration.
* Updated the `Makefile` to include the `install-elasticsearch-exporter` target in both `install` and `install-stable` commands, ensuring the exporter is installed during setup.
* Introduced a conditional `install-elasticsearch-exporter` target in the `Makefile` that installs the exporter only if `secondary_storage` is set to `elasticsearch`.

Cleanup enhancements:

* Modified the `clean` target in the `Makefile` to uninstall the Elasticsearch Prometheus Exporter, ensuring resources are properly cleaned up.

## Dashboards:
GHA Run: https://github.com/camunda/camunda/actions/runs/20908187663

LT Dashboard: https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?var-namespace=pg-exporter-gha-benchmark&orgId=1&from=now-15m&to=now&timezone=browser&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-pod=$__all&var-partition=$__all&var-memory_state=committed

ES: https://grafana.dev.zeebe.io/d/elasticsearch/elasticsearch?orgId=1&from=now-15m&to=now&timezone=browser&var-datasource=prometheus&var-cluster=$__all&var-namespace=pg-exporter-gha-benchmark&var-index=$__all

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43117 
