### PR TITLE
fix: skip starting actor on null schedules

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -64,13 +64,15 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
       LOG.info("Backup scheduler initialized with interval {}", backupSchedule);
     }
 
-    checkpointScheduler =
-        new CheckpointScheduler(checkpointSchedule, backupSchedule, brokerClient, meterRegistry);
+    if (checkpointSchedule != null || backupSchedule != null) {
+      checkpointScheduler =
+          new CheckpointScheduler(checkpointSchedule, backupSchedule, brokerClient, meterRegistry);
+    }
   }
 
   @Override
   protected void onActorStarted() {
-    if (shouldStartSchedulers()) {
+    if (checkpointScheduler != null && shouldStartSchedulers()) {
       actorScheduler.submitActor(checkpointScheduler);
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Do not attempt to start the Scheduling actor when schedules are null. Even though this does not have any effect it will produce some NPE log noise.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
