### PR TITLE
Fix/call preflush listeners first

### DIFF
--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -200,6 +200,42 @@ class DefaultExecutionQueueTest {
   }
 
   @Test
+  public void whenPreFlushListenerAddsQueueItemTheItemIsAlsoFlushed() {
+    final var item1 =
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            1L,
+            "statement1",
+            "parameter1");
+    final var preFlushItem =
+        new QueueItem(
+            ContextType.EXPORTER_POSITION,
+            WriteStatementType.UPDATE,
+            1L,
+            "statement2",
+            "parameter2");
+    executionQueue.executeInQueue(item1);
+
+    final var preFlushListener = mock(PreFlushListener.class);
+    Mockito.doAnswer(
+            invocation -> {
+              executionQueue.executeInQueue(preFlushItem);
+              return null;
+            })
+        .when(preFlushListener)
+        .onPreFlush();
+
+    executionQueue.registerPreFlushListener(preFlushListener);
+
+    // when
+    executionQueue.flush();
+
+    // then
+    verify(session).update(preFlushItem.statementId(), preFlushItem.parameter());
+  }
+
+  @Test
   public void whenFlushIsExceptionalSessionIsRolledBack() {
     final var item1 =
         new QueueItem(


### PR DESCRIPTION
## Description

This PR fixes a problem which occurred during partition rebalancing. The RDBMS position was always wrong because the correct position was always written into the DB on the next flush instead of the current flush. This was caused by the order of execution in the ExecutionQueue:
1. copy and optimise all queue items into a new, optimised list
2. execute all preFlushListeners. Here a preFlushListener adds a new queueItem to update the exporter position in RDBMS
3. process the optimised list (without the current exporter update)

This fix changes the order to first execute the preFlushListeners and then copy and optimise the queueItems 

closes #42831
