### PR TITLE
feat: write root process instance key for exported ProcessMessageSubscriptionRecordValue

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapper.java
@@ -25,6 +25,7 @@ public class CorrelatedMessageSubscriptionEntityMapper {
         .processDefinitionId(dbModel.processDefinitionId())
         .processDefinitionKey(dbModel.processDefinitionKey())
         .processInstanceKey(dbModel.processInstanceKey())
+        .rootProcessInstanceKey(dbModel.rootProcessInstanceKey())
         .subscriptionKey(dbModel.subscriptionKey())
         .subscriptionType(dbModel.subscriptionType())
         .tenantId(dbModel.tenantId())

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -19,6 +19,7 @@ public class MessageSubscriptionEntityMapper {
         .processDefinitionId(messageSubscriptionDbModel.processDefinitionId())
         .processDefinitionKey(messageSubscriptionDbModel.processDefinitionKey())
         .processInstanceKey(messageSubscriptionDbModel.processInstanceKey())
+        .rootProcessInstanceKey(messageSubscriptionDbModel.rootProcessInstanceKey())
         .flowNodeId(messageSubscriptionDbModel.flowNodeId())
         .flowNodeInstanceKey(messageSubscriptionDbModel.flowNodeInstanceKey())
         .messageSubscriptionState(messageSubscriptionDbModel.messageSubscriptionState())

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageSubscriptionEntityMapperTest.java
@@ -32,6 +32,7 @@ public class CorrelatedMessageSubscriptionEntityMapperTest {
             .processDefinitionId("processDefinitionId")
             .processDefinitionKey(789L)
             .processInstanceKey(1011L)
+            .rootProcessInstanceKey(2022L)
             .subscriptionKey(321L)
             .subscriptionType(MessageSubscriptionType.PROCESS_EVENT)
             .tenantId("tenantId")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -295,6 +295,7 @@ public class CorrelatedMessageSubscriptionIT {
     assertThat(actual.processDefinitionId()).isEqualTo(expected.processDefinitionId());
     assertThat(actual.processDefinitionKey()).isEqualTo(expected.processDefinitionKey());
     assertThat(actual.processInstanceKey()).isEqualTo(expected.processInstanceKey());
+    assertThat(actual.rootProcessInstanceKey()).isEqualTo(expected.rootProcessInstanceKey());
     assertThat(actual.subscriptionKey()).isEqualTo(expected.subscriptionKey());
     assertThat(actual.tenantId()).isEqualTo(expected.tenantId());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
@@ -64,7 +64,9 @@ public class MessageSubscriptionIT {
 
     final var roleUpdate =
         MessageSubscriptionFixtures.createRandomized(
-            b -> b.messageSubscriptionKey(subscription.messageSubscriptionKey()));
+            b ->
+                b.messageSubscriptionKey(subscription.messageSubscriptionKey())
+                    .rootProcessInstanceKey(subscription.rootProcessInstanceKey()));
     rdbmsWriters.getMessageSubscriptionWriter().update(roleUpdate);
     rdbmsWriters.flush();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -740,7 +740,7 @@ class RdbmsExporterIT {
   public void shouldExportMessageSubscription() {
     // given
     final var messageSubscriptionRecord =
-        ImmutableRecord.builder()
+        ImmutableRecord.<ProcessMessageSubscriptionRecordValue>builder()
             .from(RecordFixtures.FACTORY.generateRecord(ValueType.PROCESS_MESSAGE_SUBSCRIPTION))
             .withIntent(ProcessMessageSubscriptionIntent.CREATED)
             .withPosition(2L)
@@ -754,6 +754,11 @@ class RdbmsExporterIT {
     final var messageSubscription =
         rdbmsService.getMessageSubscriptionReader().findOne(messageSubscriptionRecord.getKey());
     assertThat(messageSubscription).isNotEmpty();
+    final var recordValue = messageSubscriptionRecord.getValue();
+    assertThat(messageSubscription.get().processInstanceKey())
+        .isEqualTo(recordValue.getProcessInstanceKey());
+    assertThat(messageSubscription.get().rootProcessInstanceKey())
+        .isEqualTo(recordValue.getRootProcessInstanceKey());
   }
 
   @Test
@@ -808,6 +813,11 @@ class RdbmsExporterIT {
                 correlatedMessageSubscriptionRecord.getValue().getMessageKey(),
                 correlatedMessageSubscriptionRecord.getKey());
     assertThat(correlatedMessageSubscription).isNotEmpty();
+    final var recordValue = correlatedMessageSubscriptionRecord.getValue();
+    assertThat(correlatedMessageSubscription.get().processInstanceKey())
+        .isEqualTo(recordValue.getProcessInstanceKey());
+    assertThat(correlatedMessageSubscription.get().rootProcessInstanceKey())
+        .isEqualTo(recordValue.getRootProcessInstanceKey());
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/CorrelatedMessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/CorrelatedMessageSubscriptionEntityTransformer.java
@@ -30,6 +30,7 @@ public class CorrelatedMessageSubscriptionEntityTransformer
         value.getBpmnProcessId(),
         value.getProcessDefinitionKey(),
         value.getProcessInstanceKey(),
+        value.getRootProcessInstanceKey(),
         value.getSubscriptionKey(),
         toMessageSubscriptionType(value.getSubscriptionType()),
         value.getTenantId());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -23,6 +23,7 @@ public class MessageSubscriptionEntityTransformer
         value.getBpmnProcessId(),
         value.getProcessDefinitionKey(),
         value.getProcessInstanceKey(),
+        value.getRootProcessInstanceKey(),
         value.getFlowNodeId(),
         value.getFlowNodeInstanceKey(),
         toMessageSubscriptionState(value.getEventType()),

--- a/search/search-domain/src/main/java/io/camunda/search/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/CorrelatedMessageSubscriptionEntity.java
@@ -22,6 +22,7 @@ public record CorrelatedMessageSubscriptionEntity(
     String processDefinitionId,
     Long processDefinitionKey,
     Long processInstanceKey,
+    Long rootProcessInstanceKey,
     Long subscriptionKey,
     MessageSubscriptionType subscriptionType,
     String tenantId)
@@ -41,6 +42,7 @@ public record CorrelatedMessageSubscriptionEntity(
     private String processDefinitionId;
     private Long processDefinitionKey;
     private Long processInstanceKey;
+    private Long rootProcessInstanceKey;
     private Long subscriptionKey;
     private MessageSubscriptionType subscriptionType;
     private String tenantId;
@@ -95,6 +97,11 @@ public record CorrelatedMessageSubscriptionEntity(
       return this;
     }
 
+    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
+      this.rootProcessInstanceKey = rootProcessInstanceKey;
+      return this;
+    }
+
     public Builder subscriptionKey(final Long subscriptionKey) {
       this.subscriptionKey = subscriptionKey;
       return this;
@@ -122,6 +129,7 @@ public record CorrelatedMessageSubscriptionEntity(
           processDefinitionId,
           processDefinitionKey,
           processInstanceKey,
+          rootProcessInstanceKey,
           subscriptionKey,
           subscriptionType,
           tenantId);

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -16,6 +16,7 @@ public record MessageSubscriptionEntity(
     String processDefinitionId,
     Long processDefinitionKey,
     Long processInstanceKey,
+    Long rootProcessInstanceKey,
     String flowNodeId,
     Long flowNodeInstanceKey,
     MessageSubscriptionState messageSubscriptionState,
@@ -33,6 +34,7 @@ public record MessageSubscriptionEntity(
     private String processDefinitionId;
     private Long processDefinitionKey;
     private Long processInstanceKey;
+    private Long rootProcessInstanceKey;
     private String flowNodeId;
     private Long flowNodeInstanceKey;
     private MessageSubscriptionState messageSubscriptionState;
@@ -58,6 +60,11 @@ public record MessageSubscriptionEntity(
 
     public Builder processInstanceKey(final Long processInstanceKey) {
       this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
+      this.rootProcessInstanceKey = rootProcessInstanceKey;
       return this;
     }
 
@@ -103,6 +110,7 @@ public record MessageSubscriptionEntity(
           processDefinitionId,
           processDefinitionKey,
           processInstanceKey,
+          rootProcessInstanceKey,
           flowNodeId,
           flowNodeInstanceKey,
           messageSubscriptionState,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler.java
@@ -43,6 +43,7 @@ public class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHa
         .processDefinitionId(value.getBpmnProcessId())
         .processDefinitionKey(value.getProcessDefinitionKey())
         .processInstanceKey(value.getProcessInstanceKey())
+        .rootProcessInstanceKey(value.getRootProcessInstanceKey())
         .subscriptionType(MessageSubscriptionType.PROCESS_EVENT)
         .tenantId(tenantOrDefault(value.getTenantId()));
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -64,6 +64,7 @@ public class MessageSubscriptionExportHandler
         .messageSubscriptionKey(record.getKey())
         .processDefinitionId(value.getBpmnProcessId())
         .processInstanceKey(value.getProcessInstanceKey())
+        .rootProcessInstanceKey(value.getRootProcessInstanceKey())
         .flowNodeId(value.getElementId())
         .flowNodeInstanceKey(value.getElementInstanceKey())
         .processDefinitionKey(value.getProcessDefinitionKey())


### PR DESCRIPTION
so we can use it for cleanup later

Refs: #41660