### PR TITLE
Feat/improve rdbms flush

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -29,6 +29,7 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.ibatis.session.SqlSessionFactory;
 
 public class RdbmsWriterFactory {
@@ -44,7 +45,7 @@ public class RdbmsWriterFactory {
   private final PurgeMapper purgeMapper;
   private final UserTaskMapper userTaskMapper;
   private final VariableMapper variableMapper;
-  private final RdbmsWriterMetrics metrics;
+  private final MeterRegistry meterRegistry;
   private final BatchOperationDbReader batchOperationReader;
   private final JobMapper jobMapper;
   private final SequenceFlowMapper sequenceFlowMapper;
@@ -68,7 +69,7 @@ public class RdbmsWriterFactory {
       final PurgeMapper purgeMapper,
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
-      final RdbmsWriterMetrics metrics,
+      final MeterRegistry meterRegistry,
       final BatchOperationDbReader batchOperationReader,
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
@@ -91,7 +92,7 @@ public class RdbmsWriterFactory {
     this.userTaskMapper = userTaskMapper;
     this.variableMapper = variableMapper;
     this.jobMapper = jobMapper;
-    this.metrics = metrics;
+    this.meterRegistry = meterRegistry;
     this.batchOperationReader = batchOperationReader;
     this.sequenceFlowMapper = sequenceFlowMapper;
     this.usageMetricMapper = usageMetricMapper;
@@ -104,6 +105,7 @@ public class RdbmsWriterFactory {
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {
+    final var metrics = new RdbmsWriterMetrics(meterRegistry, config.partitionId());
     final var executionQueue =
         new DefaultExecutionQueue(
             sqlSessionFactory,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
@@ -187,6 +187,19 @@ public class RdbmsWriterMetrics {
     recordExportingLatency.record(Duration.ofMillis(latencyMs));
   }
 
+  /**
+   * Records which trigger caused the queue flush.
+   *
+   * @param trigger the flush trigger type (e.g., "count_limit", "memory_limit", "flush_interval")
+   */
+  public void recordQueueFlush(final FlushTrigger trigger) {
+    Counter.builder(meterName("flush"))
+        .tags("trigger", trigger.name())
+        .description("Count of queue flushes")
+        .register(meterRegistry)
+        .increment();
+  }
+
   private String meterName(final String name) {
     return NAMESPACE + "." + name;
   }
@@ -196,5 +209,12 @@ public class RdbmsWriterMetrics {
       return statementId.substring("io.camunda.db.rdbms.sql.".length());
     }
     return statementId;
+  }
+
+  public enum FlushTrigger {
+    COUNT_LIMIT,
+    MEMORY_LIMIT,
+    FLUSH_INTERVAL,
+    SHUTDOWN
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -301,11 +301,11 @@ public class RdbmsWriters {
    * @param force if true, forces an immediate flush; if false, only flushes if queue limits are
    *     reached
    */
-  public void flush(final boolean force) {
+  public boolean flush(final boolean force) {
     if (force) {
-      executionQueue.flush();
+      return executionQueue.flush() > 0;
     } else {
-      executionQueue.checkQueueForFlush();
+      return executionQueue.checkQueueForFlush();
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write.queue;
 
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
+import io.camunda.db.rdbms.write.RdbmsWriterMetrics.FlushTrigger;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +61,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     this.partitionId = partitionId;
     this.queueFlushLimit = queueFlushLimit;
     // Convert MB to bytes for internal comparison
-    this.queueMemoryLimitBytes = (long) queueMemoryLimitMb * BYTES_PER_MB;
+    queueMemoryLimitBytes = (long) queueMemoryLimitMb * BYTES_PER_MB;
     this.metrics = metrics;
   }
 
@@ -184,6 +185,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
             partitionId,
             queueSize,
             queueFlushLimit);
+        metrics.recordQueueFlush(FlushTrigger.COUNT_LIMIT);
       }
       if (memoryLimitExceeded) {
         LOG.debug(
@@ -191,6 +193,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
             partitionId,
             queueMemory,
             queueMemoryLimitBytes);
+        metrics.recordQueueFlush(FlushTrigger.MEMORY_LIMIT);
       }
       flush();
       return true;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -245,7 +245,7 @@ public class HistoryCleanupService {
   private void saveLastCleanupInterval(final int partitionId, final Duration nextDuration) {
     if (lastCleanupInterval.put(partitionId, nextDuration) == null) {
       metrics.registerCleanupBackoffDurationGauge(
-          partitionId, () -> lastCleanupInterval.get(partitionId).toMillis());
+          () -> lastCleanupInterval.get(partitionId).toMillis());
     }
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -80,7 +80,6 @@ import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
-import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.search.clients.reader.ProcessDefinitionMessageSubscriptionStatisticsReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
@@ -305,11 +304,6 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public RdbmsWriterMetrics rdbmsExporterMetrics(final MeterRegistry meterRegistry) {
-    return new RdbmsWriterMetrics(meterRegistry);
-  }
-
-  @Bean
   public RdbmsTableRowCountMetrics rdbmsTableRowCountMetrics(
       final TableMetricsMapper tableMetricsMapper, final Camunda configuration) {
     final var metricsConfig = configuration.getData().getSecondaryStorage().getRdbms().getMetrics();
@@ -342,7 +336,7 @@ public class RdbmsConfiguration {
       final PurgeMapper purgeMapper,
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
-      final RdbmsWriterMetrics metrics,
+      final MeterRegistry meterRegistry,
       final BatchOperationDbReader batchOperationReader,
       final JobMapper jobMapper,
       final SequenceFlowMapper sequenceFlowMapper,
@@ -365,7 +359,7 @@ public class RdbmsConfiguration {
         purgeMapper,
         userTaskMapper,
         variableMapper,
-        metrics,
+        meterRegistry,
         batchOperationReader,
         jobMapper,
         sequenceFlowMapper,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.rdbms;
 
 import io.camunda.db.rdbms.RdbmsSchemaManager;
+import io.camunda.db.rdbms.write.RdbmsWriterMetrics.FlushTrigger;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
@@ -370,6 +371,7 @@ public final class RdbmsExporter {
       LOG.warn("Unnecessary flush called, since flush interval is zero or max queue size is zero");
       return;
     }
+    rdbmsWriters.getMetrics().recordQueueFlush(FlushTrigger.FLUSH_INTERVAL);
     rdbmsWriters.flush(true);
   }
 


### PR DESCRIPTION
## Description

This PR adds the following:
- add metrics on why the RDBMS queue was flushed (interval, item count, memory limit)
- add the partitionId to all RDBMS metrics
- a flush of the queue based on item count or memory limit will cause the flush interval timer to reset