### PR TITLE
fix: update name field value calculation

### DIFF
--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/index.tsx
@@ -25,6 +25,7 @@ import {BatchModificationFooter} from './BatchModificationFooter';
 import type {InstanceEntityState} from 'modules/types/operate';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {InstanceOperations} from './InstanceOperations';
+import {getProcessDefinitionName} from 'modules/utils/instance';
 
 type InstancesTableProps = {
   state: 'skeleton' | 'loading' | 'error' | 'empty' | 'content';
@@ -119,7 +120,7 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
                     size={20}
                   />
 
-                  {instance.processDefinitionName}
+                  {getProcessDefinitionName(instance)}
                 </ProcessName>
               ),
               processInstanceKey: (


### PR DESCRIPTION
## Description

Uses `getProcessDefinitionName` for "Name" field calculation in PI table 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #43939 
