### PR TITLE
Properly short-circuit batch operation tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
@@ -166,7 +167,10 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
                 .withIntents(IncidentIntent.RESOLVE, IncidentIntent.RESOLVED)
                 .limit(r -> r.getIntent() == IncidentIntent.RESOLVED))
         .isNotEmpty()
-        .allSatisfy(r -> assertThat(r.getBatchOperationReference()).isEqualTo(batchOperationKey));
+        .extracting(Record::getIntent, Record::getBatchOperationReference)
+        .containsExactly(
+            tuple(IncidentIntent.RESOLVE, batchOperationKey),
+            tuple(IncidentIntent.RESOLVED, batchOperationKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation;
 
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -30,9 +31,6 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
 
   @Test
   public void shouldResolveJobIncident() {
-    // given
-    final Map<String, Object> claims = Map.of("claim1", "value1", "claim2", "value2");
-
     // create a process with a failed job
     engine
         .deployment()
@@ -74,8 +72,7 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
             .getKey();
 
     final var batchOperationKey =
-        createNewResolveIncidentsBatchOperation(
-            Map.of(processInstanceKey, Set.of(incidentKey)), claims);
+        createNewResolveIncidentsBatchOperation(Map.of(processInstanceKey, Set.of(incidentKey)));
 
     // then we have completed event
     assertThat(
@@ -109,15 +106,13 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
             .withRecordKey(incidentKey)
             .getFirst();
     assertThat(incidentCommand.getIntent()).isEqualTo(IncidentIntent.RESOLVE);
-    assertThat(incidentCommand.getAuthorizations()).isEqualTo(claims);
+    assertThat(incidentCommand.getAuthorizations())
+        .isEqualTo(Map.of(AUTHORIZED_USERNAME, OTHER_USER.getUsername()));
     assertThat(incidentCommand.getBatchOperationReference()).isEqualTo(batchOperationKey);
   }
 
   @Test
   public void shouldResolveNonJobIncident() {
-    // given
-    final Map<String, Object> claims = Map.of("claim1", "value1", "claim2", "value2");
-
     // create a process with a failed job
     engine
         .deployment()
@@ -144,8 +139,7 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
             .getKey();
 
     final var batchOperationKey =
-        createNewResolveIncidentsBatchOperation(
-            Map.of(processInstanceKey, Set.of(incidentKey)), claims);
+        createNewResolveIncidentsBatchOperation(Map.of(processInstanceKey, Set.of(incidentKey)));
 
     // then we have completed event
     assertThat(
@@ -177,16 +171,12 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
 
   @Test
   public void shouldRejectNonExistingIncident() {
-    // given
-    final Map<String, Object> claims = Map.of("claim1", "value1", "claim2", "value2");
-
     // some random keys
     final var processInstanceKey = 42L;
     final var incidentKey = 43L;
 
     final var batchOperationKey =
-        createNewResolveIncidentsBatchOperation(
-            Map.of(processInstanceKey, Set.of(incidentKey)), claims);
+        createNewResolveIncidentsBatchOperation(Map.of(processInstanceKey, Set.of(incidentKey)));
 
     // then we have completed event
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
@@ -166,7 +166,6 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
         .containsSequence(BatchOperationExecutionIntent.EXECUTE);
 
     // and we have a resolved the incident
-    assertThat(RecordingExporter.jobRecords().withProcessInstanceKey(processInstanceKey)).isEmpty();
     assertThat(
             RecordingExporter.incidentRecords()
                 .withRecordKey(incidentKey)

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -199,4 +199,10 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new HistoryDeletionRecordStream(
         filter(r -> r.getValueType() == ValueType.HISTORY_DELETION).map(Record.class::cast));
   }
+
+  public BatchOperationExecutionRecordStream batchOperationExecutionRecords() {
+    return new BatchOperationExecutionRecordStream(
+        filter(r -> r.getValueType() == ValueType.BATCH_OPERATION_EXECUTION)
+            .map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

A lot of these tests did not short-circuit the `RecordingExporter` properly. As a result we wait for 5 seconds everytime we don't limit. Since we want to enforce short-circuiting we need to get rid of existing cases like these first.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #42319 
