### PR TITLE
feat: backup management API shows available ranges

### DIFF
--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -595,6 +595,11 @@ components:
             description: List of partition backup states
             items:
               $ref: '#/components/schemas/PartitionBackupState'
+          ranges:
+            type: array
+            description: List of partition ranges
+            items:
+              $ref: '#/components/schemas/PartitionBackupRange'
 
     PartitionCheckpointState:
       title: Partition Checkpoint State
@@ -643,6 +648,27 @@ components:
           type: integer
           format: int64
           example: 1765208671134
+
+    PartitionBackupRange:
+      title: Partition Backup Range
+      description: Information about one backup range for a partition.
+      type: object
+      properties:
+        partitionId:
+          allOf:
+            - $ref: '#/components/schemas/PartitionId'
+        start:
+          allOf:
+            - $ref: '#/components/schemas/CheckpointId'
+        end:
+          allOf:
+            - $ref: '#/components/schemas/CheckpointId'
+        missingCheckpoints:
+          type: array
+          description: List of missing checkpoint IDs within the backup range
+          items:
+            allOf:
+              - $ref: '#/components/schemas/CheckpointId'
 
     BackupType:
       title: Backup Type

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.CheckpointInfo;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionBackupRange;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
@@ -693,7 +694,19 @@ final class BackupEndpointTest {
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setCheckpointStates(
           Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
-      stateResponse.setRanges(List.of(new PartitionBackupRange(1, 1, 10, Set.of())));
+      stateResponse.setRanges(
+          List.of(
+              new PartitionBackupRange(
+                  1,
+                  new CheckpointInfo(
+                      1,
+                      1L,
+                      1L,
+                      CheckpointType.SCHEDULED_BACKUP,
+                      Instant.now().minus(1, ChronoUnit.DAYS)),
+                  new CheckpointInfo(
+                      10, 100L, 150L, CheckpointType.SCHEDULED_BACKUP, Instant.now()),
+                  Set.of())));
 
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionBackupRange;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.record.ErrorCode;
@@ -692,6 +693,7 @@ final class BackupEndpointTest {
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setCheckpointStates(
           Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
+      stateResponse.setRanges(List.of(new PartitionBackupRange(1, 1, 10, Set.of())));
 
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -23,7 +23,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.BackupType;
+import io.camunda.management.backups.CheckpointState;
 import io.camunda.management.backups.Error;
+import io.camunda.management.backups.PartitionBackupRange;
+import io.camunda.management.backups.PartitionBackupState;
+import io.camunda.management.backups.PartitionCheckpointState;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
 import io.camunda.zeebe.backup.client.api.BackupAlreadyExistException;
 import io.camunda.zeebe.backup.client.api.BackupApi;
@@ -31,15 +36,15 @@ import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
 import io.camunda.zeebe.backup.client.api.BackupStatus;
 import io.camunda.zeebe.backup.client.api.PartitionBackupStatus;
 import io.camunda.zeebe.backup.client.api.State;
+import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse.CheckpointInfo;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
-import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.CheckpointInfo;
-import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionBackupRange;
-import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
@@ -232,7 +237,8 @@ final class BackupEndpointTest {
       final var requestHandler =
           mock(
               BackupRequestHandler.class,
-              withSettings().useConstructor(mock(BrokerClient.class), offset));
+              withSettings()
+                  .useConstructor(mock(BrokerClient.class), new CheckpointIdGenerator(offset)));
       final var config = mock(BackupCfg.class);
       when(config.isContinuous()).thenReturn(true);
       when(config.getOffset()).thenReturn(offset);
@@ -693,10 +699,13 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setCheckpointStates(
-          Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
-      stateResponse.setRanges(
+          Set.of(
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
+      final var rangesResponse = new BackupRangesResponse();
+      rangesResponse.setRanges(
           List.of(
-              new PartitionBackupRange(
+              new BackupRangesResponse.PartitionBackupRange(
                   1,
                   new CheckpointInfo(
                       1,
@@ -709,14 +718,31 @@ final class BackupEndpointTest {
                   Set.of())));
 
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges()).thenReturn(CompletableFuture.completedFuture(rangesResponse));
 
       // when
       final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
-          .isInstanceOf(CheckpointStateResponse.class)
-          .isEqualTo(stateResponse);
+          .isInstanceOf(CheckpointState.class)
+          .isEqualTo(
+              new CheckpointState()
+                  .checkpointStates(
+                      List.of(
+                          new PartitionCheckpointState()
+                              .partitionId(1)
+                              .checkpointId(1L)
+                              .checkpointPosition(10L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(io.camunda.management.backups.CheckpointType.MARKER)))
+                  .ranges(
+                      List.of(
+                          new PartitionBackupRange()
+                              .partitionId(1)
+                              .start(1L)
+                              .end(10L)
+                              .missingCheckpoints(List.of()))));
     }
 
     @Test
@@ -728,17 +754,29 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setBackupStates(
-          Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
-
+          Set.of(
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges())
+          .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
       final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
-          .isInstanceOf(CheckpointStateResponse.class)
-          .isEqualTo(stateResponse);
+          .isInstanceOf(CheckpointState.class)
+          .isEqualTo(
+              new CheckpointState()
+                  .backupStates(
+                      List.of(
+                          new PartitionBackupState()
+                              .partitionId(1)
+                              .checkpointId(1L)
+                              .checkpointPosition(10L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(BackupType.MANUAL_BACKUP))));
     }
 
     @Test
@@ -750,18 +788,42 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setBackupStates(
-          Set.of(new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
+          Set.of(
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
       stateResponse.setCheckpointStates(
-          Set.of(new PartitionCheckpointState(1, 2L, CheckpointType.MARKER, 30L, 50L)));
+          Set.of(
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(1, 2L, CheckpointType.MARKER, 30L, 50L)));
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges())
+          .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
       final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
-          .isInstanceOf(CheckpointStateResponse.class)
-          .isEqualTo(stateResponse);
+          .isInstanceOf(CheckpointState.class)
+          .isEqualTo(
+              new CheckpointState()
+                  .backupStates(
+                      List.of(
+                          new PartitionBackupState()
+                              .partitionId(1)
+                              .checkpointId(1L)
+                              .checkpointPosition(10L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(BackupType.MANUAL_BACKUP)))
+                  .checkpointStates(
+                      List.of(
+                          new PartitionCheckpointState()
+                              .partitionId(1)
+                              .checkpointId(2L)
+                              .checkpointPosition(50L)
+                              .checkpointTimestamp(30L)
+                              .checkpointType(
+                                  io.camunda.management.backups.CheckpointType.MARKER))));
     }
 
     @Test
@@ -774,14 +836,16 @@ final class BackupEndpointTest {
       final var stateResponse = new CheckpointStateResponse();
 
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges())
+          .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
       final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
-          .isInstanceOf(CheckpointStateResponse.class)
-          .isEqualTo(stateResponse);
+          .isInstanceOf(CheckpointState.class)
+          .isEqualTo(new CheckpointState());
     }
 
     @Test
@@ -793,32 +857,87 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
 
-      final PartitionCheckpointState p1State =
-          new PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L);
-      final PartitionCheckpointState p2State =
-          new PartitionCheckpointState(2, 1L, CheckpointType.MARKER, 20L, 20L);
-      final PartitionCheckpointState p3State =
-          new PartitionCheckpointState(3, 1L, CheckpointType.MARKER, 30L, 40L);
+      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
+          p1State =
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L);
+      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
+          p2State =
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(2, 1L, CheckpointType.MARKER, 20L, 20L);
+      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
+          p3State =
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(3, 1L, CheckpointType.MARKER, 30L, 40L);
 
-      final PartitionCheckpointState p1BackupState =
-          new PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L);
-      final PartitionCheckpointState p2BackupState =
-          new PartitionCheckpointState(2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L);
-      final PartitionCheckpointState p3BackupState =
-          new PartitionCheckpointState(3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L);
+      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
+          p1BackupState =
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L);
+      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
+          p2BackupState =
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L);
+      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
+          p3BackupState =
+              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
+                  .PartitionCheckpointState(3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L);
 
       stateResponse.setCheckpointStates(Set.of(p1State, p2State, p3State));
       stateResponse.setBackupStates(Set.of(p1BackupState, p2BackupState, p3BackupState));
 
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges())
+          .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
       final WebEndpointResponse<?> response = endpoint.query(new String[] {BackupApi.STATE});
 
       // then
       assertThat(response.getBody())
-          .isInstanceOf(CheckpointStateResponse.class)
-          .isEqualTo(stateResponse);
+          .isInstanceOf(CheckpointState.class)
+          .isEqualTo(
+              new CheckpointState()
+                  .checkpointStates(
+                      List.of(
+                          new PartitionCheckpointState()
+                              .partitionId(1)
+                              .checkpointId(1L)
+                              .checkpointPosition(10L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(io.camunda.management.backups.CheckpointType.MARKER),
+                          new PartitionCheckpointState()
+                              .partitionId(2)
+                              .checkpointId(1L)
+                              .checkpointPosition(20L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(io.camunda.management.backups.CheckpointType.MARKER),
+                          new PartitionCheckpointState()
+                              .partitionId(3)
+                              .checkpointId(1L)
+                              .checkpointPosition(40L)
+                              .checkpointTimestamp(30L)
+                              .checkpointType(io.camunda.management.backups.CheckpointType.MARKER)))
+                  .backupStates(
+                      List.of(
+                          new PartitionBackupState()
+                              .partitionId(1)
+                              .checkpointId(1L)
+                              .checkpointPosition(10L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(BackupType.MANUAL_BACKUP),
+                          new PartitionBackupState()
+                              .partitionId(2)
+                              .checkpointId(1L)
+                              .checkpointPosition(20L)
+                              .checkpointTimestamp(20L)
+                              .checkpointType(BackupType.MANUAL_BACKUP),
+                          new PartitionBackupState()
+                              .partitionId(3)
+                              .checkpointId(1L)
+                              .checkpointPosition(40L)
+                              .checkpointTimestamp(30L)
+                              .checkpointType(BackupType.MANUAL_BACKUP))));
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -71,7 +71,7 @@ public interface BackupManager {
   /**
    * @return all backup ranges for the partition
    */
-  ActorFuture<Collection<BackupRange>> listBackupRanges();
+  ActorFuture<Collection<BackupRangeStatus>> getBackupRangeStatus();
 
   void extendRange(final long previousCheckpointId, final long newCheckpointId);
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -68,6 +68,11 @@ public interface BackupManager {
   void createFailedBackup(
       final long checkpointId, BackupDescriptor backupDescriptor, String failureReason);
 
+  /**
+   * @return all backup ranges for the partition
+   */
+  ActorFuture<Collection<BackupRange>> listBackupRanges();
+
   void extendRange(final long previousCheckpointId, final long newCheckpointId);
 
   void startNewRange(final long checkpointId);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
@@ -13,6 +13,9 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public sealed interface BackupRange {
+  long firstCheckpointId();
+
+  long lastCheckpointId();
 
   boolean contains(Interval<Long> other);
 
@@ -28,6 +31,16 @@ public sealed interface BackupRange {
     @Override
     public boolean contains(final Interval<Long> other) {
       return interval().contains(other);
+    }
+
+    @Override
+    public long firstCheckpointId() {
+      return interval().start();
+    }
+
+    @Override
+    public long lastCheckpointId() {
+      return interval.end();
     }
 
     @Override
@@ -72,6 +85,16 @@ public sealed interface BackupRange {
 
     private boolean isInDeletionRange(final Interval<Long> interval) {
       return deletedCheckpointIds.stream().anyMatch(interval::contains);
+    }
+
+    @Override
+    public long firstCheckpointId() {
+      return interval().start();
+    }
+
+    @Override
+    public long lastCheckpointId() {
+      return interval.end();
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRangeStatus.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRangeStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.util.Collections;
+import java.util.Set;
+
+public sealed interface BackupRangeStatus {
+  BackupStatus first();
+
+  BackupStatus last();
+
+  Set<Long> missingCheckpoints();
+
+  record Complete(BackupStatus first, BackupStatus last) implements BackupRangeStatus {
+
+    @Override
+    public Set<Long> missingCheckpoints() {
+      return Collections.emptySet();
+    }
+  }
+
+  /**
+   * A backup range with deletions. Verification of all contained backups is required to determine
+   * whether the range is effectively complete or not.
+   */
+  record Incomplete(BackupStatus first, BackupStatus last, Set<Long> missingCheckpoints)
+      implements BackupRangeStatus {
+    public Incomplete {
+      missingCheckpoints = Set.copyOf(missingCheckpoints);
+    }
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupApi.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupApi.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.client.api;
 
+import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -52,6 +53,11 @@ public interface BackupApi {
    * @return the latest checkpoint and state for all partitions
    */
   CompletionStage<CheckpointStateResponse> getCheckpointState();
+
+  /**
+   * @return all backup ranges for all partitions
+   */
+  CompletionStage<BackupRangesResponse> getBackupRanges();
 
   /**
    * @return a list of available backups

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -273,6 +273,7 @@ public final class BackupRequestHandler implements BackupApi {
                           })
                       .toList());
             })
+        .sorted(Comparator.comparingLong(BackupStatus::backupId).reversed())
         .toList();
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -398,8 +398,11 @@ public final class BackupRequestHandler implements BackupApi {
     final var backupStates =
         responses.stream().flatMap(r -> r.getBackupStates().stream()).collect(Collectors.toSet());
 
+    final var ranges = responses.stream().flatMap(r -> r.getRanges().stream()).toList();
+
     response.setCheckpointStates(checkpointStates);
     response.setBackupStates(backupStates);
+    response.setRanges(ranges);
     return response;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRangesRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRangesRequest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.client.api;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.management.BackupRangesResponseDecoder;
+import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BrokerBackupRangesRequest extends BrokerRequest<BackupRangesResponse> {
+
+  private final BackupRequest request = new BackupRequest();
+  private final BackupRangesResponse response = new BackupRangesResponse();
+
+  public BrokerBackupRangesRequest() {
+    super(BackupRangesResponseDecoder.SCHEMA_ID, BackupRangesResponseDecoder.TEMPLATE_ID);
+    request.setType(BackupRequestType.QUERY_RANGES);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<BackupRangesResponse> readResponse() {
+    return new BrokerResponse<>(response);
+  }
+
+  @Override
+  protected BackupRangesResponse toResponseDto(final DirectBuffer buffer) {
+    return response;
+  }
+
+  @Override
+  public String getType() {
+    return "Backup#ranges";
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.BACKUP;
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.BackupRange;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -165,6 +166,11 @@ public final class BackupService extends Actor implements BackupManager {
           }
         });
     return resultFuture;
+  }
+
+  @Override
+  public ActorFuture<Collection<BackupRange>> listBackupRanges() {
+    return internalBackupManager.listBackupRanges(partitionId, actor);
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
-import io.camunda.zeebe.backup.api.BackupRange;
+import io.camunda.zeebe.backup.api.BackupRangeStatus;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -169,11 +169,6 @@ public final class BackupService extends Actor implements BackupManager {
   }
 
   @Override
-  public ActorFuture<Collection<BackupRange>> listBackupRanges() {
-    return internalBackupManager.listBackupRanges(partitionId, actor);
-  }
-
-  @Override
   public ActorFuture<Void> deleteBackup(final long checkpointId) {
     final var operationMetrics = metrics.startDeleting();
 
@@ -206,6 +201,11 @@ public final class BackupService extends Actor implements BackupManager {
           internalBackupManager.createFailedBackup(
               backupId, backupDescriptor.checkpointPosition(), failureReason, actor);
         });
+  }
+
+  @Override
+  public ActorFuture<Collection<BackupRangeStatus>> getBackupRangeStatus() {
+    return internalBackupManager.getBackupRangeStatus(partitionId, actor);
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -202,7 +202,9 @@ final class BackupServiceImpl {
 
   private void confirmBackup(final InProgressBackup inProgressBackup) {
     final var checkpointId = inProgressBackup.id().checkpointId();
-    LOG.info("Confirming backup for checkpoint {}", checkpointId);
+    LOG.atDebug()
+        .addKeyValue("backup", inProgressBackup.id())
+        .log("Confirming backup for checkpoint");
     final var checkpointPosition = inProgressBackup.backupDescriptor().checkpointPosition();
     final var checkpointType = inProgressBackup.backupDescriptor().checkpointType();
     final var confirmationWritten =
@@ -226,7 +228,7 @@ final class BackupServiceImpl {
               .setMessage("Could not confirm backup")
               .log();
       case final Either.Right<WriteFailure, Long> position ->
-          LOG.atInfo()
+          LOG.atDebug()
               .addKeyValue("backup", inProgressBackup.id())
               .addKeyValue("position", position.value())
               .setMessage("Confirmed backup")

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.BackupRange;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -46,6 +47,12 @@ public class NoopBackupManager implements BackupManager {
 
   @Override
   public ActorFuture<Collection<BackupStatus>> listBackups(final String pattern) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException(errorMessage));
+  }
+
+  @Override
+  public ActorFuture<Collection<BackupRange>> listBackupRanges() {
     return CompletableActorFuture.completedExceptionally(
         new UnsupportedOperationException(errorMessage));
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
-import io.camunda.zeebe.backup.api.BackupRange;
+import io.camunda.zeebe.backup.api.BackupRangeStatus;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -52,12 +52,6 @@ public class NoopBackupManager implements BackupManager {
   }
 
   @Override
-  public ActorFuture<Collection<BackupRange>> listBackupRanges() {
-    return CompletableActorFuture.completedExceptionally(
-        new UnsupportedOperationException(errorMessage));
-  }
-
-  @Override
   public ActorFuture<Void> deleteBackup(final long checkpointId) {
     return CompletableActorFuture.completedExceptionally(
         new UnsupportedOperationException(errorMessage));
@@ -82,6 +76,12 @@ public class NoopBackupManager implements BackupManager {
       final BackupDescriptor backupDescriptor,
       final String failureReason) {
     LOG.warn("Attempted to create failed backup, but cannot do it. {}", errorMessage);
+  }
+
+  @Override
+  public ActorFuture<Collection<BackupRangeStatus>> getBackupRangeStatus() {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException(errorMessage));
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.transport.backupapi;
 
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRangesResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.transport.ServerOutput;
@@ -44,6 +45,12 @@ public final class BackupApiResponseWriter implements ResponseWriter {
   }
 
   BackupApiResponseWriter withCheckpointState(final CheckpointStateResponse response) {
+    responseWriter = response::write;
+    lengthSupplier = response::getLength;
+    return this;
+  }
+
+  BackupApiResponseWriter withBackupRanges(final BackupRangesResponse response) {
     responseWriter = response::write;
     lengthSupplier = response::getLength;
     return this;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.backup.processing.state.CheckpointState.NO_CHECKP
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -89,6 +90,10 @@ final class BackupApiRequestHandlerTest {
 
     serverOutput = new ResponseReader();
     responseFuture = new CompletableFuture<>();
+
+    lenient()
+        .when(backupManager.listBackupRanges())
+        .thenReturn(CompletableActorFuture.completed(List.of()));
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -310,11 +310,11 @@ public class BackupRequestHandlerTest extends GatewayTest {
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
     final var backups = future.toCompletableFuture().join();
-    assertThat(backups).hasSize(2).extracting(BackupStatus::backupId).containsExactly(1L, 2L);
+    assertThat(backups).hasSize(2).extracting(BackupStatus::backupId).containsExactly(2L, 1L);
 
     assertThat(backups)
         .extracting(BackupStatus::status)
-        .containsExactly(State.INCOMPLETE, State.COMPLETED);
+        .containsExactly(State.COMPLETED, State.INCOMPLETE);
   }
 
   @Test
@@ -341,11 +341,11 @@ public class BackupRequestHandlerTest extends GatewayTest {
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
     final var backups = future.toCompletableFuture().join();
-    assertThat(backups).hasSize(2).extracting(BackupStatus::backupId).containsExactly(1L, 2L);
+    assertThat(backups).hasSize(2).extracting(BackupStatus::backupId).containsExactly(2L, 1L);
 
     assertThat(backups)
         .extracting(BackupStatus::status)
-        .containsExactly(State.COMPLETED, State.IN_PROGRESS);
+        .containsExactly(State.IN_PROGRESS, State.COMPLETED);
   }
 
   @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRangesResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRangesResponse.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import io.camunda.zeebe.protocol.management.BackupRangesResponseDecoder;
+import io.camunda.zeebe.protocol.management.BackupRangesResponseEncoder;
+import io.camunda.zeebe.protocol.management.BackupRangesResponseEncoder.RangesEncoder;
+import io.camunda.zeebe.protocol.management.CheckpointInfoEncoder;
+import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.LongHashSet;
+
+public final class BackupRangesResponse implements BufferReader, BufferWriter {
+
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final BackupRangesResponseEncoder bodyEncoder = new BackupRangesResponseEncoder();
+  private final BackupRangesResponseDecoder bodyDecoder = new BackupRangesResponseDecoder();
+
+  private List<PartitionBackupRange> ranges = new ArrayList<>();
+
+  @Override
+  public int getLength() {
+    int rangesLength = 0;
+    for (final var range : ranges) {
+      rangesLength +=
+          RangesEncoder.sbeBlockLength()
+              + RangesEncoder.MissingCheckpointsEncoder.HEADER_SIZE
+              + (range.missingCheckpoints().size()
+                  * RangesEncoder.MissingCheckpointsEncoder.sbeBlockLength());
+    }
+
+    return headerEncoder.encodedLength()
+        + bodyEncoder.sbeBlockLength()
+        + RangesEncoder.HEADER_SIZE
+        + rangesLength;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+
+    final var rangesEncoder = bodyEncoder.rangesCount(ranges.size());
+    for (final var range : ranges) {
+      final var rangeEncoder = rangesEncoder.next();
+      rangeEncoder.partitionId(range.partitionId());
+      writeCheckpointInfo(range.first(), rangeEncoder.first());
+      writeCheckpointInfo(range.last(), rangeEncoder.last());
+      final var missingCheckpointsEncoder =
+          rangesEncoder.missingCheckpointsCount(range.missingCheckpoints().size());
+      for (final var checkpointId : range.missingCheckpoints()) {
+        missingCheckpointsEncoder.next().checkpointId(checkpointId);
+      }
+    }
+  }
+
+  private static void writeCheckpointInfo(
+      final CheckpointInfo range, final CheckpointInfoEncoder rangeEncoder) {
+    if (range != null) {
+      rangeEncoder
+          .checkpointId(range.checkpointId)
+          .firstLogPosition(range.firstLogPosition)
+          .checkpointPosition(range.checkpointPosition)
+          .checkpointType(range.checkpointType.getValue())
+          .checkpointTimestamp(range.checkpointTimestamp.toEpochMilli());
+    }
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+
+    final var rangesDecoder = bodyDecoder.ranges();
+    ranges = new ArrayList<>(rangesDecoder.count());
+    for (final var range : rangesDecoder) {
+      final var missingCheckpointsDecoder = range.missingCheckpoints();
+      final var missingCheckpoints = new LongHashSet(missingCheckpointsDecoder.count());
+      for (final var missingCheckpoint : missingCheckpointsDecoder) {
+        missingCheckpoints.add(missingCheckpoint.checkpointId());
+      }
+
+      final var first = range.first();
+      final var last = range.last();
+      ranges.add(
+          new PartitionBackupRange(
+              range.partitionId(),
+              new CheckpointInfo(
+                  first.checkpointId(),
+                  first.firstLogPosition(),
+                  first.checkpointPosition(),
+                  CheckpointType.valueOf(first.checkpointType()),
+                  Instant.ofEpochMilli(first.checkpointTimestamp())),
+              new CheckpointInfo(
+                  last.checkpointId(),
+                  last.firstLogPosition(),
+                  last.checkpointPosition(),
+                  CheckpointType.valueOf(last.checkpointType()),
+                  Instant.ofEpochMilli(last.checkpointTimestamp())),
+              missingCheckpoints));
+    }
+  }
+
+  public List<PartitionBackupRange> getRanges() {
+    return ranges;
+  }
+
+  public void setRanges(final List<PartitionBackupRange> ranges) {
+    this.ranges = ranges;
+  }
+
+  public record CheckpointInfo(
+      long checkpointId,
+      long firstLogPosition,
+      long checkpointPosition,
+      CheckpointType checkpointType,
+      Instant checkpointTimestamp) {}
+
+  public record PartitionBackupRange(
+      int partitionId, CheckpointInfo first, CheckpointInfo last, Set<Long> missingCheckpoints) {}
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
@@ -7,24 +7,18 @@
  */
 package io.camunda.zeebe.protocol.impl.encoding;
 
-import io.camunda.zeebe.protocol.management.CheckpointInfoEncoder;
 import io.camunda.zeebe.protocol.management.CheckpointStateResponseDecoder;
 import io.camunda.zeebe.protocol.management.CheckpointStateResponseEncoder;
 import io.camunda.zeebe.protocol.management.CheckpointStateResponseEncoder.CheckpointStatesEncoder;
-import io.camunda.zeebe.protocol.management.CheckpointStateResponseEncoder.RangesEncoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
-import org.agrona.collections.LongHashSet;
 
 public class CheckpointStateResponse implements BufferReader, BufferWriter {
 
@@ -36,7 +30,6 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
 
   private Set<PartitionCheckpointState> checkpointStates = new HashSet<>();
   private Set<PartitionCheckpointState> backupStates = new HashSet<>();
-  private List<PartitionBackupRange> ranges = new ArrayList<>();
 
   @Override
   public int getLength() {
@@ -52,23 +45,12 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
     final int checkpointStatesLength = checkpointStates.size() * statesItemLength;
     final int backupStatesLength = backupStates.size() * statesItemLength;
 
-    int rangesLength = 0;
-    for (final var range : ranges) {
-      rangesLength +=
-          RangesEncoder.sbeBlockLength()
-              + RangesEncoder.MissingCheckpointsEncoder.HEADER_SIZE
-              + (range.missingCheckpoints().size()
-                  * RangesEncoder.MissingCheckpointsEncoder.sbeBlockLength());
-    }
-
     return headerEncoder.encodedLength()
         + bodyEncoder.sbeBlockLength()
-        // plus the length of both state sets and ranges
+        // plus the length of both state sets
         + (CheckpointStatesEncoder.HEADER_SIZE * 2)
         + checkpointStatesLength
-        + backupStatesLength
-        + RangesEncoder.HEADER_SIZE
-        + rangesLength;
+        + backupStatesLength;
   }
 
   @Override
@@ -95,31 +77,6 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
           .checkpointType(partitionState.checkpointType.getValue())
           .checkpointTimestamp(partitionState.checkpointTimestamp)
           .checkpointPosition(partitionState.checkpointPosition);
-    }
-
-    final var rangesEncoder = bodyEncoder.rangesCount(ranges.size());
-    for (final var range : ranges) {
-      final var rangeEncoder = rangesEncoder.next();
-      rangeEncoder.partitionId(range.partitionId());
-      writeCheckpointInfo(range.first(), rangeEncoder.first());
-      writeCheckpointInfo(range.last(), rangeEncoder.last());
-      final var missingCheckpointsEncoder =
-          rangesEncoder.missingCheckpointsCount(range.missingCheckpoints().size());
-      for (final var checkpointId : range.missingCheckpoints()) {
-        missingCheckpointsEncoder.next().checkpointId(checkpointId);
-      }
-    }
-  }
-
-  private static void writeCheckpointInfo(
-      final CheckpointInfo range, final CheckpointInfoEncoder rangeEncoder) {
-    if (range != null) {
-      rangeEncoder
-          .checkpointId(range.checkpointId)
-          .firstLogPosition(range.firstLogPosition)
-          .checkpointPosition(range.checkpointPosition)
-          .checkpointType(range.checkpointType.getValue())
-          .checkpointTimestamp(range.checkpointTimestamp.toEpochMilli());
     }
   }
 
@@ -150,35 +107,6 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
                         CheckpointType.valueOf(state.checkpointType()),
                         state.checkpointTimestamp(),
                         state.checkpointPosition())));
-
-    final var rangesDecoder = bodyDecoder.ranges();
-    ranges = new ArrayList<>(rangesDecoder.count());
-    for (final var range : rangesDecoder) {
-      final var missingCheckpointsDecoder = range.missingCheckpoints();
-      final var missingCheckpoints = new LongHashSet(missingCheckpointsDecoder.count());
-      for (final var missingCheckpoint : missingCheckpointsDecoder) {
-        missingCheckpoints.add(missingCheckpoint.checkpointId());
-      }
-
-      final var first = range.first();
-      final var last = range.last();
-      ranges.add(
-          new PartitionBackupRange(
-              range.partitionId(),
-              new CheckpointInfo(
-                  first.checkpointId(),
-                  first.firstLogPosition(),
-                  first.checkpointPosition(),
-                  CheckpointType.valueOf(first.checkpointType()),
-                  Instant.ofEpochMilli(first.checkpointTimestamp())),
-              new CheckpointInfo(
-                  last.checkpointId(),
-                  last.firstLogPosition(),
-                  last.checkpointPosition(),
-                  CheckpointType.valueOf(last.checkpointType()),
-                  Instant.ofEpochMilli(last.checkpointTimestamp())),
-              missingCheckpoints));
-    }
   }
 
   public Set<PartitionCheckpointState> getCheckpointStates() {
@@ -196,24 +124,6 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
   public void setBackupStates(final Set<PartitionCheckpointState> backupStates) {
     this.backupStates = backupStates;
   }
-
-  public List<PartitionBackupRange> getRanges() {
-    return ranges;
-  }
-
-  public void setRanges(final List<PartitionBackupRange> ranges) {
-    this.ranges = ranges;
-  }
-
-  public record CheckpointInfo(
-      long checkpointId,
-      long firstLogPosition,
-      long checkpointPosition,
-      CheckpointType checkpointType,
-      Instant checkpointTimestamp) {}
-
-  public record PartitionBackupRange(
-      int partitionId, CheckpointInfo first, CheckpointInfo last, Set<Long> missingCheckpoints) {}
 
   public record PartitionCheckpointState(
       int partitionId,

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -23,6 +23,7 @@
       <validValue name="LIST">2</validValue>
       <validValue name="DELETE">3</validValue>
       <validValue name="QUERY_STATE">4</validValue>
+      <validValue name="QUERY_RANGES">5</validValue>
     </enum>
 
     <enum name="BackupStatusCode" encodingType="uint8">
@@ -119,7 +120,10 @@
       <field name="checkpointPosition" id="4"  type="uint64"/>
       <field name="checkpointTimestamp" id="5"  type="uint64"/>
     </group>
-    <group name="ranges" id="3" dimensionType="largeGroupSizeEncoding">
+  </sbe:message>
+
+  <sbe:message name="BackupRangesResponse" id="7">
+    <group name="ranges" id="1" dimensionType="largeGroupSizeEncoding">
       <field name="partitionId" id="1" type="uint16"/>
       <field name="first" id="2" type="CheckpointInfo"/>
       <field name="last" id="3" type="CheckpointInfo"/>
@@ -129,5 +133,4 @@
     </group>
   </sbe:message>
 </sbe:messageSchema>
-
 

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -40,6 +40,14 @@
       <type name="numVarDataFields" primitiveType="uint16"/>
     </composite>
 
+    <composite name="CheckpointInfo">
+      <type name="checkpointId"  primitiveType="int64"/>
+      <type name="firstLogPosition" primitiveType="uint64"/>
+      <type name="checkpointPosition" primitiveType="uint64"/>
+      <type name="checkpointType" primitiveType="uint8"/>
+      <type name="checkpointTimestamp" primitiveType="uint64"/>
+    </composite>
+
   </types>
 
   <sbe:message name="AdminRequest" id="1">
@@ -111,11 +119,11 @@
       <field name="checkpointPosition" id="4"  type="uint64"/>
       <field name="checkpointTimestamp" id="5"  type="uint64"/>
     </group>
-    <group name="ranges" id="3">
+    <group name="ranges" id="3" dimensionType="largeGroupSizeEncoding">
       <field name="partitionId" id="1" type="uint16"/>
-      <field name="startId" id="2" type="int64"/>
-      <field name="endId" id="3" type="int64"/>
-      <group name="missingCheckpoints" id="4">
+      <field name="first" id="2" type="CheckpointInfo"/>
+      <field name="last" id="3" type="CheckpointInfo"/>
+      <group name="missingCheckpoints" id="4" dimensionType="largeGroupSizeEncoding">
         <field name="checkpointId" id="1" type="int64"/>
       </group>
     </group>

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -111,6 +111,14 @@
       <field name="checkpointPosition" id="4"  type="uint64"/>
       <field name="checkpointTimestamp" id="5"  type="uint64"/>
     </group>
+    <group name="ranges" id="3">
+      <field name="partitionId" id="1" type="uint16"/>
+      <field name="startId" id="2" type="int64"/>
+      <field name="endId" id="3" type="int64"/>
+      <group name="missingCheckpoints" id="4">
+        <field name="checkpointId" id="1" type="int64"/>
+      </group>
+    </group>
   </sbe:message>
 </sbe:messageSchema>
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupAcceptance.java
@@ -74,7 +74,7 @@ public interface BackupAcceptance {
         .hasSize(2)
         .extracting(BackupInfo::getBackupId, BackupInfo::getState)
         .containsExactly(
-            Tuple.tuple(1L, StateCode.COMPLETED), Tuple.tuple(2L, StateCode.COMPLETED));
+            Tuple.tuple(2L, StateCode.COMPLETED), Tuple.tuple(1L, StateCode.COMPLETED));
   }
 
   @Test
@@ -101,7 +101,7 @@ public interface BackupAcceptance {
         .hasSize(2)
         .extracting(BackupInfo::getBackupId, BackupInfo::getState)
         .containsExactly(
-            Tuple.tuple(100L, StateCode.COMPLETED), Tuple.tuple(105L, StateCode.COMPLETED));
+            Tuple.tuple(105L, StateCode.COMPLETED), Tuple.tuple(100L, StateCode.COMPLETED));
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -175,7 +175,7 @@ final class BackupRangeTrackingIT {
             });
   }
 
-  void generateLoad() {
+  private void generateLoad() {
     try (final var client = cluster.newClientBuilder().build()) {
       client
           .newPublishMessageCommand()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionBackupRange;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+final class BackupRangeTrackingIT {
+  private final Path tempDir;
+
+  @TestZeebe(initMethod = "initTestCluster")
+  private TestCluster cluster;
+
+  private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+  BackupRangeTrackingIT(final @TempDir Path tempDir) {
+    this.tempDir = tempDir;
+  }
+
+  @SuppressWarnings("unused")
+  private void initTestCluster() {
+    cluster =
+        TestCluster.builder()
+            .withBrokersCount(3)
+            .withPartitionsCount(3)
+            .withReplicationFactor(3)
+            .withEmbeddedGateway(true)
+            .withBrokerConfig(this::configureBroker)
+            .build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  private void configureBroker(final TestStandaloneBroker broker) {
+    broker.withUnifiedConfig(
+        cfg -> {
+          cfg.getData()
+              .getPrimaryStorage()
+              .getBackup()
+              .setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
+
+          final var config = new Filesystem();
+          config.setBasePath(tempDir.toAbsolutePath().toString());
+          cfg.getData().getPrimaryStorage().getBackup().setFilesystem(config);
+
+          cfg.getData().getPrimaryStorage().getBackup().setContinuous(true);
+          cfg.getData()
+              .getPrimaryStorage()
+              .getBackup()
+              .setSchedule(Duration.ofSeconds(5).toString());
+        });
+  }
+
+  @Test
+  void shouldTrackBackupRanges() {
+    // given
+    final var actuator = BackupActuator.of(cluster.availableGateway());
+
+    // when
+    executor.scheduleAtFixedRate(this::generateLoad, 0, 100, TimeUnit.MILLISECONDS);
+
+    // then
+    Awaitility.await("Until each partition has a backup range")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var states = actuator.state();
+              final var ranges = states.getRanges();
+              assertThat(ranges)
+                  .describedAs("Each partition should have exactly one backup range")
+                  .extracting(PartitionBackupRange::partitionId)
+                  .containsExactlyInAnyOrder(1, 2, 3);
+              assertThat(ranges)
+                  .allSatisfy(
+                      range -> {
+                        assertThat(states.getBackupStates())
+                            .satisfiesOnlyOnce(
+                                state -> {
+                                  assertThat(state.partitionId()).isEqualTo(range.partitionId());
+                                  assertThat(state.checkpointId())
+                                      .isGreaterThanOrEqualTo(range.first().checkpointId());
+                                });
+                        assertThat(range.last()).isNotEqualTo(range.first());
+                      });
+            });
+  }
+
+  @Test
+  void shouldTrackBackupRangesDuringLeaderChanges() {
+    // given
+    final var actuator = BackupActuator.of(cluster.availableGateway());
+    executor.scheduleAtFixedRate(this::generateLoad, 0, 100, TimeUnit.MILLISECONDS);
+
+    // when
+    final var initialLeader = cluster.leaderForPartition(1);
+    initialLeader.stop();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              try (final var client = cluster.newClientBuilder().build()) {
+                final var topology = client.newTopologyRequest().send().join();
+                TopologyAssert.assertThat(topology)
+                    .describedAs("Initial leader is no longer part of the cluster")
+                    .doesNotContainBroker(Integer.parseInt(initialLeader.nodeId().id()));
+                TopologyAssert.assertThat(topology)
+                    .describedAs("New leader for partition 1 should be elected")
+                    .hasLeaderForEachPartition(3);
+              }
+            });
+
+    final var lastBackupBeforeLeaderChange =
+        actuator.state().getBackupStates().stream()
+            .filter(state -> state.partitionId() == 1)
+            .findFirst()
+            .orElseThrow();
+
+    // then
+    Awaitility.await("New leader should continue to take backups and extend the existing range")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var states = actuator.state();
+              final var ranges = states.getRanges();
+              final var lastBackupAfterLeaderChange =
+                  actuator.state().getBackupStates().stream()
+                      .filter(state -> state.partitionId() == 1)
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(lastBackupBeforeLeaderChange)
+                  .describedAs("New leader for partition 1 should have taken a new backup")
+                  .isNotEqualTo(lastBackupAfterLeaderChange);
+              assertThat(ranges)
+                  .describedAs("Each partition should still have exactly one backup range")
+                  .extracting(PartitionBackupRange::partitionId)
+                  .containsExactlyInAnyOrder(1, 2, 3);
+              final var latestRange =
+                  ranges.stream()
+                      .filter(range -> range.partitionId() == 1)
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(latestRange.last().checkpointId())
+                  .describedAs("Range should end with the latest checkpoint")
+                  .isEqualTo(lastBackupAfterLeaderChange.checkpointId());
+            });
+  }
+
+  void generateLoad() {
+    try (final var client = cluster.newClientBuilder().build()) {
+      client
+          .newPublishMessageCommand()
+          .messageName(RandomStringUtils.insecure().next(8))
+          .correlationKey(RandomStringUtils.insecure().next(8))
+          .send()
+          .join();
+    }
+  }
+}

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -247,11 +247,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-db</artifactId>
     </dependency>
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -24,8 +24,8 @@ import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.CheckpointState;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
-import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator.ErrorResponse.Payload;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.zeebe.containers.ZeebeNode;
@@ -131,7 +131,7 @@ public interface BackupActuator {
 
   @RequestLine("GET /state")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  CheckpointStateResponse state();
+  CheckpointState state();
 
   /**
    * Custom error handler, mapping errors with body to custom types for easier


### PR DESCRIPTION
This exposes the ranges we've added in #43797 via the backup management API.

A typical response from `GET actuators/backupRuntime/state` now looks like this:
```json
{
  "checkpointStates": [
    {
      "checkpointId": 45,
      "checkpointType": "MARKER",
      "partitionId": 1,
      "checkpointPosition": 1500,
      "checkpointTimestamp": 1765208671134
    }
  ],
  "backupStates": [
    {
      "checkpointId": 39,
      "checkpointType": "MANUAL_BACKUP",
      "partitionId": 1,
      "checkpointPosition": 1500,
      "checkpointTimestamp": 1765208671134
    }
  ],
  "ranges": [
    {
      "partitionId": 1,
      "start": {
        "checkpointId": 40,
        "firstLogPosition": 123,
        "checkpointPosition": 1400,
        "checkpointType": "SCHEDULED_BACKUP",
        "checkpointTimestamp": 1765208600000
      },
      "end": {
        "checkpointId": 42,
        "firstLogPosition": 180,
        "checkpointPosition": 1500,
        "checkpointType": "SCHEDULED_BACKUP",
        "checkpointTimestamp": 1765208671134
      },
      "missingCheckpoints": [41]
    }
  ]
}
```

closes #40606
