### PR TITLE
feat: export rootProcessInstanceKey from incident record to ES/OS

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
@@ -27,5 +27,9 @@ public class IncidentResolutionAuditLogTransformer
         .setProcessInstanceKey(value.getProcessInstanceKey())
         .setElementInstanceKey(value.getElementInstanceKey())
         .setJobKey(value.getJobKey());
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
@@ -26,5 +26,9 @@ public class ProcessInstanceCreationAuditLogTransformer
     log.setProcessInstanceKey(value.getProcessInstanceKey())
         .setProcessDefinitionId(value.getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey());
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
@@ -27,5 +27,9 @@ public class ProcessInstanceMigrationAuditLogTransformer
     final var value = record.getValue();
     log.setProcessDefinitionKey(value.getTargetProcessDefinitionKey())
         .setProcessInstanceKey(value.getProcessInstanceKey());
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
@@ -26,5 +26,9 @@ public class ProcessInstanceModificationAuditLogTransformer
       final Record<ProcessInstanceModificationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setProcessInstanceKey(value.getProcessInstanceKey());
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformerTest.java
@@ -65,5 +65,8 @@ class IncidentResolutionAuditLogTransformerTest {
     assertThat(entity.getElementInstanceKey()).isEqualTo(789L);
     assertThat(entity.getJobKey()).isEqualTo(222L);
     assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreatedAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreatedAuditLogTransformerTest.java
@@ -60,5 +60,8 @@ class ProcessInstanceCreatedAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionId()).isEqualTo("test-process");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
     assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformerTest.java
@@ -59,5 +59,8 @@ class ProcessInstanceMigrationAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(123L);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(234L);
     assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModifiedAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModifiedAuditLogTransformerTest.java
