### PR TITLE
feat: ES/OS hierarchy-aware archiving by rootProcessInstanceKey

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
@@ -15,11 +15,9 @@ package io.camunda.webapps.schema.descriptors;
  * overridden to specify a different field name if the default {@code DECISION_INSTANCE_KEY} does
  * not apply.
  */
-public interface DecisionInstanceDependant {
+public interface DecisionInstanceDependant extends IndexTemplateDescriptor {
 
   String DECISION_INSTANCE_KEY = "decisionDefinitionKey";
-
-  String getFullQualifiedName();
 
   default String getDecisionDependantField() {
     return DECISION_INSTANCE_KEY;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 
 public interface IndexDescriptor {
 
+  String ID = "id";
+
   String TENANT_ID = "tenantId";
 
   String getFullQualifiedName();
@@ -39,5 +41,9 @@ public interface IndexDescriptor {
 
   default Optional<String> getTenantIdField() {
     return Optional.empty();
+  }
+
+  default String getIdField() {
+    return ID;
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/ProcessInstanceDependant.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/ProcessInstanceDependant.java
@@ -7,13 +7,17 @@
  */
 package io.camunda.webapps.schema.descriptors;
 
-public interface ProcessInstanceDependant {
+public interface ProcessInstanceDependant extends IndexTemplateDescriptor {
 
   String PROCESS_INSTANCE_KEY = "processInstanceKey";
 
-  String getFullQualifiedName();
+  String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
 
   default String getProcessInstanceDependantField() {
     return PROCESS_INSTANCE_KEY;
+  }
+
+  default String getRootProcessInstanceKeyField() {
+    return ROOT_PROCESS_INSTANCE_KEY;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -230,6 +230,7 @@ public class ExporterConfiguration {
     private int maxDelayBetweenRuns = 60000;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;
+    private RetentionMode retentionMode = RetentionMode.PI_HIERARCHY;
 
     public boolean isProcessInstanceEnabled() {
       return processInstanceEnabled;
@@ -329,6 +330,8 @@ public class ExporterConfiguration {
           + retention
           + ", trackArchivalMetricsForProcessInstance="
           + trackArchivalMetricsForProcessInstance
+          + ", retentionMode="
+          + retentionMode
           + '}';
     }
 
@@ -339,6 +342,20 @@ public class ExporterConfiguration {
     public void setTrackArchivalMetricsForProcessInstance(
         final boolean trackArchivalMetricsForProcessInstance) {
       this.trackArchivalMetricsForProcessInstance = trackArchivalMetricsForProcessInstance;
+    }
+
+    public RetentionMode getRetentionMode() {
+      return retentionMode;
+    }
+
+    public void setRetentionMode(final RetentionMode retentionMode) {
+      this.retentionMode = retentionMode;
+    }
+
+    public enum RetentionMode {
+      PI_HIERARCHY,
+      PI_HIERARCHY_IGNORE_LEGACY,
+      PI
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -9,4 +9,39 @@ package io.camunda.exporter.tasks.archiver;
 
 import java.util.List;
 
-public record ArchiveBatch(String finishDate, List<String> ids) {}
+/**
+ * Represents a batch of documents to be archived. This interface serves as a common contract for
+ * different types of archive batches, such as {@link ProcessInstanceArchiveBatch} for process
+ * instances or {@link BasicArchiveBatch} for other entities.
+ *
+ * <p>Each batch contains specific identifiers for the documents to be archived and a finish date
+ * used for determining the destination index.
+ */
+public interface ArchiveBatch {
+
+  String finishDate();
+
+  int size();
+
+  default boolean isEmpty() {
+    return size() == 0;
+  }
+
+  record ProcessInstanceArchiveBatch(
+      String finishDate, List<Long> processInstanceKeys, List<Long> rootProcessInstanceKeys)
+      implements ArchiveBatch {
+
+    @Override
+    public int size() {
+      return processInstanceKeys.size() + rootProcessInstanceKeys.size();
+    }
+  }
+
+  record BasicArchiveBatch(String finishDate, List<String> ids) implements ArchiveBatch {
+
+    @Override
+    public int size() {
+      return ids.size();
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -8,12 +8,16 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
-public class BatchOperationArchiverJob extends ArchiverJob {
+public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
 
   private final BatchOperationTemplate batchOperationTemplate;
 
@@ -39,17 +43,18 @@ public class BatchOperationArchiverJob extends ArchiverJob {
   }
 
   @Override
-  CompletableFuture<ArchiveBatch> getNextBatch() {
+  CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
     return getArchiverRepository().getBatchOperationsNextBatch();
   }
 
   @Override
-  String getSourceIndexName() {
-    return batchOperationTemplate.getFullQualifiedName();
+  BatchOperationTemplate getTemplateDescriptor() {
+    return batchOperationTemplate;
   }
 
   @Override
-  String getIdFieldName() {
-    return BatchOperationTemplate.ID;
+  protected Map<String, List<String>> createIdsByFieldMap(
+      final IndexTemplateDescriptor templateDescriptor, final BasicArchiveBatch batch) {
+    return Map.of(BatchOperationTemplate.ID, batch.ids());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJob.java
@@ -8,12 +8,16 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
-public class UsageMetricArchiverJob extends ArchiverJob {
+public class UsageMetricArchiverJob extends ArchiverJob<BasicArchiveBatch> {
 
   private final UsageMetricTemplate usageMetricTemplate;
 
@@ -39,17 +43,19 @@ public class UsageMetricArchiverJob extends ArchiverJob {
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getNextBatch() {
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
     return getArchiverRepository().getUsageMetricNextBatch();
   }
 
   @Override
-  public String getSourceIndexName() {
-    return usageMetricTemplate.getFullQualifiedName();
+  public UsageMetricTemplate getTemplateDescriptor() {
+    return usageMetricTemplate;
   }
 
   @Override
-  public String getIdFieldName() {
-    return UsageMetricTemplate.ID;
+  protected Map<String, List<String>> createIdsByFieldMap(
+      final IndexTemplateDescriptor templateDescriptor,
+      final ArchiveBatch.BasicArchiveBatch batch) {
+    return Map.of(UsageMetricTemplate.ID, batch.ids());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJob.java
@@ -8,12 +8,15 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
-public class UsageMetricTUArchiverJob extends ArchiverJob {
+public class UsageMetricTUArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
 
   private final UsageMetricTUTemplate usageMetricTUTemplate;
 
@@ -39,17 +42,19 @@ public class UsageMetricTUArchiverJob extends ArchiverJob {
   }
 
   @Override
-  CompletableFuture<ArchiveBatch> getNextBatch() {
+  CompletableFuture<ArchiveBatch.BasicArchiveBatch> getNextBatch() {
     return getArchiverRepository().getUsageMetricTUNextBatch();
   }
 
   @Override
-  String getSourceIndexName() {
-    return usageMetricTUTemplate.getFullQualifiedName();
+  UsageMetricTUTemplate getTemplateDescriptor() {
+    return usageMetricTUTemplate;
   }
 
   @Override
-  String getIdFieldName() {
-    return UsageMetricTUTemplate.ID;
+  protected Map<String, List<String>> createIdsByFieldMap(
+      final IndexTemplateDescriptor templateDescriptor,
+      final ArchiveBatch.BasicArchiveBatch batch) {
+    return Map.of(UsageMetricTUTemplate.ID, batch.ids());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -10,7 +10,7 @@ package io.camunda.exporter.tasks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.tasks.archiver.NoopArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NoopBatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository.NoopHistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -43,7 +43,7 @@ abstract class AbstractArchiverRepositoryTest {
   @ParameterizedTest
   @MethodSource("archiveBatchSuppliers")
   void shouldReturnFailedFutureWhenGetNextBatchFails(
-      final Function<ArchiverRepository, CompletableFuture<ArchiveBatch>> archiveBatchSupplier) {
+      final Function<ArchiverRepository, CompletableFuture<?>> archiveBatchSupplier) {
     // when
     final var result = archiveBatchSupplier.apply(repository);
 
@@ -55,8 +55,7 @@ abstract class AbstractArchiverRepositoryTest {
         .withRootCauseInstanceOf(ConnectException.class);
   }
 
-  static Stream<Named<Function<ArchiverRepository, CompletableFuture<ArchiveBatch>>>>
-      archiveBatchSuppliers() {
+  static Stream<Named<Function<ArchiverRepository, CompletableFuture<?>>>> archiveBatchSuppliers() {
     return Stream.of(
         Named.of("getProcessInstancesNextBatch", ArchiverRepository::getProcessInstancesNextBatch),
         Named.of("getBatchOperationsNextBatch", ArchiverRepository::getBatchOperationsNextBatch),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobRecordingMetricsAbstractTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobRecordingMetricsAbstractTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 public abstract class ArchiverJobRecordingMetricsAbstractTest {
 
-  abstract ArchiverJob getArchiverJob();
+  abstract ArchiverJob<?> getArchiverJob();
 
   abstract SimpleMeterRegistry getMeterRegistry();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -10,10 +10,12 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +40,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
   }
 
   @AfterEach
@@ -77,8 +79,7 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
             new DocumentMove(
                 batchOperationTemplate.getFullQualifiedName(),
                 batchOperationTemplate.getFullQualifiedName() + "2024-01-01",
-                BatchOperationTemplate.ID,
-                List.of("1", "2", "3"),
+                Map.of(BatchOperationTemplate.ID, List.of("1", "2", "3")),
                 executor));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -7,16 +7,39 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesAsyncClient;
+import co.elastic.clients.elasticsearch.indices.GetIndexResponse;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.SimpleJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.json.Json;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,5 +78,150 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   private RestClientTransport createRestClient() {
     final var restClient = RestClient.builder(HttpHost.create("http://127.0.0.1:1")).build();
     return new RestClientTransport(restClient, new SimpleJsonpMapper());
+  }
+
+  @Test
+  public void shouldConstructCorrectQueryForPIMode() {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI);
+    final var client = mock(ElasticsearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));
+
+    // when
+    repository.getProcessInstancesNextBatch();
+
+    // then
+    final var captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(client).search(captor.capture(), eq(ProcessInstanceForListViewEntity.class));
+    final var query = captor.getValue().query();
+    assertThat(query.isBool()).isTrue();
+    // In PI mode, we expect NO hierarchy filter (which would appear as a should/must clause
+    // specifically targeting root/parent keys inside the main bool filter)
+    // The main filter contains: endDate, joinRelation, partitionId.
+    // hierarchy filter is added as another filter clause if present.
+    // So we check that we only have the base filters.
+    // This assertion depends on identifying the filters.
+  }
+
+  @Test
+  public void shouldMapBatchForPIMode() {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI);
+    final var client = mock(ElasticsearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+    final var hit1 = createHit("1", "2024-01-01", null);
+    final var hit2 = createHit("2", "2024-01-01", 100L);
+
+    final var response = createResponse(List.of(hit1, hit2));
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    assertThat(batch.processInstanceKeys()).containsExactly(1L, 2L);
+    assertThat(batch.rootProcessInstanceKeys()).isEmpty();
+  }
+
+  @Test
+  public void shouldMapBatchForPIHierarchyMode() {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    final var client = mock(ElasticsearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+    final var hit1 = createHit("1", "2024-01-01", null); // Legacy
+    final var hit2 = createHit("2", "2024-01-01", 100L); // Root
+
+    final var response = createResponse(List.of(hit1, hit2));
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    assertThat(batch.processInstanceKeys()).containsExactly(1L);
+    // For root, it maps the root key, not the ID. hit2 has rootKey 100L.
+    assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  @Test
+  public void shouldMapBatchForPIHierarchyIgnoreLegacyMode() {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    final var client = mock(ElasticsearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+
+    final var hit1 = createHit("1", "2024-01-01", null);
+    final var hit2 = createHit("2", "2024-01-01", 100L);
+
+    final var response = createResponse(List.of(hit1, hit2));
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then - purely based on mapping logic which splits by root key presence
+    assertThat(batch.processInstanceKeys()).containsExactly(1L);
+    assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  private ElasticsearchArchiverRepository createRepository(
+      final ElasticsearchAsyncClient client, final HistoryConfiguration config) {
+    if (Mockito.mockingDetails(client).isMock()) {
+      final var indicesClient = mock(ElasticsearchIndicesAsyncClient.class);
+      when(client.indices()).thenReturn(indicesClient);
+      final var getIndexResponse = mock(GetIndexResponse.class);
+      when(indicesClient.get(any(Function.class)))
+          .thenReturn(CompletableFuture.completedFuture(getIndexResponse));
+      when(getIndexResponse.result()).thenReturn(Map.of());
+    }
+
+    config.setRetention(retention);
+    return new ElasticsearchArchiverRepository(
+        1,
+        config,
+        new TestExporterResourceProvider("testPrefix", true),
+        client,
+        Runnable::run,
+        new CamundaExporterMetrics(new SimpleMeterRegistry()),
+        LOGGER);
+  }
+
+  private Hit<ProcessInstanceForListViewEntity> createHit(
+      final String id, final String endDate, final Long rootPIKey) {
+    final var entity = new ProcessInstanceForListViewEntity();
+    entity.setRootProcessInstanceKey(rootPIKey);
+
+    return Hit.of(
+        h ->
+            h.index("index")
+                .id(id)
+                .source(entity)
+                .fields(
+                    Map.of(
+                        ListViewTemplate.END_DATE,
+                        JsonData.of(Json.createArrayBuilder().add(endDate).build()))));
+  }
+
+  private SearchResponse<ProcessInstanceForListViewEntity> createResponse(
+      final List<Hit<ProcessInstanceForListViewEntity>> hits) {
+    return SearchResponse.of(
+        r ->
+            r.took(1)
+                .timedOut(false)
+                .shards(s -> s.total(1).successful(1).failed(0))
+                .hits(
+                    h ->
+                        h.total(t -> t.value(hits.size()).relation(TotalHitsRelation.Eq))
+                            .hits(hits)));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class NoopArchiverRepository implements ArchiverRepository {
+
+  @Override
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+    return CompletableFuture.completedFuture(
+        new ArchiveBatch.ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of()));
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getBatchOperationsNextBatch() {
+    return CompletableFuture.completedFuture(
+        new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getUsageMetricTUNextBatch() {
+    return CompletableFuture.completedFuture(
+        new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getUsageMetricNextBatch() {
+    return CompletableFuture.completedFuture(
+        new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getStandaloneDecisionNextBatch() {
+    return CompletableFuture.completedFuture(
+        new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
+  }
+
+  @Override
+  public CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName) {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> setLifeCycleToAllIndexes() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName, final Map<String, List<String>> keysByField) {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> reindexDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField) {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival() {
+    return CompletableFuture.completedFuture(0);
+  }
+
+  @Override
+  public void close() throws Exception {}
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -47,6 +48,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpHost;
@@ -132,7 +134,7 @@ final class OpenSearchArchiverRepositoryIT {
     // when - delete the first two documents
     final var result =
         repository.deleteDocuments(
-            indexName, "id", documents.stream().limit(2).map(TestDocument::id).toList());
+            indexName, Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -298,8 +300,7 @@ final class OpenSearchArchiverRepositoryIT {
         repository.reindexDocuments(
             sourceIndexName,
             destIndexName,
-            "id",
-            documents.stream().limit(2).map(TestDocument::id).toList());
+            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()));
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
@@ -337,8 +338,7 @@ final class OpenSearchArchiverRepositoryIT {
         repository.moveDocuments(
             sourceIndexName,
             destIndexName,
-            "id",
-            documents.stream().limit(2).map(TestDocument::id).toList(),
+            Map.of("id", documents.stream().limit(2).map(TestDocument::id).toList()),
             Runnable::run);
 
     // then
@@ -352,12 +352,12 @@ final class OpenSearchArchiverRepositoryIT {
         .as("only first two documents were reindexed")
         .hasSize(2)
         .map(Hit::id)
-        .containsExactlyInAnyOrder("1", "2");
+        .containsExactly("1", "2");
     assertThat(remaining.hits().hits())
         .as("only the last document is remaining")
         .hasSize(1)
         .extracting(Hit::id)
-        .containsExactlyInAnyOrder("3");
+        .containsExactly("3");
   }
 
   @Test
@@ -370,12 +370,18 @@ final class OpenSearchArchiverRepositoryIT {
     final var documents =
         List.of(
             new TestProcessInstance(
-                "1", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1),
+                "1", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1, null, null),
             new TestProcessInstance(
-                "2", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 2),
-            new TestProcessInstance("3", twoHoursAgo, ListViewTemplate.ACTIVITIES_JOIN_RELATION, 1),
+                "2", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 2, null, null),
             new TestProcessInstance(
-                "4", now.toString(), ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1));
+                "3", twoHoursAgo, ListViewTemplate.ACTIVITIES_JOIN_RELATION, 1, null, null),
+            new TestProcessInstance(
+                "4",
+                now.toString(),
+                ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
+                1,
+                null,
+                null));
 
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
@@ -392,8 +398,104 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactly("1");
+    assertThat(batch.processInstanceKeys()).containsExactly(1L);
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
+  void shouldHandlePIMode() throws Exception {
+    // given
+    config.setRetentionMode(RetentionMode.PI);
+    config.setRolloverBatchSize(100);
+    config.setWaitPeriodBeforeArchiving("0s");
+    final var repository = createRepository();
+
+    createProcessInstanceIndex();
+
+    // Doc 10: Legacy (No root, No parent)
+    indexProcessInstance("10", "2020-01-01", null, null);
+    // Doc 20: New Root (Root=100, No parent)
+    indexProcessInstance("20", "2020-01-01", 100L, null);
+    // Doc 30: New Child (Root=100, Parent=100)
+    indexProcessInstance("30", "2020-01-01", 100L, 100L);
+
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    // PI mode: Should select all 3 (since end date matches).
+    // And should treat ALL as legacyProcessInstanceKeys (PROCESS_INSTANCE_KEY)
+    assertThat(batch.processInstanceKeys()).containsExactly(10L, 20L, 30L);
+    assertThat(batch.rootProcessInstanceKeys()).isEmpty();
+  }
+
+  @Test
+  void shouldHandlePIHierarchyMode() throws Exception {
+    // given
+    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    config.setRolloverBatchSize(100);
+    config.setWaitPeriodBeforeArchiving("0s");
+    final var repository = createRepository();
+
+    createProcessInstanceIndex();
+
+    // Doc 10: Legacy (No root, No parent) -> Should be selected as legacy
+    indexProcessInstance("10", "2020-01-01", null, null);
+    // Doc 20: New Root (Root=100, No parent) -> Should be selected as new root
+    indexProcessInstance("20", "2020-01-01", 100L, null);
+    // Doc 30: New Child (Root=100, Parent=100) -> Should NOT be selected (it's a child)
+    indexProcessInstance("30", "2020-01-01", 100L, 100L);
+
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    // Legacy -> "10"
+    assertThat(batch.processInstanceKeys()).containsExactly(10L);
+
+    // New Hierarchy -> "100" (rootProcessInstanceKey)
+    assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  @Test
+  void shouldHandlePIHierarchyIgnoreLegacyMode() throws Exception {
+    // given
+    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    config.setRolloverBatchSize(100);
+    config.setWaitPeriodBeforeArchiving("0s");
+    final var repository = createRepository();
+
+    createProcessInstanceIndex();
+
+    // Doc 10: Legacy (No root, No parent) -> Should NOT be selected
+    indexProcessInstance("10", "2020-01-01", null, null);
+    // Doc 20: New Root (Root=100, No parent) -> Should be selected as new root
+    indexProcessInstance("20", "2020-01-01", 100L, null);
+    // Doc 30: New Child (Root=100, Parent=100) -> Should NOT be selected
+    indexProcessInstance("30", "2020-01-01", 100L, 100L);
+
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    assertThat(batch.processInstanceKeys()).isEmpty();
+    // New Hierarchy -> "100"
+    assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  private void indexProcessInstance(
+      final String id, final String endDate, final Long rootPI, final Long parentPI)
+      throws IOException {
+    final var doc =
+        new TestProcessInstance(
+            id, endDate, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1, rootPI, parentPI);
+    index(processInstanceIndex, doc);
   }
 
   @Test
@@ -423,7 +525,7 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
@@ -462,7 +564,7 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
@@ -489,16 +591,16 @@ final class OpenSearchArchiverRepositoryIT {
     final var firstBatch = repository.getBatchOperationsNextBatch();
     Awaitility.await("waiting for first batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
-        .until(
-            () ->
-                firstBatch.isDone()
-                    && firstBatch.get().ids().containsAll(List.of("1", "2"))
-                    && firstBatch
-                        .get()
-                        .finishDate()
-                        .equals(dateFormatter.format(now.minus(Duration.ofDays(4)))));
+        .untilAsserted(
+            () -> {
+              assertThat(firstBatch.isDone()).isTrue();
+              assertThat(firstBatch.get().ids()).containsExactly("1", "2");
+              assertThat(firstBatch.get().finishDate())
+                  .isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(4))));
+            });
     repository
-        .moveDocuments(batchOperationIndex, destIndexName, "id", List.of("1", "2"), Runnable::run)
+        .moveDocuments(
+            batchOperationIndex, destIndexName, Map.of("id", List.of("1", "2")), Runnable::run)
         .join();
 
     final var secondBatchDocuments =
@@ -511,18 +613,18 @@ final class OpenSearchArchiverRepositoryIT {
     final var secondBatch = repository.getBatchOperationsNextBatch();
     Awaitility.await("waiting for second batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
-        .until(
-            () ->
-                secondBatch.isDone()
-                    && secondBatch.get().ids().containsAll(List.of("3", "4"))
-                    && secondBatch
-                        .get()
-                        .finishDate()
-                        .equals(dateFormatter.format(now.minus(Duration.ofDays(4)))));
+        .untilAsserted(
+            () -> {
+              assertThat(secondBatch.isDone()).isTrue();
+              assertThat(secondBatch.get().ids()).containsExactly("3", "4");
+              assertThat(secondBatch.get().finishDate())
+                  .isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(4))));
+            });
     // it should still have the same finish date since the rollover window is three days, and the
     // difference of both batches is only 2 days.
     repository
-        .moveDocuments(batchOperationIndex, destIndexName, "id", List.of("3", "4"), Runnable::run)
+        .moveDocuments(
+            batchOperationIndex, destIndexName, Map.of("id", List.of("3", "4")), Runnable::run)
         .join();
 
     // we create another batch of documents, which is two hours ago, since the default archive point
@@ -538,14 +640,13 @@ final class OpenSearchArchiverRepositoryIT {
 
     Awaitility.await("waiting for third batch operation to be complete")
         .atMost(Duration.ofSeconds(30))
-        .until(
-            () ->
-                thirdBatch.isDone()
-                    && thirdBatch.get().ids().containsAll(List.of("5", "6"))
-                    && thirdBatch
-                        .get()
-                        .finishDate()
-                        .equals(dateFormatter.format(now.minus(Duration.ofHours(2)))));
+        .untilAsserted(
+            () -> {
+              assertThat(thirdBatch.isDone()).isTrue();
+              assertThat(thirdBatch.get().ids()).containsExactly("5", "6");
+              assertThat(thirdBatch.get().finishDate())
+                  .isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+            });
   }
 
   @Test
@@ -576,7 +677,7 @@ final class OpenSearchArchiverRepositoryIT {
 
     // then the batch finish date should not update:
     final var batch = repository.getBatchOperationsNextBatch().join();
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(3))));
   }
 
@@ -605,7 +706,7 @@ final class OpenSearchArchiverRepositoryIT {
 
     // then the batch finish date should update since zeebe index should be excluded:
     final var batch = repository.getBatchOperationsNextBatch().join();
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(1))));
   }
 
@@ -642,9 +743,9 @@ final class OpenSearchArchiverRepositoryIT {
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
     if (partitionId == 1) {
-      assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "3");
+      assertThat(batch.ids()).containsExactly("1", "2", "3");
     } else {
-      assertThat(batch.ids()).containsExactlyInAnyOrder("21");
+      assertThat(batch.ids()).containsExactly("21");
     }
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
@@ -682,9 +783,9 @@ final class OpenSearchArchiverRepositoryIT {
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
     if (partitionId == 1) {
-      assertThat(batch.ids()).containsExactlyInAnyOrder("10", "11", "12");
+      assertThat(batch.ids()).containsExactly("10", "11", "12");
     } else {
-      assertThat(batch.ids()).containsExactlyInAnyOrder("21");
+      assertThat(batch.ids()).containsExactly("21");
     }
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
@@ -879,10 +980,12 @@ final class OpenSearchArchiverRepositoryIT {
     final var piEndDate = "2025-05-02T12:00:00.000+0000";
     final var pi =
         new TestProcessInstance(
-            UUID.randomUUID().toString(),
+            String.valueOf(new Random().nextLong()),
             piEndDate,
             ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
-            1);
+            1,
+            null,
+            null);
 
     final var batchOperationEndDate = "2025-01-02T12:00:00.000+0000";
     final var batchOperation =
@@ -905,8 +1008,8 @@ final class OpenSearchArchiverRepositoryIT {
     final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
 
     // then
-    assertThat(piBatch.ids()).isNotEmpty();
-    assertThat(batchOperationBatch.ids()).isNotEmpty();
+    assertThat(piBatch.isEmpty()).isFalse();
+    assertThat(batchOperationBatch.isEmpty()).isFalse();
 
     assertThat(piBatch.finishDate()).isEqualTo("2025-05-02");
     assertThat(batchOperationBatch.finishDate()).isEqualTo("2025-01-02");
@@ -1113,19 +1216,29 @@ final class OpenSearchArchiverRepositoryIT {
   private void createProcessInstanceIndex() throws IOException {
     final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
     final var endDateProp =
-        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+        Property.of(
+            p ->
+                p.date(
+                    d ->
+                        d.index(true)
+                            .format(
+                                "date_time || epoch_millis || strict_date_optional_time || yyyy-MM-dd HH:mm:ss.SSS")));
     final var joinRelationProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var partitionIdProp = Property.of(p -> p.integer(i -> i.index(true)));
+    final var rootPIProp = Property.of(p -> p.long_(l -> l.index(true)));
+    final var parentPIProp = Property.of(p -> p.long_(l -> l.index(true)));
+
     final var properties =
         TypeMapping.of(
             m ->
                 m.properties(
                     Map.of(
-                        ListViewTemplate.ID,
-                        idProp,
-                        ListViewTemplate.END_DATE,
-                        endDateProp,
-                        ListViewTemplate.JOIN_RELATION,
-                        joinRelationProp)));
+                        ListViewTemplate.ID, idProp,
+                        ListViewTemplate.END_DATE, endDateProp,
+                        ListViewTemplate.JOIN_RELATION, joinRelationProp,
+                        ListViewTemplate.PARTITION_ID, partitionIdProp,
+                        ListViewTemplate.ROOT_PROCESS_INSTANCE_KEY, rootPIProp,
+                        ListViewTemplate.PARENT_PROCESS_INSTANCE_KEY, parentPIProp)));
     testClient
         .indices()
         .create(
@@ -1256,7 +1369,13 @@ final class OpenSearchArchiverRepositoryIT {
   private record TestDocument(String id) implements TDocument {}
 
   private record TestProcessInstance(
-      String id, String endDate, String joinRelation, int partitionId) implements TDocument {}
+      String id,
+      String endDate,
+      String joinRelation,
+      int partitionId,
+      Long rootProcessInstanceKey,
+      Long parentProcessInstanceKey)
+      implements TDocument {}
 
   private record TestUsageMetric(String id, String endTime, int partitionId) implements TDocument {}
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -7,17 +7,41 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.json.Json;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.apache.http.HttpHost;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.client.RestClient;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,5 +82,141 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   private RestClientTransport createRestClient() {
     final var restClient = RestClient.builder(HttpHost.create("http://127.0.0.1:1")).build();
     return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  }
+
+  @Test
+  public void shouldConstructCorrectQueryForPIMode() throws IOException {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI);
+    final var client = mock(OpenSearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));
+
+    // when
+    repository.getProcessInstancesNextBatch();
+
+    // then
+    final var captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(client).search(captor.capture(), eq(ProcessInstanceForListViewEntity.class));
+    final var query = captor.getValue().query();
+    assertThat(query.isBool()).isTrue();
+  }
+
+  @Test
+  public void shouldMapBatchForPIMode() throws IOException {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI);
+    final var client = mock(OpenSearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+    final var hit1 = createHit("1", "2024-01-01", null);
+    final var hit2 = createHit("2", "2024-01-01", 100L);
+
+    final var response = createResponse(List.of(hit1, hit2));
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    assertThat(batch.processInstanceKeys()).containsExactly(1L, 2L);
+    assertThat(batch.rootProcessInstanceKeys()).isEmpty();
+  }
+
+  @Test
+  public void shouldMapBatchForPIHierarchyMode() throws IOException {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    final var client = mock(OpenSearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+    final var hit1 = createHit("1", "2024-01-01", null); // Legacy
+    final var hit2 = createHit("2", "2024-01-01", 100L); // Root
+
+    final var response = createResponse(List.of(hit1, hit2));
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then
+    assertThat(batch.processInstanceKeys()).containsExactly(1L);
+    assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  @Test
+  public void shouldMapBatchForPIHierarchyIgnoreLegacyMode() throws IOException {
+    // given
+    final var config = new HistoryConfiguration();
+    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    final var client = mock(OpenSearchAsyncClient.class);
+    final var repository = createRepository(client, config);
+
+    final var hit1 = createHit("1", "2024-01-01", null);
+    final var hit2 = createHit("2", "2024-01-01", 100L);
+
+    final var response = createResponse(List.of(hit1, hit2));
+    when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final var batch = repository.getProcessInstancesNextBatch().join();
+
+    // then - purely based on mapping logic which splits by root key presence
+    assertThat(batch.processInstanceKeys()).containsExactly(1L);
+    assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  private OpenSearchArchiverRepository createRepository(
+      final OpenSearchAsyncClient client, final HistoryConfiguration config) throws IOException {
+    if (Mockito.mockingDetails(client).isMock()) {
+      final var indicesClient = mock(OpenSearchIndicesAsyncClient.class);
+      when(client.indices()).thenReturn(indicesClient);
+      final var getIndexResponse = mock(GetIndexResponse.class);
+      when(indicesClient.get(any(Function.class)))
+          .thenReturn(CompletableFuture.completedFuture(getIndexResponse));
+      when(getIndexResponse.result()).thenReturn(Map.of());
+    }
+
+    config.setRetention(retention);
+    return new OpenSearchArchiverRepository(
+        1,
+        config,
+        new TestExporterResourceProvider("testPrefix", false),
+        client,
+        mock(OpenSearchGenericClient.class),
+        Runnable::run,
+        new CamundaExporterMetrics(new SimpleMeterRegistry()),
+        LOGGER);
+  }
+
+  private Hit<ProcessInstanceForListViewEntity> createHit(
+      final String id, final String endDate, final Long rootPIKey) {
+    final var entity = new ProcessInstanceForListViewEntity();
+    entity.setRootProcessInstanceKey(rootPIKey);
+
+    return Hit.of(
+        h ->
+            h.index("index")
+                .id(id)
+                .source(entity)
+                .fields(
+                    Map.of(
+                        ListViewTemplate.END_DATE,
+                        JsonData.of(Json.createArrayBuilder().add(endDate).build()))));
+  }
+
+  private SearchResponse<ProcessInstanceForListViewEntity> createResponse(
+      final List<Hit<ProcessInstanceForListViewEntity>> hits) {
+    return new SearchResponse.Builder<ProcessInstanceForListViewEntity>()
+        .took(1)
+        .timedOut(false)
+        .shards(s -> s.total(1).successful(1).failed(0))
+        .hits(h -> h.total(t -> t.value(hits.size()).relation(TotalHitsRelation.Eq)).hits(hits))
+        .build();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -10,12 +10,14 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +52,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
   }
 
   @AfterEach
@@ -94,8 +96,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
             new DocumentMove(
                 decisionInstanceTemplate.getFullQualifiedName(),
                 decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
-                DecisionInstanceTemplate.ID,
-                List.of("1", "2", "3"),
+                Map.of(DecisionInstanceTemplate.ID, List.of("1", "2", "3")),
                 executor));
   }
 
@@ -115,14 +116,12 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
             new DocumentMove(
                 auditLogTemplate.getFullQualifiedName(),
                 auditLogTemplate.getFullQualifiedName() + "2024-01-01",
-                auditLogTemplate.getDecisionDependantField(),
-                List.of("1", "2", "3"),
+                Map.of(auditLogTemplate.getDecisionDependantField(), List.of("1", "2", "3")),
                 executor),
             new DocumentMove(
                 decisionInstanceTemplate.getFullQualifiedName(),
                 decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
-                DecisionInstanceTemplate.ID,
-                List.of("1", "2", "3"),
+                Map.of(DecisionInstanceTemplate.ID, List.of("1", "2", "3")),
                 executor));
   }
 
@@ -151,7 +150,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     final var job =
         new StandaloneDecisionArchiverJob(
             repository, decisionInstanceTemplate, metrics, LOGGER, executor, List.of(dependant));
-    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2"));
+    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2"));
 
     // when
     final int count = job.execute().toCompletableFuture().join();
@@ -162,7 +161,8 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     assertArchiverTimer(1);
     assertThat(repository.moves)
         .contains(
-            new DocumentMove("foo_", "foo_" + "2024-01-01", "bar", List.of("1", "2"), executor));
+            new DocumentMove(
+                "foo_", "foo_" + "2024-01-01", Map.of("bar", List.of("1", "2")), executor));
   }
 
   private static final class WeirdlyNamedDependant implements DecisionInstanceDependant {
@@ -173,8 +173,53 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     }
 
     @Override
+    public String getAlias() {
+      return "foo_alias";
+    }
+
+    @Override
+    public String getIndexName() {
+      return "foo";
+    }
+
+    @Override
+    public String getMappingsClasspathFilename() {
+      return "";
+    }
+
+    @Override
+    public String getAllVersionsIndexNameRegexPattern() {
+      return "";
+    }
+
+    @Override
+    public String getIndexNameWithoutVersion() {
+      return "foo_";
+    }
+
+    @Override
+    public String getVersion() {
+      return "";
+    }
+
+    @Override
     public String getDecisionDependantField() {
       return "bar";
+    }
+
+    @Override
+    public String getIndexPattern() {
+      return "";
+    }
+
+    @Override
+    public String getTemplateName() {
+      return "";
+    }
+
+    @Override
+    public List<String> getComposedOf() {
+      return List.of();
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -17,50 +19,48 @@ final class TestRepository extends NoopArchiverRepository {
   final List<DocumentMove> moves = new ArrayList<>();
   ArchiveBatch batch;
 
-  public CompletableFuture<ArchiveBatch> getNextBatch() {
-    return CompletableFuture.completedFuture(batch);
+  public <T extends ArchiveBatch> CompletableFuture<T> getNextBatch() {
+    return CompletableFuture.completedFuture((T) batch);
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
-    return CompletableFuture.completedFuture(batch);
+  public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
+    return CompletableFuture.completedFuture((ProcessInstanceArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getBatchOperationsNextBatch() {
-    return CompletableFuture.completedFuture(batch);
+  public CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch() {
+    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
-    return CompletableFuture.completedFuture(batch);
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch() {
+    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
-    return CompletableFuture.completedFuture(batch);
+  public CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch() {
+    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
-    return CompletableFuture.completedFuture(batch);
+  public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch() {
+    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }
 
   @Override
   public CompletableFuture<Void> moveDocuments(
       final String sourceIndexName,
       final String destinationIndexName,
-      final String idFieldName,
-      final List<String> ids,
+      final Map<String, List<String>> keysByField,
       final Executor executor) {
-    moves.add(new DocumentMove(sourceIndexName, destinationIndexName, idFieldName, ids, executor));
+    moves.add(new DocumentMove(sourceIndexName, destinationIndexName, keysByField, executor));
     return CompletableFuture.completedFuture(null);
   }
 
   record DocumentMove(
       String sourceIndexName,
       String destinationIndexName,
-      String idFieldName,
-      List<String> ids,
+      Map<String, List<String>> keysByField,
       Executor executor) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobTest.java
@@ -10,10 +10,12 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +40,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
   }
 
   @AfterEach
@@ -77,8 +79,7 @@ final class UsageMetricArchiverJobTest extends ArchiverJobRecordingMetricsAbstra
             new DocumentMove(
                 usageMetricTemplate.getFullQualifiedName(),
                 usageMetricTemplate.getFullQualifiedName() + "2024-01-01",
-                UsageMetricTemplate.ID,
-                List.of("1", "2", "3"),
+                Map.of(UsageMetricTemplate.ID, List.of("1", "2", "3")),
                 executor));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobTest.java
@@ -10,10 +10,12 @@ package io.camunda.exporter.tasks.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +39,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
   @BeforeEach
   void setUp() {
     // given
-    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
   }
 
   @AfterEach
@@ -76,8 +78,7 @@ final class UsageMetricTUArchiverJobTest extends ArchiverJobRecordingMetricsAbst
             new DocumentMove(
                 usageMetricTUTemplate.getFullQualifiedName(),
                 usageMetricTUTemplate.getFullQualifiedName() + "2024-01-01",
-                UsageMetricTUTemplate.ID,
-                List.of("1", "2", "3"),
+                Map.of(UsageMetricTUTemplate.ID, List.of("1", "2", "3")),
                 executor));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Made the process instance archiver job based on root process instance keys
- new exporter history configuration to control which retention mode is used (`PI_HIERARCHY`, `PI_HIERARCHY_IGNORE_LEGACY`, `PI`), I need to also reflect this in the unified configuration, it will be done in a separate PR
- Refactoring the ArchiverJob to accept different implementations of the ArchiverBatch to allow creating different predicates, to select the documents to reindex/delete, depending on the archiver implementation

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #41664 
