### PR TITLE
Add MCP incident tools

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.mock;
 import io.camunda.application.initializers.McpGatewayInitializer;
 import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.IncidentServices;
+import io.camunda.service.JobServices;
 import io.camunda.service.TopologyServices;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -36,6 +38,8 @@ class McpGatewayConfigurationTest {
   public void includesMcpToolComponentsWhenEnabled() {
     baseRunner()
         .withBean(TopologyServices.class, () -> mock(TopologyServices.class))
+        .withBean(IncidentServices.class, () -> mock(IncidentServices.class))
+        .withBean(JobServices.class, () -> mock(JobServices.class))
         .withBean(
             CamundaAuthenticationProvider.class, () -> mock(CamundaAuthenticationProvider.class))
         .withPropertyValues("camunda.mcp.enabled=true")

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
@@ -38,7 +38,7 @@ public class GatewayErrorMapper {
     if (error == null) {
       return null;
     }
-    // SeviceExceptions can be wrapped in Java exceptions because they are handled in Java futures
+    // ServiceExceptions can be wrapped in Java exceptions because they are handled in Java futures
     final var exception = unwrapError(error);
     if (exception instanceof final ServiceException se) {
       return createProblemDetail(mapStatus(se.getStatus()), se.getMessage(), se.getStatus().name());
@@ -58,7 +58,7 @@ public class GatewayErrorMapper {
    * @return the cause of the exception if wrapped, otherwise the exception itself
    */
   public static Throwable unwrapError(final Throwable throwable) {
-    // SeviceExceptions can be wrapped in Java exceptions because they are handled in Java futures
+    // ServiceExceptions can be wrapped in Java exceptions because they are handled in Java futures
     if (throwable instanceof CompletionException || throwable instanceof ExecutionException) {
       return throwable.getCause();
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
@@ -24,27 +24,55 @@ public class GatewayErrorMapper {
   public static final Function<String, Throwable> REQUEST_CANCELED_EXCEPTION_PROVIDER =
       RuntimeException::new;
 
-  public static final Logger LOG = LoggerFactory.getLogger(GatewayErrorMapper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GatewayErrorMapper.class);
 
+  /**
+   * Maps a {@link ServiceException} to a {@link ProblemDetail}, unwrapping potential Java
+   * concurrent exceptions wrapping the causing {@link ServiceException}. The {@link Status} of the
+   * service exception is mapped to an HTTP status.
+   *
+   * @param error the {@link ServiceException}, can be wrapped in a Java concurrent exception
+   * @return the problem detail mapping the service exception content respectively
+   */
   public static ProblemDetail mapErrorToProblem(final Throwable error) {
     if (error == null) {
       return null;
     }
     // SeviceExceptions can be wrapped in Java exceptions because they are handled in Java futures
-    if (error instanceof CompletionException || error instanceof ExecutionException) {
-      return mapErrorToProblem(error.getCause());
-    }
-    if (error instanceof final ServiceException se) {
+    final var exception = unwrapError(error);
+    if (exception instanceof final ServiceException se) {
       return createProblemDetail(mapStatus(se.getStatus()), se.getMessage(), se.getStatus().name());
     } else {
       LOG.error("Expected to handle REST request, but an unexpected error occurred", error);
       return createProblemDetail(
           HttpStatus.INTERNAL_SERVER_ERROR,
-          "Unexpected error occurred during the request processing: " + error.getMessage(),
-          error.getClass().getName());
+          "Unexpected error occurred during the request processing: " + exception.getMessage(),
+          exception.getClass().getName());
     }
   }
 
+  /**
+   * Unwrapping potential Java concurrent exceptions wrapping the real cause.
+   *
+   * @param throwable the potentially wrapping Java concurrent exception
+   * @return the cause of the exception if wrapped, otherwise the exception itself
+   */
+  public static Throwable unwrapError(final Throwable throwable) {
+    // SeviceExceptions can be wrapped in Java exceptions because they are handled in Java futures
+    if (throwable instanceof CompletionException || throwable instanceof ExecutionException) {
+      return throwable.getCause();
+    }
+    return throwable;
+  }
+
+  /**
+   * Creates a {@link ProblemDetail} from a status, detail, and title.
+   *
+   * @param status the status of the problem
+   * @param detail the detail text of the problem
+   * @param title the title of the problem
+   * @return a problem detail reflecting the provided input
+   */
   public static ProblemDetail createProblemDetail(
       final HttpStatusCode status, final String detail, final String title) {
     final var problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
@@ -52,7 +80,7 @@ public class GatewayErrorMapper {
     return problemDetail;
   }
 
-  public static HttpStatus mapStatus(final Status status) {
+  protected static HttpStatus mapStatus(final Status status) {
     return switch (status) {
       case ABORTED -> HttpStatus.BAD_GATEWAY;
       case UNAVAILABLE, RESOURCE_EXHAUSTED -> HttpStatus.SERVICE_UNAVAILABLE;

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -15,7 +15,6 @@
     <version>8.9.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
-
   <artifactId>camunda-gateway-mcp</artifactId>
   <packaging>jar</packaging>
   <name>Camunda Gateway MCP server</name>
@@ -33,6 +32,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
 
@@ -41,6 +45,10 @@
       <artifactId>camunda-service</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
@@ -84,6 +92,32 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations-jakarta</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/mapper/McpSearchQueryMapper.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/mapper/McpSearchQueryMapper.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.mapper;
+
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ONLY_ONE_FIELD;
+import static java.util.Optional.ofNullable;
+import static java.util.function.Predicate.not;
+
+import io.camunda.gateway.protocol.model.AdvancedDateTimeFilter;
+import io.camunda.gateway.protocol.model.AdvancedIncidentErrorTypeFilter;
+import io.camunda.gateway.protocol.model.AdvancedIncidentStateFilter;
+import io.camunda.gateway.protocol.model.AdvancedStringFilter;
+import io.camunda.gateway.protocol.model.BasicStringFilter;
+import io.camunda.gateway.protocol.model.BasicStringFilterProperty;
+import io.camunda.gateway.protocol.model.CursorBackwardPagination;
+import io.camunda.gateway.protocol.model.CursorForwardPagination;
+import io.camunda.gateway.protocol.model.LimitPagination;
+import io.camunda.gateway.protocol.model.OffsetPagination;
+import io.camunda.gateway.protocol.model.StringFilterProperty;
+import io.camunda.gateway.protocol.model.simple.DateTimeFilterProperty;
+import io.camunda.gateway.protocol.model.simple.IncidentFilter;
+import io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest;
+import io.camunda.service.exception.ServiceError;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class McpSearchQueryMapper {
+
+  public static io.camunda.gateway.protocol.model.SearchQueryPageRequest toPageRequest(
+      final SearchQueryPageRequest page) {
+    if (page == null) {
+      return new LimitPagination();
+    }
+    // validate fields
+    if (page.from() == null
+        && page.before() == null
+        && page.after() == null
+        && page.limit() == null) {
+      throw new ServiceException(
+          new ServiceError(
+              ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(
+                      List.of("after", "before", "from", "limit"))
+                  + " in the page.",
+              Status.INVALID_ARGUMENT));
+    }
+    if (Stream.of(page.from(), page.before(), page.after()).filter(not(Objects::isNull)).count()
+        > 1) {
+      throw new ServiceException(
+          new ServiceError(
+              ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(List.of("after", "before", "from"))
+                  + " in the page.",
+              Status.INVALID_ARGUMENT));
+    }
+    // create page request
+    if (page.before() != null) {
+      return new CursorBackwardPagination().before(page.before()).limit(page.limit());
+    }
+    if (page.after() != null) {
+      return new CursorForwardPagination().after(page.after()).limit(page.limit());
+    }
+    if (page.from() != null) {
+      return new OffsetPagination().from(page.from()).limit(page.limit());
+    }
+    return new LimitPagination().limit(page.limit());
+  }
+
+  public static <T> List<T> toSortRequest(final List<T> sort) {
+    return sort == null ? Collections.emptyList() : sort;
+  }
+
+  public static io.camunda.gateway.protocol.model.IncidentFilter toIncidentFilter(
+      final IncidentFilter filter) {
+    final var filterModel = new io.camunda.gateway.protocol.model.IncidentFilter();
+    if (filter != null) {
+      ofNullable(filter.processDefinitionId())
+          .map(McpSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::processDefinitionId);
+      ofNullable(filter.errorType())
+          .map(e -> new AdvancedIncidentErrorTypeFilter().$eq(e))
+          .ifPresent(filterModel::errorType);
+      ofNullable(filter.elementId())
+          .map(McpSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::elementId);
+      ofNullable(filter.creationTime())
+          .map(McpSearchQueryMapper::getDateTimeFilter)
+          .ifPresent(filterModel::creationTime);
+      ofNullable(filter.state())
+          .map(s -> new AdvancedIncidentStateFilter().$eq(s))
+          .ifPresent(filterModel::state);
+      ofNullable(filter.processDefinitionKey())
+          .map(McpSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::processDefinitionKey);
+      ofNullable(filter.processInstanceKey())
+          .map(McpSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::processInstanceKey);
+    }
+    return filterModel;
+  }
+
+  private static StringFilterProperty getStringFilter(final String value) {
+    return new AdvancedStringFilter().$eq(value);
+  }
+
+  private static BasicStringFilterProperty getBasicStringFilter(final long value) {
+    return new BasicStringFilter().$eq(String.valueOf(value));
+  }
+
+  private static StringFilterProperty getStringFilter(final Enum<?> value) {
+    return new AdvancedStringFilter().$eq(value.name());
+  }
+
+  private static io.camunda.gateway.protocol.model.DateTimeFilterProperty getDateTimeFilter(
+      final DateTimeFilterProperty value) {
+    if (value == null
+        || (value.from() == null || value.from().isBlank())
+            && (value.to() == null || value.to().isBlank())) {
+      return null;
+    }
+    final var filterModel = new AdvancedDateTimeFilter();
+    if (value.from() != null && !value.from().isBlank()) {
+      filterModel.$gte(value.from());
+    }
+
+    if (value.to() != null && !value.to().isBlank()) {
+      filterModel.$lt(value.to());
+    }
+    return filterModel;
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/mapper/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/mapper/SimpleSearchQueryMapper.java
@@ -34,7 +34,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class McpSearchQueryMapper {
+/**
+ * Mapper for converting simple search request models into advanced search query representations.
+ *
+ * <p>This class provides static helper methods to:
+ *
+ * <ul>
+ *   <li>Validate and map simple {@link SearchQueryPageRequest} instances to advanced pagination
+ *       requests (e.g. limit, cursor, and offset-based pagination).
+ *   <li>Map simple filters to advanced query components with equality semantics.
+ */
+public class SimpleSearchQueryMapper {
 
   public static io.camunda.gateway.protocol.model.SearchQueryPageRequest toPageRequest(
       final SearchQueryPageRequest page) {
@@ -83,25 +93,25 @@ public class McpSearchQueryMapper {
     final var filterModel = new io.camunda.gateway.protocol.model.IncidentFilter();
     if (filter != null) {
       ofNullable(filter.processDefinitionId())
-          .map(McpSearchQueryMapper::getStringFilter)
+          .map(SimpleSearchQueryMapper::getStringFilter)
           .ifPresent(filterModel::processDefinitionId);
       ofNullable(filter.errorType())
           .map(e -> new AdvancedIncidentErrorTypeFilter().$eq(e))
           .ifPresent(filterModel::errorType);
       ofNullable(filter.elementId())
-          .map(McpSearchQueryMapper::getStringFilter)
+          .map(SimpleSearchQueryMapper::getStringFilter)
           .ifPresent(filterModel::elementId);
       ofNullable(filter.creationTime())
-          .map(McpSearchQueryMapper::getDateTimeFilter)
+          .map(SimpleSearchQueryMapper::getDateTimeFilter)
           .ifPresent(filterModel::creationTime);
       ofNullable(filter.state())
           .map(s -> new AdvancedIncidentStateFilter().$eq(s))
           .ifPresent(filterModel::state);
       ofNullable(filter.processDefinitionKey())
-          .map(McpSearchQueryMapper::getBasicStringFilter)
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
           .ifPresent(filterModel::processDefinitionKey);
       ofNullable(filter.processInstanceKey())
-          .map(McpSearchQueryMapper::getBasicStringFilter)
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
           .ifPresent(filterModel::processInstanceKey);
     }
     return filterModel;
@@ -113,10 +123,6 @@ public class McpSearchQueryMapper {
 
   private static BasicStringFilterProperty getBasicStringFilter(final long value) {
     return new BasicStringFilter().$eq(String.valueOf(value));
-  }
-
-  private static StringFilterProperty getStringFilter(final Enum<?> value) {
-    return new AdvancedStringFilter().$eq(value.name());
   }
 
   private static io.camunda.gateway.protocol.model.DateTimeFilterProperty getDateTimeFilter(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool;
+
+/**
+ * Common description fragments for MCP tool annotations.
+ *
+ * <p>Use these constants to ensure consistent messaging across all tools.
+ */
+public final class ToolDescriptions {
+
+  /**
+   * Append this to descriptions of tools that query the search index (Elasticsearch/OpenSearch).
+   * These operations are eventually consistent - data may not immediately reflect recent writes.
+   *
+   * <p>Usage:
+   *
+   * <pre>{@code
+   * @McpTool(description = "Search for incidents. " + EVENTUAL_CONSISTENCY_NOTE)
+   * }</pre>
+   */
+  public static final String EVENTUAL_CONSISTENCY_NOTE =
+      "Note: Results are eventually consistent and may not immediately reflect recent changes.";
+
+  public static final String DATE_TIME_FORMAT =
+      "RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00').";
+
+  private ToolDescriptions() {
+    // Utility class
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.incident;
+
+import static io.camunda.gateway.mcp.mapper.CallToolResultMapper.mapErrorToResult;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+
+import io.camunda.gateway.mapping.http.GatewayErrorMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
+import io.camunda.gateway.mcp.mapper.McpSearchQueryMapper;
+import io.camunda.gateway.protocol.model.IncidentSearchQuery;
+import io.camunda.gateway.protocol.model.IncidentSearchQuerySortRequest;
+import io.camunda.gateway.protocol.model.JobActivationResult;
+import io.camunda.gateway.protocol.model.simple.IncidentFilter;
+import io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.IncidentServices;
+import io.camunda.service.JobServices;
+import io.camunda.service.JobServices.UpdateJobChangeset;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.util.Either;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@ConditionalOnMcpGatewayEnabled
+@Validated
+public class IncidentTools {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(IncidentTools.class);
+
+  private final IncidentServices incidentServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+  private final JobServices<JobActivationResult> jobServices;
+
+  public IncidentTools(
+      final IncidentServices incidentServices,
+      final CamundaAuthenticationProvider authenticationProvider,
+      final JobServices<JobActivationResult> jobServices) {
+    this.incidentServices = incidentServices;
+    this.authenticationProvider = authenticationProvider;
+    this.jobServices = jobServices;
+  }
+
+  @McpTool(
+      description = "Search for incidents. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult searchIncidents(
+      @McpToolParam(description = "Filter search by the given fields", required = false)
+          final IncidentFilter filter,
+      @McpToolParam(description = "Sort criteria", required = false)
+          final List<IncidentSearchQuerySortRequest> sort,
+      @McpToolParam(description = "Pagination criteria", required = false)
+          final SearchQueryPageRequest page) {
+    try {
+      final var incidentSearchQuery =
+          SearchQueryRequestMapper.toIncidentQuery(
+              new IncidentSearchQuery()
+                  .filter(McpSearchQueryMapper.toIncidentFilter(filter))
+                  .page(McpSearchQueryMapper.toPageRequest(page))
+                  .sort(McpSearchQueryMapper.toSortRequest(sort)));
+
+      if (incidentSearchQuery.isLeft()) {
+        return CallToolResultMapper.mapProblemToResult(incidentSearchQuery.getLeft());
+      }
+
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toIncidentSearchQueryResponse(
+              incidentServices
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                  .search(incidentSearchQuery.get())));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  @McpTool(
+      description = "Get incident by key. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult getIncident(
+      @McpToolParam(
+              description =
+                  "The assigned key of the incident, which acts as a unique identifier for this incident.")
+          @Positive(message = "Incident key must be a positive number.")
+          final Long incidentKey) {
+    try {
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toIncident(
+              incidentServices
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                  .getByKey(incidentKey)));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  @McpTool(description = "Resolve incident by key. " + EVENTUAL_CONSISTENCY_NOTE)
+  public CallToolResult resolveIncident(
+      @McpToolParam(description = "Key of the incident to resolve.") @Positive
+          final Long incidentKey) {
+    try {
+      return CallToolResultMapper.fromPrimitive(
+          incidentServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .resolveIncident(incidentKey, null),
+          r -> "Incident with key %s resolved.".formatted(incidentKey),
+          error ->
+              isNoJobRetriesLeft(error)
+                  ? resolveJobIncident(incidentKey)
+                  : mapErrorToResult(error));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  private static boolean isNoJobRetriesLeft(final Throwable error) {
+    return GatewayErrorMapper.unwrapError(error) instanceof final ServiceException se
+        && Status.INVALID_STATE.equals(se.getStatus())
+        && se.getMessage().contains("no retries left");
+  }
+
+  private CallToolResult resolveJobIncident(final Long incidentKey) {
+    try {
+      final CamundaAuthentication camundaAuthentication =
+          authenticationProvider.getCamundaAuthentication();
+      // fetch the incident to retrieve the job key
+      final IncidentEntity incident =
+          incidentServices.withAuthentication(camundaAuthentication).getByKey(incidentKey);
+      // incident cannot be null, service throws exception if incident not found
+      final Long jobKey = incident.jobKey();
+      if (jobKey == null) {
+        throw new ServiceException(
+            "Cannot retrieve job key for job-based incident.", Status.INVALID_STATE);
+      }
+      // update retries for the job to 1
+      final Either<Throwable, JobRecord> updateResult =
+          CallToolResultMapper.executeServiceMethod(
+              jobServices
+                  .withAuthentication(camundaAuthentication)
+                  .updateJob(jobKey, null, new UpdateJobChangeset(1, null)));
+      if (updateResult.isLeft()) {
+        return CallToolResultMapper.mapErrorToResult(updateResult.getLeft());
+      }
+      // resolve incident again
+      return CallToolResultMapper.fromPrimitive(
+          incidentServices.resolveIncident(incidentKey, null), r -> "RESOLVED");
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -14,7 +14,7 @@ import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
-import io.camunda.gateway.mcp.mapper.McpSearchQueryMapper;
+import io.camunda.gateway.mcp.mapper.SimpleSearchQueryMapper;
 import io.camunda.gateway.protocol.model.IncidentSearchQuery;
 import io.camunda.gateway.protocol.model.IncidentSearchQuerySortRequest;
 import io.camunda.gateway.protocol.model.JobActivationResult;
@@ -74,9 +74,9 @@ public class IncidentTools {
       final var incidentSearchQuery =
           SearchQueryRequestMapper.toIncidentQuery(
               new IncidentSearchQuery()
-                  .filter(McpSearchQueryMapper.toIncidentFilter(filter))
-                  .page(McpSearchQueryMapper.toPageRequest(page))
-                  .sort(McpSearchQueryMapper.toSortRequest(sort)));
+                  .filter(SimpleSearchQueryMapper.toIncidentFilter(filter))
+                  .page(SimpleSearchQueryMapper.toPageRequest(page))
+                  .sort(SimpleSearchQueryMapper.toSortRequest(sort)));
 
       if (incidentSearchQuery.isLeft()) {
         return CallToolResultMapper.mapProblemToResult(incidentSearchQuery.getLeft());

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -114,7 +114,8 @@ public class IncidentTools {
 
   @McpTool(description = "Resolve incident by key. " + EVENTUAL_CONSISTENCY_NOTE)
   public CallToolResult resolveIncident(
-      @McpToolParam(description = "Key of the incident to resolve.") @Positive
+      @McpToolParam(description = "Key of the incident to resolve.")
+          @Positive(message = "Incident key must be a positive number.")
           final Long incidentKey) {
     try {
       return CallToolResultMapper.fromPrimitive(
@@ -161,7 +162,8 @@ public class IncidentTools {
       }
       // resolve incident again
       return CallToolResultMapper.fromPrimitive(
-          incidentServices.resolveIncident(incidentKey, null), r -> "RESOLVED");
+          incidentServices.resolveIncident(incidentKey, null),
+          r -> "Incident with key %s resolved.".formatted(incidentKey));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -13,7 +13,6 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
-import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.gateway.mcp.mapper.McpSearchQueryMapper;
 import io.camunda.gateway.protocol.model.IncidentSearchQuery;

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -43,7 +43,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 @Component
-@ConditionalOnMcpGatewayEnabled
 @Validated
 public class IncidentTools {
 

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/protocol/model/simple/DateTimeFilterProperty.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/protocol/model/simple/DateTimeFilterProperty.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.protocol.model.simple;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.camunda.gateway.mcp.tool.ToolDescriptions;
+
+public record DateTimeFilterProperty(
+    @JsonProperty
+        @JsonPropertyDescription(
+            "Filter from this time (inclusive). " + ToolDescriptions.DATE_TIME_FORMAT)
+        String from,
+    @JsonProperty
+        @JsonPropertyDescription(
+            "Filter up to this time (exclusive). " + ToolDescriptions.DATE_TIME_FORMAT)
+        String to) {}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/protocol/model/simple/IncidentFilter.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/protocol/model/simple/IncidentFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.protocol.model.simple;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.camunda.gateway.protocol.model.IncidentErrorTypeEnum;
+import io.camunda.gateway.protocol.model.IncidentStateEnum;
+
+public record IncidentFilter(
+    @JsonProperty @JsonPropertyDescription("The process definition ID associated to the incident.")
+        String processDefinitionId,
+    @JsonProperty @JsonPropertyDescription("Incident error type.") IncidentErrorTypeEnum errorType,
+    @JsonProperty
+        @JsonPropertyDescription(
+            "The element ID associated to the incident - the BPMN element ID in the process.")
+        String elementId,
+    @JsonProperty @JsonPropertyDescription("The date and time the incident was created at.")
+        DateTimeFilterProperty creationTime,
+    @JsonProperty @JsonPropertyDescription("State of the incident.") IncidentStateEnum state,
+    @JsonProperty @JsonPropertyDescription("The process definition key associated to the incident.")
+        Long processDefinitionKey,
+    @JsonProperty @JsonPropertyDescription("The process instance key associated to the incident.")
+        Long processInstanceKey) {}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/protocol/model/simple/SearchQueryPageRequest.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/protocol/model/simple/SearchQueryPageRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.protocol.model.simple;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.Nullable;
+
+@Schema(
+    name = "SearchQueryPageRequest",
+    description =
+        "Pagination configuration for search queries. Supports cursor-based pagination (before/after), offset-based pagination (from), or simple limit-based pagination.")
+public record SearchQueryPageRequest(
+    @Nullable
+        @Pattern(regexp = "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=)?$")
+        @Size(min = 2, max = 300)
+        @Schema(
+            name = "before",
+            example = "WzIyNTE3OTk4MTM2ODcxMDJd",
+            description =
+                "Use the `startCursor` value from the previous response to fetch the previous page of results.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String before,
+    @Nullable
+        @Pattern(regexp = "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=)?$")
+        @Size(min = 2, max = 300)
+        @Schema(
+            name = "after",
+            example = "WzIyNTE3OTk4MTM2ODcxMDJd",
+            description =
+                "Use the `endCursor` value from the previous response to fetch the next page of results.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String after,
+    @Nullable
+        @Min(value = 0)
+        @Schema(
+            name = "from",
+            description = "The index of items to start searching from (offset-based pagination).",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Integer from,
+    @Nullable
+        @Min(value = 1)
+        @Max(value = 100)
+        @Schema(
+            name = "limit",
+            description = "The maximum number of items to return in one request.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Integer limit) {}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.tool.ToolsTest;
+import io.camunda.gateway.protocol.model.IncidentResult;
+import io.camunda.gateway.protocol.model.JobActivationResult;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.IncidentEntity.ErrorType;
+import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.service.IncidentServices;
+import io.camunda.service.JobServices;
+import io.camunda.service.JobServices.UpdateJobChangeset;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ContextConfiguration(classes = {IncidentTools.class})
+class IncidentToolsTest extends ToolsTest {
+
+  static final IncidentEntity INCIDENT_ENTITY =
+      new IncidentEntity(
+          5L,
+          23L,
+          "complexProcess",
+          42L,
+          42L,
+          ErrorType.JOB_NO_RETRIES,
+          "No retries left.",
+          "elementId",
+          17L,
+          OffsetDateTime.parse("2024-05-23T23:05:00.000Z"),
+          IncidentState.ACTIVE,
+          101L,
+          "tenantId");
+
+  static final SearchQueryResult<IncidentEntity> SEARCH_QUERY_RESULT =
+      new Builder<IncidentEntity>()
+          .total(1L)
+          .items(List.of(INCIDENT_ENTITY))
+          .startCursor("f")
+          .endCursor("v")
+          .build();
+
+  @MockitoBean private IncidentServices incidentServices;
+  @MockitoBean private JobServices<JobActivationResult> jobServices;
+
+  @Autowired private ObjectMapper objectMapper;
+  @Captor private ArgumentCaptor<IncidentQuery> queryCaptor;
+
+  @BeforeEach
+  void mockApiServices() {
+    mockApiServiceAuthentication(incidentServices);
+    mockApiServiceAuthentication(jobServices);
+  }
+
+  @Test
+  void shouldGetIncidentByKey() {
+    // given
+    when(incidentServices.getByKey(any())).thenReturn(INCIDENT_ENTITY);
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("getIncident")
+                .arguments(Map.of("incidentKey", 5L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+    assertThat(result.structuredContent()).isNotNull();
+
+    final var incident =
+        objectMapper.convertValue(result.structuredContent(), IncidentResult.class);
+    assertThat(incident)
+        .usingRecursiveComparison()
+        .isEqualTo(SearchQueryResponseMapper.toIncident(INCIDENT_ENTITY));
+
+    verify(incidentServices).getByKey(5L);
+  }
+
+  @Test
+  void shouldFailGetIncidentByKeyOnException() {
+    // given
+    when(incidentServices.getByKey(any()))
+        .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("getIncident")
+                .arguments(Map.of("incidentKey", 5L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.content()).isEmpty();
+    assertThat(result.structuredContent()).isNotNull();
+
+    final var problemDetail =
+        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+  }
+
+  @Test
+  void shouldFailGetIncidentByKeyOnInvalidKey() {
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("getIncident")
+                .arguments(Map.of("incidentKey", -3L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.structuredContent()).isNull();
+    assertThat(result.content())
+        .hasSize(1)
+        .first()
+        .isInstanceOfSatisfying(
+            TextContent.class,
+            textContent ->
+                assertThat(textContent.text()).contains("Incident key must be a positive number."));
+  }
+
+  @Test
+  void shouldSearchIncidentsWithCreationTimeDateRangeFilter() {
+    // given
+    when(incidentServices.search(any(IncidentQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+
+    final var creationTimeFrom = OffsetDateTime.of(2025, 5, 23, 9, 35, 12, 0, ZoneOffset.UTC);
+    final var creationTimeTo = OffsetDateTime.of(2025, 12, 18, 17, 22, 33, 0, ZoneOffset.UTC);
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("searchIncidents")
+                .arguments(
+                    Map.of(
+                        "filter",
+                        Map.of(
+                            "creationTime",
+                            Map.of("from", "2025-05-23T09:35:12Z", "to", "2025-12-18T17:22:33Z"))))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+
+    verify(incidentServices).search(queryCaptor.capture());
+    final IncidentQuery capturedQuery = queryCaptor.getValue();
+
+    assertThat(capturedQuery.filter().creationTimeOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(
+            tuple(Operator.GREATER_THAN_EQUALS, creationTimeFrom),
+            tuple(Operator.LOWER_THAN, creationTimeTo));
+  }
+
+  @Test
+  void shouldSearchIncidentsWithFilterSortAndPaging() {
+    // given
+    when(incidentServices.search(any(IncidentQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("searchIncidents")
+                .arguments(
+                    Map.of(
+                        "filter",
+                        Map.of("state", "ACTIVE", "errorType", "JOB_NO_RETRIES"),
+                        "sort",
+                        List.of(Map.of("field", "incidentKey", "order", "DESC")),
+                        "page",
+                        Map.of("limit", 25, "after", "WzEwMjRd")))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+
+    verify(incidentServices).search(queryCaptor.capture());
+    final IncidentQuery capturedQuery = queryCaptor.getValue();
+
+    final IncidentFilter filter = capturedQuery.filter();
+    assertThat(filter.stateOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(tuple(Operator.EQUALS, "ACTIVE"));
+
+    assertThat(filter.errorTypeOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(tuple(Operator.EQUALS, "JOB_NO_RETRIES"));
+
+    assertThat(capturedQuery.sort().orderings())
+        .extracting(FieldSorting::field, FieldSorting::order)
+        .containsExactly(tuple("incidentKey", SortOrder.DESC));
+
+    assertThat(capturedQuery.page().size()).isEqualTo(25);
+    assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+  }
+
+  @Test
+  void shouldFailSearchIncidentsOnException() {
+    // given
+    when(incidentServices.search(any(IncidentQuery.class)))
+        .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder().name("searchIncidents").arguments(Map.of()).build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.content()).isEmpty();
+    assertThat(result.structuredContent()).isNotNull();
+
+    final var problemDetail =
+        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+  }
+
+  @Test
+  void shouldResolveIncidentByKey() {
+    // given
+    when(incidentServices.resolveIncident(anyLong(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new IncidentRecord()));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("resolveIncident")
+                .arguments(Map.of("incidentKey", 5L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+    assertThat(result.content())
+        .hasSize(1)
+        .first()
+        .isInstanceOfSatisfying(
+            TextContent.class,
+            textContent ->
+                assertThat(textContent.text()).isEqualTo("Incident with key 5 resolved."));
+
+    verify(incidentServices).resolveIncident(5L, null);
+  }
+
+  @Test
+  void shouldResolveJobIncidentByKey() {
+    // given
+    final var incidentEntity = mock(IncidentEntity.class);
+    // noinspection unchecked
+    when(incidentServices.resolveIncident(anyLong(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("no retries left", Status.INVALID_STATE)),
+            CompletableFuture.completedFuture(new IncidentRecord()));
+    when(incidentEntity.jobKey()).thenReturn(4L);
+    when(incidentServices.getByKey(anyLong())).thenReturn(incidentEntity);
+    when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class)))
+        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("resolveIncident")
+                .arguments(Map.of("incidentKey", 5L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+    assertThat(result.content())
+        .hasSize(1)
+        .first()
+        .isInstanceOfSatisfying(
+            TextContent.class, textContent -> assertThat(textContent.text()).isEqualTo("RESOLVED"));
+
+    verify(incidentServices, times(2)).resolveIncident(5L, null);
+    verify(incidentServices).getByKey(5L);
+    verify(jobServices).updateJob(4L, null, new UpdateJobChangeset(1, null));
+  }
+
+  @Test
+  void shouldFailResolveJobIncidentByKey() {
+    // given
+    final var incidentEntity = mock(IncidentEntity.class);
+    // noinspection unchecked
+    when(incidentServices.resolveIncident(anyLong(), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("no retries left", Status.INVALID_STATE)),
+            CompletableFuture.completedFuture(new IncidentRecord()));
+    when(incidentEntity.jobKey()).thenReturn(4L);
+    when(incidentServices.getByKey(anyLong())).thenReturn(incidentEntity);
+    when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException("Expected failure", Status.NOT_FOUND)));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("resolveIncident")
+                .arguments(Map.of("incidentKey", 5L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.content()).isEmpty();
+    assertThat(result.structuredContent()).isNotNull();
+
+    final var problemDetail =
+        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+    verify(incidentServices).resolveIncident(5L, null);
+    verify(incidentServices).getByKey(5L);
+    verify(jobServices).updateJob(4L, null, new UpdateJobChangeset(1, null));
+  }
+}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -326,7 +326,9 @@ class IncidentToolsTest extends ToolsTest {
         .hasSize(1)
         .first()
         .isInstanceOfSatisfying(
-            TextContent.class, textContent -> assertThat(textContent.text()).isEqualTo("RESOLVED"));
+            TextContent.class,
+            textContent ->
+                assertThat(textContent.text()).isEqualTo("Incident with key 5 resolved."));
 
     verify(incidentServices, times(2)).resolveIncident(5L, null);
     verify(incidentServices).getByKey(5L);
@@ -372,5 +374,27 @@ class IncidentToolsTest extends ToolsTest {
     verify(incidentServices).resolveIncident(5L, null);
     verify(incidentServices).getByKey(5L);
     verify(jobServices).updateJob(4L, null, new UpdateJobChangeset(1, null));
+  }
+
+  @Test
+  void shouldFailResolveIncidentByKeyOnInvalidKey() {
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("resolveIncident")
+                .arguments(Map.of("incidentKey", -3L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.structuredContent()).isNull();
+    assertThat(result.content())
+        .hasSize(1)
+        .first()
+        .isInstanceOfSatisfying(
+            TextContent.class,
+            textContent ->
+                assertThat(textContent.text()).contains("Incident key must be a positive number."));
   }
 }


### PR DESCRIPTION
## Description

Adds incident tools for MCP:
- Get incident by key
- Seach incidents with a simplified search interface
- Resolve incidents (complex tool, handling job incidents transparently)

This adds simplified models for incident filerting, search paginaion, and date-time filters.
With a follow-up issue, we'll try to generate those automatically from OpenAPI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #43605 