@@ -57,5 +57,8 @@ class ProcessInstanceModifiedAuditLogTransformerTest {
     // then
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
     assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -110,7 +110,12 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
 
     entity.setTreePath(buildTreePath(record));
 
-    final Intent intent = (record == null) ? null : record.getIntent();
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
+
+    final Intent intent = record.getIntent();
     if (intent == null) {
       LOGGER.warn("Intent is null for incident: id {}", entity.getId());
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -77,6 +77,10 @@ public class PostImporterQueueFromIncidentHandler
         .setCreationTime(OffsetDateTime.now())
         .setPartitionId(record.getPartitionId())
         .setProcessInstanceKey(recordValue.getProcessInstanceKey());
+    final long rootProcessInstanceKey = recordValue.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
@@ -36,8 +36,7 @@ public class ProcessInstanceMigrationOperationHandler
 
   @Override
   long getRootProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
-    return -1; // TODO implement when available in the record
-    // https://github.com/camunda/camunda/pull/43315
+    return record.getValue().getRootProcessInstanceKey();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
@@ -41,8 +41,7 @@ public class ProcessInstanceModificationOperationHandler
 
   @Override
   long getRootProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
-    return -1; // TODO implement when available in the record
-    // https://github.com/camunda/camunda/pull/43315
+    return record.getValue().getRootProcessInstanceKey();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
@@ -31,8 +31,7 @@ public class ResolveIncidentOperationHandler
 
   @Override
   long getRootProcessInstanceKey(final Record<IncidentRecordValue> record) {
-    return -1; // TODO implement when available in the record
-    // https://github.com/camunda/camunda/pull/43320
+    return record.getValue().getRootProcessInstanceKey();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -190,6 +190,28 @@ public class IncidentHandlerTest {
   }
 
   @Test
+  void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+    // given
+    final IncidentRecordValue incidentRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .withRootProcessInstanceKey(-1L)
+            .build();
+
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withIntent(IncidentIntent.CREATED).withValue(incidentRecordValue));
+
+    // when
+    final IncidentEntity incidentEntity = new IncidentEntity();
+    underTest.updateEntity(incidentRecord, incidentEntity);
+
+    // then
+    assertThat(incidentEntity.getRootProcessInstanceKey()).isNull();
+  }
+
+  @Test
   void shouldUpdateEntityFromFollowUpRecord() {
     // given
     final long recordKey = 123L;
@@ -561,5 +583,8 @@ public class IncidentHandlerTest {
         .isEqualTo(incidentRecordValue.getElementInstanceKey());
     assertThat(incidentEntity.getErrorMessageHash())
         .isEqualTo(incidentRecordValue.getErrorMessage().hashCode());
+    assertThat(incidentEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(incidentRecordValue.getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -167,6 +167,31 @@ public class PostImporterQueueFromIncidentHandlerTest {
     assertThat(postImporterQueueEntity.getPosition()).isEqualTo(incidentRecord.getPosition());
     assertThat(postImporterQueueEntity.getProcessInstanceKey())
         .isEqualTo(incidentRecordValue.getProcessInstanceKey());
+    assertThat(postImporterQueueEntity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(incidentRecordValue.getRootProcessInstanceKey());
+  }
+
+  @Test
+  void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+    // given
+    final IncidentRecordValue incidentRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .withRootProcessInstanceKey(-1L)
+            .build();
+
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withIntent(IncidentIntent.CREATED).withValue(incidentRecordValue));
+
+    // when
+    final PostImporterQueueEntity postImporterQueueEntity = new PostImporterQueueEntity();
+    underTest.updateEntity(incidentRecord, postImporterQueueEntity);
+
+    // then
+    assertThat(postImporterQueueEntity.getRootProcessInstanceKey()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -31,6 +31,9 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
@@ -246,6 +249,31 @@ class BatchOperationStatusHandlerTest {
           .containsExactly(batchOperationKey + "_" + handler.getItemKey(record));
     }
 
+    @ParameterizedTest
+    @MethodSource("recordProviderStream")
+    void shouldUpdateEntitySetRootProcessInstanceKey(
+        final Function<AbstractOperationStatusHandlerTest<T>, Record<T>> recordProvider) {
+      final var record = recordProvider.apply(this);
+      final var entity = new OperationEntity();
+
+      handler.updateEntity(record, entity);
+
+      if (shouldHandleRootProcessInstanceKey()) {
+        assertThat(entity.getRootProcessInstanceKey())
+            .isPositive()
+            .isEqualTo(getRootProcessInstanceKey(record));
+      } else {
+        assertThat(entity.getRootProcessInstanceKey()).isNull();
+      }
+    }
+
+    static <T extends RecordValue>
+        Stream<Function<AbstractOperationStatusHandlerTest<T>, Record<T>>> recordProviderStream() {
+      return Stream.of(
+          AbstractOperationStatusHandlerTest::createSuccessRecord,
+          AbstractOperationStatusHandlerTest::createFailureRecord);
+    }
+
     @Test
     abstract void shouldExtractCorrectItemKey();
 
@@ -255,6 +283,14 @@ class BatchOperationStatusHandlerTest {
     abstract Record<T> createSuccessRecord();
 
     abstract Record<T> createFailureRecord();
+
+    long getRootProcessInstanceKey(final Record<T> record) {
+      return handler.getRootProcessInstanceKey(record);
+    }
+
+    boolean shouldHandleRootProcessInstanceKey() {
+      return true;
+    }
   }
 
   @Nested
@@ -299,6 +335,32 @@ class BatchOperationStatusHandlerTest {
                   .withIntent(ProcessInstanceModificationIntent.MODIFY)
                   .withBatchOperationReference(batchOperationKey));
     }
+
+    @Test
+    void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+      // given
+      final Record<ProcessInstanceModificationRecordValue> record =
+          factory.generateRecord(
+              ValueType.PROCESS_INSTANCE_MODIFICATION,
+              b ->
+                  b.withRejectionType(RejectionType.PROCESSING_ERROR)
+                      .withIntent(ProcessInstanceModificationIntent.MODIFY)
+                      .withValue(
+                          ImmutableProcessInstanceModificationRecordValue.builder()
+                              .from(
+                                  factory.generateObject(
+                                      ProcessInstanceModificationRecordValue.class))
+                              .withRootProcessInstanceKey(-1L)
+                              .build())
+                      .withBatchOperationReference(batchOperationKey));
+
+      // when
+      final var entity = new OperationEntity();
+      handler.updateEntity(record, entity);
+
+      // then
+      assertThat(entity.getRootProcessInstanceKey()).isNull();
+    }
   }
 
   @Nested
@@ -342,6 +404,31 @@ class BatchOperationStatusHandlerTest {
               b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
                   .withBatchOperationReference(batchOperationKey));
+    }
+
+    @Test
+    void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+      // given
+      final Record<ProcessInstanceMigrationRecordValue> record =
+          factory.generateRecord(
+              ValueType.PROCESS_INSTANCE_MIGRATION,
+              b ->
+                  b.withRejectionType(RejectionType.PROCESSING_ERROR)
+                      .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
+                      .withValue(
+                          ImmutableProcessInstanceMigrationRecordValue.builder()
+                              .from(
+                                  factory.generateObject(ProcessInstanceMigrationRecordValue.class))
+                              .withRootProcessInstanceKey(-1L)
+                              .build())
+                      .withBatchOperationReference(batchOperationKey));
+
+      // when
+      final var entity = new OperationEntity();
+      handler.updateEntity(record, entity);
+
+      // then
+      assertThat(entity.getRootProcessInstanceKey()).isNull();
     }
   }
 
