### PR TITLE
fix: reliably join when log doesn't contain latest configuration entry yet

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -65,14 +65,19 @@ public final class ReconfigurationHelper {
             result.completeExceptionally(e);
           }
 
-          // Always transition to the current member type, which is right now always PASSIVE before
-          // joining the cluster. This is required so that if the join was partially completed
-          // before the restart of this member, then this member should continue participating in
-          // the raft protocol in an active role. If the member stays INACTIVE, it won't respond to
-          // the requests from the other members. This is particularly important when joining a
-          // single member cluster, because the other member can continue the reconfiguration
-          // process only if this member responds to append and vote requests.
-          raftContext.transition(raftContext.getCluster().getLocalMember().getType());
+          // Always transition to PASSIVE or the last member type as found by
+          // `tryReloadConfigurationFromLog`.
+          // This ensures that the member trying to join is not stuck in `INACTIVE` which would
+          // prevent the joining from completing, particularly when joining a single-member cluster
+          // where this new node is already required for quorum.
+          switch (raftContext.getCluster().getLocalMember().getType()) {
+            // The last configuration entry is probably old and has the local member as INACTIVE.
+            // Ignore this and become PASSIVE instead.
+            case INACTIVE -> raftContext.transition(Type.PASSIVE);
+            // The last configuration entry has the local member as PASSIVE or ACTIVE, we can
+            // directly transition to that.
+            case final Type memberType -> raftContext.transition(memberType);
+          }
 
           // We don't know if the latest configuration loaded from the log is valid. So we will
           // retry join any way.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -63,6 +63,7 @@ public final class ReconfigurationHelper {
           } catch (final Exception e) {
             LOGGER.warn("Failed to join cluster, could not reload configuration from log", e);
             result.completeExceptionally(e);
+            return;
           }
 
           // Always transition to PASSIVE or the last member type as found by

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -755,28 +755,27 @@ final class LeaderAppender {
       member.openReplicationContext(raft.getLog());
     }
 
-    // If prior requests to the member have failed, build an empty append request to send to the
-    // member
-    // to prevent having to read from disk to configure, install, or append to an unavailable
-    // member.
-    if (member.getFailureCount() >= MIN_BACKOFF_FAILURE_COUNT) {
-      // If the member is not reachable for a long time, only send heartbeats to ping the follower.
-      // When the follower starts acknowledging, leader will start sending the actual events.
-      sendAppendRequest(member, buildAppendEmptyRequest(member));
-    }
     // If the member term is less than the current term or the member's configuration index is less
     // than the local configuration index, send a configuration update to the member.
     // Ensure that only one configuration attempt per member is attempted at any given time by
     // storing the
     // member state in a set of configuring members.
     // Once the configuration is complete sendAppendRequest will be called recursively.
-    else if (member.getConfigTerm() < raft.getTerm()
+    if (member.getConfigTerm() < raft.getTerm()
         || member.getConfigIndex() < raft.getCluster().getConfiguration().index()) {
       if (member.canConfigure()) {
         sendConfigureRequest(member, buildConfigureRequest());
       } else if (member.canHeartbeat()) {
         sendAppendRequest(member, buildAppendEmptyRequest(member));
       }
+    }
+    // If prior requests to the member have failed, build an empty append request to send to the
+    // member to prevent having to read from disk to configure, install, or append to an unavailable
+    // member.
+    else if (member.getFailureCount() >= MIN_BACKOFF_FAILURE_COUNT) {
+      // If the member is not reachable for a long time, only send heartbeats to ping the follower.
+      // When the follower starts acknowledging, leader will start sending the actual events.
+      sendAppendRequest(member, buildAppendEmptyRequest(member));
     }
     // If there's a snapshot at the member's nextIndex, replicate the snapshot.
     else if (member.getMember().getType() == RaftMember.Type.ACTIVE


### PR DESCRIPTION
This fixes a bug where a node fails to join because it is stuck in the `INACTIVE` role, introduced by #37977.

:lady_beetle: The problem is that `tryReloadConfigurationFromLog` is not guaranteed to find a recent configuration entry where the joining member is already part of the cluster. If it finds an old configuration entry without the joining member, we will update the local member type from `PASSIVE` to `INACTIVE` which makes the following transition a no-op. The joining member would stay in `INACTIVE` and reject all appends from the leader.
:adhesive_bandage: On join, we never transition to `INACTIVE`. If `tryReloadConfigurationFromLog` didn't give us a better node type, we will continue to assume `PASSIVE`.

:lady_beetle: Once the member is `INACTIVE`, a new configuration request from the leader would help but if the joining member has failed too many requests, the leader will only try to send heartbeats and fail again. 
:adhesive_bandage: This logic is fixed by always sending configure requests if the receiving member is outdated. Even if many requests have failed, we now send configure requests instead of heartbeats.

Discovered here: https://camunda.slack.com/archives/C013MEVQ4M9/p1768215159317599