### PR TITLE
fix: optimize property substitution

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -771,9 +771,9 @@
       <testResource>
         <filtering>false</filtering>
         <directory>src/it/resources</directory>
-        <includes>
-          <include>**/*</include>
-        </includes>
+        <excludes>
+          <exclude>**/*.properties</exclude>
+        </excludes>
       </testResource>
       <testResource>
         <directory>src/test/resources</directory>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Exclude `*.properties` file from being copied in the `target/test-resources` after being substituted already once.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
