### PR TITLE
[Design Prototype] Business Key in Operate

### DIFF
--- a/operate/client/src/App/OperationsLog/InstancesTable/CellOperationType.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/CellOperationType.tsx
@@ -9,7 +9,7 @@
 import type {AuditLog} from '@camunda/camunda-api-zod-schemas/8.9/audit-log';
 import {Link} from '@carbon/react';
 import {OperationLogName} from './styled';
-import {ClassicBatch} from '@carbon/react/icons';
+import {BatchJob} from '@carbon/react/icons';
 import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
 
 type Props = {
@@ -21,7 +21,7 @@ const CellOperationType: React.FC<Props> = ({item}) => {
     <>
       <OperationLogName>
         {item.entityType === 'BATCH' && item.batchOperationType ? (
-          <ClassicBatch />
+          <BatchJob />
         ) : undefined}
         {spaceAndCapitalize(item.operationType)}&nbsp;
         {spaceAndCapitalize(item.entityType)}
@@ -31,7 +31,7 @@ const CellOperationType: React.FC<Props> = ({item}) => {
       </OperationLogName>
       {item.entityType !== 'BATCH' && item.batchOperationKey ? (
         <OperationLogName>
-          <ClassicBatch />
+          <BatchJob />
           <Link
             href={`/batch-operations/${item.batchOperationKey}`}
             target="_self"

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -27,6 +27,7 @@ const headerColumns = [
   'Process Name',
   'Process Instance Key',
   'Version',
+  'Business Key',
   'Version Tag',
   'Tenant',
   'Start Date',
@@ -50,6 +51,10 @@ const skeletonColumns: {
   {
     name: 'Version',
     skeletonWidth: '34px',
+  },
+  {
+    name: 'Business Key',
+    skeletonWidth: '120px',
   },
   {
     name: 'Start Date',
@@ -154,6 +159,12 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
               {processDefinitionVersion}
             </Link>
           ),
+        },
+        {
+          // Mock business key for UI prototype
+          title: `ORDER-${processInstanceKey.slice(-6)}`,
+          content: `ORDER-${processInstanceKey.slice(-6)}`,
+          dataTestId: 'business-key',
         },
         ...(hasVersionTag
           ? [

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
@@ -8,7 +8,7 @@
 
 import {observer} from 'mobx-react';
 import {Button} from '@carbon/react';
-import {ClassicBatch} from '@carbon/react/icons';
+import {BatchJob} from '@carbon/react/icons';
 import {useNavigate} from 'react-router-dom';
 import isNil from 'lodash/isNil';
 import {CopiableProcessID} from 'App/Processes/CopiableProcessID';
@@ -92,7 +92,7 @@ const DiagramHeader: React.FC<DiagramHeaderProps> = observer(
             kind="tertiary"
             onClick={() => navigate(Paths.batchOperations())}
             iconDescription="View batch operations"
-            renderIcon={ClassicBatch}
+            renderIcon={BatchJob}
             title="View batch operations"
             aria-label="View batch operations"
             size="sm"

--- a/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
@@ -41,6 +41,7 @@ import {Variable} from './VariableField';
 type OptionalFilter =
   | 'variable'
   | 'ids'
+  | 'businessKey'
   | 'parentInstanceId'
   | 'operationId'
   | 'errorMessage'
@@ -51,6 +52,7 @@ type OptionalFilter =
 const optionalFilters: Array<OptionalFilter> = [
   'variable',
   'ids',
+  'businessKey',
   'operationId',
   'parentInstanceId',
   'errorMessage',
@@ -84,6 +86,11 @@ const OPTIONAL_FILTER_FIELDS: Record<
       validateIdsLength,
       validatesIdsComplete,
     ),
+  },
+  businessKey: {
+    keys: ['businessKey'],
+    label: 'Business Key',
+    type: 'text',
   },
   operationId: {
     keys: ['operationId'],

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -187,6 +187,8 @@ const InstancesTable: React.FC = observer(() => {
               </Link>
             ),
             processVersion: instance.processVersion,
+            // Mock business key for UI prototype
+            businessKey: `ORDER-${instance.id.slice(-6)}`,
             versionTag: instance.processVersionTag ?? '--',
             tenant: isTenantColumnVisible ? instance.tenantId : undefined,
             startDate: formatDate(instance.startDate),
@@ -249,6 +251,11 @@ const InstancesTable: React.FC = observer(() => {
           {
             header: 'Version',
             key: 'processVersion',
+          },
+          {
+            header: 'Business Key',
+            key: 'businessKey',
+            isDisabled: true,
           },
           ...(hasVersionTags
             ? [

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
@@ -109,6 +109,9 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
               ? 'INCIDENT'
               : instance.state;
 
+            // Mock business key for UI prototype
+            const mockBusinessKey = `ORDER-${instance.processInstanceKey.slice(-6)}`;
+
             return {
               id: instance.processInstanceKey,
               processName: (
@@ -138,6 +141,7 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
                 </Link>
               ),
               processVersion: instance.processDefinitionVersion,
+              businessKey: mockBusinessKey,
               versionTag: instance.processDefinitionVersionTag ?? '--',
               tenant: isTenantColumnVisible ? instance.tenantId : undefined,
               startDate: formatDate(instance.startDate),
@@ -191,6 +195,11 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
               header: 'Version',
               key: 'processVersion',
               sortKey: 'processDefinitionVersion',
+            },
+            {
+              header: 'Business Key',
+              key: 'businessKey',
+              isDisabled: true,
             },
             ...(hasVersionTags
               ? [

--- a/operate/client/src/modules/utils/filter/shared.ts
+++ b/operate/client/src/modules/utils/filter/shared.ts
@@ -10,6 +10,7 @@ type ProcessInstanceFilterField =
   | 'process'
   | 'version'
   | 'ids'
+  | 'businessKey'
   | 'parentInstanceId'
   | 'errorMessage'
   | 'incidentErrorHashCode'
@@ -32,6 +33,7 @@ type ProcessInstanceFilters = {
   process?: string;
   version?: string;
   ids?: string;
+  businessKey?: string;
   parentInstanceId?: string;
   errorMessage?: string;
   incidentErrorHashCode?: number;
@@ -55,6 +57,7 @@ const PROCESS_INSTANCE_FILTER_FIELDS: ProcessInstanceFilterField[] = [
   'process',
   'version',
   'ids',
+  'businessKey',
   'parentInstanceId',
   'errorMessage',
   'incidentErrorHashCode',

--- a/tasklist/client/public/mockServiceWorker.js
+++ b/tasklist/client/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.10.2'
-const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const PACKAGE_VERSION = '2.12.7'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -71,11 +71,6 @@ addEventListener('message', async function (event) {
       break
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
-    }
-
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
 
@@ -94,6 +89,8 @@ addEventListener('message', async function (event) {
 })
 
 addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
     return
@@ -110,23 +107,29 @@ addEventListener('fetch', function (event) {
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
-  // after it's been deleted (still remains active until the next reload).
+  // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
     return
   }
 
   const requestId = crypto.randomUUID()
-  event.respondWith(handleRequest(event, requestId))
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
 })
 
 /**
  * @param {FetchEvent} event
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  */
-async function handleRequest(event, requestId) {
+async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
-  const response = await getResponse(event, client, requestId)
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
@@ -202,9 +205,10 @@ async function resolveMainClient(event) {
  * @param {FetchEvent} event
  * @param {Client | undefined} client
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  * @returns {Promise<Response>}
  */
-async function getResponse(event, client, requestId) {
+async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
   const requestClone = event.request.clone()
@@ -255,6 +259,7 @@ async function getResponse(event, client, requestId) {
       type: 'REQUEST',
       payload: {
         id: requestId,
+        interceptedAt: requestInterceptedAt,
         ...serializedRequest,
       },
     },


### PR DESCRIPTION
## Description

Introduces a 'Business Key' (value is mocked) column to process instance tables and headers for UI prototyping, and adds support for filtering by business key.

<img width="1512" height="826" alt="Screenshot 2026-01-12 at 15 50 10" src="https://github.com/user-attachments/assets/a3b51a17-55cc-4fb6-9e65-b2555009821a" />

<img width="1512" height="828" alt="Screenshot 2026-01-12 at 15 50 21" src="https://github.com/user-attachments/assets/cd153847-80e3-40fb-8690-e7a4074664e7" />

## Related issues

https://github.com/camunda/product-hub/issues/2003
