### PR TITLE
feat: Enable property-based authorization checks support for user tasks (search layer) 

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/UserTaskDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/UserTaskDbQuery.java
@@ -20,6 +20,7 @@ public record UserTaskDbQuery(
     List<String> authorizedProcessDefinitionIds,
     List<Long> authorizedUserTaskKeys,
     List<String> authorizedTenantIds,
+    UserTaskAuthorizationProperties authorizationProperties,
     DbQuerySorting<UserTaskEntity> sort,
     DbQueryPage page) {
 
@@ -36,6 +37,8 @@ public record UserTaskDbQuery(
     private List<String> authorizedProcessDefinitionIds = java.util.Collections.emptyList();
     private List<Long> authorizedUserTaskKeys = java.util.Collections.emptyList();
     private List<String> authorizedTenantIds = java.util.Collections.emptyList();
+    private UserTaskAuthorizationProperties authorizationProperties =
+        UserTaskAuthorizationProperties.EMPTY;
     private DbQuerySorting<UserTaskEntity> sort;
     private DbQueryPage page;
 
@@ -65,6 +68,12 @@ public record UserTaskDbQuery(
       return this;
     }
 
+    public Builder authorizationProperties(
+        final UserTaskAuthorizationProperties authorizationProperties) {
+      this.authorizationProperties = authorizationProperties;
+      return this;
+    }
+
     public UserTaskDbQuery.Builder authorizedTenantIds(final List<String> authorizedTenantIds) {
       this.authorizedTenantIds = authorizedTenantIds;
       return this;
@@ -91,13 +100,64 @@ public record UserTaskDbQuery(
           Objects.requireNonNullElse(authorizedProcessDefinitionIds, List.of());
       authorizedUserTaskKeys = Objects.requireNonNullElse(authorizedUserTaskKeys, List.of());
       authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      authorizationProperties =
+          Objects.requireNonNullElse(
+              authorizationProperties, UserTaskAuthorizationProperties.EMPTY);
       return new UserTaskDbQuery(
           filter,
           authorizedProcessDefinitionIds,
           authorizedUserTaskKeys,
           authorizedTenantIds,
+          authorizationProperties,
           sort,
           page);
+    }
+  }
+
+  public record UserTaskAuthorizationProperties(
+      String assignee, List<String> candidateUsers, List<String> candidateGroups) {
+
+    public static final UserTaskAuthorizationProperties EMPTY =
+        new UserTaskAuthorizationProperties(null, List.of(), List.of());
+
+    // used inside UserTaskMapper.xml ("searchFilter"), when building authorization queries
+    public boolean hasAnyProperty() {
+      return (assignee != null && !assignee.isEmpty())
+          || (candidateUsers != null && !candidateUsers.isEmpty())
+          || (candidateGroups != null && !candidateGroups.isEmpty());
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+
+      private String assignee;
+      private List<String> candidateUsers = List.of();
+      private List<String> candidateGroups = List.of();
+
+      public Builder assignee(final String assignee) {
+        this.assignee = assignee;
+        return this;
+      }
+
+      public Builder candidateUsers(final List<String> candidateUsers) {
+        this.candidateUsers = candidateUsers;
+        return this;
+      }
+
+      public Builder candidateGroups(final List<String> candidateGroups) {
+        this.candidateGroups = candidateGroups;
+        return this;
+      }
+
+      public UserTaskAuthorizationProperties build() {
+        return new UserTaskAuthorizationProperties(
+            assignee,
+            Objects.requireNonNullElse(candidateUsers, List.of()),
+            Objects.requireNonNullElse(candidateGroups, List.of()));
+      }
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -148,23 +148,55 @@
   <sql id="searchFilter">
     <where>
       <!-- authorization filters -->
-      <if test="(authorizedProcessDefinitionIds != null and !authorizedProcessDefinitionIds.isEmpty()) or (authorizedUserTaskKeys != null and !authorizedUserTaskKeys.isEmpty())">
+      <if test="(authorizedProcessDefinitionIds != null and !authorizedProcessDefinitionIds.isEmpty())
+              or (authorizedUserTaskKeys != null and !authorizedUserTaskKeys.isEmpty())
+              or (authorizationProperties != null and authorizationProperties.hasAnyProperty())">
         AND
         <trim prefix="(" suffix=")" prefixOverrides="OR">
+          <!-- ID-based: process definition -->
           <if test="authorizedProcessDefinitionIds != null and !authorizedProcessDefinitionIds.isEmpty()">
             OR ut.PROCESS_DEFINITION_ID IN
             <foreach collection="authorizedProcessDefinitionIds" item="processDefinitionId" open="(" separator="," close=")">
               #{processDefinitionId}
             </foreach>
           </if>
+          <!-- ID-based: user task key -->
           <if test="authorizedUserTaskKeys != null and !authorizedUserTaskKeys.isEmpty()">
             OR ut.USER_TASK_KEY IN
             <foreach collection="authorizedUserTaskKeys" item="userTaskKey" open="(" separator="," close=")">
               #{userTaskKey}
             </foreach>
           </if>
+          <!-- Property-based: assignee -->
+          <if test="authorizationProperties != null and authorizationProperties.assignee != null and !authorizationProperties.assignee.isEmpty()">
+            OR ut.ASSIGNEE = #{authorizationProperties.assignee}
+          </if>
+          <!-- Property-based: candidate users -->
+          <if test="authorizationProperties != null and authorizationProperties.candidateUsers != null and !authorizationProperties.candidateUsers.isEmpty()">
+            OR EXISTS (
+            SELECT 1 FROM ${prefix}CANDIDATE_USER cu
+            WHERE cu.USER_TASK_KEY = ut.USER_TASK_KEY
+            AND cu.CANDIDATE_USER IN
+            <foreach collection="authorizationProperties.candidateUsers" item="candidateUser" open="(" separator="," close=")">
+              #{candidateUser}
+            </foreach>
+            )
+          </if>
+          <!-- Property-based: candidate groups -->
+          <if test="authorizationProperties != null and authorizationProperties.candidateGroups != null and !authorizationProperties.candidateGroups.isEmpty()">
+            OR EXISTS (
+            SELECT 1 FROM ${prefix}CANDIDATE_GROUP cg
+            WHERE cg.USER_TASK_KEY = ut.USER_TASK_KEY
+            AND cg.CANDIDATE_GROUP IN
+            <foreach collection="authorizationProperties.candidateGroups" item="candidateGroup" open="(" separator="," close=")">
+              #{candidateGroup}
+            </foreach>
+            )
+          </if>
         </trim>
       </if>
+
+      <!-- tenant filter -->
       <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
         AND ut.TENANT_ID IN
         <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
@@ -35,7 +35,7 @@ public final class UserTaskFixtures extends CommonFixtures {
             .rootProcessInstanceKey(nextKey())
             .creationDate(NOW)
             .completionDate(NOW.plusDays(1))
-            .assignee("bud spencer")
+            .assignee(generateRandomString(5, "user"))
             .state(UserTaskState.CREATED)
             .formKey(nextKey())
             .processDefinitionKey(nextKey())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -100,22 +100,25 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
       final CamundaAuthentication authentication,
       final Authorization<T> requiredAuthorization,
       final T resource) {
+    final var resourceId = resolveResourceId(requiredAuthorization, resource);
+    return hasResourceAccessByResourceId(authentication, requiredAuthorization, resourceId);
+  }
+
+  private <T> String resolveResourceId(
+      final Authorization<T> requiredAuthorization, final T resource) {
     final var resourceIdSupplier = requiredAuthorization.resourceIdSupplier();
     final var resourceIds = requiredAuthorization.resourceIds();
-    final var resourceId =
-        Optional.ofNullable(resourceIdSupplier)
-            .map(supplier -> supplier.apply(resource))
-            .orElseGet(
-                () ->
-                    Optional.ofNullable(resourceIds)
-                        .filter(l -> l.size() == 1)
-                        .map(List::getFirst)
-                        .orElseThrow(
-                            () ->
-                                new CamundaSearchException(
-                                    "Expected one resource id to check resource access, but received none or more than one")));
-
-    return hasResourceAccessByResourceId(authentication, requiredAuthorization, resourceId);
+    return Optional.ofNullable(resourceIdSupplier)
+        .map(supplier -> supplier.apply(resource))
+        .orElseGet(
+            () ->
+                Optional.ofNullable(resourceIds)
+                    .filter(l -> l.size() == 1)
+                    .map(List::getFirst)
+                    .orElseThrow(
+                        () ->
+                            new CamundaSearchException(
+                                "Expected one resource id to check resource access, but received none or more than one")));
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -67,7 +67,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
       return ResourceAccess.denied(authorization);
     }
 
-    return ResourceAccess.allowed(authorization.with(authorizedResourceIds));
+    return ResourceAccess.allowed(authorization.withResourceIds(authorizedResourceIds));
   }
 
   private <T> ResourceAccess resolveResourceAccessByPropertyNames(
@@ -85,7 +85,8 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
         authorization.resourcePropertyNames().stream()
             .filter(authorizedResourcePropertyNames::contains)
             .collect(Collectors.toSet());
-    final var resolvedAuthorization = authorization.with(resolvedResourcePropertyNames);
+    final var resolvedAuthorization =
+        authorization.withResourcePropertyNames(resolvedResourcePropertyNames);
 
     if (resolvedResourcePropertyNames.isEmpty()) {
       return ResourceAccess.denied(resolvedAuthorization);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/matcher/ResourcePropertyMatcher.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/matcher/ResourcePropertyMatcher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.auth.matcher;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import java.util.Set;
+
+/**
+ * Matches resource properties against authentication context to determine access.
+ *
+ * <p>Implementations extract property values from a resource and check if the authenticated user
+ * matches any of the authorized properties.
+ *
+ * @param <T> the resource type
+ */
+public interface ResourcePropertyMatcher<T> {
+
+  /**
+   * Checks if the authenticated user matches any of the specified properties on the resource.
+   *
+   * @param resource the resource to check
+   * @param authorizedPropertyNames the property names that can grant access
+   * @param authentication the authentication context
+   * @return true if the user matches any authorized property
+   */
+  boolean matches(
+      T resource, Set<String> authorizedPropertyNames, CamundaAuthentication authentication);
+
+  /** Returns the resource class this matcher handles. */
+  Class<T> getResourceClass();
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/matcher/ResourcePropertyMatcherRegistry.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/matcher/ResourcePropertyMatcherRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.auth.matcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Registry for resource property matchers.
+ *
+ * <p>Provides lookup of matchers by resource class for property-based authorization checks.
+ */
+public class ResourcePropertyMatcherRegistry {
+
+  private final Map<Class<?>, ResourcePropertyMatcher<?>> matchers = new HashMap<>();
+
+  public ResourcePropertyMatcherRegistry() {
+    register(new UserTaskPropertyMatcher());
+  }
+
+  public <T> void register(final ResourcePropertyMatcher<T> matcher) {
+    matchers.put(matcher.getResourceClass(), matcher);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> Optional<ResourcePropertyMatcher<T>> getMatcher(final T resource) {
+    if (resource == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable((ResourcePropertyMatcher<T>) matchers.get(resource.getClass()));
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/matcher/UserTaskPropertyMatcher.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/matcher/UserTaskPropertyMatcher.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.auth.matcher;
+
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Matches user task properties against authentication context.
+ *
+ * <p>Supports matching:
+ *
+ * <ul>
+ *   <li>assignee - user is the task assignee
+ *   <li>candidateUsers - user is in the task candidate users list
+ *   <li>candidateGroups - any of user's groups is in the task candidate groups list
+ * </ul>
+ */
+public class UserTaskPropertyMatcher implements ResourcePropertyMatcher<UserTaskEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UserTaskPropertyMatcher.class);
+
+  @Override
+  public boolean matches(
+      final UserTaskEntity resource,
+      final Set<String> authorizedPropertyNames,
+      final CamundaAuthentication authentication) {
+    final var username = authentication.authenticatedUsername();
+    final var userGroups = authentication.authenticatedGroupIds();
+
+    for (final var propertyName : authorizedPropertyNames) {
+      if (matchesProperty(resource, propertyName, username, userGroups)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private boolean matchesProperty(
+      final UserTaskEntity resource,
+      final String propertyName,
+      final String username,
+      final List<String> userGroups) {
+
+    return switch (propertyName) {
+      case Authorization.PROP_ASSIGNEE -> matchesAssignee(resource, username);
+      case Authorization.PROP_CANDIDATE_USERS -> matchesCandidateUsers(resource, username);
+      case Authorization.PROP_CANDIDATE_GROUPS -> matchesCandidateGroups(resource, userGroups);
+      default -> {
+        LOG.warn("Unknown property name '{}' for UserTaskEntity matching; ignoring.", propertyName);
+        yield false;
+      }
+    };
+  }
+
+  private boolean matchesAssignee(final UserTaskEntity resource, final String username) {
+    if (username == null || username.isEmpty()) {
+      return false;
+    }
+    final var assignee = resource.assignee();
+    return assignee != null && assignee.equals(username);
+  }
+
+  private boolean matchesCandidateUsers(final UserTaskEntity resource, final String username) {
+    if (username == null || username.isEmpty()) {
+      return false;
+    }
+    final var candidateUsers = resource.candidateUsers();
+    return candidateUsers != null && candidateUsers.contains(username);
+  }
+
+  private boolean matchesCandidateGroups(
+      final UserTaskEntity resource, final List<String> userGroups) {
+    if (userGroups == null || userGroups.isEmpty()) {
+      return false;
+    }
+    final var candidateGroups = resource.candidateGroups();
+    if (candidateGroups == null || candidateGroups.isEmpty()) {
+      return false;
+    }
+
+    return userGroups.stream().anyMatch(candidateGroups::contains);
+  }
+
+  @Override
+  public Class<UserTaskEntity> getResourceClass() {
+    return UserTaskEntity.class;
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -11,8 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -183,7 +186,7 @@ class DefaultResourceAccessProviderTest {
   }
 
   @Test
-  void shouldAllowAccessToResource() {
+  void shouldAllowAccessToResourceByIdBasedAuthorization() {
     // given
     final var authScopeInvoice = AuthorizationScope.id("invoice");
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
@@ -211,7 +214,7 @@ class DefaultResourceAccessProviderTest {
   }
 
   @Test
-  void shouldDenyAccessToResource() {
+  void shouldDenyAccessToResourceByIdBasedAuthorization() {
     // given
     final var authScopeInvoice = AuthorizationScope.id("invoice");
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
@@ -330,6 +333,123 @@ class DefaultResourceAccessProviderTest {
   }
 
   @Test
+  void shouldAllowAccessToResourceByPropertyBasedAuthorization() {
+    // given
+    final var authentication =
+        CamundaAuthentication.of(a -> a.user("trevor").groupIds(List.of("managers")));
+    final var authorization =
+        Authorization.of(
+            (Authorization.Builder<UserTaskEntity> a) ->
+                a.userTask().readUserTask().authorizedByAssignee().authorizedByCandidateGroups());
+
+    final var userTask = createUserTask("trevor");
+
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(CamundaAuthentication.class), any(Authorization.class)))
+        .thenReturn(
+            List.of(
+                AuthorizationScope.property(Authorization.PROP_ASSIGNEE),
+                AuthorizationScope.property(Authorization.PROP_CANDIDATE_USERS),
+                AuthorizationScope.property(Authorization.PROP_CANDIDATE_GROUPS)));
+
+    // when
+    final var result =
+        resourceAccessProvider.hasResourceAccess(authentication, authorization, userTask);
+
+    // then
+    assertThat(result.allowed()).isTrue();
+    assertThat(result.denied()).isFalse();
+    assertThat(result.wildcard()).isFalse();
+    assertThat(result.authorization().resourcePropertyNames())
+        .containsExactlyInAnyOrder(
+            Authorization.PROP_ASSIGNEE, Authorization.PROP_CANDIDATE_GROUPS);
+  }
+
+  @Test
+  void shouldDenyAccessToResourceByPropertyBasedAuthorizationWhenNoPropertiesAuthorized() {
+    // given
+    final var authentication = CamundaAuthentication.of(a -> a.user("jimmy").groupIds(List.of()));
+    final var authorization =
+        Authorization.of(
+            (Authorization.Builder<UserTaskEntity> a) ->
+                a.userTask().readUserTask().authorizedByAssignee());
+
+    final var userTask = createUserTask("jimmy");
+
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(CamundaAuthentication.class), any(Authorization.class)))
+        .thenReturn(List.of());
+
+    // when
+    final var result =
+        resourceAccessProvider.hasResourceAccess(authentication, authorization, userTask);
+
+    // then
+    assertThat(result.denied()).isTrue();
+    assertThat(result.allowed()).isFalse();
+    assertThat(result.wildcard()).isFalse();
+    assertThat(result.authorization().resourcePropertyNames()).isEmpty();
+  }
+
+  @Test
+  void shouldDenyAccessToResourceByPropertyBasedAuthorizationWhenResourceDoesNotMatch() {
+    // given
+    final var authentication =
+        CamundaAuthentication.of(a -> a.user("franklin").groupIds(List.of()));
+    final var authorization =
+        Authorization.of(
+            (Authorization.Builder<UserTaskEntity> a) ->
+                a.userTask().readUserTask().authorizedByAssignee());
+
+    // User task is assigned to someone else
+    final var userTask = createUserTask("michael");
+
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(CamundaAuthentication.class), any(Authorization.class)))
+        .thenReturn(List.of(AuthorizationScope.property(Authorization.PROP_ASSIGNEE)));
+
+    // when
+    final var result =
+        resourceAccessProvider.hasResourceAccess(authentication, authorization, userTask);
+
+    // then
+    assertThat(result.denied()).isTrue();
+    assertThat(result.allowed()).isFalse();
+    assertThat(result.wildcard()).isFalse();
+    assertThat(result.authorization().resourcePropertyNames())
+        .containsExactly(Authorization.PROP_ASSIGNEE);
+  }
+
+  @Test
+  void shouldDenyAccessToResourceByPropertyBasedAuthorizationWhenNoMatcherRegisteredForResource() {
+    // given
+    final var authentication = CamundaAuthentication.of(a -> a.user("martin"));
+    final var authorization =
+        Authorization.of(
+            (Authorization.Builder<TestResource> a) ->
+                a.processDefinition()
+                    .readProcessDefinition()
+                    .authorizedByProperty("anotherValue")
+                    .authorizedByProperty("unknownProperty"));
+
+    final var resource = new TestResource("id123", "value456");
+
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(CamundaAuthentication.class), any(Authorization.class)))
+        .thenReturn(List.of(AuthorizationScope.property("anotherValue")));
+
+    // when
+    final var result =
+        resourceAccessProvider.hasResourceAccess(authentication, authorization, resource);
+
+    // then
+    assertThat(result.denied()).isTrue();
+    assertThat(result.allowed()).isFalse();
+    assertThat(result.wildcard()).isFalse();
+    assertThat(result.authorization().resourcePropertyNames()).containsExactly("anotherValue");
+  }
+
+  @Test
   void shouldAllowAccessToResourceByResourceId() {
     // given
     final var authScopeInvoice = AuthorizationScope.id("invoice");
@@ -383,6 +503,12 @@ class DefaultResourceAccessProviderTest {
     assertThat(result.allowed()).isFalse();
     assertThat(result.wildcard()).isFalse();
     assertThat(result.authorization()).isEqualTo(authorization);
+  }
+
+  private UserTaskEntity createUserTask(final String assignee) {
+    final var mockedTask = mock(UserTaskEntity.class);
+    lenient().when(mockedTask.assignee()).thenReturn(assignee);
+    return mockedTask;
   }
 
   record TestResource(String id, String anotherValue) {}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/matcher/UserTaskPropertyMatcherTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/matcher/UserTaskPropertyMatcherTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.auth.matcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class UserTaskPropertyMatcherTest {
+
+  private UserTaskPropertyMatcher matcher;
+
+  @BeforeEach
+  void setUp() {
+    matcher = new UserTaskPropertyMatcher();
+  }
+
+  @Test
+  void shouldReturnUserTaskEntityClass() {
+    // when
+    final var resourceClass = matcher.getResourceClass();
+
+    // then
+    assertThat(resourceClass).isEqualTo(UserTaskEntity.class);
+  }
+
+  @Test
+  void shouldMatchWhenUserIsAssignee() {
+    // given
+    final var userTask = createUserTask("frodo", List.of(), List.of());
+    final var authentication = CamundaAuthentication.of(a -> a.user("frodo"));
+    final var propertyNames = Set.of(Authorization.PROP_ASSIGNEE);
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isTrue();
+  }
+
+  @ParameterizedTest(name = "assignee=''{0}'', username=''{1}'' should not match")
+  @MethodSource("provideAssigneeNegativeCases")
+  void shouldNotMatchForInvalidAssigneeCases(final String assignee, final String username) {
+    // given
+    final var userTask = createUserTask(assignee, List.of(), List.of());
+    final var authentication = CamundaAuthentication.of(a -> a.user(username));
+    final var propertyNames = Set.of(Authorization.PROP_ASSIGNEE);
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isFalse();
+  }
+
+  static Stream<Arguments> provideAssigneeNegativeCases() {
+    return Stream.of(
+        Arguments.of("gandalf", "frodo"), // different assignee
+        Arguments.of(null, "frodo"), // null assignee
+        Arguments.of("frodo", null), // null username
+        Arguments.of("frodo", "") // empty username
+        );
+  }
+
+  @Test
+  void shouldMatchWhenUserIsInCandidateUsers() {
+    // given
+    final var userTask = createUserTask("gandalf", List.of("frodo", "aragorn"), List.of());
+    final var authentication = CamundaAuthentication.of(a -> a.user("frodo"));
+    final var propertyNames = Set.of(Authorization.PROP_CANDIDATE_USERS);
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isTrue();
+  }
+
+  @ParameterizedTest(name = "candidateUsers={0}, username=''{1}'' should not match")
+  @MethodSource("provideCandidateUsersNegativeCases")
+  void shouldNotMatchForInvalidCandidateUsersCases(
+      final List<String> candidateUsers, final String username) {
+    // given
+    final var userTask = createUserTask("gandalf", candidateUsers, List.of());
+    final var authentication = CamundaAuthentication.of(a -> a.user(username));
+    final var propertyNames = Set.of(Authorization.PROP_CANDIDATE_USERS);
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isFalse();
+  }
+
+  static Stream<Arguments> provideCandidateUsersNegativeCases() {
+    return Stream.of(
+        Arguments.of(List.of("aragorn", "legolas"), "frodo"), // user not in list
+        Arguments.of(null, "frodo"), // null candidate users
+        Arguments.of(List.of(), "frodo"), // empty candidate users
+        Arguments.of(List.of("aragorn"), null) // null username
+        );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideCandidateGroupsPositiveCases")
+  void shouldMatchWhenUserGroupsMatchCandidateGroups(
+      final String testName, final List<String> candidateGroups, final List<String> userGroups) {
+    // given
+    final var userTask = createUserTask("gandalf", List.of(), candidateGroups);
+    final var authentication = CamundaAuthentication.of(a -> a.user("frodo").groupIds(userGroups));
+    final var propertyNames = Set.of(Authorization.PROP_CANDIDATE_GROUPS);
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isTrue();
+  }
+
+  static Stream<Arguments> provideCandidateGroupsPositiveCases() {
+    return Stream.of(
+        Arguments.of("single user group matches", List.of("hobbits", "elves"), List.of("hobbits")),
+        Arguments.of(
+            "multiple user groups match",
+            List.of("hobbits", "elves"),
+            List.of("dwarves", "elves", "wizards", "hobbits")));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideCandidateGroupsNegativeCases")
+  void shouldNotMatchForInvalidCandidateGroupsCases(
+      final String testName, final List<String> candidateGroups, final List<String> userGroups) {
+    // given
+    final var userTask = createUserTask("gandalf", List.of(), candidateGroups);
+    final var authentication = CamundaAuthentication.of(a -> a.user("frodo").groupIds(userGroups));
+    final var propertyNames = Set.of(Authorization.PROP_CANDIDATE_GROUPS);
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isFalse();
+  }
+
+  static Stream<Arguments> provideCandidateGroupsNegativeCases() {
+    return Stream.of(
+        Arguments.of(
+            "no user group matches", List.of("hobbits", "elves"), List.of("dwarves", "wizards")),
+        Arguments.of("user groups is null", List.of("hobbits"), null),
+        Arguments.of("user groups is empty", List.of("hobbits"), List.of()),
+        Arguments.of("candidate groups is null", null, List.of("hobbits")),
+        Arguments.of("candidate groups is empty", List.of(), List.of("hobbits")));
+  }
+
+  @Test
+  void shouldNotMatchWhenPropertyNameIsUnknown() {
+    // given
+    final var userTask = createUserTask("frodo", List.of(), List.of());
+    final var authentication = CamundaAuthentication.of(a -> a.user("frodo"));
+    final var propertyNames = Set.of("unknownProperty");
+
+    // when
+    final var matches = matcher.matches(userTask, propertyNames, authentication);
+
+    // then
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  void shouldNotMatchWhenPropertyNamesIsEmpty() {
+    // given
+    final var userTask = createUserTask("frodo", List.of(), List.of());
+    final var authentication = CamundaAuthentication.of(a -> a.user("frodo"));
+
+    // when
+    final var matches = matcher.matches(userTask, Set.of(), authentication);
+
+    // then
+    assertThat(matches).isFalse();
+  }
+
+  private UserTaskEntity createUserTask(
+      final String assignee,
+      final List<String> candidateUsers,
+      final List<String> candidateGroups) {
+    final var userTask = mock(UserTaskEntity.class);
+    when(userTask.assignee()).thenReturn(assignee);
+    when(userTask.candidateUsers()).thenReturn(candidateUsers);
+    when(userTask.candidateGroups()).thenReturn(candidateGroups);
+    return userTask;
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -535,7 +535,9 @@ public class CamundaSearchClients implements SearchClientsProxy {
   protected ResourceAccessChecks disableTenantCheck(
       final ResourceAccessChecks resourceAccessChecks) {
     return ResourceAccessChecks.of(
-        resourceAccessChecks.authorizationCheck(), TenantCheck.disabled());
+        resourceAccessChecks.authorizationCheck(),
+        TenantCheck.disabled(),
+        resourceAccessChecks.authentication());
   }
 
   protected <T> SearchQueryResult<T> ensureSingeResultIfNecessary(

--- a/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
@@ -60,10 +60,12 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
   protected <T> T doPreFiltering(
       final SecurityContext securityContext, final Function<ResourceAccessChecks, T> applier) {
     final var authorizationCheck = determineAuthorizationCheck(securityContext);
-    final var tenantCheck = determineTenantCheck(securityContext.authentication());
+    final var authentication = securityContext.authentication();
+    final var tenantCheck = determineTenantCheck(authentication);
 
     // read with resource access checks
-    final var resourceAccessChecks = ResourceAccessChecks.of(authorizationCheck, tenantCheck);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, tenantCheck, authentication);
     return applier.apply(resourceAccessChecks);
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -95,7 +95,7 @@ public record Authorization<T>(
         transitive());
   }
 
-  public Authorization<T> with(final List<String> resourceIds) {
+  public Authorization<T> withResourceIds(final List<String> resourceIds) {
     return new Authorization<>(
         resourceType(),
         permissionType(),
@@ -117,7 +117,7 @@ public record Authorization<T>(
         transitive());
   }
 
-  public Authorization<T> with(final Set<String> resourcePropertyNames) {
+  public Authorization<T> withResourcePropertyNames(final Set<String> resourcePropertyNames) {
     return new Authorization<>(
         resourceType(),
         permissionType(),

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -117,6 +117,17 @@ public record Authorization<T>(
         transitive());
   }
 
+  public Authorization<T> with(final Set<String> resourcePropertyNames) {
+    return new Authorization<>(
+        resourceType(),
+        permissionType(),
+        resourceIds(),
+        resourceIdSupplier(),
+        resourcePropertyNames,
+        condition(),
+        transitive());
+  }
+
   public Authorization<T> withCondition(final Predicate<T> condition) {
     return new Authorization<>(
         resourceType(),

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -41,7 +41,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -51,11 +53,25 @@ public record Authorization<T>(
     @JsonProperty("permission_type") PermissionType permissionType,
     @JsonProperty("resource_ids") List<String> resourceIds,
     @JsonIgnore Function<T, String> resourceIdSupplier,
+    @JsonProperty("resource_property_names") Set<String> resourcePropertyNames,
     @JsonIgnore Predicate<T> condition,
     @JsonProperty("transitive") boolean transitive) {
 
+  // USER TASK property names
+  public static final String PROP_ASSIGNEE = "assignee";
+  public static final String PROP_CANDIDATE_USERS = "candidateUsers";
+  public static final String PROP_CANDIDATE_GROUPS = "candidateGroups";
+
   public boolean hasAnyResourceIds() {
     return resourceIds != null && !resourceIds.isEmpty();
+  }
+
+  public boolean hasAnyResourcePropertyNames() {
+    return resourcePropertyNames != null && !resourcePropertyNames.isEmpty();
+  }
+
+  public boolean hasAnyResourceAccess() {
+    return hasAnyResourceIds() || hasAnyResourcePropertyNames();
   }
 
   public static <T> Authorization<T> withAuthorization(
@@ -74,6 +90,7 @@ public record Authorization<T>(
         permissionType(),
         List.of(resourceId),
         resourceIdSupplier(),
+        resourcePropertyNames(),
         condition(),
         transitive());
   }
@@ -84,6 +101,7 @@ public record Authorization<T>(
         permissionType(),
         List.copyOf(resourceIds),
         resourceIdSupplier(),
+        resourcePropertyNames(),
         condition(),
         transitive());
   }
@@ -94,6 +112,7 @@ public record Authorization<T>(
         permissionType(),
         resourceIds(),
         resourceIdSupplier,
+        resourcePropertyNames(),
         condition(),
         transitive());
   }
@@ -104,6 +123,7 @@ public record Authorization<T>(
         permissionType(),
         resourceIds(),
         resourceIdSupplier(),
+        resourcePropertyNames(),
         condition,
         transitive());
   }
@@ -127,6 +147,7 @@ public record Authorization<T>(
     private PermissionType permissionType;
     private List<String> resourceIds;
     private Function<T, String> resourceIdSupplier;
+    private Set<String> resourcePropertyNames;
     private Predicate<T> condition = null;
     private boolean transitive = false;
 
@@ -272,9 +293,40 @@ public record Authorization<T>(
       return this;
     }
 
+    public Builder<T> resourcePropertyNames(final Set<String> resourcePropertyNames) {
+      this.resourcePropertyNames = resourcePropertyNames;
+      return this;
+    }
+
+    public Builder<T> authorizedByProperty(final String propertyName) {
+      if (this.resourcePropertyNames == null) {
+        this.resourcePropertyNames = new HashSet<>();
+      }
+      this.resourcePropertyNames.add(propertyName);
+      return this;
+    }
+
+    public Builder<T> authorizedByAssignee() {
+      return authorizedByProperty(PROP_ASSIGNEE);
+    }
+
+    public Builder<T> authorizedByCandidateUsers() {
+      return authorizedByProperty(PROP_CANDIDATE_USERS);
+    }
+
+    public Builder<T> authorizedByCandidateGroups() {
+      return authorizedByProperty(PROP_CANDIDATE_GROUPS);
+    }
+
     public Authorization<T> build() {
       return new Authorization<>(
-          resourceType, permissionType, resourceIds, resourceIdSupplier, condition, transitive);
+          resourceType,
+          permissionType,
+          resourceIds,
+          resourceIdSupplier,
+          resourcePropertyNames,
+          condition,
+          transitive);
     }
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
@@ -10,6 +10,7 @@ package io.camunda.security.reader;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.condition.AuthorizationCondition;
 import io.camunda.security.auth.condition.AuthorizationConditions;
+import java.util.function.Predicate;
 
 /**
  * Enables or disables a {@link AuthorizationCheck}. If enabled, then the {@code
@@ -30,10 +31,18 @@ public record AuthorizationCheck(boolean enabled, AuthorizationCondition authori
   }
 
   public boolean hasAnyResourceAccess() {
-    return !enabled || hasAnyResourceIdAccess();
+    return !enabled || hasAnyResourceIdAccess() || hasAnyResourcePropertyAccess();
   }
 
   private boolean hasAnyResourceIdAccess() {
+    return anyAuthorizationMatches(Authorization::hasAnyResourceIds);
+  }
+
+  private boolean hasAnyResourcePropertyAccess() {
+    return anyAuthorizationMatches(Authorization::hasAnyResourcePropertyNames);
+  }
+
+  private boolean anyAuthorizationMatches(Predicate<Authorization<?>> predicate) {
     if (authorizationCondition == null) {
       return false;
     }
@@ -43,6 +52,6 @@ public record AuthorizationCheck(boolean enabled, AuthorizationCondition authori
       return false;
     }
 
-    return auths.stream().anyMatch(Authorization::hasAnyResourceIds);
+    return auths.stream().anyMatch(predicate);
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessChecks.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/ResourceAccessChecks.java
@@ -8,6 +8,7 @@
 package io.camunda.security.reader;
 
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.condition.AuthorizationCondition;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -16,15 +17,26 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public record ResourceAccessChecks(AuthorizationCheck authorizationCheck, TenantCheck tenantCheck) {
+public record ResourceAccessChecks(
+    AuthorizationCheck authorizationCheck,
+    TenantCheck tenantCheck,
+    CamundaAuthentication authentication) {
 
   public static ResourceAccessChecks disabled() {
-    return new ResourceAccessChecks(AuthorizationCheck.disabled(), TenantCheck.disabled());
+    return new ResourceAccessChecks(
+        AuthorizationCheck.disabled(), TenantCheck.disabled(), CamundaAuthentication.none());
   }
 
   public static ResourceAccessChecks of(
       final AuthorizationCheck authorizationCheck, final TenantCheck tenantCheck) {
-    return new ResourceAccessChecks(authorizationCheck, tenantCheck);
+    return new ResourceAccessChecks(authorizationCheck, tenantCheck, CamundaAuthentication.none());
+  }
+
+  public static ResourceAccessChecks of(
+      final AuthorizationCheck authorizationCheck,
+      final TenantCheck tenantCheck,
+      final CamundaAuthentication authentication) {
+    return new ResourceAccessChecks(authorizationCheck, tenantCheck, authentication);
   }
 
   /**

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -13,6 +13,7 @@ import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -68,10 +69,17 @@ public class AuthorizationChecker {
                           .unlimited());
           return authorizationReader.search(query, ResourceAccessChecks.disabled()).items().stream()
               .filter(e -> e.permissionTypes().contains(permissionType))
-              .map(authorizationEntity -> AuthorizationScope.of(authorizationEntity.resourceId()))
+              .map(this::toAuthorizationScope)
               .toList();
         },
         List::of);
+  }
+
+  private AuthorizationScope toAuthorizationScope(final AuthorizationEntity authorizationEntity) {
+    return new AuthorizationScope(
+        AuthorizationResourceMatcher.from(authorizationEntity.resourceMatcher()),
+        authorizationEntity.resourceId(),
+        authorizationEntity.resourcePropertyName());
   }
 
   /**


### PR DESCRIPTION
## Description

This PR introduces **property-based authorization** for the **USER_TASK** resource type in the search layer. This enables access control based on task properties (assignee, candidate users, candidate groups) rather than just resource IDs.

### Key features

- **Property-based authorization model**: Users can now be granted access to user tasks based on their relationship to task properties: 
  - `assignee` - User is the task assignee
  - `candidateUsers` - User is in the task's candidate users list
  - `candidateGroups` - Any of the user's groups matches any of the task's candidate groups

- **Dual authorization support**: The system now supports both:
  - **ID-based authorization**: Existing mechanism based on explicit resource IDs and wildcard (*)
  - **Property-based authorization**: New mechanism based on matching user identity against resource properties

- **Full search layer integration**: Property-based authorization is implemented across all search backends: 
  - Elasticsearch/OpenSearch (`UserTaskFilterTransformer`)
  - RDBMS (`UserTaskDbReader`, `UserTaskMapper.xml`)

## How to use
> [!NOTE]  
> Property-based authorization does not support wildcard permissions. It should be provided in addition to ID/ANY-based authorization, not instead of it.

### Example: User task search with property-based authorization

Currently, a user task search endpoint enforces ID-based permission checks:

To add property-based authorization to search endpoint with ID-based permission checks
<details><summary><code>search user tasks (ID/ANY)</code></summary>

```java
@Override
public SearchQueryResult<UserTaskEntity> search(final UserTaskQuery query) {
  return search(
      query,
      securityContextProvider.provideSecurityContext(
          authentication,
          AuthorizationConditions.anyOf(
              Authorization.<UserTaskEntity>of(a -> a.processDefinition().readUserTask()),
              Authorization.<UserTaskEntity>of(a -> a.userTask().read()))));
}
```
</details>

We need to include an additional authorization branch with property checks:

<details><summary><code>search user tasks (ID/ANY + PROPERTY)</code></summary>

```java
@Override
public SearchQueryResult<UserTaskEntity> search(final UserTaskQuery query) {
  return search(
      query,
      securityContextProvider.provideSecurityContext(
          authentication,
          AuthorizationConditions.anyOf(
              // ID-based:  process definition permission (procesDefinitionIds, wildcards)
              Authorization.<UserTaskEntity>of(a -> a.processDefinition().readUserTask()),
              // ID-based: user task permission (userTaskKeys, wildcards)
              Authorization.<UserTaskEntity>of(a -> a.userTask().read()),
              // Property-based: access via task assignment
              Authorization.<UserTaskEntity>of(
                  a -> a.userTask()
                      .read()
                      .authorizedByAssignee()
                      .authorizedByCandidateUsers()
                      .authorizedByCandidateGroups()))));
}
```
</details>

### Example: Get user task by key with property-based authorization
<details><summary><code>Get user task by key (ID/ANY)</code></summary>

```java
public UserTaskEntity getByKey(final long userTaskKey) {
  return executeSearchRequest(
      () ->
          userTaskSearchClient
              .withSecurityContext(
                  securityContextProvider.provideSecurityContext(
                      authentication,
                      AuthorizationConditions.anyOf(
                          Authorization.<UserTaskEntity>of(
                              a -> a.processDefinition()
                                  .readUserTask()
                                  .resourceIdSupplier(UserTaskEntity::processDefinitionId)),
                          Authorization.<UserTaskEntity>of(
                              a -> a.userTask()
                                  .read()
                                  .resourceId(String.valueOf(userTaskKey))))))
              .getUserTask(userTaskKey));
}
```
</details>

With property-based authorization added:
<details><summary><code>Get user task by key (ID/ANY + PROPERTY)</code></summary>

```java
public UserTaskEntity getByKey(final long userTaskKey) {
  return executeSearchRequest(
      () ->
          userTaskSearchClient
              . withSecurityContext(
                  securityContextProvider.provideSecurityContext(
                      authentication,
                      AuthorizationConditions.anyOf(
                          // ID-based: process definition permission
                          Authorization.<UserTaskEntity>of(
                              a -> a.processDefinition()
                                  .readUserTask()
                                  .resourceIdSupplier(UserTaskEntity::processDefinitionId)),
                          // ID-based: user task permission
                          Authorization.<UserTaskEntity>of(
                              a -> a.userTask()
                                  .read()
                                  .resourceId(String.valueOf(userTaskKey))),
                          // Property-based: access via task assignment
                          Authorization.<UserTaskEntity>of(
                              a -> a.userTask()
                                  . read()
                                  .authorizedByAssignee()
                                  .authorizedByCandidateUsers()
                                  .authorizedByCandidateGroups()))))
              .getUserTask(userTaskKey));
}
```
</details>

## Adoption guidelines

To introduce property-based authorization support for other resource types (beyond `USER_TASK`), follow these steps:

### 1. Define property constants in [Authorization](https://github.com/camunda/camunda/blob/main/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java#L49)

Add property name constants for the new resource type:

```java
public static final String PROP_YOUR_PROPERTY = "yourProperty";
```

### 2. Add Builder methods in `Authorization.Builder`

Create convenience methods for the new property(ies):

```java
public Builder<T> authorizedByYourProperty() {
    return authorizedByProperty(PROP_YOUR_PROPERTY);
}
```

### 3. Implement a property matcher

Create a new matcher implementing `ResourcePropertyMatcher<T>`:
<details><summary><code>YourPropertyMatcher.java</code></summary>

```java
public class YourPropertyMatcher implements ResourcePropertyMatcher<YourEntity> {

    @Override
    public boolean matches(
            final YourEntity resource,
            final Set<String> authorizedPropertyNames,
            final CamundaAuthentication authentication) {
        // Implement matching logic for each property
        for (String propertyName : authorizedPropertyNames) {
            if (matchesProperty(resource, propertyName, authentication)) {
                return true;
            }
        }
        return false;
    }

    @Override
    public Class<YourEntity> getResourceClass() {
        return YourEntity.class;
    }
}
```
</details>

### 4. Register the Matcher

Add the new matcher to `ResourcePropertyMatcherRegistry`:

```java
public ResourcePropertyMatcherRegistry() {
    register(new UserTaskPropertyMatcher());
    register(new YourPropertyMatcher());  // Add new matcher
}
```

### 5. Implement ES/OS Filter transformer support

Override `toAuthorizationCheckSearchQueryByProperties()` in the corresponding [filter transformer](https://github.com/camunda/camunda/tree/main/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter):

<details><summary><code>toAuthorizationCheckSearchQueryByProperties</code></summary>

```java
@Override
protected SearchQuery toAuthorizationCheckSearchQueryByProperties(
        Authorization<? > authorization, CamundaAuthentication authentication) {
    
    if (authorization.resourceType() != AuthorizationResourceType.YOUR_RESOURCE_TYPE) {
        return matchNone();
    }
    
    final var queries = new ArrayList<SearchQuery>();
    for (String propertyName : authorization.resourcePropertyNames()) {
        switch (propertyName) {
            case Authorization.PROP_YOUR_PROPERTY -> {
                // build query
            }
            //... 
        }
    }
    
    return or(queries);
}
```
</details>

### 6. Implement RDBMS Support

#### 6.1 Add properties to `***DbQuery` and adjust `***DbReader`

Add the authorization properties to the corresponding [`***DbQuery`](https://github.com/camunda/camunda/tree/main/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain) class and update the corresponding [`***DbReader`](https://github.com/camunda/camunda/tree/main/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service) to resolve properties from `ResourceAccessChecks`.

#### 6.2 Update MyBatis mapper XML

Add property-based predicates to the authorization filter section in dedicated `***Mapper.xml`

## Related issues

closes #40128 
