### PR TITLE
[Backport stable/8.8] ci: update CODEOWNERS for identity directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -117,8 +117,11 @@
 /zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
 /zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport @camunda/zeebe-distributed-platform
 
-# Identity
-/identity/        @camunda/identity
+###############
+## Identity  ##
+###############
+
+/identity/        @camunda/identity-frontend
 /authentication/  @camunda/identity
 /security/        @camunda/identity
 


### PR DESCRIPTION
# Description
Backport of #43933 to `stable/8.8`.

relates to 