### PR TITLE
fix: remove MessageCorrelationKey type

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5701,14 +5701,6 @@ components:
       type: string
       allOf:
         - $ref: "#/components/schemas/LongKey"
-    MessageCorrelationKey:
-      description: System-generated key for a message correlation.
-      format: MessageCorrelationKey
-      x-semantic-type: MessageCorrelationKey
-      example: "2251799813634265"
-      type: string
-      allOf:
-        - $ref: "#/components/schemas/LongKey"
     DecisionDefinitionKey:
       description: System-generated key for a decision definition.
       format: DecisionDefinitionKey
@@ -8052,8 +8044,7 @@ components:
           description: The name of the message associated with the message subscription.
           type: string
         correlationKey:
-          allOf:
-            - $ref: "#/components/schemas/MessageCorrelationKey"
+          type: string
           description: The correlation key of the message subscription.
         tenantId:
           $ref: "#/components/schemas/TenantId"
@@ -11068,7 +11059,7 @@ components:
             - $ref: "#/components/schemas/TenantId"
         messageKey:
           allOf:
-            - $ref: "#/components/schemas/MessageCorrelationKey"
+            - $ref: "#/components/schemas/MessageKey"
           description: The key of the correlated message
         processInstanceKey:
           description: The key of the first process instance the message correlated with


### PR DESCRIPTION
## Description

This PR addresses #43907 for the 8.8 specification. 

- `MessageSubscriptionResult.correlationKey` is changed to type `string`.
- `MessageCorrelationResult.messageKey` is changed to type `MessageKey`.
- `MessageCorrelationKey` type is removed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
