### PR TITLE
refactor: add platform-helm-values input to load test workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -31,7 +31,7 @@ on:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       platform-helm-values:
-        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
         type: string
         default: ""
         required: false
@@ -67,7 +67,7 @@ on:
         default: ""
         required: false
       platform-helm-values:
-        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
         type: string
         default: ""
         required: false

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,6 +30,11 @@ on:
       load-test-load:
         description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
+      platform-helm-values:
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
+        type: string
+        default: ""
+        required: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
         type: boolean
@@ -58,6 +63,11 @@ on:
         required: false
       reuse-tag:
         description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      platform-helm-values:
+        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which is deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set console.resources.memory=2Gi'
         type: string
         default: ""
         required: false
@@ -295,7 +305,7 @@ jobs:
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
-
+          ${{ inputs.platform-helm-values }}
 
       - name: Summarize deployment
         if: success()


### PR DESCRIPTION
## Description
This pull request updates the Camunda load test GitHub Actions workflow to improve the flexibility of Helm deployments. The main change is the introduction of a new input parameter that allows users to pass additional Helm values to the Camunda platform chart during deployment. This makes it easier to customize platform resources and configurations directly from the workflow.

**Workflow input enhancements:**

* Added a new `platform-helm-values` input parameter to `.github/workflows/camunda-load-test.yml`, allowing users to specify extra Helm values for the Camunda platform chart. This enables customization such as modifying resource allocations (e.g., `--set console.resources.memory=2Gi`). [[1]](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R33-R37) [[2]](diffhunk://#diff-38f8fadb6cc10a82a3db16c869fcf3011395c384211d2658d0557ce2258fb4d0R69-R73)

**Deployment customization:**

* Updated the Helm deployment command to include the new `platform-helm-values` input, ensuring any additional configuration passed through the workflow is applied during deployment.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41844
