### PR TITLE
fix: Extend conditional evaluation API response

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/EvaluateConditionalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/EvaluateConditionalCommandStep1.java
@@ -22,7 +22,7 @@ public interface EvaluateConditionalCommandStep1
     extends CommandWithCommunicationApiStep<EvaluateConditionalCommandStep1>,
         CommandWithVariables<EvaluateConditionalCommandStep2> {
 
-  public interface EvaluateConditionalCommandStep2
+  interface EvaluateConditionalCommandStep2
       extends CommandWithTenantStep<EvaluateConditionalCommandStep2>,
           FinalCommandStep<EvaluateConditionalResponse> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluateConditionalResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluateConditionalResponse.java
@@ -20,6 +20,16 @@ import java.util.List;
 public interface EvaluateConditionalResponse {
 
   /**
+   * @return the unique key of the evaluated conditional.
+   */
+  long getConditionalEvaluationKey();
+
+  /**
+   * @return the tenant ID of the evaluated conditional.
+   */
+  String getTenantId();
+
+  /**
    * @return list of process instances created. If no root-level conditional start events evaluated
    *     to true, the list will be empty.
    */

--- a/clients/java/src/main/java/io/camunda/client/api/response/EvaluateConditionalResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/EvaluateConditionalResponse.java
@@ -20,12 +20,12 @@ import java.util.List;
 public interface EvaluateConditionalResponse {
 
   /**
-   * @return the unique key of the evaluated conditional.
+   * @return the unique key of the conditional evaluation operation.
    */
   long getConditionalEvaluationKey();
 
   /**
-   * @return the tenant ID of the evaluated conditional.
+   * @return the tenant ID of the conditional evaluation operation.
    */
   String getTenantId();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateConditionalResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateConditionalResponseImpl.java
@@ -24,10 +24,14 @@ import java.util.stream.Collectors;
 
 public final class EvaluateConditionalResponseImpl implements EvaluateConditionalResponse {
 
+  private final long conditionalEvaluationKey;
+  private final String tenantId;
   private final List<ProcessInstanceReference> processInstances;
 
   public EvaluateConditionalResponseImpl(
       final GatewayOuterClass.EvaluateConditionalResponse grpcResponse) {
+    conditionalEvaluationKey = grpcResponse.getConditionalEvaluationKey();
+    tenantId = grpcResponse.getTenantId();
     processInstances =
         grpcResponse.getProcessInstancesList().stream()
             .map(ProcessInstanceReferenceImpl::new)
@@ -35,11 +39,23 @@ public final class EvaluateConditionalResponseImpl implements EvaluateConditiona
   }
 
   public EvaluateConditionalResponseImpl(final EvaluateConditionalResult restResponse) {
+    conditionalEvaluationKey = Long.parseLong(restResponse.getConditionalEvaluationKey());
+    tenantId = restResponse.getTenantId();
     final List<io.camunda.client.protocol.rest.ProcessInstanceReference> restInstances =
         restResponse.getProcessInstances();
 
     processInstances =
         restInstances.stream().map(ProcessInstanceReferenceImpl::new).collect(Collectors.toList());
+  }
+
+  @Override
+  public long getConditionalEvaluationKey() {
+    return conditionalEvaluationKey;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -546,10 +546,24 @@ public final class RecordingGatewayService extends GatewayImplBase {
 
   public void onEvaluateConditionalRequest(
       final long processDefinitionKey, final long processInstanceKey) {
+    onEvaluateConditionalRequest(
+        12345L,
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER,
+        processDefinitionKey,
+        processInstanceKey);
+  }
+
+  public void onEvaluateConditionalRequest(
+      final long conditionalEvaluationKey,
+      final String tenantId,
+      final long processDefinitionKey,
+      final long processInstanceKey) {
     addRequestHandler(
         EvaluateConditionalRequest.class,
         request ->
             EvaluateConditionalResponse.newBuilder()
+                .setConditionalEvaluationKey(conditionalEvaluationKey)
+                .setTenantId(tenantId)
                 .addProcessInstances(
                     ProcessInstanceReference.newBuilder()
                         .setProcessDefinitionKey(processDefinitionKey)
@@ -561,7 +575,11 @@ public final class RecordingGatewayService extends GatewayImplBase {
   public void onEvaluateConditionalRequest() {
     addRequestHandler(
         EvaluateConditionalRequest.class,
-        request -> EvaluateConditionalResponse.newBuilder().build());
+        request ->
+            EvaluateConditionalResponse.newBuilder()
+                .setConditionalEvaluationKey(12345L)
+                .setTenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER)
+                .build());
   }
 
   public void onCreateProcessInstanceWithResultRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -532,9 +532,10 @@ public final class ResponseMapper {
   }
 
   public static EvaluateConditionalResult toConditionalEvaluationResponse(
-      final ConditionalEvaluationRecord brokerResponse) {
+      final BrokerResponse<ConditionalEvaluationRecord> brokerResponse) {
+    final var response = brokerResponse.getResponse();
     final var processInstances =
-        brokerResponse.getStartedProcessInstances().stream()
+        response.getStartedProcessInstances().stream()
             .map(
                 instance ->
                     new ProcessInstanceReference()
@@ -543,7 +544,10 @@ public final class ResponseMapper {
                         .processInstanceKey(KeyUtil.keyToString(instance.getProcessInstanceKey())))
             .toList();
 
-    return new EvaluateConditionalResult().processInstances(processInstances);
+    return new EvaluateConditionalResult()
+        .conditionalEvaluationKey(KeyUtil.keyToString(brokerResponse.getKey()))
+        .tenantId(response.getTenantId())
+        .processInstances(processInstances);
   }
 
   public static AuthorizationCreateResult toAuthorizationCreateResponse(

--- a/service/src/main/java/io/camunda/service/ConditionalServices.java
+++ b/service/src/main/java/io/camunda/service/ConditionalServices.java
@@ -11,6 +11,7 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerEvaluateConditionalRequest;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalEvaluationRecord;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class ConditionalServices extends ApiServices<ConditionalServices> {
         brokerRequestAuthorizationConverter);
   }
 
-  public CompletableFuture<ConditionalEvaluationRecord> evaluateConditional(
+  public CompletableFuture<BrokerResponse<ConditionalEvaluationRecord>> evaluateConditional(
       final EvaluateConditionalRequest request) {
     final var brokerRequest =
         new BrokerEvaluateConditionalRequest()
@@ -50,7 +51,7 @@ public class ConditionalServices extends ApiServices<ConditionalServices> {
             .setTenantId(request.tenantId())
             .setVariables(getDocumentOrEmpty(request.variables()));
 
-    return sendBrokerRequest(brokerRequest);
+    return sendBrokerRequestWithFullResponse(brokerRequest);
   }
 
   public record EvaluateConditionalRequest(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -511,7 +511,9 @@ public final class ResponseMapper {
   public static EvaluateConditionalResponse toEvaluateConditionalResponse(
       final long key, final ConditionalEvaluationRecord brokerResponse) {
     final EvaluateConditionalResponse.Builder responseBuilder =
-        EvaluateConditionalResponse.newBuilder();
+        EvaluateConditionalResponse.newBuilder()
+            .setConditionalEvaluationKey(key)
+            .setTenantId(brokerResponse.getTenantId());
 
     brokerResponse.getStartedProcessInstances().stream()
         .map(

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -893,6 +893,10 @@ message ProcessInstanceReference {
 message EvaluateConditionalResponse {
   // List of process instances created. If no root-level conditional start events evaluated to true, the list will be empty.
   repeated ProcessInstanceReference processInstances = 1;
+  // The unique key of the evaluated conditional.
+  int64 conditionalEvaluationKey = 2;
+  // The tenant ID of the evaluated conditional.
+  string tenantId = 3;
 }
 
 service Gateway {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -893,9 +893,9 @@ message ProcessInstanceReference {
 message EvaluateConditionalResponse {
   // List of process instances created. If no root-level conditional start events evaluated to true, the list will be empty.
   repeated ProcessInstanceReference processInstances = 1;
-  // The unique key of the evaluated conditional.
+  // The unique key of the conditional evaluation operation.
   int64 conditionalEvaluationKey = 2;
-  // The tenant ID of the evaluated conditional.
+  // The tenant ID of the conditional evaluation operation.
   string tenantId = 3;
 }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -96,12 +96,33 @@ components:
       type: object
       required:
         - processInstances
+        - conditionalEvaluationKey
+        - tenantId
+      x-semantic-provider:
+        - conditionalEvaluationKey
       properties:
+        conditionalEvaluationKey:
+          allOf:
+            - $ref: '#/components/schemas/ConditionalEvaluationKey'
+          description: The unique key of the evaluated conditional.
+        tenantId:
+          description: The tenant ID of the evaluated conditional.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/TenantId'
         processInstances:
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceReference'
           description: List of process instances created. If no root-level conditional start events evaluated to true, the list will be empty.
+
+    ConditionalEvaluationKey:
+      allOf:
+        - $ref: 'keys.yaml#/components/schemas/LongKey'
+      description: System-generated key for a conditional evaluation.
+      format: ConditionalEvaluationKey
+      x-semantic-type: ConditionalEvaluationKey
+      example: "2251799813687654"
+      type: string
 
     ProcessInstanceReference:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -104,9 +104,9 @@ components:
         conditionalEvaluationKey:
           allOf:
             - $ref: '#/components/schemas/ConditionalEvaluationKey'
-          description: The unique key of the evaluated conditional.
+          description: The unique key of the conditional evaluation operation.
         tenantId:
-          description: The tenant ID of the evaluated conditional.
+          description: The tenant ID of the conditional evaluation operation.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
         processInstances:

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/EvaluateConditionalTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/EvaluateConditionalTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.EvaluateConditionalCommandStep1;
 import io.camunda.client.api.response.EvaluateConditionalResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
@@ -67,6 +68,8 @@ public final class EvaluateConditionalTest {
             .join();
 
     // then
+    assertThat(response.getConditionalEvaluationKey()).isPositive();
+    assertThat(response.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getProcessInstances()).hasSize(1);
     final var processInstance = response.getProcessInstances().getFirst();
     assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
@@ -95,6 +98,8 @@ public final class EvaluateConditionalTest {
         getCommand(client, useRest).variables(Map.of("x", 100)).send().join();
 
     // then
+    assertThat(response.getConditionalEvaluationKey()).isPositive();
+    assertThat(response.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getProcessInstances()).hasSize(2);
 
     final var processInstance1Key =
@@ -137,6 +142,8 @@ public final class EvaluateConditionalTest {
         getCommand(client, useRest).variables(Map.of("x", 10)).send().join();
 
     // then
+    assertThat(response.getConditionalEvaluationKey()).isPositive();
+    assertThat(response.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getProcessInstances()).isEmpty();
 
     assertThat(
@@ -178,6 +185,8 @@ public final class EvaluateConditionalTest {
             .join();
 
     // then
+    assertThat(response.getConditionalEvaluationKey()).isPositive();
+    assertThat(response.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getProcessInstances()).hasSize(2);
     assertThat(response.getProcessInstances())
         .allSatisfy(
@@ -269,6 +278,8 @@ public final class EvaluateConditionalTest {
         getCommand(client, useRest).variables(Map.of("x", 100)).send().join();
 
     // then
+    assertThat(response.getConditionalEvaluationKey()).isPositive();
+    assertThat(response.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getProcessInstances()).hasSize(1);
     final var processInstance = response.getProcessInstances().getFirst();
     assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(processDefinitionKeyV2);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
@@ -1629,6 +1629,8 @@ public class MultiTenancyIT {
           .succeedsWithin(Duration.ofSeconds(20))
           .satisfies(
               response -> {
+                assertThat(response.getConditionalEvaluationKey()).isPositive();
+                assertThat(response.getTenantId()).isEqualTo(TENANT_A);
                 assertThat(response.getProcessInstances()).hasSize(1);
                 assertThat(response.getProcessInstances().getFirst().getProcessDefinitionKey())
                     .isPositive();
@@ -1696,6 +1698,8 @@ public class MultiTenancyIT {
           .succeedsWithin(Duration.ofSeconds(20))
           .satisfies(
               response -> {
+                assertThat(response.getConditionalEvaluationKey()).isPositive();
+                assertThat(response.getTenantId()).isEqualTo(DEFAULT_TENANT);
                 assertThat(response.getProcessInstances()).hasSize(1);
                 assertThat(response.getProcessInstances().getFirst().getProcessDefinitionKey())
                     .isPositive();


### PR DESCRIPTION
## Description

Address the following:

* Remove `public` modifier from `EvaluateConditionalCommandStep2`
* Add key of evaluated conditional and tenant ID to the conditional evaluation response

These items were taken from this review of [a previous PR](https://github.com/camunda/camunda/pull/42586#pullrequestreview-3583361359) 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/42184
