### PR TITLE
feat: expose fetch error flag for useProcessInstanceElementSelection

### DIFF
--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.test.tsx
@@ -301,6 +301,7 @@ describe('useProcessInstanceElementSelection', () => {
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
 
       expect(result.current.resolvedElementInstance).toBeNull();
+      expect(result.current.isFetchingElementError).toBe(true);
     });
   });
 
@@ -424,6 +425,7 @@ describe('useProcessInstanceElementSelection', () => {
       await waitFor(() => expect(result.current.isFetchingElement).toBe(false));
 
       expect(result.current.resolvedElementInstance).toBeNull();
+      expect(result.current.isFetchingElementError).toBe(true);
     });
 
     it('should prefer elementInstanceKey over elementId search', async () => {

--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -144,18 +144,22 @@ const useProcessInstanceElementSelection = () => {
   const {
     data: elementInstanceByKey,
     isFetching: isFetchingElementInstanceByKey,
+    isError: isFetchingElementInstanceError,
   } = useElementInstance(elementInstanceKey ?? '', {
     enabled: !!elementInstanceKey && isPlaceholder === false,
   });
 
   // If only elementId is in URL, search for all instances
-  const {data: searchResult, isFetching: isFetchingElementInstancesSearch} =
-    useElementInstancesSearch({
-      elementId: elementId ?? '',
-      processInstanceKey: processInstanceKey ?? '',
-      elementType: isMultiInstanceBody ? 'MULTI_INSTANCE_BODY' : undefined,
-      enabled: !!elementId && !elementInstanceKey && !!processInstanceKey,
-    });
+  const {
+    data: searchResult,
+    isFetching: isFetchingElementInstancesSearch,
+    isError: isFetchingElementInstancesSearchError,
+  } = useElementInstancesSearch({
+    elementId: elementId ?? '',
+    processInstanceKey: processInstanceKey ?? '',
+    elementType: isMultiInstanceBody ? 'MULTI_INSTANCE_BODY' : undefined,
+    enabled: !!elementId && !elementInstanceKey && !!processInstanceKey,
+  });
 
   const resolvedElementInstance =
     elementInstanceByKey ??
@@ -202,6 +206,8 @@ const useProcessInstanceElementSelection = () => {
     selectedAnchorElementId: anchorElementId,
     isFetchingElement:
       isFetchingElementInstanceByKey || isFetchingElementInstancesSearch,
+    isFetchingElementError:
+      isFetchingElementInstanceError || isFetchingElementInstancesSearchError,
     isSelected,
   };
 };

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -19,6 +19,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
 import {TOKEN_OPERATIONS} from 'modules/constants';
 import {useElementSelectionInstanceKey} from './useElementSelectionInstanceKey';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 const useHasNoContent = () => {
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
@@ -76,8 +77,12 @@ const useDisplayStatus = ({
   const hasNoContent = useHasNoContent();
   const hasMultipleInstances = useHasMultipleInstances();
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
+  const isFetchingElementError = IS_ELEMENT_SELECTION_V2
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useProcessInstanceElementSelection().isFetchingElementError
+    : flowNodeMetaDataStore.state.status === 'error';
 
-  if (isError || flowNodeMetaDataStore.state.status === 'error') {
+  if (isError || isFetchingElementError) {
     return 'error';
   }
 


### PR DESCRIPTION
## Description

This PR migrates one usage of the `flowNodeMetadata` store that we seem to have missed previously. To achieve this, a new `isFetchingElementError` flag (open for better name suggestions) is exposed from the `useProcessInstanceElementSelection` hook.

## Related issues

relates #41832
