### PR TITLE
build: add agentic AI team to codeowners for MCP

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,7 +122,10 @@
 /zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
 /zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
 
-# Identity
+###############
+## Identity  ##
+###############
+
 /identity/        @camunda/identity
 /authentication/  @camunda/identity
 /security/        @camunda/identity
@@ -135,3 +138,10 @@
 # Performance + Load testing
 /load-tests/ @camunda/reliability-testing
 /.github/workflows/*load-test*.yml @camunda/reliability-testing
+
+#################
+## Agentic AI  ##
+#################
+
+# MCP gateway
+/gateways/gateway-mcp @camunda/connectors-agentic-ai


### PR DESCRIPTION
## Description

Adds the agentic AI team as code owner for the MCP gateway

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/43560
