### PR TITLE
feat: replace navigation history for element selection

### DIFF
--- a/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
+++ b/operate/client/src/modules/hooks/useProcessInstanceElementSelection.ts
@@ -87,12 +87,15 @@ const useProcessInstanceElementSelection = () => {
       elementId: string;
       isMultiInstanceBody?: boolean;
     }) => {
-      setSearchParams((params) => {
-        return updateSelectionSearchParams(params, {
-          elementId,
-          isMultiInstanceBody,
-        });
-      });
+      setSearchParams(
+        (params) => {
+          return updateSelectionSearchParams(params, {
+            elementId,
+            isMultiInstanceBody,
+          });
+        },
+        {replace: true},
+      );
     },
     [setSearchParams],
   );
@@ -111,23 +114,29 @@ const useProcessInstanceElementSelection = () => {
       isPlaceholder?: boolean;
       anchorElementId?: string;
     }) => {
-      setSearchParams((params) => {
-        return updateSelectionSearchParams(params, {
-          elementId,
-          elementInstanceKey,
-          isMultiInstanceBody,
-          isPlaceholder,
-          anchorElementId,
-        });
-      });
+      setSearchParams(
+        (params) => {
+          return updateSelectionSearchParams(params, {
+            elementId,
+            elementInstanceKey,
+            isMultiInstanceBody,
+            isPlaceholder,
+            anchorElementId,
+          });
+        },
+        {replace: true},
+      );
     },
     [setSearchParams],
   );
 
   const clearSelection = useCallback(() => {
-    setSearchParams((params) => {
-      return deleteSelectionSearchParams(params);
-    });
+    setSearchParams(
+      (params) => {
+        return deleteSelectionSearchParams(params);
+      },
+      {replace: true},
+    );
   }, [setSearchParams]);
 
   // If elementInstanceKey is in URL, fetch element instance by key.


### PR DESCRIPTION
## Description

In the current implementation, changing the element selection (changes URL search params) adds new entries to the navigation history. When users use the browser's back/forward navigation, they navigate to the previous/next element selection. In the v1 implementation they are navigated back to the previous page, e.g. processes list.

I think navigation back to a previous page is the better behavior for this use case. The currently selected element feels like state that - although nice to have in URL - should not aggregate its changes in navigation history.

With this change, the selection replaces the latest history item. Navigating back navigates back to the previous history and not the previous selection.

## Related issues

relates #40425
