### PR TITLE
[Backport stable/8.6] ci: update CODEOWNERS for identity directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,92 @@
 /.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team
+<<<<<<< HEAD
+=======
+/.github/workflows/check-outdated-prs.yml                @camunda/monorepo-devops-team
+/.github/workflows/create-urgent-hotfix-img.yml          @camunda/monorepo-devops-team
+
+###################
+## Core Features ##
+###################
+
+# CI Files
+/.github/workflows/operate-ci-build-observe-reusable.yml  @camunda/core-features
+/.github/workflows/operate-ci-build-reusable.yml          @camunda/core-features
+/.github/workflows/operate-ci.yml                         @camunda/core-features
+/.github/workflows/operate-ci-test-reusable.yml           @camunda/core-features
+/.github/workflows/operate-e2e-tests.yml                  @camunda/core-features
+/.github/workflows/operate-playwright.yml                 @camunda/core-features
+/.github/workflows/ci-operate.yml                         @camunda/core-features
+/.github/workflows/ci-tasklist.yml                        @camunda/core-features
+/.github/workflows/tasklist-ci-test-reusable.yml          @camunda/core-features
+/.github/workflows/tasklist-ci.yml                        @camunda/core-features
+/.github/workflows/tasklist-e2e-tests.yml                 @camunda/core-features
+/.github/workflows/ci-optimize.yml                        @camunda/core-features
+/.github/workflows/optimize-check-c4.yml                  @camunda/core-features
+/.github/workflows/optimize-e2e-test-cloud.yml            @camunda/core-features
+/.github/workflows/optimize-e2e-tests-sm.yml              @camunda/core-features
+
+# Unit Test Suites
+/operate/common/src/test/java/io/camunda/operate/OperateCoreFeaturesTestSuite.java    @camunda/core-features
+/operate/webapp/src/test/java/io/camunda/operate/OperateCoreFeaturesTestSuite.java    @camunda/core-features
+
+# Workflows
+/.github/workflows/gh-inherit-core-fields.yml            @camunda/core-features
+
+################
+## Data Layer ##
+################
+
+# CI Files
+/.github/workflows/operate-test-backup-restore.yml                @camunda/data-layer
+/.github/workflows/operate-test-importer.yml                      @camunda/data-layer
+/.github/workflows/ci-operate.yml
+
+# Unit Test Suites
+/operate/common/src/test/java/io/camunda/operate/OperateDataLayerTestSuite.java    @camunda/data-layer
+/operate/webapp/src/test/java/io/camunda/operate/OperateDataLayerTestSuite.java    @camunda/data-layer
+
+##########################
+## Distributed Platform ##
+##########################
+
+/zeebe/atomix @camunda/zeebe-distributed-platform
+/zeebe/backup @camunda/zeebe-distributed-platform
+/zeebe/backup-stores @camunda/zeebe-distributed-platform
+/zeebe/broker-client @camunda/zeebe-distributed-platform
+/zeebe/docker @camunda/zeebe-distributed-platform
+/zeebe/dynamic-config @camunda/zeebe-distributed-platform
+/zeebe/journal @camunda/zeebe-distributed-platform
+/zeebe/logstreams @camunda/zeebe-distributed-platform
+/zeebe/restore @camunda/zeebe-distributed-platform
+/zeebe/scheduler @camunda/zeebe-distributed-platform
+/zeebe/snapshot @camunda/zeebe-distributed-platform
+/zeebe/stream-platform @camunda/zeebe-distributed-platform
+/zeebe/transport @camunda/zeebe-distributed-platform
+/zeebe/dynamic-node-id-provider @camunda/zeebe-distributed-platform
+
+# Broker packages
+/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup @camunda/zeebe-distributed-platform
+/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering @camunda/zeebe-distributed-platform
+/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams @camunda/zeebe-distributed-platform
+/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams @camunda/zeebe-distributed-platform
+/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning @camunda/zeebe-distributed-platform
+/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning @camunda/zeebe-distributed-platform
+/zeebe/broker/src/main/java/io/camunda/zeebe/broker/raft @camunda/zeebe-distributed-platform
+/zeebe/broker/src/test/java/io/camunda/zeebe/broker/raft @camunda/zeebe-distributed-platform
+/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
+/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
+
+###############
+## Identity  ##
+###############
+
+/identity/        @camunda/identity-frontend
+/authentication/  @camunda/identity
+/security/        @camunda/identity
+
+>>>>>>> 9cdbd46f (ci: update CODEOWNERS for identity directory)
 
 ##########################
 ## Reliability Testing  ##

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,82 +30,6 @@
 /.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team
