### PR TITLE
Increase rocksDB overhead factor.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class RocksDbSharedCache {
   public static final long MINIMUM_PARTITION_MEMORY_LIMIT = 32 * 1024 * 1024L;
-  private static final double ROCKSDB_OVERHEAD_FACTOR = 0.15;
+  private static final double ROCKSDB_OVERHEAD_FACTOR = 0.50;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -140,7 +140,7 @@ class RocksDbSharedCacheTest {
     // - max heap is 128mb
     // - max non-heap is 128mb
     // so available memory is 512 - 128 - 128 = 256mb with a
-    // ROCKSDB_OVERHEAD_FACTOR of 0.15 we can allocate 217.6mb to rocksdb
+    // ROCKSDB_OVERHEAD_FACTOR of 0.5 we can allocate 128mb to rocksdb
     try (final var managementFactoryMock =
         mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
       assertThatCode(
@@ -152,7 +152,7 @@ class RocksDbSharedCacheTest {
     }
 
     final int morePartitionsCount = 7;
-    // should not be valid with 7 partitions since 217.6 / 7 = 31.08mb < 32mb
+    // should not be valid with 7 partitions since 128 / 7 = 19mb < 32mb
     try (final var managementFactoryMock =
         mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
       final var throwable =
@@ -166,7 +166,7 @@ class RocksDbSharedCacheTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
               "Expected the allocated memory for RocksDB per partition to be at least %s bytes, but was %s bytes.",
-              MINIMUM_PARTITION_MEMORY_LIMIT, 32_595_733); // 217.6mb / 7 partitions
+              MINIMUM_PARTITION_MEMORY_LIMIT, 19_173_961); // 128mb / 7 partitions
     }
   }
 
@@ -179,7 +179,7 @@ class RocksDbSharedCacheTest {
       // 25% of 512MB = 128MB fallback for non-heap
       final long expectedNonHeap = 128L * 1024 * 1024;
       final long expectedAvailable =
-          (long) (((512L * 1024 * 1024) - (128L * 1024 * 1024) - expectedNonHeap) * (1.0 - 0.15));
+          (long) (((512L * 1024 * 1024) - (128L * 1024 * 1024) - expectedNonHeap) * (1.0 - 0.5));
       // Assert
       assertThat(available).isEqualTo(expectedAvailable);
     }


### PR DESCRIPTION
## Description

Related with the OOMs that were found in the weekly typical benchmarks caused by the AUTO memory allocation strategy, this PR increases the `ROCKSDB_OVERHEAD_FACTOR` to 50%.

The issue was caused because we were not taking into account all memory components used by the applitcation leading us to allocate way to much memory for RocksDB which lead to OOM issues.

This PR is intended as a quick fix since that the correct solution should be to account for all memory components used for this calculation (or at least the vast majority with some buffer).

For now will not backport this PR to 8.8 as the default strategy there is `PARTITION`, if we endup making permanent changes to this value then this will be backported.
 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