@@ -417,30 +504,26 @@ class BatchOperationStatusHandlerTest {
                   .withBatchOperationReference(batchOperationKey));
     }
 
-    @ParameterizedTest
-    @MethodSource("recordProviderStream")
-    void shouldUpdateEntitySetRootProcessInstanceKey(
-        final Function<
-                ProcessInstanceCancellationOperationHandlerTest, Record<ProcessInstanceRecordValue>>
-            recordProvider) {
-      final var record = recordProvider.apply(this);
-      final var entity = new OperationEntity();
+    @Test
+    void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+      // given
+      final Record<ProcessInstanceRecordValue> record =
+          factory.generateRecord(
+              ValueType.PROCESS_INSTANCE,
+              b ->
+                  b.withValue(
+                          ImmutableProcessInstanceRecordValue.builder()
+                              .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                              .withRootProcessInstanceKey(-1L)
+                              .build())
+                      .withBatchOperationReference(batchOperationKey));
 
+      // when
+      final var entity = new OperationEntity();
       handler.updateEntity(record, entity);
 
-      assertThat(entity.getRootProcessInstanceKey())
-          .isPositive()
-          .isEqualTo(record.getValue().getRootProcessInstanceKey());
-    }
-
-    static Stream<
-            Function<
-                ProcessInstanceCancellationOperationHandlerTest,
-                Record<ProcessInstanceRecordValue>>>
-        recordProviderStream() {
-      return Stream.of(
-          ProcessInstanceCancellationOperationHandlerTest::createSuccessRecord,
-          ProcessInstanceCancellationOperationHandlerTest::createFailureRecord);
+      // then
+      assertThat(entity.getRootProcessInstanceKey()).isNull();
     }
   }
 
@@ -484,6 +567,28 @@ class BatchOperationStatusHandlerTest {
               b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(IncidentIntent.RESOLVE)
                   .withBatchOperationReference(batchOperationKey));
+    }
+
+    @Test
+    void shouldNotSetRootProcessInstanceKeyWhenDefault() {
+      // given
+      final Record<IncidentRecordValue> record =
+          factory.generateRecord(
+              ValueType.INCIDENT,
+              b ->
+                  b.withValue(
+                          ImmutableIncidentRecordValue.builder()
+                              .from(factory.generateObject(IncidentRecordValue.class))
+                              .withRootProcessInstanceKey(-1L)
+                              .build())
+                      .withBatchOperationReference(batchOperationKey));
+
+      // when
+      final var entity = new OperationEntity();
+      handler.updateEntity(record, entity);
+
+      // then
+      assertThat(entity.getRootProcessInstanceKey()).isNull();
     }
   }
 
@@ -529,6 +634,11 @@ class BatchOperationStatusHandlerTest {
                   .withIntent(HistoryDeletionIntent.DELETE)
                   .withBatchOperationReference(batchOperationKey));
     }
+
+    @Override
+    boolean shouldHandleRootProcessInstanceKey() {
+      return false;
+    }
   }
 
   @Nested
@@ -572,6 +682,11 @@ class BatchOperationStatusHandlerTest {
               b.withRejectionType(RejectionType.PROCESSING_ERROR)
                   .withIntent(HistoryDeletionIntent.DELETE)
                   .withBatchOperationReference(batchOperationKey));
+    }
+
+    @Override
+    boolean shouldHandleRootProcessInstanceKey() {
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Exporting rootProcessInstanceKey from 
- IncidentRecord
- ProcessInstanceCreationRecord
- ProcessInstanceModificationRecord
- ProcessInstanceMigrationRecord

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41658 