-<<<<<<< HEAD
-=======
-/.github/workflows/check-outdated-prs.yml                @camunda/monorepo-devops-team
-/.github/workflows/create-urgent-hotfix-img.yml          @camunda/monorepo-devops-team
-
-###################
-## Core Features ##
-###################
-
-# CI Files
-/.github/workflows/operate-ci-build-observe-reusable.yml  @camunda/core-features
-/.github/workflows/operate-ci-build-reusable.yml          @camunda/core-features
-/.github/workflows/operate-ci.yml                         @camunda/core-features
-/.github/workflows/operate-ci-test-reusable.yml           @camunda/core-features
-/.github/workflows/operate-e2e-tests.yml                  @camunda/core-features
-/.github/workflows/operate-playwright.yml                 @camunda/core-features
-/.github/workflows/ci-operate.yml                         @camunda/core-features
-/.github/workflows/ci-tasklist.yml                        @camunda/core-features
-/.github/workflows/tasklist-ci-test-reusable.yml          @camunda/core-features
-/.github/workflows/tasklist-ci.yml                        @camunda/core-features
-/.github/workflows/tasklist-e2e-tests.yml                 @camunda/core-features
-/.github/workflows/ci-optimize.yml                        @camunda/core-features
-/.github/workflows/optimize-check-c4.yml                  @camunda/core-features
-/.github/workflows/optimize-e2e-test-cloud.yml            @camunda/core-features
-/.github/workflows/optimize-e2e-tests-sm.yml              @camunda/core-features
-
-# Unit Test Suites
-/operate/common/src/test/java/io/camunda/operate/OperateCoreFeaturesTestSuite.java    @camunda/core-features
-/operate/webapp/src/test/java/io/camunda/operate/OperateCoreFeaturesTestSuite.java    @camunda/core-features
-
-# Workflows
-/.github/workflows/gh-inherit-core-fields.yml            @camunda/core-features
-
-################
-## Data Layer ##
-################
-
-# CI Files
-/.github/workflows/operate-test-backup-restore.yml                @camunda/data-layer
-/.github/workflows/operate-test-importer.yml                      @camunda/data-layer
-/.github/workflows/ci-operate.yml
-
-# Unit Test Suites
-/operate/common/src/test/java/io/camunda/operate/OperateDataLayerTestSuite.java    @camunda/data-layer
-/operate/webapp/src/test/java/io/camunda/operate/OperateDataLayerTestSuite.java    @camunda/data-layer
-
-##########################
-## Distributed Platform ##
-##########################
-
-/zeebe/atomix @camunda/zeebe-distributed-platform
-/zeebe/backup @camunda/zeebe-distributed-platform
-/zeebe/backup-stores @camunda/zeebe-distributed-platform
-/zeebe/broker-client @camunda/zeebe-distributed-platform
-/zeebe/docker @camunda/zeebe-distributed-platform
-/zeebe/dynamic-config @camunda/zeebe-distributed-platform
-/zeebe/journal @camunda/zeebe-distributed-platform
-/zeebe/logstreams @camunda/zeebe-distributed-platform
-/zeebe/restore @camunda/zeebe-distributed-platform
-/zeebe/scheduler @camunda/zeebe-distributed-platform
-/zeebe/snapshot @camunda/zeebe-distributed-platform
-/zeebe/stream-platform @camunda/zeebe-distributed-platform
-/zeebe/transport @camunda/zeebe-distributed-platform
-/zeebe/dynamic-node-id-provider @camunda/zeebe-distributed-platform
-
-# Broker packages
-/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup @camunda/zeebe-distributed-platform
-/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering @camunda/zeebe-distributed-platform
-/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams @camunda/zeebe-distributed-platform
-/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams @camunda/zeebe-distributed-platform
-/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning @camunda/zeebe-distributed-platform
-/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning @camunda/zeebe-distributed-platform
-/zeebe/broker/src/main/java/io/camunda/zeebe/broker/raft @camunda/zeebe-distributed-platform
-/zeebe/broker/src/test/java/io/camunda/zeebe/broker/raft @camunda/zeebe-distributed-platform
-/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
-/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
 
 ###############
 ## Identity  ##
@@ -114,8 +38,6 @@
 /identity/        @camunda/identity-frontend
 /authentication/  @camunda/identity
 /security/        @camunda/identity
-
->>>>>>> 9cdbd46f (ci: update CODEOWNERS for identity directory)
 
 ##########################
 ## Reliability Testing  ##


### PR DESCRIPTION
# Description
Backport of #43933 to `stable/8.6`.

relates to 