### PR TITLE
Decouple MCP gateway from REST gateway

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/authentication/CamundaAuthenticationConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/CamundaAuthenticationConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.authentication;
+
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
+import io.camunda.authentication.ConditionalOnUnprotectedApi;
+import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
+import io.camunda.authentication.converter.CamundaAuthenticationDelegatingConverter;
+import io.camunda.authentication.converter.UnprotectedCamundaAuthenticationConverter;
+import io.camunda.authentication.holder.CamundaAuthenticationDelegatingHolder;
+import io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder;
+import io.camunda.authentication.holder.RequestContextBasedAuthenticationHolder;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+
+@Configuration(proxyBeanMethods = false)
+@ComponentScan(basePackages = {"io.camunda.service.validation"})
+@ConditionalOnAnyHttpGatewayEnabled
+public class CamundaAuthenticationConfiguration {
+
+  @Bean
+  @ConditionalOnUnprotectedApi
+  public CamundaAuthenticationConverter<Authentication> unprotectedAuthenticationConverter() {
+    return new UnprotectedCamundaAuthenticationConverter();
+  }
+
+  @Bean
+  public CamundaAuthenticationHolder requestContextBasedAuthenticationHolder(
+      final HttpServletRequest request) {
+    return new RequestContextBasedAuthenticationHolder(request);
+  }
+
+  @Bean
+  public CamundaAuthenticationHolder httpSessionBasedAuthenticationHolder(
+      final HttpServletRequest request, final SecurityConfiguration securityConfiguration) {
+    return new HttpSessionBasedAuthenticationHolder(
+        request, securityConfiguration.getAuthentication());
+  }
+
+  @Bean
+  public CamundaAuthenticationProvider camundaAuthenticationProvider(
+      final List<CamundaAuthenticationHolder> holders,
+      final List<CamundaAuthenticationConverter<Authentication>> converters) {
+    return new DefaultCamundaAuthenticationProvider(
+        new CamundaAuthenticationDelegatingHolder(holders),
+        new CamundaAuthenticationDelegatingConverter(converters));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnAnyHttpGatewayEnabled.java
+++ b/dist/src/main/java/io/camunda/application/commons/condition/ConditionalOnAnyHttpGatewayEnabled.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.condition;
+
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled.AnyHttpGatewayEnabledCondition;
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.context.annotation.Conditional;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(AnyHttpGatewayEnabledCondition.class)
+public @interface ConditionalOnAnyHttpGatewayEnabled {
+
+  class AnyHttpGatewayEnabledCondition extends AnyNestedCondition {
+
+    public AnyHttpGatewayEnabledCondition() {
+      super(ConfigurationPhase.PARSE_CONFIGURATION);
+    }
+
+    @ConditionalOnRestGatewayEnabled
+    static class RestGatewayEnabled {}
+
+    @ConditionalOnMcpGatewayEnabled
+    static class McpGatewayEnabled {}
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.configuration;
 import io.atomix.cluster.ClusterConfig;
 import io.camunda.application.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
 import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -18,7 +19,6 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.gateway.RestApiCompositeFilter;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
 import jakarta.servlet.Filter;
 import java.time.Duration;
@@ -79,7 +79,7 @@ public class BrokerBasedConfiguration {
     return new SchedulerConfiguration(cpuThreads, ioThreads, metricsEnabled, "Broker", nodeId);
   }
 
-  @ConditionalOnRestGatewayEnabled
+  @ConditionalOnAnyHttpGatewayEnabled
   @Bean
   public CompositeFilter restApiCompositeFilter() {
     final List<FilterCfg> filterCfgs = properties.getGateway().getFilters();

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -15,6 +15,7 @@ import io.atomix.cluster.protocol.SwimMembershipProtocolConfig;
 import io.atomix.utils.net.Address;
 import io.camunda.application.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
 import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.zeebe.gateway.RestApiCompositeFilter;
@@ -22,7 +23,6 @@ import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.MembershipCfg;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
 import jakarta.servlet.Filter;
 import java.time.Duration;
@@ -59,7 +59,7 @@ public final class GatewayBasedConfiguration {
     return lifecycleProperties.getTimeoutPerShutdownPhase();
   }
 
-  @ConditionalOnRestGatewayEnabled
+  @ConditionalOnAnyHttpGatewayEnabled
   @Bean
   public CompositeFilter restApiCompositeFilter() {
     final List<FilterCfg> filterCfgs = properties.getFilters();

--- a/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.application.commons.identity;
 
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
@@ -21,7 +21,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 @ComponentScan(basePackages = {"io.camunda.authentication"})
 @ConfigurationPropertiesScan(basePackages = {"io.camunda.authentication"})
 @Profile("consolidated-auth")
-@ConditionalOnRestGatewayEnabled
+@ConditionalOnAnyHttpGatewayEnabled
 public class AuthenticationConfiguration {
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/job/JobHandlerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/job/JobHandlerConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.job;
 
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.protocol.model.JobActivationResult;
@@ -17,7 +18,6 @@ import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
 import io.camunda.zeebe.gateway.rest.controller.ResponseObserverProvider;
 import io.camunda.zeebe.scheduler.Actor;
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.unit.DataSize;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnRestGatewayEnabled
+@ConditionalOnAnyHttpGatewayEnabled
 public class JobHandlerConfiguration {
 
   private final ActivateJobHandlerConfiguration config;

--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -7,55 +7,11 @@
  */
 package io.camunda.application.commons.rest;
 
-import io.camunda.authentication.ConditionalOnUnprotectedApi;
-import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
-import io.camunda.authentication.converter.CamundaAuthenticationDelegatingConverter;
-import io.camunda.authentication.converter.UnprotectedCamundaAuthenticationConverter;
-import io.camunda.authentication.holder.CamundaAuthenticationDelegatingHolder;
-import io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder;
-import io.camunda.authentication.holder.RequestContextBasedAuthenticationHolder;
-import io.camunda.security.auth.CamundaAuthenticationConverter;
-import io.camunda.security.auth.CamundaAuthenticationHolder;
-import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.core.Authentication;
 
 @Configuration(proxyBeanMethods = false)
-@ComponentScan(basePackages = {"io.camunda.zeebe.gateway.rest", "io.camunda.service.validation"})
+@ComponentScan(basePackages = {"io.camunda.zeebe.gateway.rest"})
 @ConditionalOnRestGatewayEnabled
-public class RestApiConfiguration {
-
-  @Bean
-  @ConditionalOnUnprotectedApi
-  public CamundaAuthenticationConverter<Authentication> unprotectedAuthenticationConverter() {
-    return new UnprotectedCamundaAuthenticationConverter();
-  }
-
-  @Bean
-  public CamundaAuthenticationHolder requestContextBasedAuthenticationHolder(
-      final HttpServletRequest request) {
-    return new RequestContextBasedAuthenticationHolder(request);
-  }
-
-  @Bean
-  public CamundaAuthenticationHolder httpSessionBasedAuthenticationHolder(
-      final HttpServletRequest request, final SecurityConfiguration securityConfiguration) {
-    return new HttpSessionBasedAuthenticationHolder(
-        request, securityConfiguration.getAuthentication());
-  }
-
-  @Bean
-  public CamundaAuthenticationProvider camundaAuthenticationProvider(
-      final List<CamundaAuthenticationHolder> holders,
-      final List<CamundaAuthenticationConverter<Authentication>> converters) {
-    return new DefaultCamundaAuthenticationProvider(
-        new CamundaAuthenticationDelegatingHolder(holders),
-        new CamundaAuthenticationDelegatingConverter(converters));
-  }
-}
+public class RestApiConfiguration {}

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.service;
 
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.document.store.EnvironmentConfigurationLoader;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.gateway.protocol.model.JobActivationResult;
@@ -73,7 +74,6 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.context.annotation.Bean;
@@ -81,7 +81,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnRestGatewayEnabled
+@ConditionalOnAnyHttpGatewayEnabled
 public class CamundaServicesConfiguration {
 
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/condition/ConditionalOnAnyHttpGatewayEnabledTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/condition/ConditionalOnAnyHttpGatewayEnabledTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabledTest.ConditionalOnAnyHttpGatewayEnabledTestConfiguration.FooService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+public class ConditionalOnAnyHttpGatewayEnabledTest {
+
+  private WebApplicationContextRunner contextRunner() {
+    return new WebApplicationContextRunner()
+        .withUserConfiguration(ConditionalOnAnyHttpGatewayEnabledTestConfiguration.class);
+  }
+
+  @Test
+  void enabledWhenRestGatewayImplicitelyEnabled() {
+    contextRunner().run(context -> assertThat(context).hasSingleBean(FooService.class));
+  }
+
+  @Test
+  void enabledWhenRestGatewayExplicitelyEnabled() {
+    contextRunner()
+        .withPropertyValues("camunda.rest.enabled=true")
+        .run(context -> assertThat(context).hasSingleBean(FooService.class));
+  }
+
+  @Test
+  void enabledWhenMcpGatewayEnabled() {
+    contextRunner()
+        .withPropertyValues("camunda.rest.enabled=false", "camunda.mcp.enabled=true")
+        .run(context -> assertThat(context).hasSingleBean(FooService.class));
+  }
+
+  @Test
+  void enabledWhenBothGatewaysEnabled() {
+    contextRunner()
+        .withPropertyValues("camunda.rest.enabled=true", "camunda.mcp.enabled=true")
+        .run(context -> assertThat(context).hasSingleBean(FooService.class));
+  }
+
+  @Test
+  void disabledWhenBothGatewaysDisabled() {
+    contextRunner()
+        .withPropertyValues("camunda.rest.enabled=false", "camunda.mcp.enabled=false")
+        .run(context -> assertThat(context).doesNotHaveBean(FooService.class));
+  }
+
+  @Test
+  void disabledWhenZeebeBrokerGatewayDisabled() {
+    contextRunner()
+        .withPropertyValues(
+            "camunda.rest.enabled=true",
+            "camunda.mcp.enabled=true",
+            "zeebe.broker.gateway.enable=false")
+        .run(context -> assertThat(context).doesNotHaveBean(FooService.class));
+  }
+
+  @TestConfiguration
+  @ConditionalOnAnyHttpGatewayEnabled
+  static class ConditionalOnAnyHttpGatewayEnabledTestConfiguration {
+
+    @Bean
+    public FooService fooService() {
+      return new FooService("test");
+    }
+
+    record FooService(String name) {}
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -10,52 +10,74 @@ package io.camunda.application.commons.mcp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.camunda.application.commons.service.CamundaServicesConfiguration;
 import io.camunda.application.initializers.McpGatewayInitializer;
 import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.service.IncidentServices;
-import io.camunda.service.JobServices;
-import io.camunda.service.TopologyServices;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 
 class McpGatewayConfigurationTest {
 
   private static final Class<ClusterTools> TEST_TOOL_BEAN_CLASS = ClusterTools.class;
 
-  private WebApplicationContextRunner baseRunner() {
-    return new WebApplicationContextRunner()
-        .withInitializer(new McpGatewayInitializer())
-        .withUserConfiguration(McpGatewayConfiguration.class);
+  private WebApplicationContextRunner contextRunner() {
+    WebApplicationContextRunner runner =
+        new WebApplicationContextRunner()
+            .withInitializer(new McpGatewayInitializer())
+            .withUserConfiguration(McpGatewayConfiguration.class);
+
+    final List<Class<?>> mockBeans = new ArrayList<>();
+    mockBeans.add(CamundaAuthenticationProvider.class);
+    mockBeans.add(BrokerClient.class);
+
+    // create mocks for all declared services in CamundaServicesConfiguration
+    Arrays.stream(CamundaServicesConfiguration.class.getDeclaredMethods())
+        .filter(method -> AnnotatedElementUtils.hasAnnotation(method, Bean.class))
+        .map(Method::getReturnType)
+        .forEach(mockBeans::add);
+
+    for (final Class<?> mockedBean : mockBeans) {
+      runner = addMockedBean(runner, mockedBean);
+    }
+
+    return runner;
+  }
+
+  private <T> WebApplicationContextRunner addMockedBean(
+      final WebApplicationContextRunner runner, final Class<T> type) {
+    return runner.withBean(type, () -> mock(type));
   }
 
   @Test
   public void doesNotIncludeMcpToolComponentsByDefault() {
-    baseRunner().run(context -> assertThat(context).doesNotHaveBean(TEST_TOOL_BEAN_CLASS));
+    contextRunner().run(context -> assertThat(context).doesNotHaveBean(TEST_TOOL_BEAN_CLASS));
   }
 
   @Test
   public void includesMcpToolComponentsWhenEnabled() {
-    baseRunner()
-        .withBean(TopologyServices.class, () -> mock(TopologyServices.class))
-        .withBean(IncidentServices.class, () -> mock(IncidentServices.class))
-        .withBean(JobServices.class, () -> mock(JobServices.class))
-        .withBean(
-            CamundaAuthenticationProvider.class, () -> mock(CamundaAuthenticationProvider.class))
+    contextRunner()
         .withPropertyValues("camunda.mcp.enabled=true")
         .run(context -> assertThat(context).hasSingleBean(TEST_TOOL_BEAN_CLASS));
   }
 
   @Test
   public void doesNotIncludeMcpToolComponentsWhenDisabled() {
-    baseRunner()
+    contextRunner()
         .withPropertyValues("camunda.mcp.enabled=false")
         .run(context -> assertThat(context).doesNotHaveBean(TEST_TOOL_BEAN_CLASS));
   }
 
   @Test
   public void doesNotIncludeMcpToolComponentsWhenBrokerGatewayIsDisabled() {
-    baseRunner()
+    contextRunner()
         .withPropertyValues("zeebe.broker.gateway.enable=false", "camunda.mcp.enabled=true")
         .run(context -> assertThat(context).doesNotHaveBean(TEST_TOOL_BEAN_CLASS));
   }


### PR DESCRIPTION
## Description

Configure services needed in both REST and MCP gateways to be produced when at least one of the gateways is 
enabled.

Introduces a new `@ConditionalOnAnyHttpGatewayEnabled` condition which is enabled when either the HTTP or the MCP gateway are enabled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43604 
