### PR TITLE
feat: add operation filtering options in operate generic audit log

### DIFF
--- a/operate/client/src/App/OperationsLog/Filters/FilterMultiselect.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/FilterMultiselect.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Field} from 'react-final-form';
+import {MultiSelect} from '@carbon/react';
+import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
+
+interface FilterMultiselectProps {
+  name: string;
+  titleText: string;
+  items: string[];
+}
+
+const FilterMultiselect: React.FC<FilterMultiselectProps> = ({
+  name,
+  titleText,
+  items,
+}) => {
+  return (
+    <Field name={name}>
+      {({input}) => {
+        let itemsArray;
+        if (typeof input.value === 'string') {
+          itemsArray = input.value ? input.value.split(',') : [];
+        } else {
+          itemsArray = input.value;
+        }
+
+        return (
+          <MultiSelect
+            id={name}
+            data-testid={name}
+            items={items}
+            selectedItems={itemsArray}
+            itemToString={(selectedItem) => spaceAndCapitalize(selectedItem)}
+            label="Choose option(s)"
+            useTitleInItem={false}
+            titleText={titleText}
+            onChange={({selectedItems}) => {
+              if (selectedItems.length === 0) {
+                input.onChange(undefined);
+              } else {
+                input.onChange(selectedItems);
+              }
+            }}
+            size="sm"
+          />
+        );
+      }}
+    </Field>
+  );
+};
+
+export {FilterMultiselect};

