### PR TITLE
Fix flaky ProcessCacheTest by using key-based stubbing

### DIFF
--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
@@ -136,7 +136,7 @@ class ProcessCacheTest {
 
               // This test calls getCacheItem(k) which builds a query containing exactly that key.
               final List<Long> keys = query.filter().processDefinitionKeys();
-              if (keys == null || keys.isEmpty()) {
+              if (keys.isEmpty()) {
                 return SearchQueryResult.of();
               }
               final long key = keys.getFirst();

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
@@ -141,16 +141,16 @@ class ProcessCacheTest {
               }
               final long key = keys.getFirst();
 
-              return switch ((int) key) {
-                case 1 ->
+              return switch (key) {
+                case 1L ->
                     SearchQueryResult.of(
                         new ProcessDefinitionEntity(
                             1L, "n1", "d1", null, null, 1, null, "t", null));
-                case 2 ->
+                case 2L ->
                     SearchQueryResult.of(
                         new ProcessDefinitionEntity(
                             2L, "n2", "d2", null, null, 1, null, "t", null));
-                case 3 ->
+                case 3L ->
                     SearchQueryResult.of(
                         new ProcessDefinitionEntity(
                             3L, "n3", "d3", null, null, 1, null, "t", null));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
@@ -139,18 +139,18 @@ class ProcessCacheTest {
               if (keys.isEmpty()) {
                 return SearchQueryResult.of();
               }
-              final long key = keys.getFirst();
+              final int key = Math.toIntExact(keys.getFirst());
 
               return switch (key) {
-                case 1L ->
+                case 1 ->
                     SearchQueryResult.of(
                         new ProcessDefinitionEntity(
                             1L, "n1", "d1", null, null, 1, null, "t", null));
-                case 2L ->
+                case 2 ->
                     SearchQueryResult.of(
                         new ProcessDefinitionEntity(
                             2L, "n2", "d2", null, null, 1, null, "t", null));
-                case 3L ->
+                case 3 ->
                     SearchQueryResult.of(
                         new ProcessDefinitionEntity(
                             3L, "n3", "d3", null, null, 1, null, "t", null));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/cache/ProcessCacheTest.java
@@ -136,6 +136,9 @@ class ProcessCacheTest {
 
               // This test calls getCacheItem(k) which builds a query containing exactly that key.
               final List<Long> keys = query.filter().processDefinitionKeys();
+              if (keys == null || keys.isEmpty()) {
+                return SearchQueryResult.of();
+              }
               final long key = keys.getFirst();
 
               return switch ((int) key) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR stabilizes `search/search-client-query-transformer`’s `ProcessCacheTest.shouldRepopulateAndRemoveLeastRecentlyUsed` by removing invocation-order dependent mocking and returning search results based on the requested processDefinitionKey. This makes the LRU eviction assertion deterministic and prevents intermittent empty cache states observed in [CI](https://github.com/camunda/camunda/actions/runs/20933517425/attempts/2).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
