### PR TITLE
[Backport stable/8.7] ci: update CODEOWNERS for identity directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,14 @@
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team
 
+###############
+## Identity  ##
+###############
+
+/identity/        @camunda/identity-frontend
+/authentication/  @camunda/identity
+/security/        @camunda/identity
+
 ##########################
 ## Reliability Testing  ##
 ##########################


### PR DESCRIPTION
# Description
Backport of #43933 to `stable/8.7`.

relates to 