### PR TITLE
Tasklist skeleton for java client for ES

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -311,7 +311,9 @@ public class ElasticsearchConnector {
     try {
       return RetryOperation.<Boolean>newBuilder()
           .noOfRetry(50)
-          .retryOn(IOException.class, co.elastic.clients.elasticsearch._types.ElasticsearchException.class)
+          .retryOn(
+              IOException.class,
+              co.elastic.clients.elasticsearch._types.ElasticsearchException.class)
           .delayInterval(3, TimeUnit.SECONDS)
           .message(
               String.format(

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -311,7 +311,7 @@ public class ElasticsearchConnector {
     try {
       return RetryOperation.<Boolean>newBuilder()
           .noOfRetry(50)
-          .retryOn(IOException.class, ElasticsearchException.class)
+          .retryOn(IOException.class, co.elastic.clients.elasticsearch._types.ElasticsearchException.class)
           .delayInterval(3, TimeUnit.SECONDS)
           .message(
               String.format(

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -101,6 +101,11 @@
       <artifactId>elasticsearch</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-java</artifactId>
+    </dependency>
+
     <!-- Opensearch -->
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -296,7 +296,9 @@ public class ElasticsearchConnector {
     try {
       return RetryOperation.<Boolean>newBuilder()
           .noOfRetry(50)
-          .retryOn(IOException.class, ElasticsearchException.class)
+          .retryOn(
+              IOException.class,
+              co.elastic.clients.elasticsearch._types.ElasticsearchException.class)
           .delayInterval(3, TimeUnit.SECONDS)
           .message(
               String.format(

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -131,7 +131,7 @@ public class ElasticsearchConnector {
   }
 
   @Bean
-  public ElasticsearchClient es8Client() {
+  public ElasticsearchClient tasklistEs8Client() {
     esClientRepository.load(tasklistProperties.getElasticsearch().getInterceptorPlugins());
     return createEs8Client(tasklistProperties.getElasticsearch(), esClientRepository);
   }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.tasklist.connect;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -14,11 +18,13 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.camunda.search.connect.plugin.PluginRepository;
+import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.ElasticsearchProperties;
 import io.camunda.tasklist.property.SslProperties;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.RetryOperation;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -37,6 +43,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
@@ -121,6 +128,45 @@ public class ElasticsearchConnector {
       LOGGER.debug("Elasticsearch connection was successfully created.");
     }
     return esClient;
+  }
+
+  @Bean
+  public ElasticsearchClient es8Client() {
+    esClientRepository.load(tasklistProperties.getElasticsearch().getInterceptorPlugins());
+    return createEs8Client(tasklistProperties.getElasticsearch(), esClientRepository);
+  }
+
+  public ElasticsearchClient createEs8Client(
+      final ElasticsearchProperties elsConfig, final PluginRepository pluginRepository) {
+    LOGGER.debug("Creating Elasticsearch connection...");
+
+    final RestClientBuilder restClientBuilder =
+        RestClient.builder(getHttpHost(elsConfig))
+            .setHttpClientConfigCallback(
+                httpClientBuilder ->
+                    configureHttpClient(
+                        httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()));
+    if (elsConfig.getConnectTimeout() != null || elsConfig.getSocketTimeout() != null) {
+      restClientBuilder.setRequestConfigCallback(
+          configCallback -> setTimeouts(configCallback, elsConfig));
+    }
+
+    final RestClientTransport transport =
+        new RestClientTransport(
+            restClientBuilder.build(), new JacksonJsonpMapper(CommonUtils.OBJECT_MAPPER));
+
+    final var client = new ElasticsearchClient(transport);
+
+    if (tasklistProperties.getElasticsearch().isHealthCheckEnabled()) {
+      if (!checkHealth(client)) {
+        LOGGER.warn("Elasticsearch cluster is not accessible");
+      } else {
+        LOGGER.debug("Elasticsearch connection was successfully created.");
+      }
+    } else {
+      LOGGER.warn("Elasticsearch cluster health check is disabled.");
+    }
+    return client;
   }
 
   private HttpAsyncClientBuilder configureHttpClient(
@@ -243,6 +289,29 @@ public class ElasticsearchConnector {
                   esClient.cluster().health(new ClusterHealthRequest(), RequestOptions.DEFAULT);
               return clusterHealthResponse.getClusterName().equals(elsConfig.getClusterName());
             });
+  }
+
+  boolean checkHealth(final ElasticsearchClient esClient) {
+    final ElasticsearchProperties elsConfig = tasklistProperties.getElasticsearch();
+    try {
+      return RetryOperation.<Boolean>newBuilder()
+          .noOfRetry(50)
+          .retryOn(IOException.class, ElasticsearchException.class)
+          .delayInterval(3, TimeUnit.SECONDS)
+          .message(
+              String.format(
+                  "Connect to Elasticsearch cluster [%s] at %s",
+                  elsConfig.getClusterName(), elsConfig.getUrl()))
+          .retryConsumer(
+              () -> {
+                final HealthResponse clusterHealthResponse = esClient.cluster().health();
+                return clusterHealthResponse.clusterName().equals(elsConfig.getClusterName());
+              })
+          .build()
+          .retry();
+    } catch (final Exception e) {
+      throw new TasklistRuntimeException("Couldn't connect to Elasticsearch. Abort.", e);
+    }
   }
 
   private RetryPolicy<Boolean> getConnectionRetryPolicy(final ElasticsearchProperties elsConfig) {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantCheckApplier.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantCheckApplier.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 
 public interface TenantCheckApplier<T> {
 
-  void apply(final T searchRequest);
+  T apply(final T searchRequest);
 
-  void apply(final T searchRequest, Collection<String> tenantIds);
+  T apply(final T searchRequest, Collection<String> tenantIds);
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/ScrollException.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/ScrollException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.store;
+
+public class ScrollException extends RuntimeException {
+
+  public ScrollException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
@@ -8,10 +8,10 @@
 package io.camunda.tasklist.store.elasticsearch;
 
 import static io.camunda.tasklist.util.ElasticsearchUtil.UPDATE_RETRY_COUNT;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.PersistenceException;
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -33,7 +34,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -105,24 +105,31 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
   public List<DraftTaskVariableEntity> getVariablesByTaskIdAndVariableNames(
       final String taskId, final List<String> variableNames) {
     try {
-      final BoolQueryBuilder queryBuilder =
-          QueryBuilders.boolQuery()
-              .must(QueryBuilders.termQuery(DraftTaskVariableTemplate.TASK_ID, taskId));
+      final var taskIdQuery =
+          ElasticsearchUtil.termsQuery(DraftTaskVariableTemplate.TASK_ID, taskId);
 
-      // Add variable names to query only if the list is not empty
-      if (!CollectionUtils.isEmpty(variableNames)) {
-        queryBuilder.must(QueryBuilders.termsQuery(DraftTaskVariableTemplate.NAME, variableNames));
-      }
+      final var query =
+          CollectionUtils.isEmpty(variableNames)
+              ? taskIdQuery
+              : ElasticsearchUtil.joinWithAnd(
+                  taskIdQuery,
+                  ElasticsearchUtil.termsQuery(DraftTaskVariableTemplate.NAME, variableNames));
 
-      final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(queryBuilder);
+      final var searchRequestBuilder =
+          new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
+              .index(draftTaskVariableTemplate.getFullQualifiedName())
+              .query(query);
 
-      final SearchRequest searchRequest =
-          new SearchRequest(draftTaskVariableTemplate.getFullQualifiedName());
-      searchRequest.source(sourceBuilder);
+      final var scrollStream =
+          ElasticsearchUtil.scrollAllStream(
+              es8Client, searchRequestBuilder, DraftTaskVariableEntity.class);
 
-      return ElasticsearchUtil.scroll(
-          searchRequest, DraftTaskVariableEntity.class, objectMapper, esClient);
-    } catch (final IOException e) {
+      return scrollStream
+          .flatMap(response -> response.hits().hits().stream())
+          .map(Hit::source)
+          .filter(Objects::nonNull)
+          .toList();
+    } catch (final Exception e) {
       throw new TasklistRuntimeException(
           String.format(
               "Error executing the query to get draft task variable instances for task [%s] with variable names %s",
@@ -162,15 +169,22 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
 
   @Override
   public List<String> getDraftVariablesIdsByTaskIds(final List<String> taskIds) {
-    final SearchRequest searchRequest =
-        new SearchRequest(draftTaskVariableTemplate.getFullQualifiedName())
-            .source(
-                SearchSourceBuilder.searchSource()
-                    .query(termsQuery(DraftTaskVariableTemplate.TASK_ID, taskIds))
-                    .fetchField(DraftTaskVariableTemplate.ID));
     try {
-      return ElasticsearchUtil.scrollIdsToList(searchRequest, esClient);
-    } catch (final IOException e) {
+      final var query = ElasticsearchUtil.termsQuery(DraftTaskVariableTemplate.TASK_ID, taskIds);
+
+      final var searchRequestBuilder =
+          new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
+              .index(draftTaskVariableTemplate.getFullQualifiedName())
+              .query(query)
+              .source(s -> s.filter(f -> f.includes(DraftTaskVariableTemplate.ID)));
+
+      return ElasticsearchUtil.scrollAllStream(
+              es8Client, searchRequestBuilder, ElasticsearchUtil.MAP_CLASS)
+          .flatMap(response -> response.hits().hits().stream())
+          .map(Hit::id)
+          .filter(Objects::nonNull)
+          .toList();
+    } catch (final Exception e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
@@ -60,7 +60,9 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
-  @Autowired private ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  private ElasticsearchClient es8Client;
 
   @Autowired private DraftTaskVariableTemplate draftTaskVariableTemplate;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -65,7 +65,9 @@ public class FormStoreElasticSearch implements FormStore {
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
-  @Autowired private ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  private ElasticsearchClient es8Client;
 
   @Override
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -11,6 +11,8 @@ import static io.camunda.tasklist.util.ElasticsearchUtil.fromSearchHit;
 import static io.camunda.tasklist.util.ElasticsearchUtil.getRawResponseWithTenantCheck;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.GetRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.NotFoundException;
@@ -27,11 +29,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -65,6 +64,8 @@ public class FormStoreElasticSearch implements FormStore {
   @Autowired
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
+
+  @Autowired private ElasticsearchClient es8Client;
 
   @Override
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {
@@ -103,12 +104,13 @@ public class FormStoreElasticSearch implements FormStore {
 
   @Override
   public Optional<FormIdView> getFormByKey(final String formKey) {
-    final GetRequest getRequest = new GetRequest(formIndex.getFullQualifiedName(), formKey);
+    final var getRequest =
+        GetRequest.of(b -> b.index(formIndex.getFullQualifiedName()).id(formKey));
 
     try {
-      final GetResponse response = esClient.get(getRequest, RequestOptions.DEFAULT);
-      if (response.isExists()) {
-        final Map<String, Object> sourceAsMap = response.getSourceAsMap();
+      final var response = es8Client.get(getRequest, ElasticsearchUtil.MAP_CLASS);
+      if (response.found()) {
+        final var sourceAsMap = response.source();
         return Optional.of(
             new FormIdView(
                 (String) sourceAsMap.get(FormIndex.ID),

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -62,7 +62,9 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
-  @Autowired private ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  private ElasticsearchClient es8Client;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -93,7 +93,9 @@ public class TaskStoreElasticSearch implements TaskStore {
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
-  @Autowired private ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  private ElasticsearchClient es8Client;
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchTenantHelper.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchTenantHelper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.util;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
+import io.camunda.tasklist.tenant.TenantCheckApplier;
+import java.util.Collection;
+import java.util.Optional;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Helper class for applying tenant checks to ES8 queries. This is used to ensure multi-tenancy
+ * security by filtering queries based on the authenticated user's tenant access.
+ */
+@Conditional(ElasticSearchCondition.class)
+@Component
+public class ElasticsearchTenantHelper {
+  private final Optional<TenantCheckApplier<Query>> es8TenantCheckApplier;
+
+  // Using Optional as this is equivalent to @Autowired(required=false) for constructor injection
+  public ElasticsearchTenantHelper(
+      final Optional<TenantCheckApplier<Query>> es8TenantCheckApplier) {
+    this.es8TenantCheckApplier = es8TenantCheckApplier;
+  }
+
+  /**
+   * Makes a query tenant-aware by applying tenant filtering based on the authenticated user's
+   * tenant access.
+   *
+   * @param query The original query
+   * @return A new query with tenant filtering applied, or the original query if tenant checking is
+   *     disabled
+   */
+  public Query makeQueryTenantAware(final Query query) {
+    if (es8TenantCheckApplier.isEmpty()) {
+      return query;
+    }
+
+    return es8TenantCheckApplier.get().apply(query);
+  }
+
+  public Query makeQueryTenantAware(final Query query, final Collection<String> tenantIds) {
+    if (es8TenantCheckApplier.isEmpty()) {
+      return query;
+    }
+
+    return es8TenantCheckApplier.get().apply(query, tenantIds);
+  }
+}

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -89,6 +89,8 @@ public abstract class ElasticsearchUtil {
   public static final Function<SearchHit, Long> SEARCH_HIT_ID_TO_LONG =
       (hit) -> Long.valueOf(hit.getId());
   public static final Function<SearchHit, String> SEARCH_HIT_ID_TO_STRING = SearchHit::getId;
+  public static final Class<Map<String, Object>> MAP_CLASS =
+      (Class<Map<String, Object>>) (Class<?>) Map.class;
 
   /** IndicesOptions */
   public static final IndicesOptions LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARC
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.tasklist.management.SearchEngineHealthIndicator;
@@ -20,7 +21,6 @@ import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
 import java.util.Map;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,7 +58,7 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
           .withPassword("elastic")
           .withExposedPorts(9200);
 
-  @Autowired RestHighLevelClient tasklistEsClient;
+  @Autowired ElasticsearchClient es8Client;
 
   @BeforeAll
   static void beforeAll() {
@@ -72,7 +72,7 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
   @Test
   public void canConnect() {
-    assertThat(tasklistEsClient).isNotNull();
+    assertThat(es8Client).isNotNull();
   }
 
   static class ElasticsearchStarter

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
@@ -58,7 +59,9 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
           .withPassword("elastic")
           .withExposedPorts(9200);
 
-  @Autowired ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  ElasticsearchClient es8Client;
 
   @BeforeAll
   static void beforeAll() {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -76,7 +77,9 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
           .withEnv(Map.of("xpack.security.enabled", "true", "ELASTIC_PASSWORD", ES_ADMIN_PASSWORD))
           .withExposedPorts(9200);
 
-  @Autowired ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  ElasticsearchClient es8Client;
 
   @Autowired private TestRestTemplate testRestTemplate;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -33,7 +33,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,7 +76,7 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
           .withEnv(Map.of("xpack.security.enabled", "true", "ELASTIC_PASSWORD", ES_ADMIN_PASSWORD))
           .withExposedPorts(9200);
 
-  @Autowired RestHighLevelClient tasklistEsClient;
+  @Autowired ElasticsearchClient es8Client;
 
   @Autowired private TestRestTemplate testRestTemplate;
 
@@ -90,7 +89,7 @@ public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends Taskli
 
   @Test
   public void canConnect() {
-    assertThat(tasklistEsClient).isNotNull();
+    assertThat(es8Client).isNotNull();
     final var healthCheck =
         testRestTemplate.getForEntity(
             "http://localhost:" + managementPort + "/actuator/health", Map.class);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
@@ -67,7 +68,9 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
           .waitingFor(
               Wait.forHttps("/").allowInsecure().withBasicCredentials("elastic", "elastic"));
 
-  @Autowired ElasticsearchClient es8Client;
+  @Autowired
+  @Qualifier("tasklistEs8Client")
+  ElasticsearchClient es8Client;
 
   @BeforeAll
   static void beforeAll() {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARC
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
@@ -19,7 +20,6 @@ import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import java.util.Map;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,7 +67,7 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
           .waitingFor(
               Wait.forHttps("/").allowInsecure().withBasicCredentials("elastic", "elastic"));
 
-  @Autowired RestHighLevelClient tasklistEsClient;
+  @Autowired ElasticsearchClient es8Client;
 
   @BeforeAll
   static void beforeAll() {
@@ -76,7 +76,7 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
 
   @Test
   public void canConnect() {
-    assertThat(tasklistEsClient).isNotNull();
+    assertThat(es8Client).isNotNull();
   }
 
   static class ElasticsearchStarter

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/tenant/OpenSearchTenantCheckApplier.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/tenant/OpenSearchTenantCheckApplier.java
@@ -36,13 +36,15 @@ public class OpenSearchTenantCheckApplier implements TenantCheckApplier<SearchRe
   @Autowired private TenantService tenantService;
 
   @Override
-  public void apply(final SearchRequest.Builder searchRequest) {
+  public SearchRequest.Builder apply(final SearchRequest.Builder searchRequest) {
     final var tenantAccess = tenantService.getAuthenticatedTenants();
     applyTenantCheckOnQuery(searchRequest, tenantAccess, tenantAccess.tenantIds());
+    return searchRequest;
   }
 
   @Override
-  public void apply(final SearchRequest.Builder searchRequest, final Collection<String> tenantIds) {
+  public SearchRequest.Builder apply(
+      final SearchRequest.Builder searchRequest, final Collection<String> tenantIds) {
     final var tenantAccess = tenantService.getAuthenticatedTenants();
     final var authorizedTenantIds =
         Optional.ofNullable(tenantAccess.tenantIds()).map(Set::copyOf).orElseGet(HashSet::new);
@@ -50,6 +52,8 @@ public class OpenSearchTenantCheckApplier implements TenantCheckApplier<SearchRe
         tenantIds.stream().filter(authorizedTenantIds::contains).collect(Collectors.toSet());
 
     applyTenantCheckOnQuery(searchRequest, tenantAccess, searchByTenantIds);
+
+    return searchRequest;
   }
 
   private void applyTenantCheckOnQuery(


### PR DESCRIPTION
## Description

Start converting tasklist to use the java client instead of the rhlc, this adds the skeleton and helper methods, added the tenant related classes even though they aren't currently used.
