### PR TITLE
fix: use user-supplied JAVA_HOME when filepath.EvalSymlinks fails but…

### DIFF
--- a/c8run/internal/start/startuphandler_test.go
+++ b/c8run/internal/start/startuphandler_test.go
@@ -1,7 +1,11 @@
 package start
 
 import (
+	"errors"
 	"net"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -25,5 +29,47 @@ func TestEnsurePortAvailable(t *testing.T) {
 
 	if err := ensurePortAvailable(port); err != nil {
 		t.Fatalf("expected port %d to be reported as available: %v", port, err)
+	}
+}
+
+func TestResolveJavaHomeAndBinaryKeepsCustomPathWhenSymlinkResolutionFails(t *testing.T) {
+	t.Setenv("JAVA_HOME", "")
+
+	javaHome := filepath.Join(t.TempDir(), "java-home")
+	binDir := filepath.Join(javaHome, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("failed to create bin directory: %v", err)
+	}
+
+	javaBinaryName := "java"
+	if runtime.GOOS == "windows" {
+		javaBinaryName = "java.exe"
+	}
+	expectedJavaBinary := filepath.Join(binDir, javaBinaryName)
+	if err := os.WriteFile(expectedJavaBinary, []byte("echo java\n"), 0o755); err != nil {
+		t.Fatalf("failed to create java binary placeholder: %v", err)
+	}
+
+	t.Setenv("JAVA_HOME", javaHome)
+
+	originalEvalSymlinks := evalSymlinks
+	defer func() {
+		evalSymlinks = originalEvalSymlinks
+	}()
+	evalSymlinks = func(path string) (string, error) {
+		return "", errors.New("forced symlink failure")
+	}
+
+	resolvedHome, resolvedBinary, err := resolveJavaHomeAndBinary()
+	if err != nil {
+		t.Fatalf("resolveJavaHomeAndBinary returned error: %v", err)
+	}
+
+	if resolvedHome != javaHome {
+		t.Fatalf("expected JAVA_HOME %s, got %s", javaHome, resolvedHome)
+	}
+
+	if resolvedBinary != expectedJavaBinary {
+		t.Fatalf("expected java binary %s, got %s", expectedJavaBinary, resolvedBinary)
 	}
 }


### PR DESCRIPTION
Use the user-supplied JAVA_HOME when filepath.EvalSymlinks fails but the path itself exists, so custom Windows installs that rely on reparse points/
virtual drives no longer get their JAVA_HOME cleared (which is what caused our binary lookup to fall back to PATH and eventually emit “Failed to get Java version”)

closes https://github.com/camunda/camunda/issues/42351