### PR TITLE
ci: disable license checks on fork PRs

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -30,6 +30,8 @@ jobs:
       actions: read
       contents: read
     runs-on: gcp-core-16-default
+    # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
     timeout-minutes: 31
     strategy:


### PR DESCRIPTION
## Description

Those checks need private access to FOSSA which does not work on fork PRs due to lack of credentials.

Same approach as e.g. used in and working: https://github.com/camunda/camunda/blob/b3c61e6ca754f3d2b0079d9038994eb341dca3a7/.github/workflows/ci-zeebe.yml#L369-L370

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

[Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1768287332770249?thread_ts=1766041475.632179&cid=C071KP5BTHB)
