### PR TITLE
fix: remove MessageCorrelationKey type

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -275,8 +275,7 @@ components:
           description: The name of the message associated with the message subscription.
           type: string
         correlationKey:
-          allOf:
-            - $ref: '#/components/schemas/MessageCorrelationKey'
+          type: string
           description: The correlation key of the message subscription.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
@@ -625,15 +624,6 @@ components:
       format: MessageSubscriptionKey
       x-semantic-type: MessageSubscriptionKey
       example: "2251799813632456"
-      type: string
-      allOf:
-        - $ref: 'keys.yaml#/components/schemas/LongKey'
-
-    MessageCorrelationKey:
-      description: System-generated key for a message correlation.
-      format: MessageCorrelationKey
-      x-semantic-type: MessageCorrelationKey
-      example: "2251799813634265"
       type: string
       allOf:
         - $ref: 'keys.yaml#/components/schemas/LongKey'


### PR DESCRIPTION
## Description

This PR addresses https://github.com/camunda/camunda/issues/43907 for the 8.9 specification.

- `MessageSubscriptionResult.correlationKey` is changed to type `string`.
- `MessageCorrelationKey` type is removed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
(https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43907
