### PR TITLE
Create authorization API role, client, group, mapping rule test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -168,6 +168,12 @@ export class OperateFiltersPanelPage {
     await this.page.getByLabel(`Remove ${filterName} Filter`).click();
   }
 
+  async isOptionalFilterDisplayed(filterName: OptionalFilter): Promise<boolean> {
+    return await this.page
+      .getByLabel(filterName, {exact: true})
+      .isVisible();
+  }
+
   async selectProcess(option: string) {
     await waitForAssertion({
       assertion: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -154,6 +154,9 @@ export class OperateFiltersPanelPage {
   }
 
   async displayOptionalFilter(filterName: OptionalFilter) {
+    if (await this.isOptionalFilterDisplayed(filterName)) {
+      return;
+    }
     await this.moreFiltersButton.click();
     await this.moreFiltersMenu.waitFor({state: 'visible'});
     const menuitem = this.page.getByRole('menuitem', {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
@@ -22,47 +22,56 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
-import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
+import {cleanupMappingRules} from '../../../../utils/mappingRuleCleanup';
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  createMappingRule,
+} from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
   CREATE_CUSTOM_AUTHORIZATION_BODY,
+  CREATE_NEW_MAPPING_RULE,
   authorizedComponentRequiredFields,
 } from '../../../../utils/beans/requestBeans';
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
-test.describe.serial('Create Authorization API - Success and Conflict', () => {
-  let successUser: {
-    username: string;
+test.describe.serial('Create Authorization API for Mapping Rule - Success and Conflict', () => {
+  let successMappingRule: {
+    mappingRuleId: string;
+    claimName: string;
+    claimValue: string;
     name: string;
-    email: string;
-    password: string;
   };
   test.beforeAll(async ({request}) => {
-    await test.step('Setup - Create user for Authorization tests', async () => {
-      successUser = await createUser(request);
-      console.log('Created user with username:', successUser.username);
+    await test.step('Setup - Create Mapping Rule for Authorization tests', async () => {
+      successMappingRule = await createMappingRule(request);
+      console.log(
+        'Created Mapping Rule with mappingRuleId:',
+        successMappingRule.mappingRuleId,
+      );
     });
   });
 
   test.afterAll(async ({request}) => {
     await test.step(
-      'Teardown - Delete user with username ' +
-        successUser.username +
+      'Teardown - Delete Mapping Rule with mappingRuleId ' +
+        successMappingRule.mappingRuleId +
         ' created for Authorization tests',
       async () => {
-        await cleanupUsers(request, [successUser.username]);
+        await cleanupMappingRules(request, [successMappingRule.mappingRuleId]);
       },
     );
   });
 
-  test('Create Authorization for user - Success', async ({request}) => {
+  test('Create Authorization for Mapping Rule - Success', async ({request}) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      successUser.username,
-      'USER',
+      successMappingRule.mappingRuleId,
+      'MAPPING_RULE',
       '*',
-      'PROCESS_DEFINITION',
-      ['CREATE_PROCESS_INSTANCE'],
+      'DECISION_REQUIREMENTS_DEFINITION',
+      ['READ'],
     );
 
     await expect(async () => {
@@ -89,17 +98,17 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - Multiple permissionTypes - Success', async ({
+  test('Create Authorization for Mapping Rule - Multiple permissionTypes - Success', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      successUser.username,
-      'USER',
+      successMappingRule.mappingRuleId,
+      'MAPPING_RULE',
       '*',
-      'SYSTEM',
+      'DOCUMENT',
       [
-        'READ_USAGE_METRIC',
-        'UPDATE'
+        'CREATE',
+        'READ'
       ],
     );
 
@@ -127,10 +136,12 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 409 Conflict', async ({request}) => {
+  test('Create Authorization for Mapping Rule - 409 Conflict', async ({
+    request,
+  }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      successUser.username,
-      'USER',
+      successMappingRule.mappingRuleId,
+      'MAPPING_RULE',
       '*',
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -146,37 +157,47 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
       );
       await assertConflictRequest(
         authRes,
-        `Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to create authorization for owner '${successUser.username}' for resource identifier '*', but an authorization for this resource identifier already exists.`,
+        `Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to create authorization for owner '${successMappingRule.mappingRuleId}' for resource identifier '*', but an authorization for this resource identifier already exists.`,
       );
     }).toPass(defaultAssertionOptions);
   });
 });
 
-test.describe.parallel('Create Authorization API - Unhappy paths', () => {
-  let user: {username: string; name: string; email: string; password: string};
+test.describe.parallel('Create Authorization API for Mapping Rule - Unhappy paths', () => {
+  let unhappyPathMappingRule: {
+    mappingRuleId: string;
+    claimName: string;
+    claimValue: string;
+    name: string;
+  };
   test.beforeAll(async ({request}) => {
-    await test.step('Setup - Create user for Authorization tests', async () => {
-      user = await createUser(request);
-      console.log('Created user with username:', user.username);
+    await test.step('Setup - Create Mapping Rule for Authorization tests', async () => {
+      unhappyPathMappingRule = await createMappingRule(request);
+      console.log(
+        'Created Mapping Rule with mappingRuleId:',
+        unhappyPathMappingRule.mappingRuleId,
+      );
     });
   });
 
   test.afterAll(async ({request}) => {
     await test.step(
-      'Teardown - Delete user with username ' +
-        user.username +
+      'Teardown - Delete Mapping Rule with mappingRuleId ' +
+        unhappyPathMappingRule.mappingRuleId +
         ' created for Authorization tests',
       async () => {
-        await cleanupUsers(request, [user.username]);
+        await cleanupMappingRules(request, [
+          unhappyPathMappingRule.mappingRuleId,
+        ]);
       },
     );
   });
 
-  test('Create Authorization for user - 400 Bad Request - wrong value for ownerType', async ({
+  test('Create Authorization for Mapping Rule - 400 Bad Request - wrong value for ownerType', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
+      unhappyPathMappingRule.mappingRuleId,
       'WRONG_VALUE_FOR_TEST',
       '*',
       'PROCESS_DEFINITION',
@@ -198,12 +219,12 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 400 Bad Request - wrong value for resourceType', async ({
+  test('Create Authorization for Mapping Rule - 400 Bad Request - wrong value for resourceType', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
-      'USER',
+      unhappyPathMappingRule.mappingRuleId,
+      'MAPPING_RULE',
       '*',
       'WRONG_VALUE_FOR_TEST',
       ['CREATE_PROCESS_INSTANCE'],
@@ -224,13 +245,13 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 400 Invalid Argument - invalid resourceId', async ({
+  test('Create Authorization for Mapping Rule - 400 Invalid Argument - invalid resourceId', async ({
     request,
   }) => {
     const invalidResourceId = ';;;;';
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
-      'USER',
+      unhappyPathMappingRule.mappingRuleId,
+      'MAPPING_RULE',
       invalidResourceId,
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -252,12 +273,12 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 401 Unauthorized', async ({
+  test('Create Authorization for Mapping Rule - 401 Unauthorized', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
-      'USER',
+      unhappyPathMappingRule.mappingRuleId,
+      'MAPPING_RULE',
       '*',
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -277,13 +298,13 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 404 Not Found - not existing ownerId', async ({
+  test('Create Authorization for Mapping Rule - 404 Not Found - not existing ownerId', async ({
     request,
   }) => {
     const notExistingOwnerId = 'nonExistingOwnerId12345';
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
       notExistingOwnerId,
-      'USER',
+      'MAPPING_RULE',
       '*',
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -299,19 +320,15 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
       );
       await assertNotFoundRequest(
         authRes,
-        `Command 'CREATE' rejected with code 'NOT_FOUND': Expected to create or update authorization with ownerId or resourceId '${notExistingOwnerId}', but a user with this ID does not exist.`,
+        `Command 'CREATE' rejected with code 'NOT_FOUND': Expected to create or update authorization with ownerId or resourceId '${notExistingOwnerId}', but a mapping rule with this ID does not exist.`,
       );
     }).toPass(defaultAssertionOptions);
   });
 });
 
-test.describe('Create Authorization for User - Forbidden', () => {
-  let userToGrantAuthorization: {
-    username: string;
-    name: string;
-    email: string;
-    password: string;
-  };
+test.describe('Create Authorization for Mapping Rule - Forbidden', () => {
+  let forbiddenMappingRule = CREATE_NEW_MAPPING_RULE();
+
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
     name: string;
@@ -327,8 +344,6 @@ test.describe('Create Authorization for User - Forbidden', () => {
         request,
         userWithResourcesAuthorizationToSendRequest,
       );
-
-      userToGrantAuthorization = await createUser(request);
     },
   );
 
@@ -337,18 +352,19 @@ test.describe('Create Authorization for User - Forbidden', () => {
     async ({request}) => {
       await cleanupUsers(request, [
         userWithResourcesAuthorizationToSendRequest.username,
-        userToGrantAuthorization.username,
       ]);
     },
   );
-  test('Create Authorization for user - 403 Forbidden', async ({request}) => {
+  test('Create Authorization for Mapping Rule - 403 Forbidden', async ({
+    request,
+  }) => {
     await test.step('Test - Create Authorization with user credentials', async () => {
       const token = encode(
         `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
       );
       const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-        userToGrantAuthorization.username,
-        'USER',
+        forbiddenMappingRule.mappingRuleId,
+        'MAPPING_RULE',
         '*',
         'PROCESS_DEFINITION',
         ['CREATE_PROCESS_INSTANCE'],

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
@@ -20,9 +20,17 @@ import {
   assertRequiredFields,
   assertForbiddenRequest,
 } from '../../../../utils/http';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
-import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
+import {cleanupRoles} from '../../../../utils/rolesCleanup';
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  createRole,
+} from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
   CREATE_CUSTOM_AUTHORIZATION_BODY,
@@ -31,38 +39,38 @@ import {
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
-test.describe.serial('Create Authorization API - Success and Conflict', () => {
-  let successUser: {
-    username: string;
-    name: string;
-    email: string;
-    password: string;
+test.describe.serial('Create Authorization API for role - Success and Conflict', () => {
+  const uid = generateUniqueId();
+  let successRole = {
+    roleId: `role-create-authorization-${uid}`,
+    name: `authorization Role`,
+    description: 'Create Authorization Success API test role',
   };
   test.beforeAll(async ({request}) => {
-    await test.step('Setup - Create user for Authorization tests', async () => {
-      successUser = await createUser(request);
-      console.log('Created user with username:', successUser.username);
+    await test.step('Setup - Create role for Authorization tests', async () => {
+      successRole = await createRole(request);
+      console.log('Created role with roleId:', successRole.roleId);
     });
   });
 
   test.afterAll(async ({request}) => {
     await test.step(
-      'Teardown - Delete user with username ' +
-        successUser.username +
+      'Teardown - Delete role with roleId ' +
+        successRole.roleId +
         ' created for Authorization tests',
       async () => {
-        await cleanupUsers(request, [successUser.username]);
+        await cleanupRoles(request, [successRole.roleId]);
       },
     );
   });
 
-  test('Create Authorization for user - Success', async ({request}) => {
+  test('Create Authorization for role - Success', async ({request}) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      successUser.username,
-      'USER',
+      successRole.roleId,
+      'ROLE',
       '*',
-      'PROCESS_DEFINITION',
-      ['CREATE_PROCESS_INSTANCE'],
+      'GROUP',
+      ['DELETE'],
     );
 
     await expect(async () => {
@@ -89,17 +97,17 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - Multiple permissionTypes - Success', async ({
+  test('Create Authorization for role - Multiple permissionTypes - Success', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      successUser.username,
-      'USER',
+      successRole.roleId,
+      'ROLE',
       '*',
-      'SYSTEM',
+      'MAPPING_RULE',
       [
-        'READ_USAGE_METRIC',
-        'UPDATE'
+        'CREATE',
+        'READ'
       ],
     );
 
@@ -127,10 +135,10 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 409 Conflict', async ({request}) => {
+  test('Create Authorization for role - 409 Conflict', async ({request}) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      successUser.username,
-      'USER',
+      successRole.roleId,
+      'ROLE',
       '*',
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -146,37 +154,43 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
       );
       await assertConflictRequest(
         authRes,
-        `Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to create authorization for owner '${successUser.username}' for resource identifier '*', but an authorization for this resource identifier already exists.`,
+        `Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to create authorization for owner '${successRole.roleId}' for resource identifier '*', but an authorization for this resource identifier already exists.`,
       );
     }).toPass(defaultAssertionOptions);
   });
 });
 
-test.describe.parallel('Create Authorization API - Unhappy paths', () => {
-  let user: {username: string; name: string; email: string; password: string};
+test.describe
+  .parallel('Create Authorization API for role - Unhappy paths', () => {
+  const uid = generateUniqueId();
+  let failRole = {
+    roleId: `role-create-authorization-${uid}`,
+    name: `authorization fail role`,
+    description: 'Create Authorization Fail API test role',
+  };
   test.beforeAll(async ({request}) => {
-    await test.step('Setup - Create user for Authorization tests', async () => {
-      user = await createUser(request);
-      console.log('Created user with username:', user.username);
+    await test.step('Setup - Create role for Authorization tests', async () => {
+      failRole = await createRole(request);
+      console.log('Created role with roleId:', failRole.roleId);
     });
   });
 
   test.afterAll(async ({request}) => {
     await test.step(
-      'Teardown - Delete user with username ' +
-        user.username +
+      'Teardown - Delete role with roleId ' +
+        failRole.roleId +
         ' created for Authorization tests',
       async () => {
-        await cleanupUsers(request, [user.username]);
+        await cleanupRoles(request, [failRole.roleId]);
       },
     );
   });
 
-  test('Create Authorization for user - 400 Bad Request - wrong value for ownerType', async ({
+  test('Create Authorization for role - 400 Bad Request - wrong value for ownerType', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
+      failRole.roleId,
       'WRONG_VALUE_FOR_TEST',
       '*',
       'PROCESS_DEFINITION',
@@ -198,12 +212,12 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 400 Bad Request - wrong value for resourceType', async ({
+  test('Create Authorization for role - 400 Bad Request - wrong value for resourceType', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
-      'USER',
+      failRole.roleId,
+      'ROLE',
       '*',
       'WRONG_VALUE_FOR_TEST',
       ['CREATE_PROCESS_INSTANCE'],
@@ -224,13 +238,13 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 400 Invalid Argument - invalid resourceId', async ({
+  test('Create Authorization for role - 400 Invalid Argument - invalid resourceId', async ({
     request,
   }) => {
     const invalidResourceId = ';;;;';
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
-      'USER',
+      failRole.roleId,
+      'ROLE',
       invalidResourceId,
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -252,12 +266,12 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 401 Unauthorized', async ({
+  test('Create Authorization for role - 401 Unauthorized', async ({
     request,
   }) => {
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-      user.username,
-      'USER',
+      failRole.roleId,
+      'ROLE',
       '*',
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -277,13 +291,13 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Create Authorization for user - 404 Not Found - not existing ownerId', async ({
+  test('Create Authorization for role - 404 Not Found - not existing ownerId', async ({
     request,
   }) => {
     const notExistingOwnerId = 'nonExistingOwnerId12345';
     const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
       notExistingOwnerId,
-      'USER',
+      'ROLE',
       '*',
       'PROCESS_DEFINITION',
       ['CREATE_PROCESS_INSTANCE'],
@@ -299,18 +313,18 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
       );
       await assertNotFoundRequest(
         authRes,
-        `Command 'CREATE' rejected with code 'NOT_FOUND': Expected to create or update authorization with ownerId or resourceId '${notExistingOwnerId}', but a user with this ID does not exist.`,
+        `Command 'CREATE' rejected with code 'NOT_FOUND': Expected to create or update authorization with ownerId or resourceId '${notExistingOwnerId}', but a role with this ID does not exist.`,
       );
     }).toPass(defaultAssertionOptions);
   });
 });
 
-test.describe('Create Authorization for User - Forbidden', () => {
-  let userToGrantAuthorization: {
-    username: string;
-    name: string;
-    email: string;
-    password: string;
+test.describe('Create Authorization for role - Forbidden', () => {
+  const uid = generateUniqueId();
+  let forbiddenRole = {
+    roleId: `role-create-authorization-${uid}`,
+    name: `authorization forbidden role`,
+    description: 'Create Authorization forbidden API test role',
   };
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
@@ -327,8 +341,6 @@ test.describe('Create Authorization for User - Forbidden', () => {
         request,
         userWithResourcesAuthorizationToSendRequest,
       );
-
-      userToGrantAuthorization = await createUser(request);
     },
   );
 
@@ -337,36 +349,34 @@ test.describe('Create Authorization for User - Forbidden', () => {
     async ({request}) => {
       await cleanupUsers(request, [
         userWithResourcesAuthorizationToSendRequest.username,
-        userToGrantAuthorization.username,
       ]);
     },
   );
-  test('Create Authorization for user - 403 Forbidden', async ({request}) => {
-    await test.step('Test - Create Authorization with user credentials', async () => {
-      const token = encode(
-        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
-      );
-      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
-        userToGrantAuthorization.username,
-        'USER',
-        '*',
-        'PROCESS_DEFINITION',
-        ['CREATE_PROCESS_INSTANCE'],
-      );
+  test('Create Authorization for role - 403 Forbidden', async ({request}) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
 
-      await expect(async () => {
-        const authRes = await request.post(
-          buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
-          {
-            headers: jsonHeaders(token), // overrides default demo:demo
-            data: authorizationBody,
-          },
-        );
-        await assertForbiddenRequest(
-          authRes,
-          "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'",
-        );
-      }).toPass(defaultAssertionOptions);
-    });
+    const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+      forbiddenRole.roleId,
+      'ROLE',
+      '*',
+      'PROCESS_DEFINITION',
+      ['CREATE_PROCESS_INSTANCE'],
+    );
+
+    await expect(async () => {
+      const authRes = await request.post(
+        buildUrl(CREATE_AUTHORIZATION_ENDPOINT),
+        {
+          headers: jsonHeaders(token), // overrides default demo:demo
+          data: authorizationBody,
+        },
+      );
+      await assertForbiddenRequest(
+        authRes,
+        "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'",
+      );
+    }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-search-api.spec.ts
@@ -16,7 +16,10 @@ import {
   assertRequiredFields,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import {createMammalProcessInstanceAndDeployMammalDecision, DecisionInstance} from '@requestHelpers';
+import {
+  createMammalProcessInstanceAndDeployMammalDecision,
+  DecisionInstance,
+} from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
 import {decisionInstanceRequiredFields} from 'utils/beans/requestBeans';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -27,6 +27,8 @@ import {
   roleRequiredFields,
 } from '../../../../utils/beans/requestBeans';
 import {generateUniqueId} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {cleanupRoles} from '../../../../utils/rolesCleanup';
 
 const USAGE_METRICS_GET_ENDPOINT = '/system/usage-metrics';
 const CREATE_USER_ENDPOINT = '/users';
@@ -191,112 +193,14 @@ test.describe('Get Usage Metrics API Tests - User with no permission', () => {
   });
 
   test.afterAll(async ({request}) => {
-    console.log('Starting teardown... MEOW');
-    await test.step('Teardown - Delete limited authorization and verify deletion', async () => {
-      const res = await request.delete(
-        buildUrl('/authorizations/{authorizationKey}', {
-          authorizationKey: limitedAuthorizationKey,
-        }),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-      expect(res.status()).toBe(204);
-
-      // Verify authorization is gone
-      let after = await request.get(
-        buildUrl('/authorizations/{authorizationKey}', {
-          authorizationKey: limitedAuthorizationKey,
-        }),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-
-      await waitForAssertion({
-        assertion: async () => {
-          await assertNotFoundRequest(
-            after,
-            `Authorization with key '${limitedAuthorizationKey}' not found`,
-          );
-        },
-        onFailure: async () => {
-          after = await request.get(
-            buildUrl('/authorizations/{authorizationKey}', {
-              authorizationKey: limitedAuthorizationKey,
-            }),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-        },
-        maxRetries: 60,
-      });
-    });
+    console.log('Starting teardown...');
 
     await test.step('Teardown - Delete limited role and verify deletion', async () => {
-      const res = await request.delete(
-        buildUrl('/roles/{roleId}', {roleId: LIMITED_ROLE.roleId}),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-      expect(res.status()).toBe(204);
-
-      // Verify role is gone
-      let after = await request.get(
-        buildUrl('/roles/{roleId}', {roleId: LIMITED_ROLE.roleId}),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-      await waitForAssertion({
-        assertion: async () => {
-          await assertNotFoundRequest(
-            after,
-            `Role with id '${LIMITED_ROLE.roleId}' not found`,
-          );
-        },
-        onFailure: async () => {
-          after = await request.get(
-            buildUrl('/roles/{roleId}', {roleId: LIMITED_ROLE.roleId}),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-        },
-        maxRetries: 90,
-      });
+      await cleanupRoles(request, [LIMITED_ROLE.roleId]);
     });
 
     await test.step('Teardown - Delete limited user and verify deletion', async () => {
-      const res = await request.delete(
-        buildUrl('/users/{username}', {username: LIMITED_USER.username}),
-        {headers: jsonHeaders()},
-      );
-      expect(res.status()).toBe(204);
-
-      // Verify user is gone
-      let after = await request.get(
-        buildUrl('/users/{username}', {username: LIMITED_USER.username}),
-        {headers: jsonHeaders()},
-      );
-
-      await waitForAssertion({
-        assertion: async () => {
-          await assertNotFoundRequest(
-            after,
-            `User with username '${LIMITED_USER.username}' not found`,
-          );
-        },
-        onFailure: async () => {
-          after = await request.get(
-            buildUrl('/users/{username}', {username: LIMITED_USER.username}),
-            {headers: jsonHeaders()},
-          );
-        },
-        maxRetries: 90,
-      });
+      await cleanupUsers(request, [LIMITED_USER.username]);
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -153,13 +153,9 @@ test.describe('Child Process Instance Migration', () => {
           await page.reload();
           await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
           await operateFiltersPanelPage.selectVersion(sourceVersion);
-          if (!operateFiltersPanelPage.isOptionalFilterDisplayed(
+          await operateFiltersPanelPage.displayOptionalFilter(
             'Parent Process Instance Key',
-          )) {
-            await operateFiltersPanelPage.displayOptionalFilter(
-              'Parent Process Instance Key',
-            );
-          }
+          );
           await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
             parentInstanceKey,
           );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -153,9 +153,13 @@ test.describe('Child Process Instance Migration', () => {
           await page.reload();
           await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
           await operateFiltersPanelPage.selectVersion(sourceVersion);
-          await operateFiltersPanelPage.displayOptionalFilter(
+          if (!operateFiltersPanelPage.isOptionalFilterDisplayed(
             'Parent Process Instance Key',
-          );
+          )) {
+            await operateFiltersPanelPage.displayOptionalFilter(
+              'Parent Process Instance Key',
+            );
+          }
           await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
             parentInstanceKey,
           );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -531,6 +531,7 @@ test.describe.serial('Process Instance Migration', () => {
     operateFiltersPanelPage,
     operateProcessesPage,
     operateDiagramPage,
+    page,
   }) => {
     const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
     const targetVersion = testProcesses.processV3.version.toString();
@@ -561,12 +562,15 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify Business rule task incident migration', async () => {
-      await operateDiagramPage.clickFlowNode('BusinessRuleTask2');
-      await operateDiagramPage.clickShowMetaData();
-
-      await operateDiagramPage.verifyIncidentInPopover(/invalid.*decision/i);
-
-      await operateDiagramPage.closeMetadataModal();
+      await waitForAssertion({
+        assertion: async () => {
+          await operateDiagramPage.clickFlowNode('BusinessRuleTask2');
+          await operateDiagramPage.verifyIncidentInPopover(/invalid.*decision/i);
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -124,8 +124,15 @@ test.describe('Processes', () => {
         `${instanceWithoutAnIncident.processInstanceKey}, ${instanceWithAnIncident.processInstanceKey}`,
       );
 
-      await expect(operateProcessesPage.dataList).toBeVisible();
-      await expect(operateProcessesPage.processInstancesTable).toHaveCount(2);
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.dataList).toBeVisible();
+          await expect(operateProcessesPage.processInstancesTable).toHaveCount(2);
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
 
       await waitForAssertion({
         assertion: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/mappingRuleCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/mappingRuleCleanup.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupMappingRules(
+  request: APIRequestContext,
+  mappingRuleIds: string[],
+): Promise<void> {
+  if (mappingRuleIds.length === 0) return;
+  console.log(`Cleaning up ${mappingRuleIds.length} mapping rules via API...`);
+
+  await Promise.allSettled(
+    mappingRuleIds.map(async (mappingRuleId) => {
+      try {
+        const response = await request.delete(
+          buildUrl('/mapping-rules/{mappingRuleId}', {mappingRuleId}),
+          {headers: jsonHeaders()},
+        );
+        if (response.status() === 204) {
+          console.log(`Successfully deleted mapping rule: ${mappingRuleId}`);
+        } else if (response.status() === 404) {
+          console.log(
+            `Mapping rule already deleted or doesn't exist: ${mappingRuleId}`,
+          );
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for mapping rule ${mappingRuleId}`,
+          );
+        }
+      } catch {}
+    }),
+  );
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
@@ -152,3 +152,26 @@ export function assertGroupsInResponse(
   assertRequiredFields(matchingItem, ['groupId']);
   assertEqualsForKeys(matchingItem, expectedBody, ['groupId']);
 }
+
+export async function createGroup(
+  request: APIRequestContext,
+  state?: Record<string, unknown>,
+  key?: string,
+) {
+  const body = CREATE_NEW_GROUP();
+
+  const res = await request.post(buildUrl('/groups'), {
+    headers: jsonHeaders(),
+    data: body,
+  });
+
+  await assertStatusCode(res, 201);
+  const json = await res.json();
+  assertRequiredFields(json, groupRequiredFields);
+  if (state && key) {
+    state[`groupId${key}`] = json.groupId;
+    state[`name${key}`] = json.name;
+    state[`description${key}`] = json.description;
+  }
+  return body;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -31,6 +31,7 @@ export {assertTenantInResponse} from './tenant-requestHelpers';
 export {assertDecisionDefinitionInResponse} from './decision-definition-requestHelpers';
 export {deployDecisionAndStoreResponse} from './decision-definition-requestHelpers';
 export {assertGroupsInResponse} from './group-requestHelpers';
+export {createGroup} from './group-requestHelpers';
 export {createGroupAndStoreResponseFields} from './group-requestHelpers';
 export {DECISION_DEFINITION_RESPONSE_FROM_DEPLOYMENT} from '../beans/requestBeans';
 export {assertUserInResponse} from './user-requestHelpers';
@@ -40,7 +41,8 @@ export {assignRoleToUsers} from './user-requestHelpers';
 export {createUsersAndStoreResponseFields} from './user-requestHelpers';
 export {
   createComponentAuthorization,
-  grantUserResourceAuthorization
+  grantUserResourceAuthorization,
+  cleanupAuthorizations,
 } from './authorization-requestHelpers';
 export {assertRoleInResponse} from './role-requestHelpers';
 export {assertClientsInResponse} from './clients-requestHelpers';


### PR DESCRIPTION
## Description

This PR covers Create Authorization API, covering `ownerType` ROLE, CLIENT, GROUP, MAPPING RULE. There are happy path tests: 

- Create Authorization for `ownerType` - Success
- Create Authorization for `ownerType` - Multiple permissionTypes - Success

And unhappy path tests:

- Create Authorization for `ownerType` - 400 Bad Request - wrong value for ownerType
- Create Authorization for `ownerType` - 400 Bad Request - wrong value for resourceType
- Create Authorization for `ownerType` - 400 Invalid Argument - invalid resourceId
- Create Authorization for `ownerType` - 401 Unauthorized
- Create Authorization for `ownerType` - 404 Not Found - not existing ownerId – except of CLIENT. CLIENT ownerType isn't verified.
- Create Authorization for `ownerType` - 409 Conflict
- Create Authorization for `ownerType` - 403 Forbidden

In the backport update of responses for 400 will be required.

Each 'Create authorization' file looks exactly the same :)

Also the PR introduces new functions: `mappingRuleCleanup`, `cleanupAuthorizations ` and `createGroup`. In `OperateFiltersPanelPage.ts` it introduces `isOptionalFilterDisplayed` function.

Among other things this PR updates some tests that failed during on-demand-workflow runs:

- `childProcessInstanceMigration.spec.ts`: verification if filter is already enabled (to avoid failing on retries)
- `processInstanceMigration.spec.ts`: remove unnecessary opening of metadata and additional `waitForAssertion()`
- `usage-metrics-api.spec.ts`: instead of plain code, reusing existing functions for cleanup. Cleanup for authorization was removed, as it is deleted with role.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related #37204

## On demand workflow
[Was successul](https://github.com/camunda/camunda/actions/runs/20956665802)