### PR TITLE
fix: Re-throw assertion errors

### DIFF
--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/TestScenarioRunnerProxy.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/TestScenarioRunnerProxy.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.proxy;
 
 import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,6 +45,16 @@ public class TestScenarioRunnerProxy extends AbstractInvocationHandler {
               + method
               + " on TestScenarioRunner, as TestScenarioRunner is currently not initialized. Maybe you run outside of a testcase?");
     }
-    return method.invoke(delegate, args);
+    try {
+      return method.invoke(delegate, args);
+
+    } catch (final InvocationTargetException e) {
+      if (e.getCause() instanceof final AssertionError assertionError) {
+        // unwrap assertion errors to make them visible to the test framework
+        throw assertionError;
+      } else {
+        throw e;
+      }
+    }
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/TestScenarioRunnerProxyTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/TestScenarioRunnerProxyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl;
+
+import static org.mockito.Mockito.doThrow;
+
+import io.camunda.process.test.api.dsl.TestCase;
+import io.camunda.process.test.api.dsl.TestScenarioRunner;
+import io.camunda.process.test.impl.proxy.TestScenarioRunnerProxy;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TestScenarioRunnerProxyTest {
+
+  @Mock private TestCase testCase;
+  @Mock private TestScenarioRunner testScenarioRunner;
+
+  @Test
+  void shouldThrowAssertionError() {
+    // given
+    final TestScenarioRunnerProxy proxy = new TestScenarioRunnerProxy();
+    proxy.setRunner(testScenarioRunner);
+
+    final AssertionError assertionError = new AssertionError("expected");
+    doThrow(assertionError).when(testScenarioRunner).run(testCase);
+
+    // when/then
+    Assertions.assertThatThrownBy(
+            () ->
+                proxy.invoke(
+                    proxy,
+                    TestScenarioRunner.class.getMethod("run", TestCase.class),
+                    new Object[] {testCase}))
+        .isEqualTo(assertionError);
+  }
+}


### PR DESCRIPTION
## Description

Currently, the `TestScenarioRunner` in a `CamundaSpringProcessTest` throws the following exception if an assertion failed: 

```
java.lang.reflect.UndeclaredThrowableException
	at jdk.proxy1/jdk.proxy1.$Proxy85.run(Unknown Source)
	at io.camunda.process.test.api.SpringTestScenarioIT.shouldPass(SpringTestScenarioIT.java:52)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.camunda.process.test.impl.proxy.TestScenarioRunnerProxy.handleInvocation(TestScenarioRunnerProxy.java:47)
	at io.camunda.process.test.impl.proxy.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:56)
	... 2 more
Caused by: java.lang.AssertionError: Process instance [process-id: 'process'] should be active but was completed.
	at io.camunda.process.test.impl.assertions.util.AwaitilityBehavior.untilAsserted(AwaitilityBehavior.java:66)
	at io.camunda.process.test.api.CamundaAssertAwaitBehavior.untilAsserted(CamundaAssertAwaitBehavior.java:50)
	at io.camunda.process.test.impl.assertions.ProcessInstanceAssertj.hasProcessInstanceInState(ProcessInstanceAssertj.java:405)
	at io.camunda.process.test.impl.assertions.ProcessInstanceAssertj.isActive(ProcessInstanceAssertj.java:91)
	at io.camunda.process.test.impl.dsl.instructions.AssertProcessInstanceInstructionHandler.assertState(AssertProcessInstanceInstructionHandler.java:63)
	at io.camunda.process.test.impl.dsl.instructions.AssertProcessInstanceInstructionHandler.lambda$execute$0(AssertProcessInstanceInstructionHandler.java:46)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at io.camunda.process.test.impl.dsl.instructions.AssertProcessInstanceInstructionHandler.execute(AssertProcessInstanceInstructionHandler.java:46)
```

This PR unwraps assertion error to report the assertion correctly to JUnit. Now, the `TestScenarioRunner` throws the following exception, similar to CPT's Java API:

```
java.lang.AssertionError: Process instance [process-id: 'process'] should be active but was completed.

	at io.camunda.process.test.impl.assertions.util.AwaitilityBehavior.untilAsserted(AwaitilityBehavior.java:66)
	at io.camunda.process.test.api.CamundaAssertAwaitBehavior.untilAsserted(CamundaAssertAwaitBehavior.java:50)
	at io.camunda.process.test.impl.assertions.ProcessInstanceAssertj.hasProcessInstanceInState(ProcessInstanceAssertj.java:405)
	at io.camunda.process.test.impl.assertions.ProcessInstanceAssertj.isActive(ProcessInstanceAssertj.java:91)
	at io.camunda.process.test.api.SpringTestScenarioIT.shouldPass(SpringTestScenarioIT.java:55)
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/product-hub/issues/3195