--- a/operate/client/src/App/OperationsLog/Filters/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.test.tsx
@@ -98,15 +98,17 @@ describe('OperationsLog Filters', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should render process instance key input field', () => {
+  it('should render all filter fields', () => {
     render(<Filters />, {
       wrapper: Wrapper,
     });
 
-    const processInstanceKeyInput =
-      screen.getByLabelText(/process instance key/i);
-    expect(processInstanceKeyInput).toBeInTheDocument();
-    expect(processInstanceKeyInput).toHaveAttribute('type', 'text');
+    expect(screen.getByText('Process instance key')).toBeInTheDocument();
+    expect(screen.getByText('Operation type')).toBeInTheDocument();
+    expect(screen.getByText('Entity type')).toBeInTheDocument();
+    expect(screen.getByText('Operations status')).toBeInTheDocument();
+    expect(screen.getByText('Actor')).toBeInTheDocument();
+    expect(screen.getByText('Timestamp date range')).toBeInTheDocument();
   });
 
   it('should have reset button disabled when filters are empty', () => {

--- a/operate/client/src/App/OperationsLog/Filters/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.test.tsx
@@ -6,13 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {Filters} from './index';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import React from 'react';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
 import {processesStore} from 'modules/stores/processes/processes.list';
 

--- a/operate/client/src/App/OperationsLog/Filters/index.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.tsx
@@ -160,7 +160,7 @@ const Filters: React.FC = observer(() => {
                             label="Choose option"
                             aria-label="Choose option"
                             titleText="Operations status"
-                            id="-result"
+                            id="result-field"
                             onChange={({selectedItem}) =>
                               input.onChange(
                                 selectedItem === 'all'

--- a/operate/client/src/App/OperationsLog/Filters/index.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import {useLocation, useNavigate} from 'react-router-dom';
-import {Stack} from '@carbon/react';
+import {Dropdown, Stack} from '@carbon/react';
 import {updateFiltersSearchString} from 'modules/utils/filter';
 import {Container} from './styled';
 import {Field, Form} from 'react-final-form';
@@ -31,12 +31,23 @@ import {
   type OperationsLogFilterField,
   type OperationsLogFilters,
 } from '../shared';
+import {
+  auditLogEntityTypeSchema,
+  auditLogOperationTypeSchema,
+  auditLogResultSchema,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
+import {DateRangeField} from 'modules/components/DateRangeField';
+import {useState} from 'react';
+import {FilterMultiselect} from './FilterMultiselect';
 
 const initialValues: OperationsLogFilters = {};
 
 const Filters: React.FC = observer(() => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [isDateRangeModalOpen, setIsDateRangeModalOpen] =
+    useState<boolean>(false);
 
   const filterValues = getFilters<
     OperationsLogFilterField,
@@ -86,7 +97,15 @@ const Filters: React.FC = observer(() => {
               }}
             >
               <Container>
-                <AutoSubmit fieldsToSkipTimeout={['process', 'version']} />
+                <AutoSubmit
+                  fieldsToSkipTimeout={[
+                    'process',
+                    'version',
+                    'operationType',
+                    'entityType',
+                    'result',
+                  ]}
+                />
                 <Stack gap={5}>
                   {window.clientConfig?.multiTenancyEnabled && (
                     <div>
@@ -120,6 +139,66 @@ const Filters: React.FC = observer(() => {
                           />
                         )}
                       </Field>
+                    </Stack>
+                  </div>
+                  <div>
+                    <Title>Operation</Title>
+                    <Stack gap={5}>
+                      <FilterMultiselect
+                        name="operationType"
+                        titleText="Operation type"
+                        items={auditLogOperationTypeSchema.options}
+                      />
+                      <FilterMultiselect
+                        name="entityType"
+                        titleText="Entity type"
+                        items={auditLogEntityTypeSchema.options}
+                      />
+                      <Field name="result">
+                        {({input}) => (
+                          <Dropdown
+                            label="Choose option"
+                            aria-label="Choose option"
+                            titleText="Operations status"
+                            id="-result"
+                            onChange={({selectedItem}) =>
+                              input.onChange(
+                                selectedItem === 'all'
+                                  ? undefined
+                                  : selectedItem,
+                              )
+                            }
+                            items={['all', ...auditLogResultSchema.options]}
+                            itemToString={(item) =>
+                              item === 'all' ? 'All' : spaceAndCapitalize(item)
+                            }
+                            selectedItem={input.value}
+                            size="sm"
+                          />
+                        )}
+                      </Field>
+                      <Field name="actorId">
+                        {({input}) => (
+                          <TextInputField
+                            {...input}
+                            id="actorId"
+                            size="sm"
+                            labelText="Actor"
+                            type="text"
+                            placeholder="Username or client ID"
+                          />
+                        )}
+                      </Field>
+                      <DateRangeField
+                        isModalOpen={isDateRangeModalOpen}
+                        onModalClose={() => setIsDateRangeModalOpen(false)}
+                        onClick={() => setIsDateRangeModalOpen(true)}
+                        filterName="timestamp"
+                        popoverTitle="Filter by timestamp date range"
+                        label="Timestamp date range"
+                        fromDateTimeKey="timestampAfter"
+                        toDateTimeKey="timestampBefore"
+                      />
                     </Stack>
                   </div>
                 </Stack>

--- a/operate/client/src/App/OperationsLog/Filters/index.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.tsx
@@ -30,7 +30,7 @@ import {
   AUDIT_LOG_FILTER_FIELDS,
   type OperationsLogFilterField,
   type OperationsLogFilters,
-} from '../shared';
+} from '../auditLogFilters';
 import {
   auditLogEntityTypeSchema,
   auditLogOperationTypeSchema,

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -59,7 +59,6 @@ describe('OperationsLog InstancesTable', () => {
 
   afterEach(() => {
     processesStore.reset();
-    vi.clearAllMocks();
   });
 
   it('should render operations log header', () => {

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -6,13 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {InstancesTable} from './index';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import React from 'react';
 import {mockQueryAuditLogs} from 'modules/mocks/api/v2/auditLogs/queryAuditLogs';
 import {notificationsStore} from 'modules/stores/notifications';
 import {processesStore} from 'modules/stores/processes/processes.list';

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -17,7 +17,6 @@ import {mockQueryAuditLogs} from 'modules/mocks/api/v2/auditLogs/queryAuditLogs'
 import {notificationsStore} from 'modules/stores/notifications';
 import {processesStore} from 'modules/stores/processes/processes.list';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
-import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 vi.mock('modules/stores/notifications', () => ({
   notificationsStore: {
@@ -31,29 +30,12 @@ vi.mock('modules/tracking', () => ({
   },
 }));
 
-const Wrapper = ({
-  children,
-  initialPath = '/operations-log',
-  processDefinitionKey = null,
-}: {
-  children?: React.ReactNode;
-  initialPath?: string;
-  processDefinitionKey?: string | null;
-}) => {
+const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => {
   return (
     <QueryClientProvider client={getMockQueryClient()}>
-      <MemoryRouter initialEntries={[initialPath]}>
+      <MemoryRouter initialEntries={['/operations-log']}>
         <Routes>
-          <Route
-            path="/operations-log"
-            element={
-              <ProcessDefinitionKeyContext.Provider
-                value={processDefinitionKey ?? undefined}
-              >
-                {children}
-              </ProcessDefinitionKeyContext.Provider>
-            }
-          />
+          <Route path="/operations-log" element={children} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -31,7 +31,7 @@ import {
   AUDIT_LOG_FILTER_FIELDS,
   type OperationsLogFilterField,
   type OperationsLogFilters,
-} from '../shared';
+} from '../auditLogFilters';
 import {getFilters} from 'modules/utils/filter/getProcessInstanceFilters';
 import {observer} from 'mobx-react';
 import {CellAppliedTo} from './CellAppliedTo';

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -38,7 +38,7 @@ import {CellAppliedTo} from './CellAppliedTo';
 import {CellOperationType} from './CellOperationType';
 import {CellResult} from './CellResult';
 import {CellComment} from './CellComment';
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {processesStore} from 'modules/stores/processes/processes.list';
 import {
   auditLogEntityTypeSchema,
   auditLogOperationTypeSchema,
@@ -100,7 +100,11 @@ const InstancesTable: React.FC = observer(() => {
     OperationsLogFilterField,
     OperationsLogFilters
   >(location.search, AUDIT_LOG_FILTER_FIELDS, []);
-  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const processDefinitionKey = processesStore.getProcessId({
+    process: filterValues.process,
+    tenant: filterValues.tenant,
+    version: filterValues.version,
+  });
 
   const request: QueryAuditLogsRequestBody = useMemo(() => {
     return {

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -39,6 +39,12 @@ import {CellOperationType} from './CellOperationType';
 import {CellResult} from './CellResult';
 import {CellComment} from './CellComment';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {
+  auditLogEntityTypeSchema,
+  auditLogOperationTypeSchema,
+  auditLogResultSchema,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+import {formatToISO} from 'modules/utils/date/formatDate';
 
 const ROW_HEIGHT = 46;
 const SMOOTH_SCROLL_STEP_SIZE = 5 * ROW_HEIGHT;
@@ -109,14 +115,34 @@ const InstancesTable: React.FC = observer(() => {
         processDefinitionKey: processDefinitionKey,
         processInstanceKey: filterValues.processInstanceKey,
         tenantId: filterValues.tenant,
+        operationType: filterValues.operationType
+          ? {
+              $in: filterValues.operationType
+                .split(',')
+                .map((v) => auditLogOperationTypeSchema.parse(v)),
+            }
+          : undefined,
+        entityType: filterValues.entityType
+          ? {
+              $in: filterValues.entityType
+                .split(',')
+                .map((v) => auditLogEntityTypeSchema.parse(v)),
+            }
+          : undefined,
+        result: filterValues.result
+          ? auditLogResultSchema.parse(filterValues.result)
+          : undefined,
+        timestamp:
+          filterValues.timestampBefore || filterValues.timestampAfter
+            ? {
+                $gt: formatToISO(filterValues.timestampAfter),
+                $lt: formatToISO(filterValues.timestampBefore),
+              }
+            : undefined,
+        actorId: filterValues.actorId,
       },
     };
-  }, [
-    filterValues.processInstanceKey,
-    filterValues.tenant,
-    processDefinitionKey,
-    sort,
-  ]);
+  }, [filterValues, processDefinitionKey, sort]);
 
   const {
     data,

--- a/operate/client/src/App/OperationsLog/auditLogFilters.ts
+++ b/operate/client/src/App/OperationsLog/auditLogFilters.ts
@@ -45,5 +45,4 @@ const AUDIT_LOG_FILTER_FIELDS: (keyof OperationsLogFilters)[] = [
 ];
 
 export type {OperationsLogFilters, OperationsLogFilterField};
-
 export {AUDIT_LOG_FILTER_FIELDS};

--- a/operate/client/src/App/OperationsLog/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/index.test.tsx
@@ -7,13 +7,21 @@
  */
 
 import {OperationsLog} from './index';
-import {render, screen} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {processesStore} from 'modules/stores/processes/processes.list';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {processInstancesStore} from 'modules/stores/processInstances';
+import {mockMe} from 'modules/mocks/api/v2/me';
+import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
+import {mockQueryAuditLogs} from 'modules/mocks/api/v2/auditLogs/queryAuditLogs';
+import {
+  createProcessDefinition,
+  createUser,
+  searchResult,
+} from 'modules/testUtils';
 
 vi.mock('modules/tracking', () => ({
   tracking: {
@@ -21,16 +29,10 @@ vi.mock('modules/tracking', () => ({
   },
 }));
 
-const Wrapper = ({
-  children,
-  initialPath = '/operations-log',
-}: {
-  children?: React.ReactNode;
-  initialPath?: string;
-}) => {
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
     <QueryClientProvider client={getMockQueryClient()}>
-      <MemoryRouter initialEntries={[initialPath]}>
+      <MemoryRouter initialEntries={['/operations-log']}>
         <Routes>
           <Route path="/operations-log" element={children} />
         </Routes>
@@ -40,6 +42,24 @@ const Wrapper = ({
 };
 
 describe('OperationsLog', () => {
+  beforeEach(() => {
+    mockMe().withSuccess(createUser());
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({name: 'Test Process', version: 1}),
+      ]),
+    );
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({name: 'Test Process', version: 1}),
+      ]),
+    );
+    mockQueryAuditLogs().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+  });
+
   afterEach(() => {
     processesStore.reset();
     processInstancesStore.reset();

--- a/operate/client/src/App/OperationsLog/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/index.test.tsx
@@ -56,15 +56,19 @@ describe('OperationsLog', () => {
   });
 
   it('should fetch processes on mount', async () => {
-    const processesStoreSpy = vi.spyOn(processesStore, 'fetchProcesses');
-
-    render(<OperationsLog />, {
+    const {user} = render(<OperationsLog />, {
       wrapper: Wrapper,
     });
 
-    expect(processesStoreSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', {name: 'Name'})).toBeEnabled();
+    });
 
-    processesStoreSpy.mockRestore();
+    await user.click(screen.getByRole('combobox', {name: 'Name'}));
+
+    expect(
+      screen.getByRole('option', {name: 'Test Process'}),
+    ).toBeInTheDocument();
   });
 
   it('should set page title to instances', () => {

--- a/operate/client/src/App/OperationsLog/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/index.test.tsx
@@ -6,13 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {describe, it, expect, vi, afterEach} from 'vitest';
 import {OperationsLog} from './index';
 import {render, screen} from 'modules/testing-library';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import React from 'react';
 import {processesStore} from 'modules/stores/processes/processes.list';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {processInstancesStore} from 'modules/stores/processInstances';

--- a/operate/client/src/App/OperationsLog/index.tsx
+++ b/operate/client/src/App/OperationsLog/index.tsx
@@ -8,13 +8,11 @@
 
 import {useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
-import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {processesStore} from 'modules/stores/processes/processes.list';
 import {PAGE_TITLE} from 'modules/constants';
 import {Filters} from './Filters';
 import {InstancesTable} from './InstancesTable';
 import {Container} from './styled';
-import {getProcessInstanceFilters} from 'modules/utils/filter';
 import {observer} from 'mobx-react';
 
 const OperationsLog: React.FC = observer(() => {
@@ -39,20 +37,11 @@ const OperationsLog: React.FC = observer(() => {
     };
   }, []);
 
-  const {process, tenant, version} = getProcessInstanceFilters(location.search);
-  const processDefinitionKey = processesStore.getProcessId({
-    process,
-    tenant,
-    version,
-  });
-
   return (
-    <ProcessDefinitionKeyContext.Provider value={processDefinitionKey}>
-      <Container>
-        <Filters />
-        <InstancesTable />
-      </Container>
-    </ProcessDefinitionKeyContext.Provider>
+    <Container>
+      <Filters />
+      <InstancesTable />
+    </Container>
   );
 });
 

--- a/operate/client/src/App/OperationsLog/shared.ts
+++ b/operate/client/src/App/OperationsLog/shared.ts
@@ -13,6 +13,9 @@ type OperationsLogFilterField =
   | 'operationType'
   | 'entityType'
   | 'actorId'
+  | 'result'
+  | 'timestampBefore'
+  | 'timestampAfter'
   | 'tenant';
 
 type OperationsLogFilters = {
@@ -22,6 +25,9 @@ type OperationsLogFilters = {
   operationType?: string;
   entityType?: string;
   actorId?: string;
+  result?: string;
+  timestampBefore?: string;
+  timestampAfter?: string;
   tenant?: string;
 };
 
@@ -32,6 +38,9 @@ const AUDIT_LOG_FILTER_FIELDS: (keyof OperationsLogFilters)[] = [
   'operationType',
   'entityType',
   'actorId',
+  'result',
+  'timestampBefore',
+  'timestampAfter',
   'tenant',
 ];
 


### PR DESCRIPTION
## Description

Add operation filtering options in operate generic audit log.

## Related issues

closes https://github.com/camunda/camunda/issues/42000
