### PR TITLE
feat: add readiness check of dynamic node id provider

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -97,11 +97,11 @@ public class NodeIdProvider {
     private Duration leaseAcquireMaxDelay = Duration.ofSeconds(30);
 
     /**
-     * Timeout for updating node ID version mappings in S3. If a node's mapping is not updated
-     * within this timeout, the node is assumed to be down and its mapping may be ignored. Must be
-     * greater than leaseDuration.
+     * Timeout for waiting until node ID version mappings is updated. If a node's mapping is not
+     * updated within this timeout, the node is assumed to be down and its mapping may be ignored.
+     * Must be greater than leaseDuration.
      */
-    private Duration nodeIdMappingUpdateTimeout = Duration.ofMinutes(2);
+    private Duration readinessCheckTimeout = Duration.ofMinutes(2);
 
     /**
      * Name of the bucket where the leases will be stored. The bucket must be already created. The
@@ -239,14 +239,13 @@ public class NodeIdProvider {
       this.leaseAcquireMaxDelay = leaseAcquireMaxDelay;
     }
 
-    public Duration getNodeIdMappingUpdateTimeout() {
-      return nodeIdMappingUpdateTimeout;
+    public Duration getReadinessCheckTimeout() {
+      return readinessCheckTimeout;
     }
 
-    public void setNodeIdMappingUpdateTimeout(final Duration nodeIdMappingUpdateTimeout) {
-      this.nodeIdMappingUpdateTimeout =
-          Objects.requireNonNull(
-              nodeIdMappingUpdateTimeout, "nodeIdMappingUpdateTimeout cannot be null");
+    public void setReadinessCheckTimeout(final Duration readinessCheckTimeout) {
+      this.readinessCheckTimeout =
+          Objects.requireNonNull(readinessCheckTimeout, "readinessCheckTimeout cannot be null");
     }
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -73,7 +73,7 @@ public class NodeIdProviderConfiguration {
             new S3NodeIdRepository.Config(
                 s3Config.getBucketName(),
                 s3Config.getLeaseDuration(),
-                s3Config.getNodeIdMappingUpdateTimeout());
+                s3Config.getReadinessCheckTimeout());
         yield S3NodeIdRepository.of(clientConfig, config, Clock.systemUTC());
       }
     };
@@ -102,7 +102,7 @@ public class NodeIdProviderConfiguration {
                 Clock.systemUTC(),
                 config.getLeaseDuration(),
                 config.getLeaseAcquireMaxDelay(),
-                config.getNodeIdMappingUpdateTimeout(),
+                config.getReadinessCheckTimeout(),
                 taskId,
                 () -> {
                   LOG.warn("NodeIdProvider terminating the process");

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -102,6 +102,7 @@ public class NodeIdProviderConfiguration {
                 Clock.systemUTC(),
                 config.getLeaseDuration(),
                 config.getLeaseAcquireMaxDelay(),
+                config.getNodeIdMappingUpdateTimeout(),
                 taskId,
                 () -> {
                   LOG.warn("NodeIdProvider terminating the process");

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -122,6 +122,12 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   }
 
   private void scheduleReadinessCheck(final int clusterSize) {
+    if (previousNodeGracefullyShutdown.join()) {
+      // if the previous node shut down gracefully, we can consider ourselves ready immediately
+      readinessFuture.complete(true);
+      return;
+    }
+
     final var readinessCheckExecutor =
         Executors.newSingleThreadScheduledExecutor(
             r -> new Thread(r, "NodeIdProvider-readiness-checker"));

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessChecker.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessChecker.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Initialized;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A readiness checker that verifies if all nodes in the cluster have up-to-date leases in the
+ * repository containing the current node's version mapping.
+ */
+public class RepositoryNodeIdProviderReadinessChecker {
+  private final int clusterSize;
+  private final int currentNodeId;
+  private final Version currentVersion;
+  private final NodeIdRepository nodeIdRepository;
+  private final ScheduledExecutorService scheduler;
+  private final Duration checkInterval;
+
+  public RepositoryNodeIdProviderReadinessChecker(
+      final int clusterSize,
+      final NodeInstance currentNodeInstance,
+      final NodeIdRepository nodeIdRepository,
+      final ScheduledExecutorService scheduler,
+      final Duration checkInterval) {
+    this.clusterSize = clusterSize;
+    currentNodeId = currentNodeInstance.id();
+    currentVersion = currentNodeInstance.version();
+    this.nodeIdRepository = nodeIdRepository;
+    this.scheduler = scheduler;
+    this.checkInterval = checkInterval;
+  }
+
+  /**
+   * Waits until all nodes in the cluster are up to date by verifying their leases contain the
+   * current version mapping. Returns a future that completes when all nodes are ready
+   *
+   * @return CompletableFuture that completes when all nodes are up to date
+   */
+  public CompletableFuture<Void> waitUntilAllNodesAreUpToDate() {
+    final var result = new CompletableFuture<Void>();
+    final var nodesToCheck = new HashSet<Integer>();
+    for (int i = 0; i < clusterSize; i++) {
+      if (i != currentNodeId) {
+        nodesToCheck.add(i);
+      }
+    }
+
+    final var startTime = System.currentTimeMillis();
+    scheduleCheck(result, nodesToCheck, startTime);
+    return result;
+  }
+
+  private void scheduleCheck(
+      final CompletableFuture<Void> result, final Set<Integer> nodesToCheck, final long startTime) {
+    scheduler.schedule(
+        () -> performCheck(result, nodesToCheck, startTime),
+        checkInterval.toMillis(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  private void performCheck(
+      final CompletableFuture<Void> result, final Set<Integer> nodesToCheck, final long startTime) {
+    try {
+      nodesToCheck.removeIf(this::isNodeUpToDate);
+    } catch (final Exception e) {
+      // In case of exception, we just retry in the next scheduled check
+    }
+
+    if (nodesToCheck.isEmpty()) {
+      result.complete(null);
+    } else {
+      scheduleCheck(result, nodesToCheck, startTime);
+    }
+  }
+
+  private boolean isNodeUpToDate(final int nodeId) {
+    try {
+      final var lease = nodeIdRepository.getLease(nodeId);
+      if (!(lease instanceof final Initialized initializedLease)) {
+        return false;
+      }
+      final var knownVersionMap =
+          initializedLease.lease().knownVersionMappings().mappingsByNodeId();
+      return knownVersionMap.containsKey(currentNodeId)
+          && knownVersionMap.get(currentNodeId).equals(currentVersion);
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessChecker.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessChecker.java
@@ -48,8 +48,8 @@ public class RepositoryNodeIdProviderReadinessChecker {
    *
    * @return CompletableFuture that completes when all nodes are up to date
    */
-  public CompletableFuture<Void> waitUntilAllNodesAreUpToDate() {
-    final var result = new CompletableFuture<Void>();
+  public CompletableFuture<Boolean> waitUntilAllNodesAreUpToDate() {
+    final var result = new CompletableFuture<Boolean>();
     final var nodesToCheck = new HashSet<Integer>();
     for (int i = 0; i < clusterSize; i++) {
       if (i != currentNodeId) {
@@ -63,7 +63,9 @@ public class RepositoryNodeIdProviderReadinessChecker {
   }
 
   private void scheduleCheck(
-      final CompletableFuture<Void> result, final Set<Integer> nodesToCheck, final long startTime) {
+      final CompletableFuture<Boolean> result,
+      final Set<Integer> nodesToCheck,
+      final long startTime) {
     scheduler.schedule(
         () -> performCheck(result, nodesToCheck, startTime),
         checkInterval.toMillis(),
@@ -71,7 +73,9 @@ public class RepositoryNodeIdProviderReadinessChecker {
   }
 
   private void performCheck(
-      final CompletableFuture<Void> result, final Set<Integer> nodesToCheck, final long startTime) {
+      final CompletableFuture<Boolean> result,
+      final Set<Integer> nodesToCheck,
+      final long startTime) {
     try {
       nodesToCheck.removeIf(this::isNodeUpToDate);
     } catch (final Exception e) {
@@ -79,7 +83,7 @@ public class RepositoryNodeIdProviderReadinessChecker {
     }
 
     if (nodesToCheck.isEmpty()) {
-      result.complete(null);
+      result.complete(true);
     } else {
       scheduleCheck(result, nodesToCheck, startTime);
     }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -410,6 +410,7 @@ class RepositoryNodeIdProviderIT {
             clock,
             EXPIRY_DURATION,
             Duration.ofSeconds(30),
+            Duration.ofSeconds(60),
             taskId,
             () -> leaseFailed = true);
     final var future = provider.initialize(clusterSize);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -330,25 +330,7 @@ class RepositoryNodeIdProviderIT {
     repository.initialize(clusterSize);
 
     // Acquire a lease that will expire
-    final var lease = repository.getLease(0);
-    final var expiredLeaseTimestamp = clock.millis();
-    final var expiredLease =
-        repository.acquire(
-            new Lease(
-                taskId + "-old",
-                expiredLeaseTimestamp + EXPIRY_DURATION.toMillis(),
-                new NodeInstance(0, lease.version().next()),
-                VersionMappings.empty()),
-            lease.eTag());
-    assertThat(expiredLease).isNotNull().isInstanceOf(StoredLease.Initialized.class);
-
-    // when - advance clock to expire the lease
-    clock.advance(EXPIRY_DURATION.plusSeconds(1));
-
-    // verify the lease is expired (still initialized but not valid)
-    final var storedLease = repository.getLease(0);
-    assertThat(storedLease).isInstanceOf(StoredLease.Initialized.class);
-    assertThat(storedLease.isStillValid(clock.millis())).isFalse();
+    createExpiredLeaseForNodeId(0);
 
     // when - new provider acquires the expired lease
     nodeIdProvider = ofSize(clusterSize);
@@ -358,6 +340,46 @@ class RepositoryNodeIdProviderIT {
     assertThat(nodeIdProvider.previousNodeGracefullyShutdown())
         .succeedsWithin(Duration.ofSeconds(1))
         .isEqualTo(false);
+  }
+
+  @Test
+  void shouldMarkReadyIfPreviousLeaseWasGracefullyReleased() {
+    // given
+    clusterSize = 3;
+    repository.initialize(clusterSize);
+
+    // when - no previous expired lease
+    nodeIdProvider = ofSize(clusterSize, true);
+
+    // then
+    assertThat(nodeIdProvider.awaitReadiness()).succeedsWithin(EXPIRY_DURATION);
+  }
+
+  @Test
+  void shouldMarkReadyOnlyWhenAllOtherNodesAreUptoDate() throws Exception {
+    // given
+    clusterSize = 3;
+    repository.initialize(clusterSize);
+
+    // First node always get an expired lease
+    createExpiredLeaseForNodeId(0);
+    nodeIdProvider = ofSize(clusterSize, true);
+
+    try (final var nodeIdProviderOtherOne = ofSize(clusterSize);
+        final var nodeIdProviderOtherTwo = ofSize(clusterSize)) {
+      // other nodes have outdated version info
+      assertThat(nodeIdProvider.awaitReadiness()).isNotCompleted();
+
+      // when
+      final NodeInstance nodeInstance = nodeIdProvider.currentNodeInstance();
+      // Only the version of this node is updated in all other nodes for this node to be ready
+      final var expectedMappings = Map.of(nodeInstance.id(), nodeInstance.version());
+      nodeIdProviderOtherOne.setMembers(getMembers(expectedMappings));
+      nodeIdProviderOtherTwo.setMembers(getMembers(expectedMappings));
+
+      // then
+      assertThat(nodeIdProvider.awaitReadiness()).succeedsWithin(EXPIRY_DURATION);
+    }
   }
 
   private void assertLeaseIsReady() {
@@ -395,5 +417,27 @@ class RepositoryNodeIdProviderIT {
       future.join();
     }
     return provider;
+  }
+
+  private void createExpiredLeaseForNodeId(final int nodeId) {
+    final var lease = repository.getLease(nodeId);
+    final var expiredLeaseTimestamp = clock.millis();
+    final var expiredLease =
+        repository.acquire(
+            new Lease(
+                taskId + "-old",
+                expiredLeaseTimestamp + EXPIRY_DURATION.toMillis(),
+                new NodeInstance(0, lease.version().next()),
+                VersionMappings.empty()),
+            lease.eTag());
+    assertThat(expiredLease).isNotNull().isInstanceOf(StoredLease.Initialized.class);
+
+    // when - advance clock to expire the lease
+    clock.advance(EXPIRY_DURATION.plusSeconds(1));
+
+    // verify the lease is expired (still initialized but not valid)
+    final var storedLease = repository.getLease(0);
+    assertThat(storedLease).isInstanceOf(StoredLease.Initialized.class);
+    assertThat(storedLease.isStillValid(clock.millis())).isFalse();
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -352,7 +352,7 @@ class RepositoryNodeIdProviderIT {
     nodeIdProvider = ofSize(clusterSize, true);
 
     // then
-    assertThat(nodeIdProvider.awaitReadiness()).succeedsWithin(EXPIRY_DURATION);
+    assertThat(nodeIdProvider.awaitReadiness()).succeedsWithin(EXPIRY_DURATION).isEqualTo(true);
   }
 
   @Test
@@ -378,7 +378,7 @@ class RepositoryNodeIdProviderIT {
       nodeIdProviderOtherTwo.setMembers(getMembers(expectedMappings));
 
       // then
-      assertThat(nodeIdProvider.awaitReadiness()).succeedsWithin(EXPIRY_DURATION);
+      assertThat(nodeIdProvider.awaitReadiness()).succeedsWithin(EXPIRY_DURATION).isEqualTo(true);
     }
   }
 

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
@@ -54,7 +54,7 @@ public class RepositoryNodeIdProviderReadinessCheckerTest {
           new Lease(
               "task" + i,
               System.currentTimeMillis(),
-              new NodeInstance(i, Version.of(100L + i)),
+              new NodeInstance(i, versionMappings.mappingsByNodeId().get(i)),
               versionMappings);
       when(nodeIdRepository.getLease(i)).thenReturn(getInitializedLease(lease));
     }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
@@ -37,7 +37,11 @@ public class RepositoryNodeIdProviderReadinessCheckerTest {
     currentNodeInstance = new NodeInstance(0, Version.of(100L));
     readinessChecker =
         new RepositoryNodeIdProviderReadinessChecker(
-            clusterSize, currentNodeInstance, nodeIdRepository, Duration.ofMillis(10));
+            clusterSize,
+            currentNodeInstance,
+            nodeIdRepository,
+            Duration.ofMillis(10),
+            Duration.ofMinutes(5));
   }
 
   @Test
@@ -233,6 +237,24 @@ public class RepositoryNodeIdProviderReadinessCheckerTest {
     assertThat(result).succeedsWithin(Duration.ofSeconds(5));
     verify(nodeIdRepository, times(1)).getLease(2);
     verify(nodeIdRepository, times(2)).getLease(1);
+  }
+
+  @Test
+  void shouldReturnTrueWhenTimedout() {
+    // given
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize,
+            currentNodeInstance,
+            nodeIdRepository,
+            Duration.ofMillis(10),
+            Duration.ofMillis(50));
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(true);
   }
 
   private static Initialized getInitializedLease(final Lease lease0) {

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dynamic.nodeid.Lease.VersionMappings;
+import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Initialized;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Uninitialized;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RepositoryNodeIdProviderReadinessCheckerTest {
+  private NodeIdRepository nodeIdRepository;
+  private ScheduledExecutorService scheduler;
+  private RepositoryNodeIdProviderReadinessChecker readinessChecker;
+  private NodeInstance currentNodeInstance;
+  private final NodeInstance nodeInstance2 = new NodeInstance(2, Version.of(2L));
+
+  @BeforeEach
+  public void setUp() {
+    nodeIdRepository = mock(NodeIdRepository.class);
+    scheduler = Executors.newSingleThreadScheduledExecutor();
+    currentNodeInstance = new NodeInstance(0, Version.of(100L));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+    }
+  }
+
+  @Test
+  public void shouldCompleteWhenAllNodesAreUpToDate() {
+    // given
+    final int clusterSize = 3;
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize, currentNodeInstance, nodeIdRepository, scheduler, Duration.ofMillis(10));
+
+    final var versionMappings =
+        new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L), 2, Version.of(102L)));
+
+    // Mock all nodes as up to date
+    for (int i = 0; i < clusterSize; i++) {
+      final var lease =
+          new Lease(
+              "task" + i,
+              System.currentTimeMillis(),
+              new NodeInstance(i, Version.of(100L + i)),
+              versionMappings);
+      when(nodeIdRepository.getLease(i)).thenReturn(getInitializedLease(lease));
+    }
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    // should verify other leases from other two nodes
+    verify(nodeIdRepository, times(clusterSize - 1)).getLease(anyInt());
+  }
+
+  @Test
+  public void shouldRetryWhenSomeNodesAreNotUpToDate() {
+    // given
+    final int clusterSize = 3;
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize, currentNodeInstance, nodeIdRepository, scheduler, Duration.ofMillis(10));
+
+    final var outdatedVersionMappings = new VersionMappings(Map.of(1, Version.of(101L)));
+    final var currentVersionMappings =
+        new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L)));
+
+    final var lease2 =
+        new Lease("task2", System.currentTimeMillis(), nodeInstance2, currentVersionMappings);
+    final var lease1Outdated =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            outdatedVersionMappings);
+    final var lease1Updated =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            currentVersionMappings);
+
+    // First check: node 1 is outdated
+    when(nodeIdRepository.getLease(2)).thenReturn(getInitializedLease(lease2));
+    when(nodeIdRepository.getLease(1))
+        .thenReturn(getInitializedLease(lease1Outdated))
+        .thenReturn(getInitializedLease(lease1Updated));
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdRepository, times(1)).getLease(2);
+    verify(nodeIdRepository, times(2)).getLease(1);
+  }
+
+  @Test
+  public void shouldRetryWhenNodeLeaseIsUninitialized() {
+    // given
+    final int clusterSize = 3;
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize, currentNodeInstance, nodeIdRepository, scheduler, Duration.ofMillis(10));
+
+    final var versionMappings =
+        new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L)));
+    final var lease2 =
+        new Lease("task2", System.currentTimeMillis(), nodeInstance2, versionMappings);
+    final var lease1 =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            versionMappings);
+
+    when(nodeIdRepository.getLease(2)).thenReturn(getInitializedLease(lease2));
+    when(nodeIdRepository.getLease(1))
+        .thenReturn(new Uninitialized(new NodeInstance(1, Version.of(0L)), "test"))
+        .thenReturn(getInitializedLease(lease1));
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdRepository, times(1)).getLease(2);
+    verify(nodeIdRepository, times(2)).getLease(1);
+  }
+
+  @Test
+  public void shouldContinueCheckingWhenRepositoryThrowsException() {
+    // given
+    final int clusterSize = 3;
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize, currentNodeInstance, nodeIdRepository, scheduler, Duration.ofMillis(10));
+
+    final var versionMappings =
+        new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L)));
+    final var lease2 =
+        new Lease("task2", System.currentTimeMillis(), nodeInstance2, versionMappings);
+    final var lease1 =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            versionMappings);
+
+    when(nodeIdRepository.getLease(2)).thenReturn(getInitializedLease(lease2));
+    when(nodeIdRepository.getLease(1))
+        .thenThrow(new RuntimeException("Repository error"))
+        .thenReturn(getInitializedLease(lease1));
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdRepository, times(1)).getLease(2);
+    verify(nodeIdRepository, times(2)).getLease(1);
+  }
+
+  @Test
+  public void shouldNotConsiderNodeUpToDateWhenVersionMissing() {
+    // given
+    final int clusterSize = 3;
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize, currentNodeInstance, nodeIdRepository, scheduler, Duration.ofMillis(10));
+
+    final var versionMappingsWithoutNode0 = new VersionMappings(Map.of(1, Version.of(101L)));
+    final var versionMappingsComplete =
+        new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L)));
+
+    final var lease2 =
+        new Lease("task2", System.currentTimeMillis(), nodeInstance2, versionMappingsComplete);
+    final var lease1Incomplete =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            versionMappingsWithoutNode0);
+    final var lease1Complete =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            versionMappingsComplete);
+
+    when(nodeIdRepository.getLease(2)).thenReturn(getInitializedLease(lease2));
+    when(nodeIdRepository.getLease(1))
+        .thenReturn(getInitializedLease(lease1Incomplete))
+        .thenReturn(getInitializedLease(lease1Complete));
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdRepository, times(1)).getLease(2);
+    verify(nodeIdRepository, times(2)).getLease(1);
+  }
+
+  @Test
+  public void shouldNotConsiderNodeUpToDateWhenVersionMismatch() {
+    // given
+    final int clusterSize = 3;
+    readinessChecker =
+        new RepositoryNodeIdProviderReadinessChecker(
+            clusterSize, currentNodeInstance, nodeIdRepository, scheduler, Duration.ofMillis(10));
+
+    final var versionMappingsWrongVersion =
+        new VersionMappings(Map.of(0, Version.of(99L), 1, Version.of(101L)));
+    final var versionMappingsCorrect =
+        new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L)));
+
+    final var lease2 =
+        new Lease("task2", System.currentTimeMillis(), nodeInstance2, versionMappingsCorrect);
+    final var lease1Wrong =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            versionMappingsWrongVersion);
+    final var lease1Correct =
+        new Lease(
+            "task1",
+            System.currentTimeMillis(),
+            new NodeInstance(1, Version.of(101L)),
+            versionMappingsCorrect);
+
+    when(nodeIdRepository.getLease(2)).thenReturn(getInitializedLease(lease2));
+    when(nodeIdRepository.getLease(1))
+        .thenReturn(getInitializedLease(lease1Wrong))
+        .thenReturn(getInitializedLease(lease1Correct));
+
+    // when
+    final var result = readinessChecker.waitUntilAllNodesAreUpToDate();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdRepository, times(1)).getLease(2);
+    verify(nodeIdRepository, times(2)).getLease(1);
+  }
+
+  private static Initialized getInitializedLease(final Lease lease0) {
+    return new Initialized(Metadata.fromLease(lease0), lease0, "test");
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderReadinessCheckerTest.java
@@ -71,7 +71,8 @@ public class RepositoryNodeIdProviderReadinessCheckerTest {
   @Test
   public void shouldRetryWhenSomeNodesAreNotUpToDate() {
     // given
-    final var outdatedVersionMappings = new VersionMappings(Map.of(1, Version.of(101L)));
+    final var outdatedVersionMappings =
+        new VersionMappings(Map.of(0, Version.of(99), 1, Version.of(101L)));
     final var currentVersionMappings =
         new VersionMappings(Map.of(0, Version.of(100L), 1, Version.of(101L)));
 


### PR DESCRIPTION
## Description

This pull request introduces a readiness check mechanism to the dynamic node ID provider, ensuring that a node only marks itself as ready after confirming that all other nodes in the cluster have up-to-date version mappings. This check is only required if  the previous lease had timed out. If the previous lease was released gracefully, then it becomes immediately ready as it is safe to start the broker immediately.

* Added a new `RepositoryNodeIdProviderReadinessChecker` class that periodically checks if all other nodes in the cluster have seen the current node's version mapping. This is executed in a different scheduler to not block the lease renewal during readiness check.
* Readiness check is scheduled immediately after the provider is initialized. The check is nor triggered when calling `awaitReadiness`.
* The node will be marked as ready after a configured timeout. This is so as not to block the startup of a node if some other nodes as down. 
* Renamed the S3 configuration property from `nodeIdMappingUpdateTimeout` to `readinessCheckTimeout` for clarity.

## Related issues

closes #43855
